### PR TITLE
fix(update): reboot-reminder-dialog install path error

### DIFF
--- a/src/dialogs/CMakeLists.txt
+++ b/src/dialogs/CMakeLists.txt
@@ -52,6 +52,6 @@ target_link_libraries(${BIN_NAME} PRIVATE
 )
 
 # bin
-install(TARGETS ${BIN_NAME} DESTINATION lib/dde-control-center/reboot-reminder-dialog)
+install(TARGETS ${BIN_NAME} DESTINATION lib/dde-control-center/)
 
 endif()


### PR DESCRIPTION
lib/dde-control-center/reboot-reminder-dialog -> lib/dde-control-center