### PR TITLE
fix: hide option for individual scaling unless extend or custom monitor configuration is in use.

### DIFF
--- a/src/frame/modules/display/displaywidget.h
+++ b/src/frame/modules/display/displaywidget.h
@@ -108,6 +108,7 @@ private:
 #ifndef DCC_DISABLE_MIRACAST
     QMap<QDBusObjectPath, NextPageWidget *> m_miracastList;
 #endif
+    void setIndividualScalingEnabled(bool enabled) const;
 };
 
 }  // namespace display


### PR DESCRIPTION
仅当使用扩展模式或者自定设置时显示为每个显示器指定缩放比例的选项