### PR TITLE
fix(Sound): skip not need values

### DIFF
--- a/src/frame/modules/sound/soundmodel.cpp
+++ b/src/frame/modules/sound/soundmodel.cpp
@@ -254,6 +254,11 @@ DDesktopServices::SystemSoundEffect SoundModel::getEffectTypeByGsettingName(cons
     return SOUND_EFFECT_MAP.key(name);
 }
 
+bool SoundModel::checkSEExist(const QString &name)
+{
+    return SOUND_EFFECT_MAP.values().contains(name);
+}
+
 void Port::setId(const QString &id)
 {
     if (id != m_id) {

--- a/src/frame/modules/sound/soundmodel.h
+++ b/src/frame/modules/sound/soundmodel.h
@@ -140,6 +140,8 @@ public:
     const QString getNameByEffectType(DDesktopServices::SystemSoundEffect effect) const;
     DDesktopServices::SystemSoundEffect getEffectTypeByGsettingName(const QString &name);
 
+    bool checkSEExist(const QString &name); // SE: Sound Effect
+
 Q_SIGNALS:
     void speakerOnChanged(bool speakerOn) const;
     void microphoneOnChanged(bool microphoneOn) const;

--- a/src/frame/modules/sound/soundworker.cpp
+++ b/src/frame/modules/sound/soundworker.cpp
@@ -304,6 +304,8 @@ void SoundWorker::getSoundEnabledMapFinished(QDBusPendingCallWatcher *watcher) {
         auto map = value.value();
 
         for (auto it = map.constBegin(); it != map.constEnd(); ++it) {
+            if (!m_model->checkSEExist(it.key())) continue;
+
             DDesktopServices::SystemSoundEffect type = m_model->getEffectTypeByGsettingName(it.key());
             m_model->setEffectData(type, it.value());
 


### PR DESCRIPTION
There is no such value in the map, which will cause the enumeration of 0 to be conflicted.

see: https://github.com/linuxdeepin/internal-discussion/issues/1160