### PR TITLE
fix(network): refresh loading icon not align center

### DIFF
--- a/src/frame/modules/network/accesspointwidget.cpp
+++ b/src/frame/modules/network/accesspointwidget.cpp
@@ -106,7 +106,7 @@ void AccessPointWidget::setPath(const QString &path)
 void AccessPointWidget::setLoadingIndicatorVisible(const bool value)
 {
     if (!ConnectingIndicator) {
-        const qreal ratio = qApp->devicePixelRatio();
+        const qreal ratio = devicePixelRatioF();
         ConnectingIndicator = new DPictureSequenceView;
         ConnectingIndicator->setMaximumSize(16 * ratio, 16 * ratio);
         ConnectingIndicator->setPictureSequence(":/widgets/themes/dark/icons/Loading/loading_%1.png", QPair<int, int>(0, 90), 3, true);


### PR DESCRIPTION
https://github.com/linuxdeepin/internal-discussion/issues/1411