### PR TITLE
fix: cannot load plugin

### DIFF
--- a/debian/dde-control-center.install
+++ b/debian/dde-control-center.install
@@ -1,6 +1,5 @@
 etc/xdg/autostart
 usr/bin
-usr/lib/libdccwidgets.so
 usr/lib/dde-control-center/develop-tool
 usr/lib/dde-control-center/reboot-reminder-dialog
 usr/share

--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -734,7 +734,7 @@ if (NOT DEFINED DISABLE_RECOVERY)
         )
 endif()
 
-add_library(dccwidgets SHARED
+add_library(dccwidgets STATIC
     ${WIDGETS_FILES}
 )
 target_include_directories(dccwidgets PUBLIC
@@ -786,7 +786,6 @@ target_link_libraries(${BIN_NAME} PRIVATE
 
 # bin
 install(TARGETS ${BIN_NAME} DESTINATION bin)
-install(TARGETS dccwidgets LIBRARY DESTINATION lib)
 
 find_package(Qt5 COMPONENTS
 Test


### PR DESCRIPTION
dccwidgets should be a static lib

Log:
Bug: https://pms.uniontech.com/zentao/bug-view-56910.html