### PR TITLE
fix: build failure due to missing include on QDBusMetaType

### DIFF
--- a/src/frame/window/modules/network/connectioneditpage.h
+++ b/src/frame/window/modules/network/connectioneditpage.h
@@ -29,6 +29,7 @@
 #include "interface/moduleinterface.h"
 #include "interface/namespace.h"
 
+#include <QDBusMetaType>
 #include <QPointer>
 #include <QPushButton>
 #include <QVBoxLayout>


### PR DESCRIPTION
Fixes the following build failure:

```
/build/deepin-control-center/src/dde-control-center-5.4.47/src/frame/window/modules/network/connectioneditpage.cpp: In member function ‘void dccV20::network::ConnectionEditPage::prepareConnection()’:
/build/deepin-control-center/src/dde-control-center-5.4.47/src/frame/window/modules/network/connectioneditpage.cpp:354:9: error: ‘qDBusRegisterMetaType’ was not declared in this scope; did you mean ‘qRegisterMetaType’?
  354 |         qDBusRegisterMetaType<QByteArrayList>();
      |         ^~~~~~~~~~~~~~~~~~~~~
      |         qRegisterMetaType
/build/deepin-control-center/src/dde-control-center-5.4.47/src/frame/window/modules/network/connectioneditpage.cpp:354:45: error: expected primary-expression before ‘>’ token
  354 |         qDBusRegisterMetaType<QByteArrayList>();
      |                                             ^
/build/deepin-control-center/src/dde-control-center-5.4.47/src/frame/window/modules/network/connectioneditpage.cpp:354:47: error: expected primary-expression before ‘)’ token
  354 |         qDBusRegisterMetaType<QByteArrayList>();
      |                                               ^
```

Log: