### PR TITLE
fix: cpu 频率使用 current speed

### DIFF
--- a/src/frame/modules/systeminfo/systeminfowork.cpp
+++ b/src/frame/modules/systeminfo/systeminfowork.cpp
@@ -80,7 +80,7 @@ SystemInfoWork::SystemInfoWork(SystemInfoModel *model, QObject *parent)
                              "/com/deepin/daemon/SystemInfo",
                              "org.freedesktop.DBus.Properties",
                              QDBusConnection::sessionBus());
-    QDBusMessage reply = Interface.call("Get", "com.deepin.daemon.SystemInfo", "CPUMaxMHz");
+    QDBusMessage reply = Interface.call("Get", "com.deepin.daemon.SystemInfo", "CurrentSpeed");
     QList<QVariant> outArgs = reply.arguments();
     double cpuMaxMhz = outArgs.at(0).value<QDBusVariant>().variant().toDouble();
     if (DSysInfo::cpuModelName().contains("Hz")) {


### PR DESCRIPTION
CPU Max MHz表示的是板载最大频率，并不符合逻辑，应该使用Current Speed

Log: 修复系统信息处理器信息不正确问题
Bug: https://pms.uniontech.com/bug-view-124665.html
Influence: 系统信息-关于本机-处理器