### PR TITLE
fix: wayland 开发者模式对话框位置不居中

### DIFF
--- a/src/frame/window/modules/commoninfo/developermodedialog.cpp
+++ b/src/frame/window/modules/commoninfo/developermodedialog.cpp
@@ -283,7 +283,11 @@ void DeveloperModeDialog::setLogin()
     }
 }
 
-void DeveloperModeDialog::showEvent(QShowEvent *)
+void DeveloperModeDialog::showEvent(QShowEvent *e)
 {
+    // FIX wayland DeveloperModeDialog postion not set
+    // DAbstractDialog showEvent 中会设置默认居中位置...
+    // kwayland-shell 插件中会根据 testAttribute(Qt::WA_Moved) 调整位置
+    DAbstractDialog::showEvent(e);
     setFocus();
 }


### PR DESCRIPTION
wayland 下显示前设置过位置的（testAttribute(Qt::WA_Moved)）窗口会在
kwayland-shell 中调整位置，DAbstractDialog::showEvent 会默认设置居中
重载了showEvent 却不调用基类方法不可取。

Log:
Influence: wayland developerModeDialog posion
Bug: https://pms.uniontech.com/bug-view-123527.html
Change-Id: Iee0743912cd64883f85caaebda1f2e46cfbb3ae7