### PR TITLE
fix: 增加修改分辨率后等待自动拼接的时间

### DIFF
--- a/src/frame/modules/display/monitorcontrolwidget.cpp
+++ b/src/frame/modules/display/monitorcontrolwidget.cpp
@@ -97,7 +97,7 @@ void MonitorControlWidget::setScreensMerged(const int mode)
 
 void MonitorControlWidget::onSetEffectiveReminderVisible(bool visible, int nEffectiveTime)
 {
-    if(visible)
+    if(visible && nEffectiveTime != 0)
         m_effectiveReminder->setText(tr("Screen rearrangement will take effect in %1s after changes").arg(nEffectiveTime));
     else
         m_effectiveReminder->setText("");

--- a/src/frame/modules/display/monitorsground.cpp
+++ b/src/frame/modules/display/monitorsground.cpp
@@ -84,6 +84,7 @@ MonitorsGround::MonitorsGround(int activateHeight, QWidget *parent)
 
         applySettings();
         Q_EMIT requestMonitorRelease(m_monitors[m_movingItem]);
+        m_effectiveTimer->setInterval(m_nEffectiveTime*1000);
     });
 
     DConfigWatcher::instance()->bind(DConfigWatcher::display,"sketchMap", this);
@@ -197,7 +198,9 @@ void MonitorsGround::onRotateChanged()
 
 //当方向改变时 当分辨率改变时
 void MonitorsGround::onCurrentModeChanged()
-{    
+{
+    m_nEffectiveTime = 0;
+    m_effectiveTimer->setInterval(m_nEffectiveTime);
     onResize();
     if (m_setMergeMode || m_isSingleDisplay)
         return;
@@ -211,7 +214,7 @@ void MonitorsGround::onCurrentModeChanged()
           }
     }
 
-   executemultiScreenAlgo(false);
+    executemultiScreenAlgo(false);
 }
 
 


### PR DESCRIPTION
DisplayModule::onRequestSetResolution 中判断多屏且拓展模式的时候增加等待自动拼接的时间

Log: 修复四屏扩展屏模式，切换屏幕分辨率，屏幕刷新不及时问题。
Bug: https://pms.uniontech.com/bug-view-125671.html
Influence: 显示