### PR TITLE
fix: 龙芯、mips禁用grub主题背景

### DIFF
--- a/src/frame/modules/systeminfo/systeminfowork.cpp
+++ b/src/frame/modules/systeminfo/systeminfowork.cpp
@@ -292,6 +292,7 @@ void SystemInfoWork::onBackgroundChanged()
 
 void SystemInfoWork::setBackground(const QString &path)
 {
+#ifndef DCC_DISABLE_GRUB_THEME
     Q_EMIT requestSetAutoHideDCC(false);
 
     QDBusPendingCall call = m_dbusGrubTheme->SetBackgroundSourceFile(path);
@@ -307,6 +308,7 @@ void SystemInfoWork::setBackground(const QString &path)
 
         w->deleteLater();
     });
+#endif
 }
 
 void SystemInfoWork::showActivatorDialog()

--- a/src/frame/window/modules/commoninfo/commoninfowork.cpp
+++ b/src/frame/window/modules/commoninfo/commoninfowork.cpp
@@ -285,6 +285,7 @@ void CommonInfoWork::onEnabledUsersChanged(const QStringList & value)
 
 void CommonInfoWork::setBackground(const QString &path)
 {
+#ifndef DCC_DISABLE_GRUB_THEME
     QDBusPendingCall call = m_dBusGrubTheme->SetBackgroundSourceFile(path);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [ = ](QDBusPendingCallWatcher * w) {
@@ -296,6 +297,7 @@ void CommonInfoWork::setBackground(const QString &path)
 
         w->deleteLater();
     });
+#endif
 }
 
 void CommonInfoWork::setUeProgram(bool enabled, DCC_NAMESPACE::MainWindow *pMainWindow)


### PR DESCRIPTION
龙芯、mips的架构不支持改功能，禁用

Log:
Bug: https://pms.uniontech.com/bug-view-134159.html
Influence: 龙芯、mips架构设置主题背景