### PR TITLE
fix: 副屏对话框显示时闪烁

### DIFF
--- a/src/frame/window/modules/display/secondaryscreendialog.cpp
+++ b/src/frame/window/modules/display/secondaryscreendialog.cpp
@@ -269,7 +269,7 @@ void SecondaryScreenDialog::resetDialog()
     if(!screen)
         return;
 
-    setGeometry(QRect(screen->geometry().topLeft(),rt.size()));
+    QDialog::setGeometry(QRect(screen->geometry().topLeft(),rt.size()));
     move(QPoint(screen->geometry().left() + (screen->geometry().width() - rt.width()) / 2,
                 screen->geometry().top() + (screen->geometry().height() - rt.height()) / 2));
 


### PR DESCRIPTION
wayland上的多屏窗口由窗管管理,先设置位置再显示才能显示在指定位置

Log:
Bug: https://pms.uniontech.com/bug-view-112204.html
Influence: none
Change-Id: I1559f5a7a1eb3098c91aebb874e657f0fdab8d07