### PR TITLE
fix: use as-needed instead of as-need

### DIFF
--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
-set(CMAKE_CXX_FLAGS "-g -Wall -Wl,--as-need -fPIE")
+set(CMAKE_CXX_FLAGS "-g -Wall -Wl,--as-needed -fPIE")
 
 # 增加安全编译参数
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all")


### PR DESCRIPTION
Log: Use as-needed to enhance compatibility with linker

Signed-off-by: Han Gao <rabenda.cn@gmail.com>