### PR TITLE
fix: 重置密码确认后一直显示重置密码弹窗

### DIFF
--- a/src/reset-password-dialog/resetpassworddialog.cpp
+++ b/src/reset-password-dialog/resetpassworddialog.cpp
@@ -74,8 +74,11 @@ void ResetPasswordDialog::hideEvent(QHideEvent *event)
         }
         this->close();
         qApp->quit();
-    } else {
-        QTimer::singleShot(1000, this, SLOT(show()));
+    }
+    if (m_isClose) {
+        QTimer::singleShot(1000, this, [this] {
+            show();
+        });
         qInfo() << "single shot show";
     }
 }


### PR DESCRIPTION
原因：重置密码隐藏后一直显示重置密码弹窗，
      未考虑确认后的正常隐藏情况。
修改：添加一个判断

Log: 修复重置密码确认后一直显示重置密码弹窗问题
Bug: https://pms.uniontech.com/bug-view-151529.html
Influence: 重置密码
Change-Id: I5263258cd98f697abfac9b9215c1738ca7b78f1b
(cherry picked from commit b8097fe94841763eb4940f20ee13e1d78adbffd0)