### PR TITLE
fix: 重置密码确认对话框最小化和关闭按钮

### DIFF
--- a/src/reset-password-dialog/resetpassworddialog.cpp
+++ b/src/reset-password-dialog/resetpassworddialog.cpp
@@ -176,17 +176,17 @@ void ResetPasswordDialog::initWidget(const QString &userName)
     auto isWayland = qEnvironmentVariable("XDG_SESSION_TYPE").contains("wayland");
     if (isWayland) {
         m_tipDialog.windowHandle()->setProperty("_d_dwayland_window-type", "override");
-        m_tipDialog.setWindowFlags(Qt::NoDropShadowWindowHint | Qt::Window);
+        m_tipDialog.setWindowFlags(Qt::NoDropShadowWindowHint | Qt::Window | Qt::CustomizeWindowHint);
         create();
         windowHandle()->setProperty("_d_dwayland_window-type", "override");
-        setWindowFlags(Qt::NoDropShadowWindowHint | Qt::Window);
+        setWindowFlags(Qt::NoDropShadowWindowHint | Qt::Window  | Qt::CustomizeWindowHint);
     } else {
         if (m_appName == "greeter" || m_appName == "lock") {
-            m_tipDialog.setWindowFlags(Qt::Popup | Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint);
-            setWindowFlags(Qt::Popup | Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint);
+            m_tipDialog.setWindowFlags(Qt::Popup | Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
+            setWindowFlags(Qt::Popup | Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
         } else {
-            m_tipDialog.setWindowFlags(Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint);
-            setWindowFlags(Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint);
+            m_tipDialog.setWindowFlags(Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
+            setWindowFlags(Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
         }
     }
     m_tipDialog.installEventFilter(this);


### PR DESCRIPTION
关闭重置密码确认对话框最小化和关闭按钮

Log: 修复重置密码确认对话框最小化和关闭按钮问题
Bug: https://pms.uniontech.com/bug-view-151535.html
Influence: 重置密码
Change-Id: Ic641be844e097d7434b4ea44420406da4ca4007c