### PR TITLE
feat: 个性化增加“窗口移动时启用透明特效”

### DIFF
--- a/configs/org.deepin.dde.control-center.personalization.json
+++ b/configs/org.deepin.dde.control-center.personalization.json
@@ -1,0 +1,17 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "effectMovewindowTranslucency": {
+            "value": "Enabled",
+            "serial": 0,
+            "flags": [],
+            "name": "effectMovewindowTranslucency",
+            "name[zh_CN]": "移动窗口展示透明特效开关",
+            "description[zh_CN]": "通过设置 打开/关闭 移动窗口显示透明特效",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+  }

--- a/src/frame/modules/personalization/personalizationmodel.cpp
+++ b/src/frame/modules/personalization/personalizationmodel.cpp
@@ -43,6 +43,7 @@ PersonalizationModel::PersonalizationModel(QObject *parent)
     m_monoFontModel  = new FontModel(this);
     m_fontSizeModel  = new FontSizeModel(this);
     m_is3DWm = true;
+    m_isMoveWindow = false;
     m_miniEffect = 0;
 }
 
@@ -62,6 +63,19 @@ void PersonalizationModel::setIs3DWm(const bool is3d)
 bool PersonalizationModel::is3DWm() const
 {
     return m_is3DWm;
+}
+
+void PersonalizationModel::setIsMoveWindow(const bool isMoveWindow)
+{
+    if (isMoveWindow != m_isMoveWindow) {
+        m_isMoveWindow = isMoveWindow;
+        Q_EMIT moveWindowChanged(isMoveWindow);
+    }
+}
+
+bool PersonalizationModel::isMoveWindow() const
+{
+    return m_isMoveWindow;
 }
 
 void PersonalizationModel::setWindowRadius(int radius)

--- a/src/frame/modules/personalization/personalizationmodel.h
+++ b/src/frame/modules/personalization/personalizationmodel.h
@@ -52,6 +52,9 @@ public:
     void setIs3DWm(const bool is3d);
     bool is3DWm() const;
 
+    void setIsMoveWindow(const bool isMoveWindow);
+    bool isMoveWindow() const;
+
     void setWindowRadius(int radius);
     int windowRadius();
 
@@ -69,6 +72,7 @@ public:
 
 Q_SIGNALS:
     void wmChanged(const bool is3d);
+    void moveWindowChanged(const bool isMoveWindow);
     void onOpacityChanged(std::pair<int, double> opacity);
     void onMiniEffectChanged(int effect);
     void onActiveColorChanged(const QString &color);
@@ -84,6 +88,7 @@ private:
     FontModel     *m_monoFontModel;
     FontSizeModel *m_fontSizeModel;
     bool m_is3DWm;
+    bool m_isMoveWindow;
     std::pair<int, double> m_opacity;
     int m_miniEffect;
     QString m_activeColor;

--- a/src/frame/modules/personalization/personalizationwork.h
+++ b/src/frame/modules/personalization/personalizationwork.h
@@ -65,6 +65,7 @@ public Q_SLOTS:
     void setFontSize(const int value);
     void switchWM();
     void windowSwitchWM(bool value);
+    void movedWindowSwitchWM(bool value);
     void setOpacity(int opcaity);
     void setMiniEffect(int effect);
     void setActiveColor(const QString &hexColor);

--- a/src/frame/window/dconfigwatcher.cpp
+++ b/src/frame/window/dconfigwatcher.cpp
@@ -218,6 +218,8 @@ void DConfigWatcher::setStatus(QString &moduleName, const QString &configName, Q
         Q_EMIT requestShowSecondMenu(item->row());
     else
         Q_EMIT requestUpdateSecondMenu(item->row(), configName);
+
+    Q_EMIT notifyDConfigChanged(moduleName, configName);
 }
 
 /**
@@ -272,6 +274,7 @@ void DConfigWatcher::onStatusModeChanged(ModuleType moduleType, const QString &k
     keys->key = key;
     keys->type = moduleType;
     Q_EMIT requestUpdateSearchMenu(moduleName + key, m_menuState.value(keys));
+    Q_EMIT notifyDConfigChanged(moduleName, key);
 }
 
 

--- a/src/frame/window/dconfigwatcher.h
+++ b/src/frame/window/dconfigwatcher.h
@@ -114,6 +114,7 @@ Q_SIGNALS:
     void requestUpdateSecondMenu(int, const QString &gsettingsName = QString());
     void requestUpdateSearchMenu(const QString &, bool);
     void requestShowSecondMenu(int); //显示第二级页面
+    void notifyDConfigChanged(const QString &, const QString &);
 
 private:
     QMultiHash<ModuleKey *, QWidget *> m_thirdMap; //三级菜单 map

--- a/src/frame/window/modules/personalization/personalizationgeneral.h
+++ b/src/frame/window/modules/personalization/personalizationgeneral.h
@@ -39,6 +39,7 @@ namespace dcc {
 namespace widgets {
 class TitledSliderItem;
 class ComboxWidget;
+class SettingsItem;
 }
 }
 
@@ -90,6 +91,7 @@ public:
 
 protected:
     void paintEvent(QPaintEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 
 private:
     void updateActiveColors(RoundColorWidget *selectedWidget);
@@ -101,6 +103,8 @@ Q_SIGNALS:
     void showFontsWidget();
     void requestSwitchWM();
     void requestWindowSwitchWM(bool value);
+    void requestMovedWindowSwitchWM(bool value);
+    void windowMovedVisibleChanged(bool value);
     void requestSetOpacity(int value);
     void requestSetMiniEffect(int effect);
     void requestSetActiveColor(const QString &color);
@@ -119,6 +123,9 @@ private:
     DTK_WIDGET_NAMESPACE::DSwitchButton *m_wmSwitch;  //是否开启特效
     dcc::widgets::TitledSliderItem *m_transparentSlider;  //透明度调节
     dcc::widgets::ComboxWidget *m_cmbMiniEffect;    //最小化效果
+    DTK_WIDGET_NAMESPACE::DSwitchButton *m_windowMovedSwitch;  //是否开启“窗口移动时启用透明特效”
+    QLabel *m_windowMovedLabel;
+    QString m_displayData;
     dcc::personalization::PersonalizationModel *m_model;
     dcc::widgets::TitledSliderItem *m_winRoundSlider;   // 自定义圆角(社区版功能)
     PerssonalizationThemeWidget *m_Themes;
@@ -128,6 +135,8 @@ private:
     bool m_bSystemIsServer;
     int m_windowRadius;
     Dtk::Gui::DGuiApplicationHelper::ColorType m_themeType;
+    bool m_isWayland;
+    dcc::widgets::SettingsItem *m_movedWinSwitchItem;
 };
 }
 }

--- a/src/frame/window/utils.h
+++ b/src/frame/window/utils.h
@@ -45,6 +45,7 @@ const QMargins ThirdPageCmbMargins(0, 0, 0, 0);
 
 const int ComboxWidgetHeight = 48;
 const int SwitchWidgetHeight = 36;
+const int MovedWindowWidgetHeight = 36;
 const int LeftTitleWitdh = 110;
 
 const QSize ListViweItemIconSize(84,84);


### PR DESCRIPTION
1.添加新功能：“窗口移动时启用透明特效”
2.英文宽度太长，修改过长使用...，宽度变大后显示全
3.增加搜索关联
4.添加gsettings控制

Log: 新需求-“窗口移动时启用透明特效”
Influence: 新需求
Task: https://pms.uniontech.com/task-view-154469.html
Change-Id: I6776d8fd6fe155823b38246c4f2d6b018856f41f