### PR TITLE
feat: 无法备份时弹窗提示用户

### DIFF
--- a/src/frame/window/modules/update/updatecontrolpanel.cpp
+++ b/src/frame/window/modules/update/updatecontrolpanel.cpp
@@ -32,10 +32,6 @@ updateControlPanel::updateControlPanel(QWidget *parent)
 
 void updateControlPanel::onStartUpdate()
 {
-    showUpdateProcess(true);
-
-    setButtonStatus(ButtonStatus::pause);
-
     Q_EMIT startUpdate();
 }
 

--- a/src/frame/window/modules/update/updatectrlwidget.cpp
+++ b/src/frame/window/modules/update/updatectrlwidget.cpp
@@ -34,9 +34,11 @@
 #include <QSettings>
 #include <QPushButton>
 #include <QScrollArea>
+
 #include <DFontSizeManager>
 #include <DPalette>
 #include <DSysInfo>
+#include <DDialog>
 
 #define UpgradeWarningSize 500
 #define FullUpdateBtnWidth 92
@@ -46,6 +48,7 @@ using namespace dcc::update;
 using namespace dcc::widgets;
 using namespace DCC_NAMESPACE;
 using namespace DCC_NAMESPACE::update;
+using namespace Dtk::Widget;
 
 UpdateCtrlWidget::UpdateCtrlWidget(UpdateModel *model, QWidget *parent)
     : QWidget(parent)
@@ -257,11 +260,20 @@ UpdateCtrlWidget::UpdateCtrlWidget(UpdateModel *model, QWidget *parent)
 void UpdateCtrlWidget::initConnect()
 {
     auto initUpdateItemConnect = [ = ](UpdateSettingItem * updateItem) {
-        connect(updateItem, &UpdateSettingItem::requestUpdate, this, &UpdateCtrlWidget::requestUpdates);
+        connect(updateItem, &UpdateSettingItem::requestUpdate, this, [updateItem, this] (ClassifyUpdateType type) {
+            if (!m_model->recoverConfigValid() && continueUpdate()) {
+                updateItem->updateStarted();
+                Q_EMIT requestUpdates(type);
+            }
+        });
         connect(updateItem, &UpdateSettingItem::requestUpdateCtrl, this, &UpdateCtrlWidget::requestUpdateCtrl);
         connect(updateItem, &UpdateSettingItem::requestRefreshSize, this, &UpdateCtrlWidget::onRequestRefreshSize);
         connect(updateItem, &UpdateSettingItem::requestRefreshWidget, this, &UpdateCtrlWidget::onRequestRefreshWidget);
-        connect(updateItem, &UpdateSettingItem::requestFixError, this, &UpdateCtrlWidget::requestFixError);
+        connect(updateItem, &UpdateSettingItem::requestFixError, this, [this] (const ClassifyUpdateType &updateType, const QString &error) {
+            if (!m_model->recoverConfigValid() && continueUpdate()) {
+                Q_EMIT requestFixError(updateType, error);
+            }
+        });
     };
 
     initUpdateItemConnect(m_systemUpdateItem);
@@ -685,7 +697,9 @@ void UpdateCtrlWidget::onFullUpdateClicked()
                 || updateItem->status() == UpdatesStatus::DownloadPaused
                 || updateItem->status() == UpdatesStatus::UpdateFailed
                 || updateItem->status() == UpdatesStatus::AutoDownloaded) {
-            Q_EMIT  requestUpdates(updateItem->classifyUpdateType());
+            if (!m_model->recoverConfigValid() && continueUpdate()) {
+                Q_EMIT requestUpdates(updateItem->classifyUpdateType());
+            }
         }
     }
 }
@@ -822,5 +836,28 @@ void UpdateCtrlWidget::onShowUpdateCtrl()
     }
 }
 
+/**
+ * @brief  当用户没有自动分区安装系、未安装ab-recovery或者是缺少某些更新文件的时候，
+ * 弹窗告知用户系统无法备份，是否要继续升级。
+ *
+ * @return true 继续升级
+ * @return false 停止升级
+ */
+bool UpdateCtrlWidget::continueUpdate()
+{
+    DDialog *tipDialog = new DDialog(this);
+    tipDialog->setAttribute(Qt::WA_DeleteOnClose);
+    tipDialog->setIcon(QIcon::fromTheme("dialog-warning"));
+    tipDialog->setMinimumSize(380, 158);
+    tipDialog->setModal(true);
+    tipDialog->setMessage(tr("Unable to perform system backup. Continue the update?"));
+    tipDialog->addButton(tr("Cancel"), false, DDialog::ButtonRecommend);
+    tipDialog->addButton(tr("Continue"), true, DDialog::ButtonNormal);
+    // 修改continue按钮的文字颜色
+    QAbstractButton* continueBtn = tipDialog->getButton(1);
+    QPalette pal = continueBtn->palette();
+    pal.setColor(QPalette::ButtonText, QColor("#FF5736"));
+    continueBtn->setPalette(pal);
 
-
+    return 1 ==  tipDialog->exec();
+}

--- a/src/frame/window/modules/update/updatectrlwidget.h
+++ b/src/frame/window/modules/update/updatectrlwidget.h
@@ -131,6 +131,7 @@ private:
     void initUpdateItem(UpdateSettingItem *updateItem);
     bool checkUpdateItemIsUpdateing(UpdateSettingItem *updateItem, ClassifyUpdateType type);
     void showAllUpdate();
+    bool continueUpdate();
 
 private:
     UpdateModel *m_model;

--- a/src/frame/window/modules/update/updatesettingitem.cpp
+++ b/src/frame/window/modules/update/updatesettingitem.cpp
@@ -330,3 +330,9 @@ void UpdateSettingItem::onRetryUpdate()
 
     onStartUpdate();
 }
+
+void UpdateSettingItem::updateStarted()
+{
+    m_controlWidget->showUpdateProcess(true);
+    m_controlWidget->setButtonStatus(ButtonStatus::pause);
+}

--- a/src/frame/window/modules/update/updatesettingitem.h
+++ b/src/frame/window/modules/update/updatesettingitem.h
@@ -66,6 +66,7 @@ public:
     void setUpdateJobErrorMessage(const UpdateErrorType &updateJobErrorMessage);
 
     void setUpdateFailedInfo();
+    void updateStarted();
 
 Q_SIGNALS:
     void UpdateSuccessed();


### PR DESCRIPTION
当用户没有自动分区安装系、未安装ab-recovery或者是缺少某些更新文件的时候，弹窗告知用户系统无法备份，是否要继续升级。

Log: 增加无法备份时弹窗提示用户的功能
Task: https://pms.uniontech.com/task-view-158163.html
Influence: 无法备份时进行更新的场景
Change-Id: Id65daf991ff7541a9220aae5a8fabf3ebc519ae6