### PR TITLE
feat: 通知-移除“在任务栏显示图标”选项

### DIFF
--- a/src/frame/modules/notification/model/sysitemmodel.cpp
+++ b/src/frame/modules/notification/model/sysitemmodel.cpp
@@ -26,7 +26,6 @@ using namespace dcc::notification;
 SysItemModel::SysItemModel(QObject *parent)
     : QObject(parent)
     , m_isDisturbMode(false)
-    , m_isShowInDock(false)
     , m_isTimeSlot(false)
     , m_isLockScreen(false)
     , m_timeStart("22:00")
@@ -40,14 +39,6 @@ void SysItemModel::setDisturbMode(const bool disturbMode)
         return;
     m_isDisturbMode = disturbMode;
     Q_EMIT disturbModeChanged(disturbMode);
-}
-
-void SysItemModel::setShowInDock(const bool showInDock)
-{
-    if (m_isShowInDock == showInDock)
-        return;
-    m_isShowInDock = showInDock;
-    Q_EMIT showInDockChanged(showInDock);
 }
 
 void SysItemModel::setTimeSlot(const bool timeSlot)
@@ -99,9 +90,6 @@ void SysItemModel::onSettingChanged(uint item, const QDBusVariant &var)
         break;
     case ENDTIME:
         setTimeEnd(var.variant().toString());
-        break;
-    case SHOWICON:
-        setShowInDock(var.variant().toBool());
         break;
     }
 }

--- a/src/frame/modules/notification/model/sysitemmodel.h
+++ b/src/frame/modules/notification/model/sysitemmodel.h
@@ -42,17 +42,13 @@ public:
         LOCKSCREENOPENDNDMODE,
         OPENBYTIMEINTERVAL,
         STARTTIME,
-        ENDTIME,
-        SHOWICON
+        ENDTIME
     } SystemConfigurationItem;
 
     explicit SysItemModel(QObject *parent = nullptr);
 
     inline bool isDisturbMode() const {return m_isDisturbMode;}
     void setDisturbMode(const bool disturbMode);
-
-    inline bool isShowInDock()const {return m_isShowInDock;}
-    void setShowInDock(const bool showInDock);
 
     inline bool isTimeSlot()const {return  m_isTimeSlot;}
     void setTimeSlot(const bool timeSlot);
@@ -70,7 +66,6 @@ public:
 
 Q_SIGNALS:
     void disturbModeChanged(bool isDisturbMode);
-    void showInDockChanged(bool isShowInDock);
     void timeSlotChanged(bool isTimeSlot);
     void lockScreenChanged(bool isLockScreen);
     void timeStartChanged(const QString &timeStart);
@@ -78,7 +73,6 @@ Q_SIGNALS:
 
 private:
     bool m_isDisturbMode;//勿扰模式
-    bool m_isShowInDock;//任务栏显示
     bool m_isTimeSlot;//时间段
     bool m_isLockScreen;//锁屏显示
     QString m_timeStart;//开始时间

--- a/src/frame/modules/notification/notificationworker.cpp
+++ b/src/frame/modules/notification/notificationworker.cpp
@@ -65,7 +65,6 @@ void NotificationWorker::initSystemSetting()
     item->setDisturbMode(m_dbus->GetSystemInfo(SysItemModel::DNDMODE).value().variant().toBool());
     item->setLockScreen(m_dbus->GetSystemInfo(SysItemModel::LOCKSCREENOPENDNDMODE).value().variant().toBool());
     item->setTimeSlot(m_dbus->GetSystemInfo(SysItemModel::OPENBYTIMEINTERVAL).value().variant().toBool());
-    item->setShowInDock(m_dbus->GetSystemInfo(SysItemModel::SHOWICON).value().variant().toBool());
     connect(m_dbus, &Notification::SystemInfoChanged, item, &SysItemModel::onSettingChanged);
     m_model->setSysSetting(item);
 }

--- a/src/frame/window/modules/notification/systemnotifywidget.cpp
+++ b/src/frame/window/modules/notification/systemnotifywidget.cpp
@@ -103,13 +103,6 @@ void SystemNotifyWidget::initUI()
     m_itemLockScreen->setTitle(tr("When the screen is locked"));
     m_settingsGrp->appendItem(m_itemLockScreen);
     mainLayout->addWidget(m_settingsGrp);
-
-    //~ contents_path /notification/System Notifications
-    //~ child_page System Notifications
-    m_btnShowInDock = new SwitchWidget(tr("Show icon on Dock"));
-    m_btnShowInDock->addBackground();
-    m_btnShowInDock->layout()->setContentsMargins(10, 0, 10, 0);
-    mainLayout->addWidget(m_btnShowInDock);
     mainLayout->addStretch();
 
     m_settingsGrp->setVisible(m_btnDisturbMode->isChecked());
@@ -123,10 +116,7 @@ void SystemNotifyWidget::initConnect()
     });
     m_btnDisturbMode->setChecked(m_model->isDisturbMode());
     m_settingsGrp->setVisible(m_model->isDisturbMode());
-    connect(m_model, &SysItemModel::showInDockChanged, this, [this](bool state) {
-        m_btnShowInDock->setChecked(state);
-    });
-    m_btnShowInDock->setChecked(m_model->isShowInDock());
+
     connect(m_model, &SysItemModel::timeSlotChanged, this, [this](bool state) {
         m_itemTimeSlot->setState(state);
     });
@@ -148,9 +138,6 @@ void SystemNotifyWidget::initConnect()
     connect(m_btnDisturbMode, &DSwitchButton::checkedChanged, this, [ = ](bool state) {
         m_settingsGrp->setVisible(state);
         Q_EMIT requestSetSysSetting(SysItemModel::DNDMODE, state);
-    });
-    connect(m_btnShowInDock, &SwitchWidget::checkedChanged, this, [ = ](bool state) {
-        Q_EMIT requestSetSysSetting(SysItemModel::SHOWICON, state);
     });
     connect(m_itemTimeSlot, &TimeSlotItem::stateChanged, this, [ = ](bool state) {
         Q_EMIT requestSetSysSetting(SysItemModel::OPENBYTIMEINTERVAL, state);

--- a/src/frame/window/modules/notification/systemnotifywidget.h
+++ b/src/frame/window/modules/notification/systemnotifywidget.h
@@ -71,7 +71,6 @@ private:
 private:
     dcc::notification::SysItemModel *m_model;
     Dtk::Widget::DSwitchButton *m_btnDisturbMode;//勿扰模式
-    dcc::widgets::SwitchWidget *m_btnShowInDock;//是否显示在Dock
     TimeSlotItem *m_itemTimeSlot;//时间段
     NotificationItem *m_itemLockScreen;
     dcc::widgets::SettingsGroup *m_settingsGrp;//自选项

--- a/tests/dde-control-center/notification/ut_systemnotifywidget.cpp
+++ b/tests/dde-control-center/notification/ut_systemnotifywidget.cpp
@@ -50,7 +50,6 @@ TEST_F(Tst_SystemNotifyWidget, FullTest)
 
     SysItemModel *sysmodel = model.getSystemModel();
     sysmodel->disturbModeChanged(true);
-    sysmodel->showInDockChanged(true);
     sysmodel->timeSlotChanged(true);
     sysmodel->timeStartChanged("07:00");
     sysmodel->timeEndChanged("18:00");


### PR DESCRIPTION
通知-移除“在任务栏显示图标”选项,在任务栏设置中有同样的功能

Log: 移除通知中“在任务栏显示图标”的选项
Task: https://pms.uniontech.com/task-view-174011.html
Influence: 控制中心通知
Change-Id: I8bc81065c2a2e07401c2f090d1cfe876a86c05aa