### PR TITLE
chore: 完善lupdate.sh逻辑，仅处理cmakelist.txt的.h和.cpp文件

### DIFF
--- a/lupdate.sh
+++ b/lupdate.sh
@@ -18,11 +18,11 @@ function lupdateProject() {
 	rm -f $TS_FILE
 	rm -f files.tmp
 	for i in $(grep "\.h" $SRC_DIR/CMakeLists.txt); do
-		echo $SRC_DIR/$i >>files.tmp
+                echo $SRC_DIR/$i | grep -q -E "\.h$" && echo $SRC_DIR/$i >>files.tmp
 	done
 
 	for i in $(grep "\.cpp" $SRC_DIR/CMakeLists.txt); do
-		echo $SRC_DIR/$i >>files.tmp
+                echo $SRC_DIR/$i | grep -q -E "\.cpp$" && echo $SRC_DIR/$i >>files.tmp
 	done
 	lupdate @files.tmp $INC_FLAG -ts -no-obsolete $TS_FILE
 	rm -f files.tmp


### PR DESCRIPTION
cmakelist.txt加了其他非.h和.cpp的文件，导致执行失败

Log: 完善lupdate.sh逻辑
Influence: 更新翻译
Change-Id: I226c18fb7e98a58c7862d7ccd5cc1ed618273dc1