### PR TITLE
fix: 货币符号发生变化更新示例

### DIFF
--- a/src/frame/window/modules/datetime/currencyformat.cpp
+++ b/src/frame/window/modules/datetime/currencyformat.cpp
@@ -125,6 +125,7 @@ void CurrencyFormat::initComboxWidgetList()
     m_positiveCurrencyFormatCbx->comboBox()->setCurrentText(m_model->positiveCurrencyFormat());
     m_negativeCurrencyFormatCbx->comboBox()->setCurrentText(m_model->negativeCurrencyFormat());
     //初次进入该页面，获取正负正数位子
+    m_currencySymbolFormatPlace = m_currencySymbolCbx->comboBox()->currentText();
     m_positiveCurrencyFormatPlace = m_positiveCurrencyFormatCbx->comboBox()->currentIndex();
     m_negativeCurrencyFormatPlace = m_negativeCurrencyFormatCbx->comboBox()->currentIndex();
 

--- a/src/frame/window/modules/datetime/currencyformat.h
+++ b/src/frame/window/modules/datetime/currencyformat.h
@@ -31,6 +31,7 @@ public:
     explicit CurrencyFormat(dcc::datetime::DatetimeModel *model, QWidget *parent = nullptr);
     ~CurrencyFormat();
 
+    QString getFirstCurrencySymbolFormat() {return m_currencySymbolFormatPlace;}
     int getFirstPositiveCurrencyFormatPlace() {return m_positiveCurrencyFormatPlace;}
     int getFirstNegativeCurrencyPlace() {return m_negativeCurrencyFormatPlace;}
 
@@ -50,6 +51,7 @@ private:
     dcc::widgets::ComboxWidget *m_currencySymbolCbx;
     dcc::widgets::ComboxWidget *m_positiveCurrencyFormatCbx;
     dcc::widgets::ComboxWidget *m_negativeCurrencyFormatCbx;
+    QString m_currencySymbolFormatPlace;
     int m_positiveCurrencyFormatPlace;
     int m_negativeCurrencyFormatPlace;
 };

--- a/src/frame/window/modules/datetime/formatsetting.cpp
+++ b/src/frame/window/modules/datetime/formatsetting.cpp
@@ -166,8 +166,10 @@ void FormatSetting::initComboxWidgetList()
     connect(m_weekStartDayCbx->comboBox(), static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
             this, &FormatSetting::weekStartDayFormatChanged);
 
+    connect(m_currencyFormatWidget, &CurrencyFormat::currencySymbolFormatChanged, m_numberFormatWidget, &NumberFormat::SetCurrencySymbolFormat);
     connect(m_currencyFormatWidget, &CurrencyFormat::positiveCurrencyFormatChanged, m_numberFormatWidget, &NumberFormat::SetPositiveCurrencyFormat);
     connect(m_currencyFormatWidget, &CurrencyFormat::negativeCurrencyChanged, m_numberFormatWidget, &NumberFormat::SetNegativeCurrency);
+    m_numberFormatWidget->SetCurrencySymbolFormat(m_currencyFormatWidget->getFirstCurrencySymbolFormat());
     m_numberFormatWidget->SetPositiveCurrencyFormat(m_currencyFormatWidget->getFirstPositiveCurrencyFormatPlace());
     m_numberFormatWidget->SetNegativeCurrency(m_currencyFormatWidget->getFirstNegativeCurrencyPlace());
 }

--- a/src/frame/window/modules/datetime/numberformat.cpp
+++ b/src/frame/window/modules/datetime/numberformat.cpp
@@ -44,6 +44,7 @@ NumberFormat::NumberFormat(dcc::datetime::DatetimeModel *model, QWidget *parent)
     , m_digitGroupingSymbolCbx(new ComboxWidget)
     , m_digitGroupingCbx(new ComboxWidget)
     , m_exampleTips(new TipsLabel)
+    , m_currencySymbolFormat("")
     , m_positiveCurrencyFormat(0)
     , m_negativeCurrency(0)
 {
@@ -116,6 +117,14 @@ NumberFormat::~NumberFormat()
     DConfigWatcher::instance()->erase(DConfigWatcher::datetime, "FromatsettingDecimalsymbol");
     DConfigWatcher::instance()->erase(DConfigWatcher::datetime, "FromatsettingDigitgroupingsymbol");
     DConfigWatcher::instance()->erase(DConfigWatcher::datetime, "FromatsettingDigitgrouping");
+}
+
+void NumberFormat::SetCurrencySymbolFormat(QString value)
+{
+    if (m_currencySymbolFormat != value) {
+        m_currencySymbolFormat = value;
+        updateExample();
+    }
 }
 
 void NumberFormat::SetPositiveCurrencyFormat(int value)

--- a/src/frame/window/modules/datetime/numberformat.h
+++ b/src/frame/window/modules/datetime/numberformat.h
@@ -42,6 +42,7 @@ Q_SIGNALS:
     void digitGroupingChanged(QString);
 
 public Q_SLOTS:
+    void SetCurrencySymbolFormat(QString value);
     void SetPositiveCurrencyFormat(int value);
     void SetNegativeCurrency(int value);
     void updateExample(int numplace = -1);
@@ -53,6 +54,7 @@ private:
     dcc::widgets::ComboxWidget *m_digitGroupingSymbolCbx;
     dcc::widgets::ComboxWidget *m_digitGroupingCbx;
     dcc::widgets::TipsLabel *m_exampleTips;
+    QString m_currencySymbolFormat;
     int m_positiveCurrencyFormat;
     int m_negativeCurrency;
 };


### PR DESCRIPTION
因为货币正数和货币负数的位置不变，在更新货币符号不会触发示例变化
因此需要把货币符号发生变化信号关联示例更新函数

Log: 同步更新示例
Influence: 数据同步
Task: https://pms.uniontech.com/task-view-154485.html
Change-Id: I11789aa4d4a16d4d27d44a060ce8c09b31ebe175