### PR TITLE
feat(accounts): 桌面专业版账户模块支持用户组编辑

### DIFF
--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -322,6 +322,7 @@ set(ACCOUNTS_FILES
                 window/modules/accounts/onlineicon.cpp
                 window/modules/accounts/unionidbindreminderdialog.cpp
                 window/modules/accounts/securityquestionspage.cpp
+                window/modules/accounts/usergroupspage.cpp
 
 )
 

--- a/src/frame/window/modules/accounts/accountsdetailwidget.h
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.h
@@ -105,11 +105,11 @@ Q_SIGNALS:
     void requestSetAvatar(dcc::accounts::User *user, const QString &filePath);
     void requestSetFullname(dcc::accounts::User *user, const QString &fullname);
     void requestCleanThumbs(dcc::accounts::User *user);
-    void requestSetGroups(dcc::accounts::User *user, const QStringList &usrGroups);
     void requsetSetPassWordAge(dcc::accounts::User *user, const int age);
     void noticeEnrollCompleted(QString username);
     void editingFinished(const QString& userFullName);
     void requestSecurityQuestionsCheck(dcc::accounts::User *user);
+    void requestShowUserGroups(dcc::accounts::User *user);
 
 public Q_SLOTS:
     void resetDelButtonState();
@@ -119,16 +119,11 @@ public Q_SLOTS:
 protected:
     void initUserInfo(QVBoxLayout *layout);
     void initSetting(QVBoxLayout *layout);
-    void initGroups(QVBoxLayout *layout);
     bool eventFilter(QObject *obj, QEvent *event) override;
-    void resizeEvent(QResizeEvent *event);
+    void resizeEvent(QResizeEvent *event) override;
 
 private Q_SLOTS:
     void deleteUserClicked();
-    void changeUserGroup(const QStringList &groups);
-    void userGroupClicked(const QModelIndex &index);
-    void setGroupInfo(const QStringList &group);
-    void onGidChanged(const QString &gid);
 
 private:
     dcc::accounts::User *m_curUser;
@@ -137,8 +132,6 @@ private:
     DTK_WIDGET_NAMESPACE::DToolButton *m_fullNameBtn;//账户全名编辑按钮
     DLineEdit *m_inputLineEdit;//账户全名编辑框
     AvatarListWidget *m_avatarListWidget;//图像列表
-    DTK_WIDGET_NAMESPACE::DListView *m_groupListView;
-    QStandardItemModel *m_groupItemModel;
     bool m_isServerSystem;
     dcc::widgets::SwitchWidget *m_autoLogin;
     dcc::widgets::SwitchWidget *m_nopasswdLogin;
@@ -152,6 +145,7 @@ private:
     QString m_groupName;
     dcc::accounts::User *m_curLoginUser;
     QLabel *m_bindStatusLabel;
+    dcc::widgets::NextPageWidget *m_groupsPage;
 };
 
 }   // namespace accounts

--- a/src/frame/window/modules/accounts/accountsmodule.cpp
+++ b/src/frame/window/modules/accounts/accountsmodule.cpp
@@ -30,6 +30,7 @@
 #include "window/gsettingwatcher.h"
 #include "window/utils.h"
 #include "securityquestionspage.h"
+#include "usergroupspage.h"
 
 #include <DDialog>
 
@@ -184,7 +185,7 @@ void AccountsModule::onShowAccountsDetailWidget(User *account)
     connect(w, &AccountsDetailWidget::requestSetAdministrator, m_accountsWorker, &AccountsWorker::setAdministrator);
     connect(w, &AccountsDetailWidget::requestNopasswdLogin, m_accountsWorker, &AccountsWorker::setNopasswdLogin);
     connect(w, &AccountsDetailWidget::requestDeleteAccount, m_accountsWorker, &AccountsWorker::deleteAccount);
-    connect(w, &AccountsDetailWidget::requestSetGroups, m_accountsWorker, &AccountsWorker::setGroups);
+    connect(w, &AccountsDetailWidget::requestShowUserGroups, this, &AccountsModule::onShowUserGroupsPage);
     connect(w, &AccountsDetailWidget::requestBack, this, [&]() {
         m_accountsWidget->setShowFirstUserInfo(false);
     });
@@ -361,6 +362,18 @@ void AccountsModule::onShowSecurityQuestionsPage(User *account)
 
     m_frameProxy->pushWidget(this, w);
     Q_EMIT w->requestSecurityQuestionsCheck(account);
+
+    w->setVisible(true);
+}
+
+void AccountsModule::onShowUserGroupsPage(User *account)
+{
+    UserGroupsPage *w = new UserGroupsPage(account, m_userModel);
+    w->setVisible(false);
+
+    connect(w, &UserGroupsPage::requestSetGroups, m_accountsWorker, &AccountsWorker::setGroups);
+
+    m_frameProxy->pushWidget(this, w, FrameProxyInterface::PushType::CoverTop);
 
     w->setVisible(true);
 }

--- a/src/frame/window/modules/accounts/accountsmodule.h
+++ b/src/frame/window/modules/accounts/accountsmodule.h
@@ -76,7 +76,7 @@ public Q_SLOTS:
     void onShowPasswordPage(dcc::accounts::User *account);
     void onShowSecurityQuestionsPage(dcc::accounts::User *account);
     void onSetMainWindowEnabled(const bool isEnabled);
-
+    void onShowUserGroupsPage(dcc::accounts::User *user);
 private:
     ~AccountsModule();
     void initSearchData() override;

--- a/src/frame/window/modules/accounts/usergroupspage.cpp
+++ b/src/frame/window/modules/accounts/usergroupspage.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
+ *
+ * Author:     dengbo <dengbo@uniontech.com>
+ *
+ * Maintainer: dengbo <dengbo@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "usergroupspage.h"
+#include "groupitem.h"
+
+#include <QVBoxLayout>
+
+#include <grp.h>
+
+using namespace dcc::accounts;
+using namespace DCC_NAMESPACE::accounts;
+
+DWIDGET_USE_NAMESPACE
+
+UserGroupsPage::UserGroupsPage(User *user, dcc::accounts::UserModel *userModel, QWidget *parent)
+    : QWidget(parent)
+    , m_groupTip(new QLabel(tr("Group")))
+    , m_layout (new QVBoxLayout(this))
+    , m_curUser(user)
+    , m_userModel(userModel)
+    , m_groupListView(new DListView(this))
+    , m_groupItemModel(new QStandardItemModel(this))
+{
+    initWidget();
+    initData();
+}
+
+UserGroupsPage::~UserGroupsPage()
+{
+
+}
+
+void UserGroupsPage::changeUserGroup(const QStringList &groups)
+{
+    int row_count = m_groupItemModel->rowCount();
+    for (int i = 0; i < row_count; ++i) {
+        QStandardItem *item = m_groupItemModel->item(i, 0);
+        item->setCheckState(item && groups.contains(item->text()) ? Qt::Checked : Qt::Unchecked);
+        item->setEnabled(item->text() != m_groupName);
+    }
+    m_groupItemModel->sort(0);
+}
+
+void UserGroupsPage::userGroupClicked(const QModelIndex &index)
+{
+    QStandardItem *item = m_groupItemModel->item(index.row(), index.column());
+    //不可移除主组
+    if (!item || item->text() == m_groupName)
+        return;
+
+    QStringList curUserGroup;
+    int row_count = m_groupItemModel->rowCount();
+    for (int i = 0; i < row_count; ++i) {
+        QStandardItem *itemGroup = m_groupItemModel->item(i, 0);
+        if (itemGroup && itemGroup->checkState()) {
+            curUserGroup << itemGroup->text();
+        }
+    }
+
+    Qt::CheckState state = item->checkState();
+    state == Qt::Checked ? (void)curUserGroup.removeOne(item->text()) : curUserGroup.append(item->text());
+
+    Q_EMIT requestSetGroups(m_curUser, curUserGroup);
+}
+
+void UserGroupsPage::setGroupInfo(const QStringList &group)
+{
+    for (const QString &item : group) {
+        GroupItem *it = new GroupItem(item);
+        it->setCheckable(false);
+        m_groupItemModel->appendRow(it);
+    }
+    changeUserGroup(m_curUser->groups());
+}
+
+void UserGroupsPage::onGidChanged(const QString &gid)
+{
+    bool ok;
+    int iGid = gid.toInt(&ok, 10);
+    if (!ok)
+        return;
+
+    const group *group = getgrgid(static_cast<__gid_t>(iGid));
+    if (nullptr == group || nullptr == group->gr_name)
+        return;
+
+    m_groupName = QString(group->gr_name);
+    for (int i = 0; i < m_groupItemModel->rowCount(); ++i) {
+        QStandardItem *item = m_groupItemModel->item(i, 0);
+        if (nullptr == item)
+            continue;
+        item->setEnabled(item->text() != m_groupName);
+    }
+}
+
+void UserGroupsPage::initWidget()
+{
+    this->setAccessibleName("UserGroupsPage");
+    m_groupListView->setModel(m_groupItemModel);
+    m_groupListView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    m_groupListView->setBackgroundType(DStyledItemDelegate::BackgroundType::ClipCornerBackground);
+    m_groupListView->setSelectionMode(QAbstractItemView::NoSelection);
+    m_groupListView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    m_groupListView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    DFontSizeManager::instance()->bind(m_groupTip, DFontSizeManager::T5, QFont::DemiBold);
+
+    m_layout->addWidget(m_groupTip);
+    m_layout->addSpacing(10);
+    m_layout->addWidget(m_groupListView);
+    setLayout(m_layout);
+}
+
+void UserGroupsPage::initData()
+{
+    QStringList userGroup = m_userModel->getAllGroups();
+
+    m_groupItemModel->clear();
+    for (QString item : userGroup) {
+        GroupItem *it = new GroupItem(item);
+        it->setCheckable(false);
+        m_groupItemModel->appendRow(it);
+    }
+
+    changeUserGroup(m_curUser->groups());
+    onGidChanged(m_curUser->gid());
+
+    connect(m_curUser, &User::groupsChanged, this, &UserGroupsPage::changeUserGroup);
+    connect(m_curUser, &User::gidChanged, this, &UserGroupsPage::onGidChanged);
+    connect(m_userModel, &UserModel::allGroupsChange, this, &UserGroupsPage::setGroupInfo);
+    connect(m_groupListView, &DListView::clicked, this, &UserGroupsPage::userGroupClicked);
+}
+

--- a/src/frame/window/modules/accounts/usergroupspage.h
+++ b/src/frame/window/modules/accounts/usergroupspage.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2022 ~ 2022 Deepin Technology Co., Ltd.
+ *
+ * Author:     dengbo <dengbo@uniontech.com>
+ *
+ * Maintainer: dengbo <dengbo@uniontech.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "modules/accounts/user.h"
+#include "modules/accounts/usermodel.h"
+#include "accountswidget.h"
+
+#include <QLabel>
+
+DWIDGET_USE_NAMESPACE
+
+namespace DCC_NAMESPACE {
+namespace accounts {
+
+class UserGroupsPage : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit UserGroupsPage(dcc::accounts::User *user, dcc::accounts::UserModel *userModel, QWidget *parent = nullptr);
+    ~UserGroupsPage();
+
+Q_SIGNALS:
+    void requestSetGroups(dcc::accounts::User *user, const QStringList &usrGroups);
+
+private Q_SLOTS:
+    void changeUserGroup(const QStringList &groups);
+    void userGroupClicked(const QModelIndex &index);
+    void setGroupInfo(const QStringList &group);
+    void onGidChanged(const QString &gid);
+
+private:
+    void initWidget();
+    void initData();
+
+private:
+    QString m_groupName;
+    QLabel *m_groupTip;
+    QVBoxLayout * m_layout;
+    dcc::accounts::User *m_curUser;
+    dcc::accounts::UserModel *m_userModel;
+    DTK_WIDGET_NAMESPACE::DListView *m_groupListView;
+    QStandardItemModel *m_groupItemModel;
+};
+
+}
+}


### PR DESCRIPTION
放开用户组编辑的限制，使用单独的页面去显示用户组，供用户去修改

Log: 实现用户组编辑功能
Influence: 控制中心账户模块用户组编辑功能
Task: https://pms.uniontech.com/task-view-154497.html
Change-Id: Iaa124e2736fe3df3b6649ee5a0bfdc92d5480553