### PR TITLE
fix: 初始化的时候设置个性化-移动窗管显示透明效果

### DIFF
--- a/src/frame/window/modules/personalization/personalizationgeneral.cpp
+++ b/src/frame/window/modules/personalization/personalizationgeneral.cpp
@@ -379,6 +379,9 @@ void PersonalizationGeneral::setModel(dcc::personalization::PersonalizationModel
             m_windowMovedSwitch->setChecked(checked);
             m_windowMovedSwitch->blockSignals(false);
         });
+        if (m_windowMovedSwitch && m_windowMovedSwitch->isChecked() != m_model->isMoveWindow()) {
+            m_windowMovedSwitch->setChecked(m_model->isMoveWindow());
+        }
 
         updateWMSwitcher(model->is3DWm());
         connect(model, &dcc::personalization::PersonalizationModel::onOpacityChanged, this,


### PR DESCRIPTION
初始化的时候设置移动窗口显示透明效果的状态

Log: 初始化设置窗口移动显示透明效果状态
Task: https://pms.uniontech.com/task-view-176955.html
Influence: 个性化开启移动显示透明效果后，切换切面再切回去
Change-Id: I943f8c3a6d57fdf9b227b19357188f2d702e6627