### PR TITLE
fix: 兼容tr("Space")与"空格"数据不匹配的情况

### DIFF
--- a/src/frame/window/modules/datetime/numberformat.cpp
+++ b/src/frame/window/modules/datetime/numberformat.cpp
@@ -155,12 +155,19 @@ void NumberFormat::initComboxWidgetList()
                                                    << QString(",")
                                                    << QString("'")
                                                    << QString(tr("Space")));
+
+    //用于区分固有数据和 tr("Space")
+    m_digitGroupingKeepList << QString(".")
+                            << QString(",")
+                            << QString("'");
+
     //根据后端的值调整显示
     m_decimalSymbolCbx->comboBox()->setCurrentText(m_model->decimalSymbol());
     m_digitGroupingSymbolCbx->comboBox()->setCurrentText(m_model->digitGroupingSymbol());
 
     //需要根据实际数据进行调整初始值
-    QString digitGroupingSymbol = m_model->digitGroupingSymbol() == tr("Space") ? " " : m_model->digitGroupingSymbol();
+    QString digitGroupingSymbol = (m_model->digitGroupingSymbol() == tr("Space") || !m_digitGroupingKeepList.contains(m_model->digitGroupingSymbol())) ? " " : m_model->digitGroupingSymbol();
+    qInfo() << Q_FUNC_INFO << " digitGroupingSymbol : " << digitGroupingSymbol << m_model->digitGroupingSymbol();
     QStringList digitGroupingList = QStringList()
                             << QString("123456789")
                             << QString("%1%2%3%4%5")
@@ -231,7 +238,8 @@ void NumberFormat::onComboxChanged()
     //切换小数点(decimalSymbol)，更新示例
     //切换分隔符(digitGroupingSymbol)，更新数字分组和示例
     //获取分隔符
-    QString digitGroupingSymbol = m_model->digitGroupingSymbol() == tr("Space") ? " " : m_model->digitGroupingSymbol();
+    QString digitGroupingSymbol = (m_model->digitGroupingSymbol() == tr("Space") || !m_digitGroupingKeepList.contains(m_model->digitGroupingSymbol())) ? " " : m_model->digitGroupingSymbol();
+    qInfo() << Q_FUNC_INFO << " digitGroupingSymbol : " << digitGroupingSymbol << m_model->digitGroupingSymbol();
     int place = m_digitGroupingCbx->comboBox()->currentIndex();//0
     //更新数字分组列表
     QStringList digitGroupingSymbolList;

--- a/src/frame/window/modules/datetime/numberformat.h
+++ b/src/frame/window/modules/datetime/numberformat.h
@@ -57,6 +57,7 @@ private:
     QString m_currencySymbolFormat;
     int m_positiveCurrencyFormat;
     int m_negativeCurrency;
+    QStringList m_digitGroupingKeepList;
 };
 
 }// namespace datetime


### PR DESCRIPTION
本地翻译内容获取不到的时候，数据为"Space"，而外部数据为"空格"
导致两个值不匹配，因此按照之前的逻辑不会显示为" "

Log: 增加兼容性，处理所有非, . '的数据，均显示成" "
Influence: 时间格式显示
Task: https://pms.uniontech.com/task-view-176989.html
Change-Id: I99e69dba746835a5dff98e74c9f2c34bfd43eba0