### PR TITLE
fix(audio): 修复正常环境下蓝牙模式被隐藏问题

### DIFF
--- a/src/frame/window/modules/sound/speakerpage.cpp
+++ b/src/frame/window/modules/sound/speakerpage.cpp
@@ -484,9 +484,6 @@ void SpeakerPage::initCombox()
     m_layout->addWidget(m_outputSoundsGrp);
     m_layout->setSpacing(10);
     m_layout->addStretch(10);
-
-    // 无端口情况下后续不会更新状态，所以默认不显示。
-    m_blueSoundCbx->setVisible(false);
 }
 
 void SpeakerPage::refreshIcon()
@@ -526,8 +523,9 @@ void SpeakerPage::showDevice()
     } else
         setDeviceVisible(true);
 
-    // 云平台关闭输出设备
+    // 云平台关闭输出设备和蓝牙模式
     m_outputSoundCbx->setVisible(!hasVirtualSink());
+    m_blueSoundCbx->setVisible(!hasVirtualSink());
 }
 
 void SpeakerPage::setDeviceVisible(bool visible)


### PR DESCRIPTION
当初始化蓝牙模式为不显示时，在切换声音二级菜单时，会导致蓝牙模式无法显示。

Log: 修复正常环境下蓝牙模式被隐藏问题
Bug: https://pms.uniontech.com/bug-view-152793.html
Influence: 声音
Change-Id: I909ca17e0e49f7d46230b385e3334497f3fc8a24