### PR TITLE
fix: 控制中心四级页面和二级页面衔接效果不美观

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -92,8 +92,8 @@ const int WidgetMinimumHeight = 634;
 //此处为带边距的宽度
 const int first_widget_min_width = 188;
 //此处为不带边距的宽度
-const int second_widget_min_width = 230;
-const int third_widget_min_width = 340;
+const int second_widget_min_width = 240;
+const int third_widget_min_width = 370;
 //窗口的总宽度，带边距
 const int widget_total_min_width = 820;
 //当窗口宽度大于 four_widget_min_widget 时，
@@ -809,7 +809,7 @@ void MainWindow::resizeEvent(QResizeEvent *event)
 
     if (m_topWidget) {
         m_topWidget->setFixedSize(event->size());
-        m_topWidget->curWidget()->setMinimumWidth(dstWidth / 2 - 40);
+        m_topWidget->curWidget()->setMinimumWidth(dstWidth / 2 - 30);
         m_topWidget->setFixedHeight(height() - this->titlebar()->height());
     }
 }
@@ -1264,7 +1264,7 @@ void FourthColWidget::initWidget(QWidget *showWidget, ModuleInterface *module)
 
     QHBoxLayout *layout = new QHBoxLayout;
     layout->setContentsMargins(0, 0, 0, 0);
-    showWidget->setMinimumWidth(this->parentWidget()->width() / 2 - 40);
+    showWidget->setMinimumWidth(this->parentWidget()->width() / 2 - 30);
     showWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Expanding);
     showWidget->setAutoFillBackground(true);
 

--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -447,6 +447,7 @@ void AccountsDetailWidget::initSetting(QVBoxLayout *layout)
     accountSettingsGrp->layout()->setMargin(0);
     accountSettingsGrp->appendItem(m_asAdministrator);
     layout->addSpacing(20);
+    m_accountSettingsTitle->setContentsMargins(20, 0, 10, 0);
     layout->addWidget(m_accountSettingsTitle);
     layout->addWidget(accountSettingsGrp);
 

--- a/src/frame/window/modules/accounts/usergroupspage.cpp
+++ b/src/frame/window/modules/accounts/usergroupspage.cpp
@@ -126,7 +126,11 @@ void UserGroupsPage::initWidget()
     m_layout->addWidget(m_groupTip);
     m_layout->addSpacing(10);
     m_layout->addWidget(m_groupListView);
-    setLayout(m_layout);
+    QHBoxLayout *layout = new QHBoxLayout(this);
+    QWidget *widget = new QWidget;
+    widget->setLayout(m_layout);
+    layout->addWidget(widget);
+    setLayout(layout);
 }
 
 void UserGroupsPage::initData()


### PR DESCRIPTION
1.调整各级页面的显示宽度，使得各级页面衔接更美观
2.账户页面中的“账户设置”左边间隔调整为20，与相应控件的文字对齐
3.用户组页面调整控件布局，优化显示效果

Log: 解决控制中心四级页面和二级页面衔接效果不美观的问题
Bug: https://pms.uniontech.com/bug-view-153201.html
Influence: 控制中心各级页面的切换
Change-Id: I4d1f29ff401a8accfc1d34bc3221a177566faaa2