### PR TITLE
fix: 升级警告弹窗按钮样式错误

### DIFF
--- a/src/frame/window/modules/update/updatectrlwidget.cpp
+++ b/src/frame/window/modules/update/updatectrlwidget.cpp
@@ -856,7 +856,7 @@ bool UpdateCtrlWidget::continueUpdate()
     tipDialog->setMinimumSize(380, 158);
     tipDialog->setModal(true);
     tipDialog->setMessage(tr("Unable to perform system backup. Continue the update?"));
-    tipDialog->addButton(tr("Cancel"), false, DDialog::ButtonRecommend);
+    tipDialog->addButton(tr("Cancel"), false, DDialog::ButtonNormal);
     tipDialog->addButton(tr("Continue"), true, DDialog::ButtonNormal);
     // 修改continue按钮的文字颜色
     QAbstractButton* continueBtn = tipDialog->getButton(1);


### PR DESCRIPTION
取消按钮应该是normal而不是recommend

Log: 修复升级警告弹窗按钮样式错误的问题
Bug: https://pms.uniontech.com/bug-view-153019.html
Influence: 升级警告弹窗样式
Change-Id: I552c2920eb67b5172e84acdbb70821dd77e2105b