### PR TITLE
fix: 在不支持性能模式的机器上隐藏对应设置项

### DIFF
--- a/src/frame/modules/power/powermodel.cpp
+++ b/src/frame/modules/power/powermodel.cpp
@@ -64,6 +64,8 @@ PowerModel::PowerModel(QObject *parent)
     , m_isShutdown(false)
     , m_powerPlan("")
     , m_isHighPerformanceSupported(false)
+    , m_isBalanceSupported(false)
+    , m_isPowerSaveSupported(false)
 {
 }
 
@@ -338,6 +340,24 @@ void PowerModel::setHighPerformanceSupported(bool isHighSupport)
 
     m_isHighPerformanceSupported = isHighSupport;
     Q_EMIT highPerformaceSupportChanged(isHighSupport);
+}
+
+void PowerModel::setBalanceSupported(bool isBalanceSupport)
+{
+    if (m_isBalanceSupported == isBalanceSupport)
+        return;
+
+    m_isBalanceSupported = isBalanceSupport;
+    Q_EMIT balanceSupportChanged(isBalanceSupport);
+}
+
+void PowerModel::setPowerSaveSupported(bool isPowerSaveSupported)
+{
+    if (m_isPowerSaveSupported == isPowerSaveSupported)
+        return;
+
+    m_isPowerSaveSupported = isPowerSaveSupported;
+    Q_EMIT powerSaveSupportChanged(isPowerSaveSupported);
 }
 
 void PowerModel::setSuspend(bool suspend)

--- a/src/frame/modules/power/powermodel.h
+++ b/src/frame/modules/power/powermodel.h
@@ -150,6 +150,12 @@ public:
     inline bool isHighPerformanceSupported() const { return m_isHighPerformanceSupported; }
     void setHighPerformanceSupported(bool isHighSupport);
 
+    inline bool isBalanceSupported() const { return m_isBalanceSupported; }
+    void setBalanceSupported(bool isBalanceSupport);
+
+    inline bool isPowerSaveSupported() const { return m_isBalanceSupported; }
+    void setPowerSaveSupported(bool isPowerSaveSupported);
+
 Q_SIGNALS:
     void sleepLockChanged(const bool sleepLock);
     void canSleepChanged(const bool canSleep);
@@ -189,6 +195,8 @@ Q_SIGNALS:
     void suspendChanged(bool suspendState);
     void powerPlanChanged(const QString &value);
     void highPerformaceSupportChanged(bool value);
+    void balanceSupportChanged(bool value);
+    void powerSaveSupportChanged(bool value);
 
 private:
     bool m_lidPresent;//以此判断是否为笔记本
@@ -228,6 +236,8 @@ private:
 
     QString m_powerPlan;
     bool m_isHighPerformanceSupported;
+    bool m_isBalanceSupported;
+    bool m_isPowerSaveSupported;
 };
 
 }

--- a/src/frame/modules/power/powerworker.cpp
+++ b/src/frame/modules/power/powerworker.cpp
@@ -83,6 +83,25 @@ PowerWorker::PowerWorker(PowerModel *model, QObject *parent)
     connect(m_powerInter, &PowerInter::LowPowerAutoSleepThresholdChanged, m_powerModel, &PowerModel::setLowPowerAutoSleepThreshold);
     //-------------------------------------------------------
     connect(m_sysPowerInter, &SysPowerInter::ModeChanged, m_powerModel, &PowerModel::setPowerPlan);
+
+    bool value = false;
+    QDBusInterface interface("com.deepin.system.Power",
+                             "/com/deepin/system/Power",
+                             "org.freedesktop.DBus.Properties",
+                             QDBusConnection::systemBus());
+    QDBusMessage reply = interface.call("Get", "com.deepin.system.Power", "IsBalanceSupported");
+    QList<QVariant> outArgs = reply.arguments();
+    if (outArgs.length() > 0) {
+        value = outArgs.at(0).value<QDBusVariant>().variant().toBool();
+        m_powerModel->setBalanceSupported(value);
+    }
+
+    reply = interface.call("Get", "com.deepin.system.Power", "IsPowerSaveSupported");
+    outArgs = reply.arguments();
+    if (outArgs.length() > 0) {
+        value = outArgs.at(0).value<QDBusVariant>().variant().toBool();
+        m_powerModel->setPowerSaveSupported(value);
+    }
 }
 
 void PowerWorker::active()

--- a/src/frame/window/modules/power/generalwidget.h
+++ b/src/frame/window/modules/power/generalwidget.h
@@ -56,13 +56,12 @@ class GeneralWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit GeneralWidget(QWidget *parent = nullptr, bool bIsBattery = false);
+    explicit GeneralWidget(dcc::power::PowerModel *model = nullptr, QWidget *parent = nullptr, bool bIsBattery = false);
     virtual ~GeneralWidget();
-
-    void setModel(const dcc::power::PowerModel *model);
 
 private:
     void initUi();     // 初始化界面
+    void initConnect();
     void initSlider(); // 初始化 slider 控件
 
 private:
@@ -92,6 +91,7 @@ private:
     dcc::widgets::TitleValueItem *m_batteryCapacity = nullptr;
 
     dcc::widgets::TitledSliderItem *m_monitorSleepOnPower = nullptr;
+    dcc::power::PowerModel *m_model = nullptr;
 
 Q_SIGNALS:
     void requestSetLowBatteryMode(const bool &state);                         // 同节能模式


### PR DESCRIPTION
在不支持性能模式的机器上隐藏对应设置项
关联相关搜索数据，已经和性能模式关联的其他设置项目

Log: 优化性能模式
Influence: 性能模式
Bug: https://pms.uniontech.com/bug-view-152811.html
Change-Id: I94b04b5048076545eee9d14bc609298271a639cf