### PR TITLE
fix: 修复打开帮助手册时无法直接跳转到UOS ID模块页面

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -708,6 +708,11 @@ void MainWindow::openManual()
     if (helpTitle.isEmpty()) {
         helpTitle = "controlcenter";
     }
+
+    if (helpTitle == "cloudsync") {
+        helpTitle = DSysInfo::isCommunityEdition() ? "Deepin ID" : "UOS ID";
+    }
+
     const QString dmanInterface = "com.deepin.Manual.Open";
     QDBusInterface interface(dmanInterface,
                              "/com/deepin/Manual/Open",


### PR DESCRIPTION
打开帮助手册时使用模块的name()的属性进行跳转的，但是网络账户的模块名称cloudsync，但是帮助手册是根据社区版或专业版显示Deepin
ID或是UOS ID,跳转字段不匹配，无法自动跳转

Log: 修复打开帮助手册时无法直接跳转到UOS ID模块页面
Task: https://pms.uniontech.com/task-view-180573.html
Influence: UOS ID模块自动跳转帮助手册对应页面