### PR TITLE
fix: 修复点击下载并安装时焦点自动跳转到搜素栏问题

### DIFF
--- a/src/frame/window/modules/update/updatecontrolpanel.cpp
+++ b/src/frame/window/modules/update/updatecontrolpanel.cpp
@@ -104,6 +104,7 @@ void updateControlPanel::showUpdateProcess(bool visible)
     m_updateButton->setVisible(!visible);
     m_startButton->setVisible(visible);
     m_progressLabel->setVisible(visible);
+    this->setFocus();
 }
 
 int updateControlPanel::getCurrentValue() const

--- a/src/frame/window/modules/update/updatewidget.cpp
+++ b/src/frame/window/modules/update/updatewidget.cpp
@@ -305,6 +305,8 @@ void UpdateWidget::onNotifyUpdateState(int state)
     default:
         break;
     }
+
+    this->setFocus();
 }
 
 void UpdateWidget::onAppendApplist(const QList<AppUpdateInfo> &infos)


### PR DESCRIPTION
更新升级模块界面焦点策略设置为Click，切换状态后会界面会失去焦点，自动转到搜素栏问题。因此切换状态时需要手动设置下焦点

Log: 修复点击下载并安装时焦点自动跳转到搜素栏问题
Bug: https://pms.uniontech.com/bug-view-152961.html
Influence: 点击下载并安装时焦点不会自动跳转到搜素栏