### PR TITLE
fix: 优化显示最小分辨率限制

### DIFF
--- a/configs/org.deepin.dde.control-center.display.json
+++ b/configs/org.deepin.dde.control-center.display.json
@@ -23,6 +23,28 @@
             "description": "",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "resolutionLimit": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "resolutionLimit",
+            "name[zh_CN]": "控制中心显示模块分辨率限制最小值",
+            "description[zh_CN]": "此配置为对显示模块分辨率限制最小值，默认为启用：当配置为启用时，使用限制；当配置为禁用时，不使用限制；",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "resolutionConfig": {
+            "value": "1024*768",
+            "serial": 0,
+            "flags": [],
+            "name": "resolutionConfig",
+            "name[zh_CN]": "控制中心显示模块支持最小分辨率",
+            "description[zh_CN]": "此配置为对显示模块分辨率限制最小值，默认为1024*768；",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
   }

--- a/src/frame/modules/display/monitor.cpp
+++ b/src/frame/modules/display/monitor.cpp
@@ -23,9 +23,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include "window/dconfigwatcher.h"
 #include "monitor.h"
 
-#include <QGSettings>
 #include <QGuiApplication>
 
 using namespace dcc::display;
@@ -188,23 +188,24 @@ bool compareResolution(const Resolution &first, const Resolution &second)
 void Monitor::setModeList(const ResolutionList &modeList)
 {
     m_modeList.clear();
-    // NOTE: limit resolution by gsettings config
-    QGSettings *settings = new QGSettings("com.deepin.dde.control-center", QByteArray(), this);
-    QStringList value = settings->get("resolutionConfig").toString().split("*");
-    settings->deleteLater();
 
-    QList<int> miniMode;
-    for (auto str : value) {
-        bool ok;
-        int res = str.toInt(&ok);
-        if (ok) {
-            miniMode << res;
+    QList<int> miniMode{0, 0};
+    if (DConfigWatcher::instance()->get(DConfigWatcher::display, "resolutionLimit").toBool()) {
+        // NOTE: limit resolution by gsettings config
+        QStringList value = DConfigWatcher::instance()->get(DConfigWatcher::display, "resolutionConfig").toString().split("*");
+
+        for (auto str : value) {
+            bool ok;
+            int res = str.toInt(&ok);
+            if (ok) {
+                miniMode << res;
+            }
         }
-    }
 
-    if (miniMode.size() != 2) {
-        miniMode.clear();
-        miniMode << 1024 << 768;
+        if (miniMode.size() != 2) {
+            miniMode.clear();
+            miniMode << 1024 << 768;
+        }
     }
 
     for (auto m : modeList) {

--- a/src/frame/window/dconfigwatcher.cpp
+++ b/src/frame/window/dconfigwatcher.cpp
@@ -237,6 +237,22 @@ const QString DConfigWatcher::getStatus(ModuleType moduleType, const QString &co
 }
 
 /**
+ * @brief DConfigWatcher::get 获取三级控件状态
+ * @param moduleType          模块类型
+ * @param key                 key值
+ * @return
+ */
+const QVariant DConfigWatcher::get(ModuleType moduleType, const QString &key)
+{
+    QString moduleName;
+
+    if (!existKey(moduleType, key, moduleName))
+        return "";
+
+    return m_mapModulesConfig[QMetaEnum::fromType<ModuleType>().valueToKey(moduleType)]->value(key);
+}
+
+/**
  * @brief DConfigWatcher::getMenuState
  * @return second menu state
  */

--- a/src/frame/window/dconfigwatcher.h
+++ b/src/frame/window/dconfigwatcher.h
@@ -100,6 +100,7 @@ public:
     void erase(ModuleType moduleType, const QString &configName, QWidget *binder);
     void insertState(ModuleType moduleType, const QString &);
     const QString getStatus(ModuleType moduleType, const QString &configName);
+    const QVariant get(ModuleType moduleType, const QString &key);
     DConfig *getModulesConfig(ModuleType moduleType);
     QMap<ModuleKey *, bool> getMenuState();
 

--- a/tests/dde-control-center/CMakeLists.txt
+++ b/tests/dde-control-center/CMakeLists.txt
@@ -156,6 +156,7 @@ file(GLOB_RECURSE KEYBOARD_Tasks_SRCS
     ../../src/frame/modules/display/monitor.cpp
     ../../src/frame/modules/keyboard/keylabel.cpp
     ../../src/frame/window/utils.h
+    ../../src/frame/window/dconfigwatcher.cpp
 )
 
 # 用于测试覆盖率的编译条件


### PR DESCRIPTION
增加显示模块最小分辨率限制，默认开启
如果关闭，则可以显示1024*768以下的分辨率

Log: 优化显示最小分辨率配置
Task: https://pms.uniontech.com/task-view-181157.html
Influence: 可以通过配置显示低于1024*768的分辨率
Change-Id: I4d95e595b49d006b7122ef65bd7fb6dc14fdc26e