### PR TITLE
fix(bluetooth): 控制中心蓝牙连接状态异常

### DIFF
--- a/src/frame/modules/bluetooth/device.cpp
+++ b/src/frame/modules/bluetooth/device.cpp
@@ -77,6 +77,13 @@ void Device::setPaired(bool paired)
 
 void Device::setState(const State &state, bool connectState)
 {
+    // 后端频繁发送属性改变信号，dbus信号处理顺序可能异常（不一定按顺序执行），会导致蓝牙连接状态显示异常
+    // 如果当前蓝牙设备状态为已连接，后端传递的状态为正在连接中，此操作视为一次异常的信号(Device::StateConnected -> Device::StateAvailable)，不做处理
+    // 正常的蓝牙连接状态为Device::StateAvailable -> Device::StateConnected
+    if (m_state == Device::StateConnected && state == Device::StateAvailable) {
+        return;
+    }
+
     if ((state != m_state) || (connectState != m_connectState)) {
         m_state = state;
         m_connectState = connectState;


### PR DESCRIPTION
当频繁断开和连接蓝牙时，后端会发送对应的属性改变信号，dbus信号处理顺序可能异常，会导致蓝牙连接状态显示异常
因此，如果当前蓝牙设备状态为已连接，后端传递的状态为正在连接中，此操作视为一次异常的信号，不去做更新设备的连接状态的处理

Log: 修复控制中心蓝牙连接状态异常的问题
Influence: 蓝牙设备连接
Bug: https://pms.uniontech.com/bug-view-140075.html
     https://pms.uniontech.com/bug-view-148683.html
Change-Id: Iace8694ccfe2b555d9e810318471a39ba1c93bfe