### PR TITLE
fix: 修复修改指纹/人脸名称后焦点自动跳转到搜索栏问题

### DIFF
--- a/src/frame/window/modules/authentication/facewidget.cpp
+++ b/src/frame/window/modules/authentication/facewidget.cpp
@@ -172,6 +172,7 @@ void FaceWidget::onFaceidListChanged(const QStringList &facelist)
             item->setTitle(newName);
             Q_EMIT requestRenameFaceItem(m_model->faceCharaType(), faceid, newName);
             Q_EMIT noticeEnrollCompleted(m_model->faceDriverName(), m_model->faceCharaType());
+            this->setFocus();
         });
 
         connect(item, &AuthenticationInfoItem::editClicked, this, [this, item, facelist]() {

--- a/src/frame/window/modules/authentication/fingerwidget.cpp
+++ b/src/frame/window/modules/authentication/fingerwidget.cpp
@@ -41,7 +41,7 @@ FingerWidget::FingerWidget(QWidget *parent)
     , m_listGrp(new SettingsGroup(nullptr, SettingsGroup::GroupBackground))
     , m_clearBtn(nullptr)
 {
-	//注册所有的事件
+    //注册所有的事件
     installEventFilter(this);
 
     m_clearBtn = new DCommandLinkButton(tr("Edit"));
@@ -154,6 +154,7 @@ void FingerWidget::onThumbsListChanged(const QStringList &thumbs)
             }
             item->setTitle(newName);
             Q_EMIT requestRenameFingerItem(m_currentUserName, finger, newName);
+            this->setFocus();
         });
 
         connect(item, &AuthenticationInfoItem::editClicked, this, [this, item, thumbs]() {

--- a/src/frame/window/modules/authentication/iriswidget.cpp
+++ b/src/frame/window/modules/authentication/iriswidget.cpp
@@ -155,6 +155,7 @@ void IrisWidget::onIrisListChanged(const QStringList &irislist)
             item->setTitle(newName);
             Q_EMIT requestRenameIrisItem(m_model->irisCharaType(), irisid, newName);
             Q_EMIT noticeEnrollCompleted(m_model->irisDriverName(), m_model->irisCharaType());
+            this->setFocus();
         });
 
         connect(item, &AuthenticationInfoItem::editClicked, this, [this, item, irislist]() {


### PR DESCRIPTION
修复修改指纹/人脸名称后焦点自动跳转到搜索栏问题

Log: 修复修改指纹/人脸名称后焦点自动跳转到搜索栏问题
Bug: https://pms.uniontech.com/bug-view-152889.html
Influence: 焦点不会自动跳转到搜索栏