### PR TITLE
feat: 替换获取更新日志的方法

### DIFF
--- a/src/frame/window/modules/update/systemupdateitem.cpp
+++ b/src/frame/window/modules/update/systemupdateitem.cpp
@@ -114,6 +114,8 @@ void SystemUpdateItem::createDetailInfoItem(const QList<DetailInfo> &detailInfoL
     DetailInfo item = detailInfoList.at(index);
     const QString &systemVersionType = DCC_NAMESPACE::IsServerSystem ? tr("Server") : tr("Desktop");
     DetailInfoItem *detailInfoItem = new DetailInfoItem(this);
+    // 根据需求，将最后一个字符替换为0（原因是不想用户看到版本频繁的更新）
+    item.name.replace(item.name.length() - 1, 1, '0');
     detailInfoItem->setTitle(systemVersionType + item.name);
     detailInfoItem->setDate(item.updateTime);
     detailInfoItem->setLinkData(item.link);

--- a/src/frame/window/modules/update/updatesettingitem.cpp
+++ b/src/frame/window/modules/update/updatesettingitem.cpp
@@ -210,8 +210,13 @@ void UpdateSettingItem::setData(UpdateItemInfo *updateItemInfo)
     QString value = updateItemInfo->updateTime().isEmpty() ? "" : tr("Release date: ") + updateItemInfo->updateTime();
     m_controlWidget->setDate(value);
     const QString &systemVersionType = DCC_NAMESPACE::IsServerSystem ? tr("Server") : tr("Desktop");
-    value = updateItemInfo->availableVersion().isEmpty() ? "" : tr("Version") + ": " + systemVersionType + updateItemInfo->availableVersion();
-    m_controlWidget->setVersion(value);
+    QString version;
+    if (!updateItemInfo->availableVersion().isEmpty()) {
+        QString avaVersion = updateItemInfo->availableVersion();
+        const QString &tmpVersion = avaVersion.replace(avaVersion.length() - 1, 1, '0'); // 替换版本号的最后一位为‘0‘
+        version = tr("Version") + ": " + systemVersionType + tmpVersion;
+    }
+    m_controlWidget->setVersion(version);
     m_controlWidget->setTitle(updateItemInfo->name());
     m_controlWidget->setDetail(updateItemInfo->explain());
 


### PR DESCRIPTION
1、显示维护版本日志，但是版本号显示大版本号。例如：1052 -> 1050
2、更新日志如果是同版本号，则按发布日期再排序，显示最新的一个。

Log:
Task: https://pms.uniontech.com/task-view-174009.html
Influence: 更新日志
Change-Id: Ic7a24db363a770fa6fb48570da2b5ce388d7ac06