### PR TITLE
fix(audio): 设备管理配置为不显示时，端口变化不影响设备管理的显示。

### DIFF
--- a/src/frame/window/modules/sound/soundmodule.cpp
+++ b/src/frame/window/modules/sound/soundmodule.cpp
@@ -327,7 +327,7 @@ void SoundModule::active()
 
     // 有端口时显示设备管理
     connect(m_model, &SoundModel::portAdded, m_soundWidget, [ this ]() {
-        if (!m_model->ports().isEmpty()) {
+        if (!m_model->ports().isEmpty() && GSettingWatcher::instance()->get("deviceManage").toBool()) {
             m_soundWidget->setSubItemHidden("deviceManage", false);
         }
     });


### PR DESCRIPTION
设备管理配置为不显示时，端口变化不影响设备管理的显示。

Log: 设备管理配置为不显示时，端口变化不影响设备管理的显示。
Bug: https://pms.uniontech.com/bug-view-154197.html
Influence: 声音-设备管理
Change-Id: I058955ada376aa2ac839279d9515d1d89c98af65