### PR TITLE
fix: 在控制中心调用重置密码时，设置界面类型为Tool

### DIFF
--- a/src/reset-password-dialog/resetpassworddialog.cpp
+++ b/src/reset-password-dialog/resetpassworddialog.cpp
@@ -189,7 +189,7 @@ void ResetPasswordDialog::initWidget(const QString &userName)
             setWindowFlags(Qt::Popup | Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
         } else {
             m_tipDialog.setWindowFlags(Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
-            setWindowFlags(Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
+            setWindowFlags(Qt::Tool | Qt::NoDropShadowWindowHint | Qt::WindowStaysOnTopHint | Qt::CustomizeWindowHint);
         }
     }
     m_tipDialog.installEventFilter(this);


### PR DESCRIPTION
在控制中心调用重置密码时，设置界面类型为Tool,此类型在任务栏上不会显示应用图标

Log: 修复通过union id重置密码的弹框在任务栏显示插件图标问题
Bug: https://pms.uniontech.com/bug-view-149387.html
Influence: 在控制中心重置密码时，不会在任务栏显示应用图标