### PR TITLE
fix: 控制中心UOS ID页面异常显示

### DIFF
--- a/src/frame/window/modules/accounts/modifypasswdpage.cpp
+++ b/src/frame/window/modules/accounts/modifypasswdpage.cpp
@@ -44,6 +44,8 @@
 
 #include <unistd.h>
 
+#define DEEPIN_DEEPINID_DAEMON_PATH QStringLiteral("/usr/lib/deepin-deepinid-daemon/deepin-deepinid-daemon")
+
 using namespace dcc::accounts;
 using namespace dcc::widgets;
 DWIDGET_USE_NAMESPACE
@@ -92,7 +94,9 @@ void ModifyPasswdPage::initWidget()
         QLabel *oldPasswdLabel = new QLabel(tr("Current Password") + ":");
         m_forgetPasswordBtn->setVisible(true);
         DFontSizeManager::instance()->bind(m_forgetPasswordBtn, DFontSizeManager::T8);
-        m_forgetPasswordBtn->setVisible(!IsCommunitySystem && getuid() < 9999); // 如果当前账户是域账号,则屏蔽重置密码入口
+        // 如果当前账户是域账号或者没有deepin-deepinid-daemon这个文件,则屏蔽重置密码入口
+        bool isShow = !IsCommunitySystem && getuid() < 9999 && QFile::exists(DEEPIN_DEEPINID_DAEMON_PATH);
+        m_forgetPasswordBtn->setVisible(isShow);
         connect(m_forgetPasswordBtn, &QPushButton::clicked, this, &ModifyPasswdPage::onForgetPasswordBtnClicked);
         QHBoxLayout *hLayout = new QHBoxLayout;
         hLayout->addWidget(oldPasswdLabel);


### PR DESCRIPTION
当没有同步模块的文件（deepin-deepinid-daemon）时，说明不支持通过UOS
ID的方式去重置密码
此时不应该显示忘记密码按钮

Log: 解决控制中心UOS ID页面异常显示的问题
Bug: https://pms.uniontech.com/bug-view-154695.html
Influence: 控制中心UOSID页面显示/控制中心忘记密码功能
Change-Id: I19e247228299df39fa2255602bf643bc794bfbce