### PR TITLE
fix: 无法在控制中心搜索框搜索到内测源更新模块

### DIFF
--- a/src/frame/window/modules/update/updatemodule.cpp
+++ b/src/frame/window/modules/update/updatemodule.cpp
@@ -280,6 +280,12 @@ void UpdateModule::initSearchData()
         m_frameProxy->setDetailVisible(module, updateSettings, tr("System"), func_is_visible("updateSystemUpdate"));
         m_frameProxy->setDetailVisible(module, updateSettings, tr("Security Updates Only"), func_is_visible("updateSecureUpdate"));
      };
+    // 如果内测渠道功能隐藏，同步隐藏搜索数据
+    connect(m_model, &UpdateModel::testingChannelStatusChanged, this, [ = ]{
+        auto visible = m_model->getTestingChannelStatus() != UpdateModel::TestingChannelStatus::Hidden;
+        m_frameProxy->setDetailVisible(module, updateSettings, tr("Updates from Internal Testing Sources"), visible);
+        m_frameProxy->updateSearchData(module);
+    });
 
     connect(GSettingWatcher::instance(), &GSettingWatcher::notifyGSettingsChanged, this, [=](const QString &gsetting, const QString &state) {
         if ("" == gsetting || !gsettingsMap.contains(gsetting)) {

--- a/src/frame/window/modules/update/updatesettings.cpp
+++ b/src/frame/window/modules/update/updatesettings.cpp
@@ -39,7 +39,6 @@ UpdateSettings::UpdateSettings(UpdateModel *model, QWidget *parent)
     , m_autoDownloadUpdateTips(new DTipLabel(tr("Switch it on to automatically download the updates in wireless or wired network"), this))
     , m_autoCheckSecureUpdateTips(new DTipLabel(tr("Switch it on to only update security vulnerabilities and compatibility issues"), this))
     , m_testingChannelTips(new DTipLabel(tr("Join the internal testing channel to get deepin latest updates")))
-    , m_testingChannelHeadingLabel(new QLabel(tr("Updates from Internal Testing Sources")))
     , m_testingChannelLinkLabel(new QLabel(""))
     , m_autoCleanCache(new SwitchWidget(this))
     , m_dconfig(nullptr)
@@ -68,6 +67,9 @@ UpdateSettings::UpdateSettings(UpdateModel *model, QWidget *parent)
     //~ contents_path /update/Update Settings
     //~ child_page Update Settings
     m_testingChannel = new SwitchWidget(tr("Join Internal Testing Channel"), this);
+    //~ contents_path /update/Update Settings
+    //~ child_page Update Settings
+    m_testingChannelHeadingLabel = new QLabel(tr("Updates from Internal Testing Sources"));
 
     initUi();
     initConnection();


### PR DESCRIPTION
控制中心新增的模块应该添加翻译注释便于搜索模块检索

Log: 解决内测源模块无法搜索的问题
Bug: https://pms.uniontech.com/bug-view-151135.html
Influence: 国际化和搜索