### PR TITLE
fix: 右键或侧键点击控制中心左侧设置模块和设置项，图标点亮但右侧不切换

### DIFF
--- a/include/widgets/multiselectlistview.h
+++ b/include/widgets/multiselectlistview.h
@@ -19,7 +19,7 @@ protected:
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
     QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
     void keyPressEvent(QKeyEvent *event) override;
-
+    void mousePressEvent(QMouseEvent *event) override;
 private:
     int m_currentIndex;
 };

--- a/src/frame/widgets/multiselectlistview.cpp
+++ b/src/frame/widgets/multiselectlistview.cpp
@@ -67,5 +67,11 @@ void MultiSelectListView::keyPressEvent(QKeyEvent *event)
     return DListView::keyPressEvent(event);
 }
 
+void MultiSelectListView::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::LeftButton)
+        return;
+    return DListView::mousePressEvent(event);
+}
 }
 }


### PR DESCRIPTION
修改为控制中心菜单对象鼠标事件只接受左键操作

Log: 修复右键或侧键点击控制中心左侧设置模块和设置项，图标点亮但右侧不切换
Bug: https://pms.uniontech.com/bug-view-155787.html
Influence: 控制中心菜单鼠标左键操作正常，其它按键不应响应
Change-Id: I4f30444f89186f37bc7ba7c3012dbe78f9cda87b