### PR TITLE
fix: 优化移动窗口开关状态

### DIFF
--- a/src/frame/modules/personalization/personalizationwork.cpp
+++ b/src/frame/modules/personalization/personalizationwork.cpp
@@ -297,14 +297,33 @@ void PersonalizationWork::onRefreshedChanged(const QString &type)
 
 void PersonalizationWork::onToggleWM(const QString &wm)
 {
-    qDebug() << "onToggleWM: " << wm;
-    m_model->setIs3DWm(wm == "deepin wm");
+    bool is3D = wm == "deepin wm";
+    qDebug() << "onToggleWM: " << wm << is3D;
+    m_model->setIs3DWm(is3D);
+    setMoveWindow(is3D);
+}
+
+void PersonalizationWork::setMoveWindow(bool state)
+{
+    if (!m_effects) {
+        qWarning() << "The Interface of org::kde::kwin::Effects is nullptr.";
+        return;
+    }
+
+    if (!state || !m_model) {
+        return;
+    }
+    bool isMoveWindow = m_effects->isEffectLoaded(effectMoveWindowArg);
+    m_model->setIsMoveWindow(isMoveWindow);
+
+    //TODO: 关联打开移动窗口功能信号(kwin4_effect_translucency)，实时响应变化
 }
 
 void PersonalizationWork::onWindowWM(bool value)
 {
     qDebug() << "onWindowWM: " << value;
     m_model->setIs3DWm(value);
+    setMoveWindow(value);
 }
 
 void PersonalizationWork::onCompositingAllowSwitch(bool value)

--- a/src/frame/modules/personalization/personalizationwork.h
+++ b/src/frame/modules/personalization/personalizationwork.h
@@ -80,6 +80,7 @@ private Q_SLOTS:
     void onGetActiveColorFinished(QDBusPendingCallWatcher *w);
     void onRefreshedChanged(const QString &type);
     void onToggleWM(const QString &wm);
+    void setMoveWindow(bool state);
     void onGetCurrentWMFinished(QDBusPendingCallWatcher *w);
     void setFontList(FontModel* model, const QString &type, const QString &list);
     void onCompositingAllowSwitch(bool value);

--- a/src/frame/window/modules/personalization/personalizationgeneral.cpp
+++ b/src/frame/window/modules/personalization/personalizationgeneral.cpp
@@ -379,7 +379,7 @@ void PersonalizationGeneral::setModel(dcc::personalization::PersonalizationModel
             m_windowMovedSwitch->setChecked(checked);
             m_windowMovedSwitch->blockSignals(false);
         });
-        if (m_windowMovedSwitch && m_windowMovedSwitch->isChecked() != m_model->isMoveWindow()) {
+        if (m_windowMovedSwitch) {
             m_windowMovedSwitch->setChecked(m_model->isMoveWindow());
         }
 
@@ -467,6 +467,10 @@ void PersonalizationGeneral::updateWMSwitcher(bool checked)
 
     if (m_winRoundSlider) {
         m_winRoundSlider->setVisible(checked || m_isWayland);
+    }
+
+    if (m_windowMovedSwitch) {
+        m_windowMovedSwitch->setChecked(m_model->isMoveWindow());
     }
 
     Q_EMIT windowMovedVisibleChanged(checked);


### PR DESCRIPTION
优化移动窗口开关状态，以前在关闭特效的时候，切到其他页面再切回去会导致该开关状态变化
现在优化，只有在特效开启的时候才更新该控件状态

Log: 优化移动窗口开关状态
Inlufence: 移动窗口透明特效状态变化
Bug: https://pms.uniontech.com/bug-view-155999.html
Change-Id: I2ccaa9ebea87001f392c6f00f49273e63b72aef6