### PR TITLE
fix(audio): 修复音效服务延时下状态不同步问题

### DIFF
--- a/src/frame/modules/sound/soundworker.cpp
+++ b/src/frame/modules/sound/soundworker.cpp
@@ -413,6 +413,8 @@ void SoundWorker::onGsettingsChanged(const QString &key)
 
 void SoundWorker::getSoundEnabledMapFinished(QDBusPendingCallWatcher *watcher)
 {
+    m_model->setEnableSoundEffect(m_soundEffectInter->enabled());
+
     if (!watcher->isError()) {
         QDBusReply<QMap<QString, bool>> value = watcher->reply();
         auto map = value.value();


### PR DESCRIPTION
dbus 同步调用超时

Log: 修复音效服务延时下状态不同步问题
Bug: https://pms.uniontech.com/bug-view-156151.html
Influence: 声音-系统音效
Change-Id: I0cb8c0f89365284665c91a0a9fcde2408f64cf7c