### PR TITLE
fix: 解决特效与移动窗口显示透明联调问题

### DIFF
--- a/configs/org.deepin.dde.control-center.personalization.json
+++ b/configs/org.deepin.dde.control-center.personalization.json
@@ -12,6 +12,17 @@
             "description": "",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "effectMoveWindowTranslucencyStatus": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "effectMoveWindowTranslucencyStatus",
+            "name[zh_CN]": "移动窗口展示透明特效开关的状态",
+            "description[zh_CN]": "移动窗口展示透明特效开关的状态",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
   }

--- a/src/frame/modules/personalization/personalizationmodel.cpp
+++ b/src/frame/modules/personalization/personalizationmodel.cpp
@@ -6,6 +6,7 @@
 #include "model/thememodel.h"
 #include "model/fontmodel.h"
 #include "model/fontsizemodel.h"
+#include "window/dconfigwatcher.h"
 
 using namespace dcc;
 using namespace dcc::personalization;
@@ -55,6 +56,16 @@ void PersonalizationModel::setIsMoveWindow(const bool isMoveWindow)
 bool PersonalizationModel::isMoveWindow() const
 {
     return m_isMoveWindow;
+}
+
+bool PersonalizationModel::getIsMoveWindowDconfig()
+{
+    return DConfigWatcher::instance()->getValue(DConfigWatcher::ModuleType::personalization, "effectMoveWindowTranslucencyStatus").toBool();
+}
+
+void PersonalizationModel::setIsMoveWindowDconfig(bool value)
+{
+    DConfigWatcher::instance()->setValue(DConfigWatcher::ModuleType::personalization, "effectMoveWindowTranslucencyStatus", QVariant(value));
 }
 
 void PersonalizationModel::setWindowRadius(int radius)

--- a/src/frame/modules/personalization/personalizationmodel.h
+++ b/src/frame/modules/personalization/personalizationmodel.h
@@ -33,6 +33,8 @@ public:
 
     void setIsMoveWindow(const bool isMoveWindow);
     bool isMoveWindow() const;
+    bool getIsMoveWindowDconfig();
+    void setIsMoveWindowDconfig(bool value);
 
     void setWindowRadius(int radius);
     int windowRadius();

--- a/src/frame/window/dconfigwatcher.cpp
+++ b/src/frame/window/dconfigwatcher.cpp
@@ -4,8 +4,6 @@
 
 #include "dconfigwatcher.h"
 
-#include <DConfig>
-
 #include <QListView>
 #include <QStandardItem>
 #include <QStandardItemModel>
@@ -220,12 +218,42 @@ const QString DConfigWatcher::getStatus(ModuleType moduleType, const QString &co
 }
 
 /**
+ * @brief DConfigWatcher::getValue   获取三级控件状态
+ * @param moduleType                 模块类型
+ * @param configName                 key值
+ * @return
+ */
+const QVariant DConfigWatcher::getValue(DConfigWatcher::ModuleType moduleType, const QString &configName)
+{
+    QString moduleName;
+    if (!existKey(moduleType, configName, moduleName))
+        return QVariant();
+    return m_mapModulesConfig[QMetaEnum::fromType<ModuleType>().valueToKey(moduleType)]->value(configName);
+}
+
+/**
  * @brief DConfigWatcher::getMenuState
  * @return second menu state
  */
 QMap<DConfigWatcher::ModuleKey *, bool> DConfigWatcher::getMenuState()
 {
     return m_menuState;
+}
+
+/**
+ * @brief DConfigWatcher::setValue   获取三级控件状态
+ * @param moduleType                 模块类型
+ * @param configName                 key值
+ * @param data                       设置的值
+ * @return
+ */
+void DConfigWatcher::setValue(DConfigWatcher::ModuleType moduleType, const QString &configName, QVariant data)
+{
+    QString moduleName;
+    if (!existKey(moduleType, configName, moduleName)) {
+        return;
+    }
+    m_mapModulesConfig[QMetaEnum::fromType<ModuleType>().valueToKey(moduleType)]->setValue(configName, data);
 }
 
 /**

--- a/src/frame/window/dconfigwatcher.h
+++ b/src/frame/window/dconfigwatcher.h
@@ -83,8 +83,10 @@ public:
     void erase(ModuleType moduleType, const QString &configName, QWidget *binder);
     void insertState(ModuleType moduleType, const QString &);
     const QString getStatus(ModuleType moduleType, const QString &configName);
+    const QVariant getValue(ModuleType moduleType, const QString &configName);
     DConfig *getModulesConfig(ModuleType moduleType);
     QMap<ModuleKey *, bool> getMenuState();
+    void setValue(ModuleType moduleType, const QString &configName, QVariant data);
 
 private:
     DConfigWatcher(QObject *parent = nullptr);


### PR DESCRIPTION
因为窗管接口，在关闭特效后返回移动窗口透明的状态存在问题
在dconfig中存储一个配置来记录关闭特效时，窗口移动显示透明的状态

Log: 特效与窗口移动显示透明效果联调
Influence: 特效与窗口移动显示透明效果
Bug: https://pms.uniontech.com/bug-view-156517.html
Change-Id: I57dc2c957532b06fd5a3365a01d757f51f48e78c