### PR TITLE
fix: 设置非中文语言时的搜索数据的图标名称

### DIFF
--- a/src/frame/window/search/searchmodel.cpp
+++ b/src/frame/window/search/searchmodel.cpp
@@ -268,6 +268,9 @@ void SearchModel::loadxml(const QString module)
                 appendRow(new QStandardItem(
                     icon.value(), QString("%1 --> %2 / %3").arg(searchBoxStrcut->actualModuleName).arg(searchBoxStrcut->childPageName).arg(searchBoxStrcut->translateContent)));
             }
+
+            // 设置图标数据
+            setData(index(rowCount() - 1, 0), icon->name(), Qt::UserRole + 1);
         }
         else {
             appendChineseData(searchBoxStrcut);


### PR DESCRIPTION
设置非中文语言时搜索数据的图标名称

Log: 修复系统语言为英文控制中心搜索结果下拉框待选项前面没有图标的问题
Bug: https://pms.uniontech.com/bug-view-156677.html
Influence: 搜索下拉框正常显示图标