### PR TITLE
fix: 修复扩展模式下切换主屏桌面闪现主屏选项框的问题

### DIFF
--- a/src/frame/modules/display/displayworker.cpp
+++ b/src/frame/modules/display/displayworker.cpp
@@ -199,7 +199,10 @@ void DisplayWorker::setMonitorRotate(Monitor *mon, const quint16 rotate)
 
 void DisplayWorker::setPrimary(const QString &name)
 {
-    m_displayInter.SetPrimary(name);
+    // 延时调用，避免卡在下拉框未收回时的一帧画面
+    QTimer::singleShot(150, this, [=] {
+        m_displayInter.SetPrimary(name);
+    });
 }
 
 void DisplayWorker::setMonitorEnable(Monitor *monitor, const bool enable)


### PR DESCRIPTION
下拉框还没有收回就开始设置主屏了,延时设置,确保下拉框收回在设置

Log: 修复扩展模式下切换主屏桌面闪现主屏选项框的问题
Bug: https://pms.uniontech.com/bug-view-156389.html
Influence: 设置主屏选项框
Change-Id: I17800cbdcdd7999e3c87a60bc0841ca2d518d325