### PR TITLE
fix: 副屏的显示设置窗口移动到主屏时设置副屏分辨率后原在主屏的副屏设置窗口会移动到副屏上

### DIFF
--- a/src/frame/window/modules/display/multiscreenwidget.cpp
+++ b/src/frame/window/modules/display/multiscreenwidget.cpp
@@ -48,7 +48,6 @@ MultiScreenWidget::MultiScreenWidget(QWidget *parent)
     , m_refreshRateWidget(new RefreshRateWidget(300, this))
     , m_rotateWidget(new RotateWidget(300, this))
     , m_model(nullptr)
-    , m_resetSecondaryScreenDlgTimer(new QTimer(this))
 {
     //初始化列表无法进行静态翻译
     //~ contents_path /display/Multiple Displays
@@ -121,9 +120,6 @@ MultiScreenWidget::MultiScreenWidget(QWidget *parent)
     QDesktopWidget *desktopwidget = QApplication::desktop();
     connect(desktopwidget,SIGNAL(workAreaResized(int)),this,SLOT(onResetSecondaryScreenDlg()));
 
-    m_resetSecondaryScreenDlgTimer->setSingleShot(true);
-    m_resetSecondaryScreenDlgTimer->setInterval(100);
-    connect(m_resetSecondaryScreenDlgTimer, &QTimer::timeout, this, &MultiScreenWidget::onResetSecondaryScreenDlgTimerOut);
 }
 
 MultiScreenWidget::~MultiScreenWidget()
@@ -370,7 +366,6 @@ void MultiScreenWidget::initPrimaryList()
 void MultiScreenWidget::initSecondaryScreenDialog()
 {
     if (m_model->displayMode() == EXTEND_MODE) {
-        m_resetSecondaryScreenDlgTimer->stop();
         for (auto dlg : m_secondaryScreenDlgList) {
             dlg->deleteLater();
         }
@@ -409,14 +404,11 @@ void MultiScreenWidget::initSecondaryScreenDialog()
         activateWindow();
 
         if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
-            m_resetSecondaryScreenDlgTimer->start();
             QTimer::singleShot(10, this, [=] {
                 for (auto dlg : m_secondaryScreenDlgList) {
                     dlg->show();
                 }
             });
-        } else {
-            onResetSecondaryScreenDlgTimerOut();
         }
     }
 }
@@ -495,20 +487,12 @@ void MultiScreenWidget::onResetFullIndication(const QRect &geometry)
     m_fullIndication->move(geometry.topLeft());
 }
 
-void MultiScreenWidget::onResetSecondaryScreenDlgTimerOut()
-{
-    for (auto dlg : m_secondaryScreenDlgList) {
-        dlg->resetDialog();
-    }
-}
-
 void MultiScreenWidget::onResetSecondaryScreenDlg()
 {
     for (int i = 0; i < m_secondaryScreenDlgList.count(); ++i) {
         SecondaryScreenDialog *screenDialog = m_secondaryScreenDlgList.at(i);
         Q_ASSERT(screenDialog);
         screenDialog->setWindowOpacity(1);
-        screenDialog->resetDialog();
     }
 }
 

--- a/src/frame/window/modules/display/multiscreenwidget.h
+++ b/src/frame/window/modules/display/multiscreenwidget.h
@@ -87,7 +87,6 @@ private Q_SLOTS:
     void onRequestCloseRecognize();
     void onResetSecondaryScreenDlg();
     void onResetFullIndication(const QRect &geometry);
-    void onResetSecondaryScreenDlgTimerOut();
     void onGSettingsChanged(const QString & gsettingsName, const QString &setting);
 
 protected:
@@ -117,7 +116,6 @@ private:
     QMap<QString, dcc::display::RecognizeWidget *> m_recognizeWidget;
 
     bool isReleaseMonitor = false;
-    QTimer *m_resetSecondaryScreenDlgTimer;
 };
 
 } // namespace display

--- a/src/frame/window/modules/display/secondaryscreendialog.cpp
+++ b/src/frame/window/modules/display/secondaryscreendialog.cpp
@@ -232,7 +232,6 @@ void SecondaryScreenDialog::setModel(DisplayModel *model, dcc::display::Monitor 
         brightnessWidget->setVisible(m_model->brightnessEnable());
         connect(m_model, &DisplayModel::brightnessEnableChanged, this, [this, brightnessWidget](const bool enable) {
             brightnessWidget->setVisible(enable);
-            resetDialog();
         });
     }
 }
@@ -256,14 +255,6 @@ void SecondaryScreenDialog::resetDialog()
     move(QPoint(screen->geometry().left() + (screen->geometry().width() - rt.width()) / 2,
                 screen->geometry().top() + (screen->geometry().height() - rt.height()) / 2));
 
-    for (auto screen : QGuiApplication::screens()) {
-        screen->disconnect(this);
-    }
-
-    connect(screen, &QScreen::geometryChanged, this, [=](const QRect &geometry) {
-        move(QPoint(geometry.left() + (geometry.width() - rt.width()) / 2,
-                    geometry.top() + (geometry.height() - rt.height()) / 2));
-    });
     show();
 }
 


### PR DESCRIPTION
已按产品备注修改为副屏窗口不随屏幕参数变化移动位置

Log: 修复副屏的显示设置窗口移动到主屏时设置副屏分辨率后原在主屏的副屏设置窗口会移动到副屏
Bug: https://pms.uniontech.com/bug-view-149435.html
Influence: 控制中心多屏设置后副屏位置不进行自动调整
Change-Id: I55416ab332b0525a001fc2c4515578a6bb4cc968