### PR TITLE
fix: 修改控制中心-声音-设备管理界面右侧间距太宽问题

### DIFF
--- a/src/frame/window/modules/sound/devicemanagespage.cpp
+++ b/src/frame/window/modules/sound/devicemanagespage.cpp
@@ -137,7 +137,7 @@ void DevicemanagesPage::initUI()
     m_outputlblTip->setAlignment(Qt::AlignLeft);
 
     m_outputGroup->getLayout()->setContentsMargins(0, 0, 0, 0);
-    m_outputGroup->setContentsMargins(0, 0, 10, 0);
+    m_outputGroup->setContentsMargins(0, 0, 0, 0);
 
     m_layout->addWidget(m_outputDeviceTitle);
     m_layout->addWidget(m_outputlblTip);
@@ -161,7 +161,7 @@ void DevicemanagesPage::initUI()
     m_inputlblTip->setAlignment(Qt::AlignLeft);
 
     m_inputGroup->getLayout()->setContentsMargins(0, 0, 0, 0);
-    m_inputGroup->setContentsMargins(0, 0, 10, 0);
+    m_inputGroup->setContentsMargins(0, 0, 0, 0);
 
     m_layout->addWidget(m_inputDeviceTitle);
     m_layout->addWidget(m_inputlblTip);


### PR DESCRIPTION
设备管理界面右侧给了10的间距

Log:
Bug: https://pms.uniontech.com/bug-view-155165.html
Influence: 控制中心-声音-设备管理-输出输入设备列表与右侧间距