### PR TITLE
fix(account): 控制中心创建账户页面英文显示异常

### DIFF
--- a/src/frame/window/modules/accounts/createaccountpage.cpp
+++ b/src/frame/window/modules/accounts/createaccountpage.cpp
@@ -308,10 +308,10 @@ void CreateAccountPage::initWidgets(QVBoxLayout *layout)
     }
 
     m_nameEdit->lineEdit()->setPlaceholderText(tr("Required"));//必填
-    m_fullnameEdit->lineEdit()->setPlaceholderText(tr("optional"));//选填
+    m_fullnameEdit->lineEdit()->setPlaceholderText(tr("Optional"));//选填
     m_passwdEdit->lineEdit()->setPlaceholderText(tr("Required"));//必填
     m_repeatpasswdEdit->lineEdit()->setPlaceholderText(tr("Required"));//必填
-    m_passwdTipsEdit->lineEdit()->setPlaceholderText(tr("optional"));//选填
+    m_passwdTipsEdit->lineEdit()->setPlaceholderText(tr("Optional"));//选填
 }
 
 void CreateAccountPage::showGroupList(const QString &index)


### PR DESCRIPTION
创建账户页面“选填”英文首字母改为大写

Log: 修复控制中心创建账户页面英文显示异常的问题
Influence: 控制中心创建账户页面正常显示
Task: https://pms.uniontech.com/bug-view-145727.html
Change-Id: I359f1acdfebcc90dc5b0a99035156dca9f4a2f82