### PR TITLE
fix(account): 重置密码框kill后无法再点击进入

### DIFF
--- a/src/reset-password-dialog/main.cpp
+++ b/src/reset-password-dialog/main.cpp
@@ -9,6 +9,7 @@
 #include <DDBusSender>
 #include <QDBusConnection>
 #include <LogManager.h>
+#include <csignal>
 
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
@@ -56,6 +57,9 @@ int main(int argc, char *argv[])
 
     Manager *manager = new Manager(userName, appName, fd);
     manager->start();
+
+    std::signal(SIGTERM, &Manager::exit);
+    std::signal(SIGKILL, &Manager::exit);
 
     return a.exec();
 }

--- a/src/reset-password-dialog/resetpassworddialog.cpp
+++ b/src/reset-password-dialog/resetpassworddialog.cpp
@@ -379,9 +379,10 @@ void ResetPasswordDialog::onGetSecurityQuestionsReplied(const QList<int> securit
 }
 
 
+ResetPasswordDialog* Manager::m_dialog = nullptr;
+
 Manager::Manager(const QString &userName, const QString &appName, const int &fd)
     : QObject()
-    , m_dialog(nullptr)
     , m_usrName(userName)
     , m_appName(appName)
     , m_fd(fd)
@@ -418,4 +419,10 @@ void Manager::start()
 {
     setupDialog();
     showDialog();
+}
+
+void Manager::exit(int retCode)
+{
+    qDebug() << "retCode:" << retCode;
+    m_dialog->onCancelBtnClicked();
 }

--- a/src/reset-password-dialog/resetpassworddialog.h
+++ b/src/reset-password-dialog/resetpassworddialog.h
@@ -34,6 +34,7 @@ public:
 
     QRect screenGeometry() const;
     void setScreenGeometry(const QRect &screenGeometry);
+    void onCancelBtnClicked();
 
 protected:
     void showEvent(QShowEvent *event);
@@ -54,7 +55,6 @@ Q_SIGNALS:
     void requestSecurityQuestions();
 
 private:
-    void onCancelBtnClicked();
     void onResetPasswordBtnClicked();
     void updatePosition();
 
@@ -96,13 +96,13 @@ public:
     ~Manager() {}
 
     void start();
-
+    static void exit(int retCode);
 private Q_SLOTS:
     void setupDialog();
     void showDialog();
 
 private:
-    ResetPasswordDialog *m_dialog;
+    static ResetPasswordDialog *m_dialog;
     QString m_usrName;
     QString m_appName;
     int m_fd;


### PR DESCRIPTION
原因：重置密码被kill后，没有与控制中心通信。
解决：捕捉kill信号，退出前与控制中心通信。

Log: 修复重置密码框被kill后无法再点击进入问题
Bug: https://pms.uniontech.com/bug-view-159321.html
Influence: 账户-重置密码
Change-Id: I9d3b11c277ab59f09555a234e6c17a1553099170