### PR TITLE
fix: 修复在控制中心界面最大化，调整显示模式、分辨率、预览相对位置时，界面无法居中显示问题

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -430,8 +430,11 @@ void MainWindow::updateWinsize(QRect rect)
     if (!qApp->screens().contains(m_primaryScreen))
         return;
 
-    if (this->isMaximized())
-        return;
+    // 界面最大化时无法move,先还原并移动到对应屏幕位置后重新最大化
+    bool isMaximized = this->isMaximized();
+    if (isMaximized) {
+        this->showNormal();
+    }
 
     // 取当前显示器大小
     int w = m_primaryScreen->geometry().width();
@@ -457,6 +460,10 @@ void MainWindow::updateWinsize(QRect rect)
     move(QPoint(m_primaryScreen->geometry().left() + (m_primaryScreen->geometry().width() - this->geometry().width()) / 2,
                 m_primaryScreen->geometry().top() + (m_primaryScreen->geometry().height() - this->geometry().height()) / 2));
     qInfo() << "Update main window geometry: " << geometry() << ", primary screen geometry: " << m_primaryScreen->geometry();
+
+    if (isMaximized) {
+        this->showMaximized();
+    }
 }
 
 void MainWindow::updateModuleVisible()
@@ -759,11 +766,6 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
 
 void MainWindow::resizeEvent(QResizeEvent *event)
 {
-    if (m_needRememberLastSize && event->oldSize() != event->size()) {
-        m_lastSize = event->oldSize();
-    }
-    m_needRememberLastSize = true;
-
     DMainWindow::resizeEvent(event);
 
     auto dstWidth = event->size().width();

--- a/src/frame/window/mainwindow.h
+++ b/src/frame/window/mainwindow.h
@@ -95,7 +95,6 @@ public:
     void initAllModule(const QString &m = "");
     inline QStack<QPair<ModuleInterface *, QWidget *>> getcontentStack() {return m_contentStack;}
     inline QSize getLastSize() const { return m_lastSize; }
-    inline void setNeedRememberLastSize(bool needRememberLastSize)  { m_needRememberLastSize = needRememberLastSize;}
     void setPrimaryScreen(QScreen *screen);
     QScreen *primaryScreen() const;
 
@@ -168,7 +167,6 @@ private:
     bool m_updateVisibale = true;
     QWidget *m_lastPushWidget{nullptr};     //用于记录最后push进来的widget控件
     QSize m_lastSize;
-    bool m_needRememberLastSize = true;     //用于判断是否需要上次resize的窗口大小
 
     //全局搜索
     QList<QJsonObject> m_lstGrandSearchTasks;

--- a/src/frame/window/modules/display/multiscreenwidget.cpp
+++ b/src/frame/window/modules/display/multiscreenwidget.cpp
@@ -379,7 +379,8 @@ void MultiScreenWidget::initSecondaryScreenDialog()
         }
         for (const auto &monitor : m_model->monitorList()) {
             if (monitor == m_model->primaryMonitor()) {
-                QTimer::singleShot(0, this, [=] { requestSetMainwindowRect(m_model->primaryMonitor(), true); });
+                // 显示Display模块时，初始化主界面对应屏幕和居中显示
+                QTimer::singleShot(0, this, &MultiScreenWidget::requestSetMainwindowRect);
                 continue;
             }
 
@@ -473,7 +474,8 @@ void MultiScreenWidget::onMonitorRelease(Monitor *monitor)
 {
     Q_UNUSED(monitor)
     m_fullIndication->setVisible(false);
-    QTimer::singleShot(1000, this, [=] { requestSetMainwindowRect(m_model->primaryMonitor(), false); });
+    // 在显示预览界面调整多屏相对位置后，重新调整主界面居中显示
+    QTimer::singleShot(1000, this, &MultiScreenWidget::requestSetMainwindowRect);
 }
 
 void MultiScreenWidget::onRequestSetMonitorPosition(QHash<dcc::display::Monitor *, QPair<int, int>> monitorPosition)

--- a/src/frame/window/modules/display/multiscreenwidget.h
+++ b/src/frame/window/modules/display/multiscreenwidget.h
@@ -65,7 +65,7 @@ Q_SIGNALS:
     void requestSetResolution(dcc::display::Monitor *monitor, const int mode);
     void requestSetRotate(dcc::display::Monitor *monitor, const int rotate);
     void requestGatherEnabled(const bool enable);
-    void requestSetMainwindowRect(dcc::display::Monitor *monitor, bool isInit);
+    void requestSetMainwindowRect();
     void requestSetFillMode(dcc::display::Monitor *monitor, const QString fillMode);
     void requestCurrFillModeChanged(dcc::display::Monitor *monitor, const QString fillMode);
 

--- a/src/frame/window/modules/display/secondaryscreendialog.cpp
+++ b/src/frame/window/modules/display/secondaryscreendialog.cpp
@@ -84,6 +84,11 @@ void SecondaryScreenDialog::OnRequestResizeDesktopVisibleChanged(bool visible)
 
 void SecondaryScreenDialog::setModel(DisplayModel *model, dcc::display::Monitor *monitor)
 {
+    // 断开原连接信号
+    if (monitor->getQScreen()) {
+        monitor->getQScreen()->disconnect(this);
+    }
+
     m_model = model;
     m_monitor = monitor;
 
@@ -104,6 +109,11 @@ void SecondaryScreenDialog::setModel(DisplayModel *model, dcc::display::Monitor 
     connect(m_resolutionWidget, &ResolutionWidget::requestResizeDesktopVisibleChanged, this, &SecondaryScreenDialog::OnRequestResizeDesktopVisibleChanged);
     connect(m_refreshRateWidget, &RefreshRateWidget::requestSetResolution, this, &SecondaryScreenDialog::requestSetResolution);
     connect(m_rotateWidget, &RotateWidget::requestSetRotate, this, &SecondaryScreenDialog::requestSetRotate);
+
+    // 连接geometryChanged信号，当geomtry改变里，重新调整界面位置居中
+    if (monitor->getQScreen()) {
+        connect(monitor->getQScreen(), &QScreen::geometryChanged, this, &SecondaryScreenDialog::resetDialog);
+    }
 
     auto tfunc = [this](const double tb) {
         int tmini = int(m_model->minimumBrightnessScale() * BrightnessMaxScale);


### PR DESCRIPTION
1 修复调整显示模式，分辨率等主界面和副屏设置界面无法居中显示问题
2 修复手动调整预览相对位置时，副屏设置界面不在对应屏幕居中显示问题

Log: 修复在控制中心界面最大化，调整显示模式、分辨率、预览相对位置时，界面无法居中显示问题
Bug: https://pms.uniontech.com/bug-view-152085.html
Influence: 调整显示模式、分辨率、预览相对位置界面在对应屏幕居中显示