### PR TITLE
fix: 重新更新失败后错误触发备份逻辑

### DIFF
--- a/src/frame/modules/update/updatework.cpp
+++ b/src/frame/modules/update/updatework.cpp
@@ -782,7 +782,7 @@ void UpdateWorker::distUpgrade(ClassifyUpdateType updateType)
     bool bConfigVlid = m_model->recoverConfigValid();
     qDebug() << Q_FUNC_INFO << " [abRecovery] 更新前,检查备份配置是否满足(true:满足) : " << bConfigVlid;
 
-    if (bConfigVlid) { //系统环境配置为可以恢复,在收到jobEnd()后,且"backup",成功,后才会继续到下一步下载数据
+    if (bConfigVlid && status != UpdatesStatus::UpdateFailed) { //系统环境配置为可以恢复,在收到jobEnd()后,且"backup",成功,后才会继续到下一步下载数据
         recoveryCanBackup(updateType);
     } else { //系统环境配置不满足,则直接跳到下一步下载数据
         qDebug() << Q_FUNC_INFO << " [abRecovery] 备份配置环境不满足,继续更新.";


### PR DESCRIPTION
如果重新备份不需要走备份流程，继续走下载流程

Log: 提示网络错误后点击刷新按钮，触发了备份进程
Bug: https://pms.uniontech.com/bug-view-155589.html
Influence: 控制中心-更新-重新更新