### PR TITLE
fix: 指纹录入界面卡死

### DIFF
--- a/src/frame/modules/authentication/widgets/disclaimersdialog.cpp
+++ b/src/frame/modules/authentication/widgets/disclaimersdialog.cpp
@@ -111,9 +111,3 @@ void DisclaimersDialog::initConnect()
     });
 }
 
-void DisclaimersDialog::closeEvent(QCloseEvent *event)
-{
-    Q_EMIT requesetCloseDlg(true);
-    QDialog::closeEvent(event);
-}
-

--- a/src/frame/modules/authentication/widgets/disclaimersdialog.h
+++ b/src/frame/modules/authentication/widgets/disclaimersdialog.h
@@ -38,18 +38,11 @@ private:
     void initWidget(DisclaimersObj state);
     void initConnect();
 
-protected:
-    void closeEvent(QCloseEvent *event) override;
-
 Q_SIGNALS:
     /**
      * @brief requestClickStatus 点击确定后 返回登陆界面 显示勾选状态
      */
     void requestClickStatus(bool isClick);
-    /**
-     * @brief requesetCloseDlg 离开免责对话框界面 需要恢复父窗口显示状态
-     */
-    void requesetCloseDlg(bool isClose);
 
 private:
     QVBoxLayout *m_mainLayout;

--- a/src/frame/modules/authentication/widgets/disclaimersitem.cpp
+++ b/src/frame/modules/authentication/widgets/disclaimersitem.cpp
@@ -56,7 +56,9 @@ void DisclaimersItem::showDisclaimers()
 {
     DisclaimersDialog *disdlg = new dcc::authentication::DisclaimersDialog(m_state);
     connect(disdlg, &DisclaimersDialog::requestClickStatus, this, &DisclaimersItem::setAcceptState);
-    connect(disdlg, &DisclaimersDialog::requesetCloseDlg, this, &DisclaimersItem::requestSetWindowEnabled);
+    connect(disdlg, &DisclaimersDialog::finished, this, [this] {
+        requestSetWindowEnabled(true);
+    });
     disdlg->setWindowFlags(Qt::Dialog | Qt::Popup | Qt::WindowStaysOnTopHint);
     disdlg->setFocus();
     disdlg->activateWindow();

--- a/src/frame/window/modules/authentication/addfaceinfodialog.cpp
+++ b/src/frame/window/modules/authentication/addfaceinfodialog.cpp
@@ -43,7 +43,7 @@ AddFaceInfoDialog::~AddFaceInfoDialog()
 
 void AddFaceInfoDialog::closeEvent(QCloseEvent *event)
 {
-    Q_EMIT requesetCloseDlg();
+    Q_EMIT requestCloseDlg();
     m_faceModel->setAddButtonStatus(true);
     QDialog::closeEvent(event);
 }

--- a/src/frame/window/modules/authentication/addfaceinfodialog.h
+++ b/src/frame/window/modules/authentication/addfaceinfodialog.h
@@ -51,7 +51,7 @@ public:
 
 Q_SIGNALS:
     void requestShowFaceInfoDialog();
-    void requesetCloseDlg();
+    void requestCloseDlg();
     void requestStopEnroll();
 
 protected:

--- a/src/frame/window/modules/authentication/addfingedialog.cpp
+++ b/src/frame/window/modules/authentication/addfingedialog.cpp
@@ -235,7 +235,7 @@ void AddFingeDialog::closeEvent(QCloseEvent *event)
     if (m_isEnrolling) {
         Q_EMIT requestStopEnroll(m_username);
     }
-    Q_EMIT requesetCloseDlg(m_username);
+    Q_EMIT requestCloseDlg(m_username);
     QDialog::closeEvent(event);
 }
 

--- a/src/frame/window/modules/authentication/addfingedialog.h
+++ b/src/frame/window/modules/authentication/addfingedialog.h
@@ -61,7 +61,7 @@ Q_SIGNALS:
     void requestStopEnroll(const QString &thumb);
     void requestReEnrollThumb();
     void requestEnrollThumb();
-    void requesetCloseDlg(const QString &name);
+    void requestCloseDlg(const QString &name);
 
 private:
     QTimer *m_timer;

--- a/src/frame/window/modules/authentication/addirisinfodialog.cpp
+++ b/src/frame/window/modules/authentication/addirisinfodialog.cpp
@@ -41,7 +41,7 @@ AddIrisInfoDialog::~AddIrisInfoDialog()
 
 void AddIrisInfoDialog::closeEvent(QCloseEvent *event)
 {
-    Q_EMIT requesetCloseDlg();
+    Q_EMIT requestCloseDlg();
     if (m_state == CharaMangerModel::AddInfoState::Processing) {
         Q_EMIT requestStopEnroll();
     }

--- a/src/frame/window/modules/authentication/addirisinfodialog.h
+++ b/src/frame/window/modules/authentication/addirisinfodialog.h
@@ -44,7 +44,7 @@ public:
 
 Q_SIGNALS:
     void requestInputIris();
-    void requesetCloseDlg();
+    void requestCloseDlg();
     void requestStopEnroll();
 
 protected:

--- a/src/frame/window/modules/authentication/fingedisclaimer.cpp
+++ b/src/frame/window/modules/authentication/fingedisclaimer.cpp
@@ -24,9 +24,12 @@ using namespace DCC_NAMESPACE::authentication;
 FingerDisclaimer::FingerDisclaimer(QWidget *parent)
     : DAbstractDialog(parent)
     , m_mainLayout(new QVBoxLayout(this))
+    , m_fingerPic(new QLabel(this))
+    , m_resultTips(nullptr)
+    , m_explainTips(nullptr)
+    , m_disclaimersItem(nullptr)
     , m_cancelBtn(new QPushButton(this))
     , m_acceptBtn(new DSuggestButton(this))
-    , m_fingerPic(new QLabel(this))
     , m_currentState(dcc::authentication::CharaMangerModel::AddInfoState::StartState)
 {
     initWidget();
@@ -39,12 +42,6 @@ FingerDisclaimer::FingerDisclaimer(QWidget *parent)
 FingerDisclaimer::~FingerDisclaimer()
 {
 
-}
-
-void FingerDisclaimer::closeEvent(QCloseEvent *event)
-{
-    Q_EMIT requesetCloseDlg();
-    QDialog::closeEvent(event);
 }
 
 bool FingerDisclaimer::eventFilter(QObject *o, QEvent *e)

--- a/src/frame/window/modules/authentication/fingedisclaimer.h
+++ b/src/frame/window/modules/authentication/fingedisclaimer.h
@@ -47,11 +47,9 @@ public:
 
 Q_SIGNALS:
     void requestShowFingeInfoDialog();
-    void requesetCloseDlg();
     void requestStopEnroll();
 
 protected:
-    void closeEvent(QCloseEvent *event) override;
     bool eventFilter(QObject *o, QEvent *e) override;
 
 private:

--- a/src/frame/window/modules/authentication/fingerdetailwidget.cpp
+++ b/src/frame/window/modules/authentication/fingerdetailwidget.cpp
@@ -130,7 +130,7 @@ void FingerDetailWidget::showAddFingeDialog(const QString &name, const QString &
         showAddFingeDialog(name, thumb);
     });
     connect(dlg, &AddFingeDialog::requestStopEnroll, this, &FingerDetailWidget::requestStopEnroll);
-    connect(dlg, &AddFingeDialog::requesetCloseDlg, dlg, [ = ](const QString & userName) {
+    connect(dlg, &AddFingeDialog::requestCloseDlg, dlg, [ = ](const QString & userName) {
         Q_EMIT noticeEnrollCompleted(userName);
         if (m_disclaimer != nullptr) {
             closeFingerDisclaimer();
@@ -184,14 +184,13 @@ void FingerDetailWidget::showFingeDisclaimer(const QString &name, const QString 
     m_disclaimer = new FingerDisclaimer(this);
     m_disclaimer->setVisible(true);
 
-    connect(m_disclaimer, &FingerDisclaimer::requestShowFingeInfoDialog, this, [ = ] {
+    connect(m_disclaimer, &FingerDisclaimer::requestShowFingeInfoDialog, this, [ this, name, thumb ] {
         m_disclaimer->setVisible(false);
         showAddFingeDialog(name, thumb);
     });
 
-    connect(m_disclaimer, &FingerDisclaimer::requesetCloseDlg, this, [ = ] {
-        if (m_disclaimer != nullptr)
-        {
+    connect(m_disclaimer, &FingerDisclaimer::finished, this, [ this ] {
+        if (m_disclaimer != nullptr) {
             closeFingerDisclaimer();
         }
     });

--- a/src/frame/window/modules/authentication/irisdetailwidget.cpp
+++ b/src/frame/window/modules/authentication/irisdetailwidget.cpp
@@ -115,11 +115,11 @@ void IrisDetailWidget::onShowAddIrisDialog(const QString &driverName, const int 
     connect(m_model, &CharaMangerModel::tryStartInputIris, irisDlg, &AddIrisInfoDialog::refreshInfoStatusDisplay);
 
     connect(irisDlg, &AddIrisInfoDialog::requestStopEnroll, this, &IrisDetailWidget::requestStopEnroll);
-    connect(irisDlg, &AddIrisInfoDialog::requesetCloseDlg, irisDlg, &AddIrisInfoDialog::deleteLater);
+    connect(irisDlg, &AddIrisInfoDialog::requestCloseDlg, irisDlg, &AddIrisInfoDialog::deleteLater);
 
     // 点击下一步开始录入
     connect(irisDlg, &AddIrisInfoDialog::requestInputIris, this, [ = ](){
-        Q_EMIT requestEntollStart(driverName, charaType, charaName);
+        Q_EMIT requestEnrollStart(driverName, charaType, charaName);
     });
 
     irisDlg->setWindowFlags(Qt::Dialog | Qt::Popup | Qt::WindowStaysOnTopHint);

--- a/src/frame/window/modules/authentication/irisdetailwidget.h
+++ b/src/frame/window/modules/authentication/irisdetailwidget.h
@@ -40,7 +40,7 @@ Q_SIGNALS:
     void requestDeleteIrisItem(const int &charaType, const QString &charaName);
     void requestRenameIrisItem(const int &charaType, const QString& oldIrisName, const QString& newIrisName);
     void noticeEnrollCompleted(const QString &driverName, const int &CharaType);
-    void requestEntollStart(const QString &driverName, const int &charaType, const QString &charaName);
+    void requestEnrollStart(const QString &driverName, const int &charaType, const QString &charaName);
     void requestStopEnroll();
 
 public Q_SLOTS:

--- a/src/frame/window/modules/authentication/loginoptionsmodule.cpp
+++ b/src/frame/window/modules/authentication/loginoptionsmodule.cpp
@@ -158,7 +158,7 @@ void LoginOptionsModule::showFaceidPage()
 void LoginOptionsModule::showIrisPage()
 {
     IrisDetailWidget *w = new IrisDetailWidget(m_charaMangerModel);
-    connect(w, &IrisDetailWidget::requestEntollStart, m_charaMangerWorker, &CharaMangerWorker::entollStart);
+    connect(w, &IrisDetailWidget::requestEnrollStart, m_charaMangerWorker, &CharaMangerWorker::entollStart);
     connect(w, &IrisDetailWidget::requestStopEnroll, m_charaMangerWorker, &CharaMangerWorker::stopEnroll);
     connect(w, &IrisDetailWidget::requestDeleteIrisItem, m_charaMangerWorker, &CharaMangerWorker::deleteCharaItem);
     connect(w, &IrisDetailWidget::requestRenameIrisItem, m_charaMangerWorker, &CharaMangerWorker::renameCharaItem);


### PR DESCRIPTION
现象：在录入指纹免责声明界面 按下ESC按键，界面卡死；
原因：没有处理esc按键的情况；
解决方案：关联dialog的finished信号，不需要单独添加信号

Log: 修复指纹录入界面卡死的问题
Bug: https://pms.uniontech.com/bug-view-158893.html
Influence: 生物认证
Change-Id: I81451825937cb1e54e94c75abdece09307e8cdd2