### PR TITLE
fix: 修复重置密码框kill后无法再点击进入

### DIFF
--- a/src/reset-password-dialog/main.cpp
+++ b/src/reset-password-dialog/main.cpp
@@ -58,8 +58,8 @@ int main(int argc, char *argv[])
     Manager *manager = new Manager(userName, appName, fd);
     manager->start();
 
-    std::signal(SIGTERM, &Manager::exit);
-    std::signal(SIGKILL, &Manager::exit);
+    std::signal(SIGTERM, Manager::exit);
+    std::signal(SIGKILL, Manager::exit);
 
     return a.exec();
 }


### PR DESCRIPTION
传函数作为入参时无需取地址后再传参

Log: 修复重置密码框kill后无法再点击进入
Bug: https://pms.uniontech.com/bug-view-159321.html
Influence: 账户-重置密码
Change-Id: Ic482a1bd0ba7107785a8a1fbfffc256c61a20bdd