### PR TITLE
fix: 更新dconfig的supportCpuGovernors的值与实际不匹配

### DIFF
--- a/src/frame/modules/power/powermodel.h
+++ b/src/frame/modules/power/powermodel.h
@@ -132,7 +132,7 @@ public:
     inline bool isBalanceSupported() const { return m_isBalanceSupported; }
     void setBalanceSupported(bool isBalanceSupport);
 
-    inline bool isPowerSaveSupported() const { return m_isBalanceSupported; }
+    inline bool isPowerSaveSupported() const { return m_isPowerSaveSupported; }
     void setPowerSaveSupported(bool isPowerSaveSupported);
 
 Q_SIGNALS:


### PR DESCRIPTION
supportCpuGovernors在控制中心model的值写成了balance的值

Log: 修正控制中心获取节能模式的值
Influence: 节能模式是否显示
Bug: https://pms.uniontech.com/bug-view-160227.html
Change-Id: I5601a1eb8e5e5b2fb1426c1059378998f82726e6