### PR TITLE
fix: 取消勾选总在最前面，控制中心无法任何操作

### DIFF
--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -294,6 +294,7 @@ set(AUTHENTICATION_FILES
     window/modules/authentication/addirisinfodialog.cpp
     modules/authentication/widgets/irisinfowidget.cpp
     window/modules/authentication/fingedisclaimer.cpp
+    window/modules/authentication/biologicalbasedialog.cpp
 )
 
 # load accounts

--- a/src/frame/modules/authentication/widgets/disclaimersdialog.cpp
+++ b/src/frame/modules/authentication/widgets/disclaimersdialog.cpp
@@ -16,8 +16,8 @@ using namespace dcc;
 using namespace dcc::widgets;
 using namespace dcc::authentication;
 
-DisclaimersDialog::DisclaimersDialog(DisclaimersObj disobj, DAbstractDialog *parent)
-    : DAbstractDialog(parent)
+DisclaimersDialog::DisclaimersDialog(DisclaimersObj disobj, QWidget *parent)
+    : QWidget(parent)
     , m_mainLayout(new QVBoxLayout(this))
     , m_cancelBtn(new QPushButton(this))
     , m_acceptBtn(new DSuggestButton(this))
@@ -34,7 +34,6 @@ DisclaimersDialog::~DisclaimersDialog()
 
 void DisclaimersDialog::initWidget(DisclaimersObj state)
 {
-    setFixedSize(QSize(454, 542));
     m_mainLayout->setAlignment(Qt::AlignHCenter);
 
     DTitlebar *titleIcon = new DTitlebar(this);
@@ -44,7 +43,7 @@ void DisclaimersDialog::initWidget(DisclaimersObj state)
     titleIcon->setTitle(tr("Disclaimer"));
 
     DTipLabel *tipLabel = new DTipLabel("");
-    if (state == DisclaimersObj::Faceid) {
+    if (state == DisclaimersObj::FaceId) {
         tipLabel->setText(tr("Before using face recognition, please note that: \n"
                              "1. Your device may be unlocked by people or objects that look or appear similar to you.\n"
                              "2. Face recognition is less secure than digital passwords and mixed passwords.\n"
@@ -56,13 +55,11 @@ void DisclaimersDialog::initWidget(DisclaimersObj state)
                              "1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.\n"
                              "2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.\n"
                              "3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.\n"));
-    } else if (state == DisclaimersObj::Finge || state == DisclaimersObj::Iris) {
-        setFixedSize(QSize(382, 446));
+    } else if (state == DisclaimersObj::Finger || state == DisclaimersObj::Iris) {
         tipLabel->setText(tr("\"Biometric authentication\" is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through \"biometric authentication\", the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.\n"
                              "Please be noted that UnionTech Software will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom. \n"
                              "UnionTech Software is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UnionTech OS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through \"Service and Support\" in the UnionTech OS. \n"));
     }
-
 
     DFontSizeManager::instance()->bind(tipLabel, DFontSizeManager::T6);
     tipLabel->adjustSize();
@@ -104,10 +101,11 @@ void DisclaimersDialog::initWidget(DisclaimersObj state)
 
 void DisclaimersDialog::initConnect()
 {
-    connect(m_cancelBtn, &QPushButton::clicked, this, &DisclaimersDialog::close);
+    connect(m_cancelBtn, &QPushButton::clicked, this, [this] {
+        acceptDisclaimer(false);
+    });
     connect(m_acceptBtn, &QPushButton::clicked, this, [this] {
-        Q_EMIT requestClickStatus(true);
-        this->close();
+        acceptDisclaimer(true);
     });
 }
 

--- a/src/frame/modules/authentication/widgets/disclaimersdialog.h
+++ b/src/frame/modules/authentication/widgets/disclaimersdialog.h
@@ -6,7 +6,6 @@
 #include "interface/namespace.h"
 #include "widgets/settingsitem.h"
 
-#include <DAbstractDialog>
 #include <DSuggestButton>
 #include <DTipLabel>
 
@@ -21,17 +20,17 @@ namespace dcc {
 namespace authentication {
 
 enum DisclaimersObj {
-    Faceid,
+    FaceId,
     Iris,
-    Finge
+    Finger
 };
 
 // 免责声明对话框
-class DisclaimersDialog : public DTK_WIDGET_NAMESPACE::DAbstractDialog
+class DisclaimersDialog : public QWidget
 {
     Q_OBJECT
 public:
-    explicit DisclaimersDialog(DisclaimersObj disobj, DAbstractDialog *parent = nullptr);
+    explicit DisclaimersDialog(DisclaimersObj disobj, QWidget *parent = nullptr);
     ~DisclaimersDialog();
 
 private:
@@ -39,10 +38,7 @@ private:
     void initConnect();
 
 Q_SIGNALS:
-    /**
-     * @brief requestClickStatus 点击确定后 返回登陆界面 显示勾选状态
-     */
-    void requestClickStatus(bool isClick);
+    void acceptDisclaimer(bool accept);
 
 private:
     QVBoxLayout *m_mainLayout;

--- a/src/frame/modules/authentication/widgets/disclaimersitem.cpp
+++ b/src/frame/modules/authentication/widgets/disclaimersitem.cpp
@@ -21,11 +21,10 @@ using namespace dcc;
 using namespace dcc::widgets;
 using namespace dcc::authentication;
 
-DisclaimersItem::DisclaimersItem(DisclaimersObj disobj, QWidget *parent)
+DisclaimersItem::DisclaimersItem(QWidget *parent)
     : SettingsItem(parent)
     , m_layout(new QHBoxLayout(this))
     , m_acceptCheck(new QCheckBox(this))
-    , m_state(disobj)
 {
     m_acceptCheck->setText(tr("I have read and agree to the"));
 
@@ -40,8 +39,7 @@ DisclaimersItem::DisclaimersItem(DisclaimersObj disobj, QWidget *parent)
     DFontSizeManager::instance()->bind(m_acceptCheck, DFontSizeManager::SizeType::T8);
     DFontSizeManager::instance()->bind(m_disclaimersBtn, DFontSizeManager::SizeType::T8);
 
-    connect(m_disclaimersBtn, &QPushButton::clicked, this, &DisclaimersItem::requestSetWindowEnabled);
-    connect(m_disclaimersBtn, &QPushButton::clicked, this, &DisclaimersItem::showDisclaimers);
+    connect(m_disclaimersBtn, &QPushButton::clicked, this, &DisclaimersItem::requestShowDisclaimers);
     connect(m_acceptCheck, &QCheckBox::toggled, this, &DisclaimersItem::setAcceptState);
     setLayout(m_layout);
 }
@@ -52,16 +50,4 @@ void DisclaimersItem::setAcceptState(const bool &state)
     Q_EMIT requestStateChange(!state);
 }
 
-void DisclaimersItem::showDisclaimers()
-{
-    DisclaimersDialog *disdlg = new dcc::authentication::DisclaimersDialog(m_state);
-    connect(disdlg, &DisclaimersDialog::requestClickStatus, this, &DisclaimersItem::setAcceptState);
-    connect(disdlg, &DisclaimersDialog::finished, this, [this] {
-        requestSetWindowEnabled(true);
-    });
-    disdlg->setWindowFlags(Qt::Dialog | Qt::Popup | Qt::WindowStaysOnTopHint);
-    disdlg->setFocus();
-    disdlg->activateWindow();
-    disdlg->exec();
-}
 

--- a/src/frame/modules/authentication/widgets/disclaimersitem.h
+++ b/src/frame/modules/authentication/widgets/disclaimersitem.h
@@ -26,15 +26,14 @@ class DisclaimersItem : public dcc::widgets::SettingsItem
 {
     Q_OBJECT
 public:
-    explicit DisclaimersItem(DisclaimersObj disobj, QWidget *parent = nullptr);
+    explicit DisclaimersItem(QWidget *parent = nullptr);
 
 public Q_SLOTS:
-    void showDisclaimers();
     void setAcceptState(const bool &state);
 
 Q_SIGNALS:
     void requestStateChange(bool state);
-    void requestSetWindowEnabled(bool checked = false);
+    void requestShowDisclaimers();
 
 private:
     QHBoxLayout *m_layout;

--- a/src/frame/window/modules/authentication/addfaceinfodialog.h
+++ b/src/frame/window/modules/authentication/addfaceinfodialog.h
@@ -7,8 +7,8 @@
 #include "interface/namespace.h"
 #include "widgets/titlelabel.h"
 #include "widgets/buttontuple.h"
-#include "modules/authentication/widgets/disclaimersitem.h"
 #include "modules/authentication/charamangermodel.h"
+#include "biologicalbasedialog.h"
 
 #include <DSuggestButton>
 #include <DAbstractDialog>
@@ -34,7 +34,7 @@ namespace DCC_NAMESPACE {
 namespace authentication {
 
 // 添加人脸对话框
-class AddFaceInfoDialog : public DTK_WIDGET_NAMESPACE::DAbstractDialog
+class AddFaceInfoDialog : public BiologicalBaseDialog
 {
     Q_OBJECT
 public:
@@ -62,17 +62,13 @@ private:
     void initWidget();
     void initConnect();
     QString getFacePicture();
-
+    void initBioWidget();
 
 private:
     dcc::authentication::CharaMangerModel *m_faceModel;
-    QVBoxLayout *m_mainLayout;
     QLabel *m_facePic; // 人脸图片
     QLabel *m_resultTips; // 录入结果说明
     DLabel *m_explainTips; // 状态说明信息
-    dcc::authentication::DisclaimersItem *m_disclaimersItem; // 免责声明
-    QPushButton* m_cancelBtn; // 取消
-    DTK_WIDGET_NAMESPACE::DSuggestButton* m_acceptBtn; // 下一步
     dcc::authentication::CharaMangerModel::AddInfoState m_currentState;
 };
 

--- a/src/frame/window/modules/authentication/addirisinfodialog.cpp
+++ b/src/frame/window/modules/authentication/addirisinfodialog.cpp
@@ -18,15 +18,11 @@ using namespace dcc::authentication;
 using namespace DCC_NAMESPACE::authentication;
 
 AddIrisInfoDialog::AddIrisInfoDialog(CharaMangerModel *model, QWidget *parent)
-    : DAbstractDialog(parent)
+    : BiologicalBaseDialog(parent)
     , m_charaModel(model)
-    , m_mainLayout(new QVBoxLayout(this))
     , m_irisInfo(new IrisInfoWidget(this))
     , m_resultTips(new QLabel(this))
     , m_explainTips(new QLabel(this))
-    , m_disclaimersItem(new DisclaimersItem(DisclaimersObj::Iris, this))
-    , m_cancelBtn(new QPushButton(this))
-    , m_acceptBtn(new DSuggestButton(this))
 {
     initWidget();
     initConnect();
@@ -58,10 +54,10 @@ bool AddIrisInfoDialog::eventFilter(QObject *o, QEvent *e)
     return false;
 }
 
-void AddIrisInfoDialog::initWidget()
+void AddIrisInfoDialog::initBioWidget()
 {
-    setFixedSize(QSize(340, 404));
-    m_mainLayout->setAlignment(Qt::AlignHCenter);
+    QVBoxLayout *bioLayout = new QVBoxLayout(this);
+    bioLayout->setAlignment(Qt::AlignHCenter);
 
     DTitlebar *titleIcon = new DTitlebar(this);
     titleIcon->setFrameStyle(QFrame::NoFrame);//无边框
@@ -98,29 +94,42 @@ void AddIrisInfoDialog::initWidget()
     btnLayout->addWidget(m_acceptBtn, Qt::AlignCenter);
     btnLayout->setContentsMargins(20, 10, 20, 20);
 
-    m_mainLayout->addWidget(titleIcon, Qt::AlignTop | Qt::AlignRight);
-    m_mainLayout->addSpacing(30);
-    m_mainLayout->addWidget(m_irisInfo, 0, Qt::AlignHCenter);
-    m_mainLayout->addSpacing(15);
-    m_mainLayout->addWidget(m_resultTips, 0, Qt::AlignHCenter);
-    m_mainLayout->addSpacing(10);
-    m_mainLayout->addLayout(tips);
-    m_mainLayout->addStretch();
-    m_mainLayout->addWidget(m_disclaimersItem, 0, Qt::AlignCenter);
-    m_mainLayout->addLayout(btnLayout);
+    bioLayout->addWidget(titleIcon, Qt::AlignTop | Qt::AlignRight);
+    bioLayout->addSpacing(30);
+    bioLayout->addWidget(m_irisInfo, 0, Qt::AlignHCenter);
+    bioLayout->addSpacing(15);
+    bioLayout->addWidget(m_resultTips, 0, Qt::AlignHCenter);
+    bioLayout->addSpacing(10);
+    bioLayout->addLayout(tips);
+    bioLayout->addStretch();
+    bioLayout->addWidget(m_disclaimersItem, 0, Qt::AlignCenter);
+    bioLayout->addLayout(btnLayout);
+    bioLayout->setMargin(0);
+    bioLayout->setSpacing(0);
 
-    m_mainLayout->setMargin(0);
-    m_mainLayout->setSpacing(0);
-    setLayout(m_mainLayout);
+    m_bioWidget->setLayout(bioLayout);
+}
+
+void AddIrisInfoDialog::initWidget()
+{
+    setFixedSize(QSize(340, 404));
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setAlignment(Qt::AlignHCenter);
+
+    mainLayout->addWidget(m_bioWidget);
+    mainLayout->setMargin(0);
+    mainLayout->setSpacing(0);
+    setLayout(mainLayout);
+
+    setDisclaimerVisible(false);
+    this->activateWindow();
+    this->setFocus();
 }
 
 void AddIrisInfoDialog::initConnect()
 {
     connect(m_charaModel, &CharaMangerModel::enrollIrisInfoState, this, &AddIrisInfoDialog::refreshInfoStatusDisplay);
     connect(m_charaModel, &CharaMangerModel::enrollIrisStatusTips, this, &AddIrisInfoDialog::refreshExplainTips);
-    connect(m_disclaimersItem, &DisclaimersItem::requestSetWindowEnabled, this, &AddIrisInfoDialog::onSetWindowEnabled);
-    connect(m_disclaimersItem, &DisclaimersItem::requestStateChange, m_acceptBtn, &QPushButton::setDisabled);
-
     connect(m_cancelBtn, &QPushButton::clicked, this, &AddIrisInfoDialog::close);
     connect(m_acceptBtn, &QPushButton::clicked, this, &AddIrisInfoDialog::requestInputIris);
     connect(m_cancelBtn, &QPushButton::clicked, this, [this]{

--- a/src/frame/window/modules/authentication/addirisinfodialog.h
+++ b/src/frame/window/modules/authentication/addirisinfodialog.h
@@ -7,14 +7,11 @@
 #include "interface/namespace.h"
 #include "widgets/titlelabel.h"
 #include "widgets/buttontuple.h"
-#include "modules/authentication/widgets/disclaimersitem.h"
 #include "modules/authentication/charamangermodel.h"
-
-#include <DSuggestButton>
-#include <DAbstractDialog>
-#include <DTipLabel>
-
 #include <modules/authentication/widgets/irisinfowidget.h>
+#include "biologicalbasedialog.h"
+
+#include <DTipLabel>
 
 QT_BEGIN_NAMESPACE
 class QVBoxLayout;
@@ -34,7 +31,7 @@ using namespace dcc::widgets;
 namespace DCC_NAMESPACE {
 namespace authentication {
 // 虹膜对话框
-class AddIrisInfoDialog : public DTK_WIDGET_NAMESPACE::DAbstractDialog
+class AddIrisInfoDialog : public BiologicalBaseDialog
 {
     Q_OBJECT
 public:
@@ -54,6 +51,7 @@ protected:
 private:
     void initWidget();
     void initConnect();
+    void initBioWidget();
 
 public Q_SLOTS:
     void refreshInfoStatusDisplay(dcc::authentication::CharaMangerModel::AddInfoState state);
@@ -62,13 +60,9 @@ public Q_SLOTS:
 
 private:
     dcc::authentication::CharaMangerModel *m_charaModel;
-    QVBoxLayout *m_mainLayout;
     dcc::authentication::IrisInfoWidget *m_irisInfo;
     QLabel *m_resultTips; // 录入结果说明
     QLabel *m_explainTips; // 状态说明信息
-    dcc::authentication::DisclaimersItem *m_disclaimersItem; // 免责声明
-    QPushButton* m_cancelBtn; // 取消
-    DTK_WIDGET_NAMESPACE::DSuggestButton* m_acceptBtn; // 下一步
     dcc::authentication::CharaMangerModel::AddInfoState m_state;
 };
 

--- a/src/frame/window/modules/authentication/biologicalbasedialog.cpp
+++ b/src/frame/window/modules/authentication/biologicalbasedialog.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "biologicalbasedialog.h"
+
+#include <QHBoxLayout>
+
+DWIDGET_USE_NAMESPACE
+using namespace dcc::authentication;
+
+namespace DCC_NAMESPACE {
+namespace authentication {
+
+BiologicalBaseDialog::BiologicalBaseDialog(QWidget *parent)
+    : DAbstractDialog(parent)
+    , m_bioWidget(new QWidget(this))
+    , m_disclaimerWidget(new DisclaimersDialog(DisclaimersObj::Finger, this))
+    , m_disclaimersItem(new DisclaimersItem(m_bioWidget))
+    , m_cancelBtn(new QPushButton(m_bioWidget))
+    , m_acceptBtn(new DSuggestButton(m_bioWidget))
+{
+    connect(m_disclaimersItem, &DisclaimersItem::requestShowDisclaimers, this, &BiologicalBaseDialog::onShowDisclaimer);
+    connect(m_disclaimersItem, &DisclaimersItem::requestStateChange, m_acceptBtn, [this] (bool state) {
+        const bool enable = !state;
+        m_acceptBtn->setEnabled(enable);
+        if (enable) {
+            m_acceptBtn->setFocus();
+        } else {
+            // 不明确设置的话，焦点可能会在关闭按钮上
+            m_disclaimersItem->setFocus();
+        }
+    });
+    connect(m_disclaimerWidget, &DisclaimersDialog::acceptDisclaimer, this, &BiologicalBaseDialog::onAcceptDisclaimer);
+    connect(this, &QDialog::finished, this, [this] {
+        setDisclaimerVisible(false);
+    });
+}
+
+BiologicalBaseDialog::~BiologicalBaseDialog()
+{
+
+}
+
+void BiologicalBaseDialog::onShowDisclaimer()
+{
+    setDisclaimerVisible(true);
+    layout()->replaceWidget(m_bioWidget, m_disclaimerWidget);
+}
+
+void BiologicalBaseDialog::onAcceptDisclaimer(bool accept)
+{
+    setDisclaimerVisible(false);
+    layout()->replaceWidget(m_disclaimerWidget, m_bioWidget);
+    m_disclaimersItem->setAcceptState(accept);
+}
+
+void BiologicalBaseDialog::setDisclaimerVisible(bool visible)
+{
+    m_bioWidget->setVisible(!visible);
+    m_disclaimerWidget->setVisible(visible);
+}
+
+}
+}

--- a/src/frame/window/modules/authentication/biologicalbasedialog.h
+++ b/src/frame/window/modules/authentication/biologicalbasedialog.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include "modules/authentication/widgets/disclaimersdialog.h"
+#include "modules/authentication/widgets/disclaimersitem.h"
+
+#include <DAbstractDialog>
+#include <DSuggestButton>
+
+namespace DCC_NAMESPACE {
+namespace authentication {
+
+/**
+ * @brief 生物特征采集弹窗的基类，公共的特性可以抽离出来放在这个类中
+ *
+ */
+class BiologicalBaseDialog : public DTK_WIDGET_NAMESPACE::DAbstractDialog
+{
+    Q_OBJECT
+public:
+    explicit BiologicalBaseDialog(QWidget *parent = nullptr);
+    ~BiologicalBaseDialog();
+
+public slots:
+    void onShowDisclaimer();
+    void onAcceptDisclaimer(bool accept);
+
+protected:
+    void setDisclaimerVisible(bool visible);
+
+protected:
+    QWidget *m_bioWidget;
+    dcc::authentication::DisclaimersDialog *m_disclaimerWidget;
+    dcc::authentication::DisclaimersItem *m_disclaimersItem; // 免责声明
+    QPushButton *m_cancelBtn; // 取消
+    DTK_WIDGET_NAMESPACE::DSuggestButton *m_acceptBtn; // 下一步
+};
+
+}
+}

--- a/src/frame/window/modules/authentication/fingedisclaimer.cpp
+++ b/src/frame/window/modules/authentication/fingedisclaimer.cpp
@@ -22,14 +22,10 @@ using namespace dcc::authentication;
 using namespace DCC_NAMESPACE::authentication;
 
 FingerDisclaimer::FingerDisclaimer(QWidget *parent)
-    : DAbstractDialog(parent)
-    , m_mainLayout(new QVBoxLayout(this))
+    : BiologicalBaseDialog(parent)
     , m_fingerPic(new QLabel(this))
     , m_resultTips(nullptr)
     , m_explainTips(nullptr)
-    , m_disclaimersItem(nullptr)
-    , m_cancelBtn(new QPushButton(this))
-    , m_acceptBtn(new DSuggestButton(this))
     , m_currentState(dcc::authentication::CharaMangerModel::AddInfoState::StartState)
 {
     initWidget();
@@ -54,10 +50,10 @@ bool FingerDisclaimer::eventFilter(QObject *o, QEvent *e)
     return false;
 }
 
-void FingerDisclaimer::initWidget()
+void FingerDisclaimer::initBioWidget()
 {
-    setFixedSize(QSize(382, 446));
-    m_mainLayout->setAlignment(Qt::AlignHCenter);
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setAlignment(Qt::AlignHCenter);
 
     DTitlebar *titleIcon = new DTitlebar();
     titleIcon->setFrameStyle(QFrame::NoFrame);//无边框
@@ -66,7 +62,7 @@ void FingerDisclaimer::initWidget()
     titleIcon->setTitle(tr("Add Fingerprint"));
 
     m_fingerPic = new QLabel(this);
-    m_fingerPic->setPixmap(QIcon::fromTheme(getFacePicture()).pixmap(128, 128));
+    m_fingerPic->setPixmap(QIcon::fromTheme(getFingerPicture()).pixmap(128, 128));
 
     // 提示信息
     m_resultTips = new QLabel(this);
@@ -81,7 +77,6 @@ void FingerDisclaimer::initWidget()
     tips->setContentsMargins(42, 10, 42, 10);
 
     // 免责声明
-    m_disclaimersItem = new DisclaimersItem(DisclaimersObj::Finge, this);
     m_disclaimersItem->show();
 
     // 下方按钮
@@ -96,20 +91,34 @@ void FingerDisclaimer::initWidget()
     btnLayout->addWidget(m_acceptBtn, Qt::AlignHorizontal_Mask);
     btnLayout->setContentsMargins(8, 10, 10, 12);
 
-    m_mainLayout->addWidget(titleIcon, Qt::AlignTop | Qt::AlignRight);
-    m_mainLayout->addSpacing(85);
-    m_mainLayout->addWidget(m_fingerPic, 0, Qt::AlignHCenter);
-    m_mainLayout->addSpacing(15);
-    m_mainLayout->addWidget(m_resultTips, 0, Qt::AlignHCenter);
-    m_mainLayout->addSpacing(10);
-    m_mainLayout->addLayout(tips);
-    m_mainLayout->addStretch();
-    m_mainLayout->addWidget(m_disclaimersItem, 0, Qt::AlignCenter);
-    m_mainLayout->addLayout(btnLayout);
+    mainLayout->addWidget(titleIcon, Qt::AlignTop | Qt::AlignRight);
+    mainLayout->addSpacing(85);
+    mainLayout->addWidget(m_fingerPic, 0, Qt::AlignHCenter);
+    mainLayout->addSpacing(15);
+    mainLayout->addWidget(m_resultTips, 0, Qt::AlignHCenter);
+    mainLayout->addSpacing(10);
+    mainLayout->addLayout(tips);
+    mainLayout->addStretch();
+    mainLayout->addWidget(m_disclaimersItem, 0, Qt::AlignCenter);
+    mainLayout->addLayout(btnLayout);
+    mainLayout->setMargin(0);
+    mainLayout->setSpacing(0);
 
-    m_mainLayout->setMargin(0);
-    m_mainLayout->setSpacing(0);
-    setLayout(m_mainLayout);
+    m_bioWidget->setLayout(mainLayout);
+}
+
+void FingerDisclaimer::initWidget()
+{
+    initBioWidget();
+    setFixedSize(QSize(382, 446));
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setAlignment(Qt::AlignHCenter);
+
+    mainLayout->addWidget(m_bioWidget);
+    mainLayout->setMargin(0);
+    mainLayout->setSpacing(0);
+    setLayout(mainLayout);
+    setDisclaimerVisible(false);
 
     this->activateWindow();
     this->setFocus();
@@ -117,13 +126,11 @@ void FingerDisclaimer::initWidget()
 
 void FingerDisclaimer::initConnect()
 {
-    connect(m_disclaimersItem, &DisclaimersItem::requestSetWindowEnabled, this, &FingerDisclaimer::onSetWindowEnabled);
-    connect(m_disclaimersItem, &DisclaimersItem::requestStateChange, m_acceptBtn, &QPushButton::setDisabled);
     connect(m_cancelBtn, &QPushButton::clicked, this, &FingerDisclaimer::close);
     connect(m_acceptBtn, &QPushButton::clicked, this, &FingerDisclaimer::requestShowFingeInfoDialog, Qt::UniqueConnection);
 }
 
-QString FingerDisclaimer::getFacePicture()
+QString FingerDisclaimer::getFingerPicture()
 {
     QString theme;
     QString icon;
@@ -141,11 +148,3 @@ QString FingerDisclaimer::getFacePicture()
 
     return QString(":/authentication/themes/%1/icons/finger/fingerprint_light.svg").arg(theme);
 }
-
-
-// 处理界面失焦效果 配合 模态对话框
-void FingerDisclaimer::onSetWindowEnabled(const bool isEnabled)
-{
-    this->setEnabled(isEnabled);
-}
-

--- a/src/frame/window/modules/authentication/fingedisclaimer.h
+++ b/src/frame/window/modules/authentication/fingedisclaimer.h
@@ -10,10 +10,9 @@
 #include "interface/namespace.h"
 #include "widgets/titlelabel.h"
 #include "widgets/buttontuple.h"
-#include "modules/authentication/widgets/disclaimersitem.h"
 #include "modules/authentication/charamangermodel.h"
+#include "biologicalbasedialog.h"
 
-#include <DSuggestButton>
 #include <DAbstractDialog>
 #include <DTipLabel>
 
@@ -36,14 +35,12 @@ using namespace dcc::widgets;
 namespace DCC_NAMESPACE {
 namespace authentication {
 
-class FingerDisclaimer : public DTK_WIDGET_NAMESPACE::DAbstractDialog
+class FingerDisclaimer : public BiologicalBaseDialog
 {
     Q_OBJECT
 public:
     explicit FingerDisclaimer(QWidget *parent = nullptr);
     ~FingerDisclaimer();
-
-    void onSetWindowEnabled(const bool isEnabled);
 
 Q_SIGNALS:
     void requestShowFingeInfoDialog();
@@ -54,18 +51,14 @@ protected:
 
 private:
     void initWidget();
+    void initBioWidget();
     void initConnect();
-    QString getFacePicture();
-
+    QString getFingerPicture();
 
 private:
-    QVBoxLayout *m_mainLayout;
     QLabel *m_fingerPic;
     QLabel *m_resultTips; // 录入结果说明
     DLabel *m_explainTips; // 状态说明信息
-    dcc::authentication::DisclaimersItem *m_disclaimersItem; // 免责声明
-    QPushButton *m_cancelBtn; // 取消
-    DTK_WIDGET_NAMESPACE::DSuggestButton *m_acceptBtn; // 下一步
     dcc::authentication::CharaMangerModel::AddInfoState m_currentState;
 };
 


### PR DESCRIPTION
现象: 添加指纹时的用户免责声明，打开窗口菜单取消勾选总在最前面，控制中心无法任何操作

修改方案：根据UI设计师的要求，将免责声明弹窗的内容作为控件合并到弹窗中，不作为独立弹窗显示。

Log: 修复取消勾选总在最前面，控制中心无法任何操作的问题
Bug: https://pms.uniontech.com/bug-view-160221.html
Influence: 免责声明标题栏右键菜单
Change-Id: I956b1f3139888082a046cadf7be73f3d86d365c1