### PR TITLE
fix: 控制中心切换显示模式时副屏显示设置窗口位置异常

### DIFF
--- a/src/frame/window/modules/display/multiscreenwidget.cpp
+++ b/src/frame/window/modules/display/multiscreenwidget.cpp
@@ -365,12 +365,14 @@ void MultiScreenWidget::initPrimaryList()
 
 void MultiScreenWidget::initSecondaryScreenDialog()
 {
-    if (m_model->displayMode() == EXTEND_MODE) {
-        for (auto dlg : m_secondaryScreenDlgList) {
-            dlg->deleteLater();
-        }
-        m_secondaryScreenDlgList.clear();
+    // 在每次显示模式切换时，先清空m_secondaryScreenDlgList
+    for (auto dlg : m_secondaryScreenDlgList) {
+        dlg->deleteLater();
+    }
 
+    m_secondaryScreenDlgList.clear();
+
+    if (m_model->displayMode() == EXTEND_MODE) {
         // x11 上 dialog 没有父窗口会导致主程序退出缓慢
         // wayland上子窗口为适应多屏就不该设置父窗口，由窗管设置
         QWidget *parent = this;

--- a/src/frame/window/modules/display/secondaryscreendialog.cpp
+++ b/src/frame/window/modules/display/secondaryscreendialog.cpp
@@ -84,6 +84,11 @@ void SecondaryScreenDialog::OnRequestResizeDesktopVisibleChanged(bool visible)
 
 void SecondaryScreenDialog::setModel(DisplayModel *model, dcc::display::Monitor *monitor)
 {
+    // 每次去显示副屏显示窗口时，先断开之前的连接
+    if (m_monitor && m_monitor->getQScreen()) {
+        m_monitor->getQScreen()->disconnect(this);
+    }
+
     m_model = model;
     m_monitor = monitor;
 
@@ -104,6 +109,11 @@ void SecondaryScreenDialog::setModel(DisplayModel *model, dcc::display::Monitor 
     connect(m_resolutionWidget, &ResolutionWidget::requestResizeDesktopVisibleChanged, this, &SecondaryScreenDialog::OnRequestResizeDesktopVisibleChanged);
     connect(m_refreshRateWidget, &RefreshRateWidget::requestSetResolution, this, &SecondaryScreenDialog::requestSetResolution);
     connect(m_rotateWidget, &RotateWidget::requestSetRotate, this, &SecondaryScreenDialog::requestSetRotate);
+
+    // 副屏的位置坐标发出改变后，再去显示副屏显示窗口的位置，防止获取到的位置异常导致窗口位置显示不对
+    if (m_monitor && m_monitor->getQScreen()) {
+       connect(m_monitor->getQScreen(), &QScreen::availableGeometryChanged, this, &SecondaryScreenDialog::resetDialog);
+    }
 
     auto tfunc = [this](const double tb) {
         int tmini = int(m_model->minimumBrightnessScale() * BrightnessMaxScale);


### PR DESCRIPTION
延时10ms后再去获取屏幕的位置信息，防止获取到的副屏的位置信息不对导致显示设置窗口显示异常

Log: 修复控制中心切换显示模式时副屏显示设置窗口位置异常的问题
Bug: https://pms.uniontech.com/bug-view-160303.html
Influence: 控制中心显示模式切换
Change-Id: I5118b805b6a3e382c04dfc139b1d14b7b68d2b15