### PR TITLE
fix: 解决时间日期-格式设置在快速切换闪其他窗口的问题

### DIFF
--- a/src/frame/window/modules/datetime/datetimemodule.cpp
+++ b/src/frame/window/modules/datetime/datetimemodule.cpp
@@ -412,7 +412,9 @@ void DatetimeModule::showFormatSetting()
 {
     Q_ASSERT(m_model);
 
-    m_fsetting = new DCC_NAMESPACE::datetime::FormatSetting(m_model);
+    dcc::ContentWidget *formatSettingsWidget = new  dcc::ContentWidget;
+
+    m_fsetting = new DCC_NAMESPACE::datetime::FormatSetting(m_model, formatSettingsWidget);
     connect(m_fsetting, &FormatSetting::weekdayFormatChanged, this, &DatetimeModule::weekdayFormatChanged);
     connect(m_fsetting, &FormatSetting::shortDateFormatChanged, this, &DatetimeModule::shortDateFormatChanged);
     connect(m_fsetting, &FormatSetting::longDateFormatChanged, this, &DatetimeModule::longDateFormatChanged);
@@ -427,8 +429,8 @@ void DatetimeModule::showFormatSetting()
     connect(m_model, &DatetimeModel::weekStartDayFormatChanged, m_fsetting, &FormatSetting::setCururentWeekStartDayFormat);
     GSettingWatcher::instance()->bind("datetimeFromatsetting", m_fsetting);
 
-    m_currencyFormatWidget = new CurrencyFormat(m_model);
-    m_numberFormatWidget = new NumberFormat(m_model);
+    m_currencyFormatWidget = new CurrencyFormat(m_model, formatSettingsWidget);
+    m_numberFormatWidget = new NumberFormat(m_model, formatSettingsWidget);
 
     connect(m_currencyFormatWidget, &CurrencyFormat::currencySymbolFormatChanged, m_numberFormatWidget, &NumberFormat::SetCurrencySymbolFormat);
     connect(m_currencyFormatWidget, &CurrencyFormat::positiveCurrencyFormatChanged, m_numberFormatWidget, &NumberFormat::SetPositiveCurrencyFormat);
@@ -437,7 +439,6 @@ void DatetimeModule::showFormatSetting()
     m_numberFormatWidget->SetPositiveCurrencyFormat(m_currencyFormatWidget->getFirstPositiveCurrencyFormatPlace());
     m_numberFormatWidget->SetNegativeCurrency(m_currencyFormatWidget->getFirstNegativeCurrencyPlace());
 
-    dcc::ContentWidget *formatSettingsWidget = new  dcc::ContentWidget;
     QWidget *widget = new QWidget(formatSettingsWidget);
     QVBoxLayout *layout = new QVBoxLayout(widget);
     layout->addWidget(m_fsetting);


### PR DESCRIPTION
给格式设置子页面设置父对象
说明:
只有在子页面构造的时候设置父对象才会生效，使用setParent没有效果

Log: 给时间日期-格式设置的3个子页面添加父对象
Influence: 格式设置快速切换
Bug: https://pms.uniontech.com/bug-view-155973.html
Change-Id: I0975fa2c979e990eb6cc9f85ddb04e170dac3237