### PR TITLE
fix: 删除键盘语言快捷键文字随活动用色变化颜色的逻辑

### DIFF
--- a/src/frame/modules/keyboard/keylabel.cpp
+++ b/src/frame/modules/keyboard/keylabel.cpp
@@ -50,7 +50,8 @@ void KeyLabel::paintEvent(QPaintEvent *event)
     option.text = m_text;
     option.palette.setBrush(QPalette::Light, option.palette.base());
     option.palette.setBrush(QPalette::Dark, option.palette.base());
-    option.palette.setBrush(QPalette::ButtonText, option.palette.highlight());
+    // 暂时删除随个性化改变数据颜色
+//    option.palette.setBrush(QPalette::ButtonText, option.palette.highlight());
     option.palette.setBrush(QPalette::Shadow, Qt::transparent);
     stylePainter.drawControl(QStyle::CE_PushButton, option);
 }


### PR DESCRIPTION
按照社区测试要求，删除键盘的语言-快捷键文字用色会随着活动用色变化的逻辑

Log: 快捷键颜色不改变颜色
Influence: 快捷键数据显示
Bug: https://pms.uniontech.com/bug-view-142957.html
Change-Id: I97bae0a18e5c114fc5684d46c21e93e91ab949e8