### PR TITLE
fix: 修复控制中心显示模块主窗口覆盖子窗口的问题

### DIFF
--- a/src/frame/window/modules/display/displaymodule.cpp
+++ b/src/frame/window/modules/display/displaymodule.cpp
@@ -285,10 +285,7 @@ void DisplayModule::showMultiScreenWidget()
     });
 
     MultiScreenWidget *multiScreenWidget = new MultiScreenWidget();
-    //wayland情况下这里设置父窗口会影响窗口最大化/还原的问题，详见bug 125867
-    if(!QGuiApplication::platformName().startsWith("wayland", Qt::CaseInsensitive)){
-        multiScreenWidget->setParent(m_pMainWindow);
-    }
+    multiScreenWidget->setParent(m_pMainWindow);
 
     multiScreenWidget->setModel(m_displayModel);
     connect(multiScreenWidget, &MultiScreenWidget::requestSwitchMode, m_displayWorker, &DisplayWorker::switchMode);

--- a/src/frame/window/modules/display/multiscreenwidget.cpp
+++ b/src/frame/window/modules/display/multiscreenwidget.cpp
@@ -373,19 +373,13 @@ void MultiScreenWidget::initSecondaryScreenDialog()
     m_secondaryScreenDlgList.clear();
 
     if (m_model->displayMode() == EXTEND_MODE) {
-        // x11 上 dialog 没有父窗口会导致主程序退出缓慢
-        // wayland上子窗口为适应多屏就不该设置父窗口，由窗管设置
-        QWidget *parent = this;
-        if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
-            parent = nullptr;
-        }
         for (const auto &monitor : m_model->monitorList()) {
             if (monitor == m_model->primaryMonitor()) {
                 QTimer::singleShot(0, this, [=] { requestSetMainwindowRect(m_model->primaryMonitor(), true); });
                 continue;
             }
 
-            SecondaryScreenDialog *dlg = new SecondaryScreenDialog(parent);
+            SecondaryScreenDialog *dlg = new SecondaryScreenDialog(this);
             dlg->setAttribute(Qt::WA_WState_WindowOpacitySet);
             dlg->setModel(m_model, monitor);
             connect(dlg, &SecondaryScreenDialog::requestRecognize, this, &MultiScreenWidget::requestRecognize);
@@ -408,7 +402,11 @@ void MultiScreenWidget::initSecondaryScreenDialog()
         if (!qgetenv("WAYLAND_DISPLAY").isEmpty()) {
             QTimer::singleShot(10, this, [=] {
                 for (auto dlg : m_secondaryScreenDlgList) {
+                    dlg->setWindowFlags(Qt::CoverWindow);
                     dlg->show();
+                    QTimer::singleShot(50, dlg, [dlg] { // 此处延时刷新子窗口位置，是因为子窗口在主屏闪现的问题(bug153993)，待窗管处理之后回退
+                        dlg->resetDialog();
+                    });
                 }
             });
         }


### PR DESCRIPTION
由于之前为了规避窗管最大化的问题，导致子窗口被可以主窗口覆盖，现回退相关代码，并延迟刷新子窗口位置，待窗管修复后，回退此操作

Log: 修复控制中心显示模块主窗口覆盖子窗口的问题
Bug: https://pms.uniontech.com/bug-view-154395.html
Influence: 显示模块窗口
Change-Id: I0e10aac2a5eab21206c459bca439f6e630cb4001