### PR TITLE
fix: wayland下监听QApplication::screenAdded信号

### DIFF
--- a/src/frame/window/modules/display/multiscreenwidget.cpp
+++ b/src/frame/window/modules/display/multiscreenwidget.cpp
@@ -120,6 +120,15 @@ MultiScreenWidget::MultiScreenWidget(QWidget *parent)
     QDesktopWidget *desktopwidget = QApplication::desktop();
     connect(desktopwidget,SIGNAL(workAreaResized(int)),this,SLOT(onResetSecondaryScreenDlg()));
 
+    // 仅HDMI屏切换到以HDMI为主屏的扩展模式时，只触发显示模式变化信号，不会触发主屏变化信号，此时只会执行一次initSecondaryScreenDialog，
+    // 此时获取QApplication::screens数据不准确，只获取到一个屏幕，另外一个屏幕无法获取，导致副界面位置不对
+    // 在SecondaryScreenDialog::resetDialog中，m_monitor->getQScreen()为空
+    connect(qApp, &QApplication::screenAdded, this, [ = ]{
+        if (qEnvironmentVariable("XDG_SESSION_TYPE").contains("wayland")) {
+            initSecondaryScreenDialog();
+        }
+    });
+
 }
 
 MultiScreenWidget::~MultiScreenWidget()


### PR DESCRIPTION
仅HDMI屏切换到以HDMI为主屏的扩展模式时，只触发显示模式变化信号，不会触发主屏变化信号，此时只会执行一次initSecondaryScreenDialog 此时获取QApplication::screens数据更新不及时，只获取到一个屏幕，在SecondaryScreenDialog::resetDialog中， m_monitor->getQScreen()为空无法获取副屏数据,导致界面位置不正确

Log: 修复复制模式切到扩展模式(HDMI主屏)或插拔VGA线,副屏显示设置显示在主屏的问题
Bug: https://pms.uniontech.com/bug-view-160303.html
Influence: 副屏显示设置界面显示到正确的位置