### PR TITLE
fix: 修复dde-daemon低于5.14.101-1版本升级重启后,首次操作快捷键[恢复默认]按钮,关闭窗口快捷键显示异常的问题

### DIFF
--- a/src/frame/window/modules/keyboard/shortcutsettingwidget.cpp
+++ b/src/frame/window/modules/keyboard/shortcutsettingwidget.cpp
@@ -480,8 +480,11 @@ void ShortCutSettingWidget::onRemoveItem(const QString &id, int type)
 
 void ShortCutSettingWidget::onShortcutChanged(ShortcutInfo *info)
 {
+    if (info->type == MEDIAKEY) { // 控制中心不处理mediakey
+        return;
+    }
     for (ShortcutItem *item : m_allList) {
-        if (item->curInfo()->id == info->id) {
+        if (item->curInfo()->id == info->id && item->curInfo()->type == info->type) {
             item->setShortcutInfo(info);
             break;
         }


### PR DESCRIPTION
dde-daemon会删除重复键值的快捷键，而close和media-close键值相同，低版本的dde-daemon未过滤close，导致被置空，升级之后，点击恢复会发出Changed信号， 此时控制中心没有对比type，导致同名快捷键被修改

Log: 修复dde-daemon低于5.14.101-1版本升级重启后,首次操作快捷键[恢复默认]按钮,关闭窗口快捷键显示异常的问题
Bug: https://pms.uniontech.com/bug-view-156565.html
Influence: 快捷键
Change-Id: Ic14d75f54a3271091e134103b452a21dcf05be33