### PR TITLE
fix(Account): 不能点击的sudo置灰,只存在一个管理账户不能移除sudo权限

### DIFF
--- a/src/frame/window/modules/accounts/usergroupspage.h
+++ b/src/frame/window/modules/accounts/usergroupspage.h
@@ -35,6 +35,7 @@ private Q_SLOTS:
 private:
     void initWidget();
     void initData();
+    int getAdministratorAccountsCount();
 
 private:
     QString m_groupName;


### PR DESCRIPTION
1. 不能点击的sudo置灰色；
2. 仅存在一个管理账户不允许移除sudo权限；

Log: 不能点击的sudo置灰，仅仅存在一个管理账户不能移除sudo权限
Influence: only one sudo account remove sudo
Bug: https://pms.uniontech.com/bug-view-162113.html
Bug: https://pms.uniontech.com/bug-view-162003.html
Change-Id: Ice29913a00bb6e78bb1eca4afe4f1edc244af6c3