### PR TITLE
chore: 修正判断管理员账户类型

### DIFF
--- a/src/frame/window/modules/accounts/usergroupspage.cpp
+++ b/src/frame/window/modules/accounts/usergroupspage.cpp
@@ -103,7 +103,7 @@ void UserGroupsPage::onGidChanged(const QString &gid)
                 break;
             }
             if (item->text() == Sudo) {
-                if (!(m_curUser && m_curUser->online()) && !(managerAccountsCount == 1 && m_curUser->userType())) {
+                if (!(m_curUser && m_curUser->online()) && !(managerAccountsCount == 1 && m_curUser->userType() == User::UserType::Administrator)) {
                     value = true;
                 }
             } else {
@@ -168,7 +168,7 @@ int UserGroupsPage::getAdministratorAccountsCount()
     }
     int count = 0;
     for (auto data : m_userModel->userList()) {
-        if (data->userType()) {
+        if (data->userType() == User::UserType::Administrator) {
             count++;
         }
     }


### PR DESCRIPTION
账户类型有3种：
    enum UserType {
        StandardUser = 0,
        Administrator,
        Customized
    };
Administrator才是管理员账户，按之前的判断方法会把域管账户也判断成管理员

Log: 修正管理员账户判断方式
Influence: 账户判断
Bug: https://pms.uniontech.com/bug-view-162003.html
Change-Id: Ib349eeaa3fe042122990e248eaddd2cc2e705f4d