### PR TITLE
fix: 优化添加时区和设置时区交互逻辑

### DIFF
--- a/src/frame/modules/datetime/timezone_dialog/popup_menu.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/popup_menu.cpp
@@ -146,6 +146,7 @@ void PopupMenu::paintEvent(QPaintEvent* event) {
 
 void PopupMenu::showEvent(QShowEvent* event) {
   qApp->installEventFilter(this);
+  Q_EMIT onShow();
   QFrame::showEvent(event);
 }
 

--- a/src/frame/modules/datetime/timezone_dialog/popup_menu.h
+++ b/src/frame/modules/datetime/timezone_dialog/popup_menu.h
@@ -26,6 +26,7 @@ class PopupMenu : public QFrame {
  Q_SIGNALS:
   // Q_EMITted when window is hidden.
   void onHide();
+  void onShow();
 
   // Q_EMITted when a menu item at |index| is activated.
   void menuActivated(int index);

--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
@@ -5,6 +5,7 @@
 #include "timezone_map.h"
 
 #include <QDebug>
+#include <QTimer>
 #include <QItemSelectionModel>
 #include <QLabel>
 #include <QListView>
@@ -58,7 +59,7 @@ TimezoneMap::~TimezoneMap() {
 }
 
 const QString TimezoneMap::getTimezone() const {
-  return current_zone_.timezone;
+    return current_zone_.timezone;
 }
 
 bool TimezoneMap::setTimezone(const QString &timezone)
@@ -117,7 +118,17 @@ void TimezoneMap::resizeEvent(QResizeEvent* event) {
 void TimezoneMap::initConnections() {
   // Hide dot when popup-zones window is hidden.
   connect(popup_window_, &PopupMenu::onHide,
-          dot_, &QLabel::hide);
+          dot_, [this]() {
+      dot_->setHidden(true);
+      Q_EMIT notifyPopupWindowVisibleChanged();
+  });
+
+  connect(popup_window_, &PopupMenu::onShow, this, [this]() {
+      QTimer::singleShot(50, [this]() {
+          // 确保该信号是在最后发送
+          Q_EMIT notifyPopupWindowVisibleChanged();
+      });
+  });
 
   // Hide popup_window_ and mark new timezone on map.
   connect(popup_window_, &PopupMenu::menuActivated,

--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.h
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.h
@@ -31,6 +31,7 @@ class TimezoneMap : public QFrame {
 
  Q_SIGNALS:
   void timezoneUpdated(const QString& timezone);
+  void notifyPopupWindowVisibleChanged();
 
  public Q_SLOTS:
   // Remark |timezone| on map.

--- a/src/frame/modules/datetime/timezone_dialog/timezonechooser.h
+++ b/src/frame/modules/datetime/timezone_dialog/timezonechooser.h
@@ -35,6 +35,7 @@ class SearchInput;
 
 namespace dcc {
 namespace datetime {
+class DatetimeModel;
 
 class TimeZoneChooser : public QFrame
 {
@@ -44,6 +45,7 @@ public:
     void setIsAddZone(const bool isAdd);
     inline bool isAddZone() { return m_isAddZone; }
     void setCurrentTimeZoneText(const QString &zone);
+    void setMode(DatetimeModel* model);
 
 Q_SIGNALS:
     void confirmed(const QString &zone);
@@ -51,6 +53,7 @@ Q_SIGNALS:
 
 public Q_SLOTS:
     void setMarkedTimeZone(const QString &timezone);
+    void setRightBtnState(QString zone = "");
 
 protected:
     void resizeEvent(QResizeEvent *event) override;
@@ -80,6 +83,7 @@ private:
     LangSelector *m_currLangSelector;
     QCompleter *m_completer;
     const installer::ZoneInfoList m_totalZones;
+    DatetimeModel* m_model;
 };
 
 } // namespace datetime

--- a/src/frame/window/modules/datetime/datetimemodule.cpp
+++ b/src/frame/window/modules/datetime/datetimemodule.cpp
@@ -393,6 +393,7 @@ void DatetimeModule::ensureZoneChooserDialog()
         return;
 
     m_dialog = new TimeZoneChooser(m_pMainWindow);
+    m_dialog->setMode(m_model);
     m_dialog->setAttribute(Qt::WA_DeleteOnClose);
 
     connect(m_dialog, &TimeZoneChooser::confirmed, this, [this](const QString & timezone) {


### PR DESCRIPTION
1.如果选择的时区与当前时区相同，则不允许点击确定；
2.如果选中的时区出现了多个时区label，也不允许点击确定，需要选择一个后才能点击确定；
3.时区地图上没有label页面也不允许点击确定；

Log: 优化添加时区和设置时区的交互逻辑；
Influence: 时区添加和时区设置
Bug: https://pms.uniontech.com/bug-view-161133.html
Change-Id: I44f361614ca189d7f9393e960a9f6b87abe3c93e