### PR TITLE
fix: 修复重试时进入下载并安装流程

### DIFF
--- a/src/frame/modules/update/updatework.cpp
+++ b/src/frame/modules/update/updatework.cpp
@@ -1833,6 +1833,10 @@ void UpdateWorker::onClassifiedUpdatablePackagesChanged(QMap<QString, QStringLis
 
 void UpdateWorker::onFixError(const ClassifyUpdateType &updateType, const QString &errorType)
 {
+    if (errorType == "noNetwork") {
+        this->checkForUpdates();
+        return;
+    }
     m_fixErrorUpdate.append(updateType);
     if (m_fixErrorJob != nullptr) {
         return;

--- a/src/frame/window/modules/update/updatesettingitem.cpp
+++ b/src/frame/window/modules/update/updatesettingitem.cpp
@@ -337,6 +337,12 @@ void UpdateSettingItem::onRetryUpdate()
         return;
     }
 
+    if (m_updateJobErrorMessage == UpdateErrorType::NoNetwork) {
+        Q_EMIT requestFixError(m_classifyUpdateType, "noNetwork");
+        return;
+    }
+
+
     onStartUpdate();
 }
 


### PR DESCRIPTION
由于网络问题重试默认进入下载并安装流程，并且lastore未提供分类下载的接口，因此网络问题重试需要进入检查更新流程，触发自动下载。另外网络问题导致中断，需要重新检查更新防止仓库更新。

Log: 修复重试时进入下载并安装流程
Bug: https://pms.uniontech.com/bug-view-161177.html
Influence: 更新重试
Change-Id: Ia17bab5a303a8c6bab6b92022ebc23dea20da37f