### PR TITLE
Revert "fix: 点击鼠标左键，快速移动鼠标，释放的时候进入对应模块"

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -148,9 +148,6 @@ MainWindow::MainWindow(QWidget *parent)
     m_searchWidget->lineEdit()->setAccessibleName("SearchModuleLineEdit");
     GSettingWatcher::instance()->bind("mainwindowSearchEdit", m_searchWidget);
 
-    m_currentIndex.first = m_navView->viewMode();
-    m_currentIndex.second = m_navView->currentIndex();
-
     DTitlebar *titlebar = this->titlebar();
     auto widhetlist = titlebar->children();
     for (auto child : widhetlist) {
@@ -755,16 +752,6 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
             openManual();
             return true;
         }
-    } else if (event->type() == QEvent::MouseButtonRelease) {
-        QMouseEvent *mouseEvent = static_cast<QMouseEvent *>(event);
-        if (mouseEvent->button() == Qt::MouseButton::LeftButton) {
-            if (m_currentIndex.first != m_navView->viewMode() ||
-                m_currentIndex.second != m_navView->currentIndex()) {
-                m_currentIndex.first = m_navView->viewMode();
-                m_currentIndex.second = m_navView->currentIndex();
-                onFirstItemClick(m_currentIndex.second);
-            }
-        }
     }
 
     return  DMainWindow::eventFilter(watched, event);
@@ -1235,10 +1222,6 @@ void MainWindow::updateViewBackground()
 
 void MainWindow::onFirstItemClick(const QModelIndex &index)
 {
-    if (index.row() < 0 || !m_modules[index.row()].first) {
-        return;
-    }
-
     ModuleInterface *inter = m_modules[index.row()].first;
 
     if (!m_contentStack.isEmpty() && m_contentStack.first().first == inter) {

--- a/src/frame/window/mainwindow.h
+++ b/src/frame/window/mainwindow.h
@@ -169,7 +169,6 @@ private:
     QWidget *m_lastPushWidget{nullptr};     //用于记录最后push进来的widget控件
     QSize m_lastSize;
     bool m_needRememberLastSize = true;     //用于判断是否需要上次resize的窗口大小
-    QPair<QListView::ViewMode, QModelIndex> m_currentIndex;
 
     //全局搜索
     QList<QJsonObject> m_lstGrandSearchTasks;


### PR DESCRIPTION
This reverts commit 384eaba93e251e855bd52e9d7f23692a8b10103c.

Log: 回退上述逻辑，使用其他方法
Influence: 点击鼠标左键不放，快速移动鼠标
Bug: https://pms.uniontech.com/bug-view-162933.html