### PR TITLE
fix: 点击鼠标左键，快速移动鼠标，释放的时候进入对应页面

### DIFF
--- a/include/widgets/multiselectlistview.h
+++ b/include/widgets/multiselectlistview.h
@@ -19,11 +19,16 @@ public:
     explicit MultiSelectListView(QWidget *parent = nullptr);
     void resetStatus(const QModelIndex &index);
 
+Q_SIGNALS:
+    void notifySelectionChanged(const QModelIndex &index);
+
 protected:
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
     QModelIndex moveCursor(CursorAction cursorAction, Qt::KeyboardModifiers modifiers) override;
     void keyPressEvent(QKeyEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
+    void selectionChanged(const QItemSelection &selected, const QItemSelection &deselected) override;
+
 private:
     int m_currentIndex;
 };

--- a/src/frame/widgets/multiselectlistview.cpp
+++ b/src/frame/widgets/multiselectlistview.cpp
@@ -77,5 +77,12 @@ void MultiSelectListView::mousePressEvent(QMouseEvent *event)
         return;
     return DListView::mousePressEvent(event);
 }
+
+void MultiSelectListView::selectionChanged(const QItemSelection &selected, const QItemSelection &deselected)
+{
+    Q_EMIT notifySelectionChanged(currentIndex());
+    return DListView::selectionChanged(selected, deselected);
+}
+
 }
 }

--- a/src/frame/window/mainwindow.h
+++ b/src/frame/window/mainwindow.h
@@ -173,6 +173,8 @@ private:
     //全局搜索
     QList<QJsonObject> m_lstGrandSearchTasks;
     QPointer<QScreen> m_primaryScreen;
+    int m_currentIndex = -1;
+    bool m_bIsNeedChange = false;
 };
 }
 


### PR DESCRIPTION
使用选中信号和鼠标左键释放信号一起确定切换页面的时机

Log: 点击鼠标左键，快速移动鼠标，释放的时候进入对应页面
Influence: 点击鼠标左键，快速移动鼠标
Bug: https://pms.uniontech.com/bug-view-162933.html
Change-Id: I11949cbbfe5434e0a65983973fc9fae561b37b53