### PR TITLE
fix: 修复设置头像成功后，控制中心标题栏返回键出现Focus状态的问题

### DIFF
--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -514,6 +514,7 @@ void AccountsDetailWidget::initSetting(QVBoxLayout *layout)
     //图像列表操作
     connect(m_avatarListWidget, &AvatarListWidget::requestSetAvatar, this, [ = ](const QString & avatarPath) {
         Q_EMIT requestSetAvatar(m_curUser, avatarPath);
+        setFocus();
     });
 
     //切换账户类型


### PR DESCRIPTION
设置头像之后，焦点被返回键捕获，窗口需要设置下焦点

Log: 修复设置头像成功后，控制中心标题栏返回键出现Focus状态的问题
Influence: 控制中心设置头像
Bug: https://pms.uniontech.com/bug-view-162947.html
Change-Id: I00f1cf44c3b4f9ff83dd261ee9d710761f94ea1a