### PR TITLE
fix: 修复在控制中心-个性化调节任务栏大小，会改变控制中心窗口位置的问题

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -295,7 +295,10 @@ void MainWindow::setPrimaryScreen(QScreen *screen)
     m_primaryScreen = screen;
     updateWinsize();
     connect(m_primaryScreen, &QScreen::geometryChanged, this, &MainWindow::updateWinsize);
-    connect(m_primaryScreen, &QScreen::availableGeometryChanged, this, &MainWindow::updateWinsize);
+    // 主屏变化后，根据新主屏的分辨率移动窗口居中
+    connect(qApp, &QGuiApplication::primaryScreenChanged, this, [this] {
+        updateWinsize(m_primaryScreen->geometry());
+    });
 }
 
 QScreen *MainWindow::primaryScreen() const


### PR DESCRIPTION
当改变任务栏大小后，也会发出availableGeometryChanged信号，导致控制中心位置更新

Log: 修复在控制中心-个性化调节任务栏大小，会改变控制中心窗口位置的问题
Bug: https://pms.uniontech.com/bug-view-163043.html
Influence: 控制中心-个性化调节任务栏大小
Change-Id: Iddb2de585eb5b1df392436905b0c6f2ed3aafb70