### PR TITLE
fix: 修复【虚拟机】【个性化】点击“移动窗口时启用透明特性”开关无响应，最小化效果为“魔灯”时无魔灯效果的问题

### DIFF
--- a/src/frame/modules/personalization/personalizationwork.cpp
+++ b/src/frame/modules/personalization/personalizationwork.cpp
@@ -386,6 +386,53 @@ void PersonalizationWork::refreshFontByType(const QString &type)
     connect(fontWatcher, &QDBusPendingCallWatcher::finished, this, &PersonalizationWork::onGetFontFinished);
 }
 
+void PersonalizationWork::refreshEffectModule()
+{
+    QDBusInterface effects("org.kde.KWin", "/Effects", "org.kde.kwin.Effects", QDBusConnection::sessionBus(), this);
+    if (effects.isValid()) {
+        QDBusPendingCall scaleEffectReply = effects.asyncCall("isEffectSupported", "kwin4_effect_scale");
+        QDBusPendingCallWatcher *scaleEffectWatcher = new QDBusPendingCallWatcher(scaleEffectReply, this);
+        connect(scaleEffectWatcher, &QDBusPendingCallWatcher::finished, [this, scaleEffectReply, scaleEffectWatcher] {
+            if (!scaleEffectReply.isError()) {
+                QDBusReply<bool> reply = scaleEffectReply.reply();
+                if (reply.value()) {
+                    Q_EMIT requestShowMiniEffect("kwin4_effect_scale");
+                }
+            } else {
+                qWarning() << "Failed to get kwin4_effect_scale state: " << scaleEffectReply.error().message();
+            }
+            scaleEffectWatcher->deleteLater();
+        });
+
+        QDBusPendingCall magiclampEffectReply = effects.asyncCall("isEffectSupported", "magiclamp");
+        QDBusPendingCallWatcher *magiclampEffectWatcher = new QDBusPendingCallWatcher(magiclampEffectReply, this);
+        connect(magiclampEffectWatcher, &QDBusPendingCallWatcher::finished, [this, magiclampEffectReply, magiclampEffectWatcher] {
+            if (!magiclampEffectReply.isError()) {
+                QDBusReply<bool> reply = magiclampEffectReply.reply();
+                if (reply.value()) {
+                    Q_EMIT requestShowMiniEffect("magiclamp");
+                }
+            } else {
+                qWarning() << "Failed to get magiclamp state: " << magiclampEffectReply.error().message();
+            }
+            magiclampEffectWatcher->deleteLater();
+        });
+
+        QDBusPendingCall translucencyEffectReply = effects.asyncCall("isEffectSupported", "kwin4_effect_translucency");
+        QDBusPendingCallWatcher *translucencyEffectWatcher = new QDBusPendingCallWatcher(translucencyEffectReply, this);
+        connect(translucencyEffectWatcher, &QDBusPendingCallWatcher::finished, [this, translucencyEffectReply, translucencyEffectWatcher] {
+            if (!translucencyEffectReply.isError()) {
+                QDBusReply<bool> reply = translucencyEffectReply.reply();
+                if (reply.value())
+                    Q_EMIT requestShowWindowMovedSwitch();
+            } else {
+                qWarning() << "Failed to get kwin4_effect_translucency state: " << translucencyEffectReply.error().message();
+            }
+            translucencyEffectWatcher->deleteLater();
+        });
+    }
+}
+
 void PersonalizationWork::refreshActiveColor(const QString &color)
 {
     m_model->setActiveColor(color);

--- a/src/frame/modules/personalization/personalizationwork.h
+++ b/src/frame/modules/personalization/personalizationwork.h
@@ -38,6 +38,11 @@ public:
     void onGetList();
     void refreshTheme();
     void refreshFont();
+    void refreshEffectModule();
+
+Q_SIGNALS:
+    void requestShowMiniEffect(const QString &option);
+    void requestShowWindowMovedSwitch();
 
 public Q_SLOTS:
     void setDefault(const QJsonObject &value);

--- a/src/frame/window/modules/personalization/personalizationgeneral.cpp
+++ b/src/frame/window/modules/personalization/personalizationgeneral.cpp
@@ -90,7 +90,7 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
     , m_centralLayout(new QVBoxLayout())
     , m_wmSwitch(nullptr)
     , m_transparentSlider(nullptr)
-    , m_cmbMiniEffect(new ComboxWidget)
+    , m_cmbMiniEffect(nullptr)
     , m_windowMovedSwitch(nullptr)
     , m_windowMovedLabel(nullptr)
     , m_displayData("")
@@ -100,6 +100,8 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
     , m_switchWidget(new QWidget)
     , m_isWayland(qEnvironmentVariable("XDG_SESSION_TYPE").contains("wayland"))
     , m_movedWinSwitchItem(nullptr)
+    , m_winEffectVLayout(nullptr)
+    , m_isShowWinEffect(false)
 {
     m_centralLayout->setMargin(0);
     m_centralLayout->setContentsMargins(ThirdPageContentsMargins);
@@ -162,9 +164,9 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
 
     if (!m_bSystemIsServer) {
         //sw switch
-        QVBoxLayout *winEffectVLayout = new QVBoxLayout();
-        winEffectVLayout->addSpacing(20);
-        m_switchWidget->setLayout(winEffectVLayout);
+        m_winEffectVLayout = new QVBoxLayout();
+        m_winEffectVLayout->addSpacing(20);
+        m_switchWidget->setLayout(m_winEffectVLayout);
         m_switchWidget->setAccessibleName("switchWidget");
 
         m_wmSwitch = new DSwitchButton();
@@ -184,9 +186,9 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
         swswitchLayout->addStretch();
         swswitchLayout->addWidget(m_wmSwitch);
         swswitchLayout->setContentsMargins(10, 0, 10, 0);
-        winEffectVLayout->addWidget(switem);
-        winEffectVLayout->setContentsMargins(0, 0, 0, 0);
-        winEffectVLayout->addSpacing(10);
+        m_winEffectVLayout->addWidget(switem);
+        m_winEffectVLayout->setContentsMargins(0, 0, 0, 0);
+        m_winEffectVLayout->addSpacing(10);
 
         //~ contents_path /personalization/General
         //~ child_page General
@@ -207,49 +209,15 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
         slider->setTickPosition(QSlider::TicksBelow);
         slider->setTickInterval(1);
         slider->setPageStep(1);
-        winEffectVLayout->addWidget(m_transparentSlider);
-        winEffectVLayout->addSpacing(10);
+        m_winEffectVLayout->addWidget(m_transparentSlider);
+        m_winEffectVLayout->addSpacing(10);
 
         //~ contents_path /personalization/General
         //~ child_page General
-        m_cmbMiniEffect->setTitle(tr("Window Minimize Effect"));
-        m_cmbMiniEffect->addBackground();
-        QStringList options;
-        options << tr("Scale") << tr("Magic Lamp");
-        m_cmbMiniEffect->setComboxOption(options);
-        winEffectVLayout->addWidget(m_cmbMiniEffect);
-
-        //窗口移动时启用透明特效
-        winEffectVLayout->addSpacing(10);
-        m_windowMovedSwitch = new DSwitchButton();
-        QHBoxLayout *movedWinSwitchLayout = new QHBoxLayout();
-        m_movedWinSwitchItem = new dcc::widgets::SettingsItem;
-        m_movedWinSwitchItem->setFixedHeight(MovedWindowWidgetHeight);
-        m_movedWinSwitchItem->addBackground();
-        m_movedWinSwitchItem->setLayout(movedWinSwitchLayout);
-
-        //用于记录原始内容长度，解决内容过长显示不全的问题
-        //~ contents_path /personalization/General
-        //~ child_page General
-        m_displayData = tr("Show transparency effects when a window is moved");
-        m_windowMovedLabel = new QLabel(m_displayData);
-        m_windowMovedLabel->setText(QFontMetrics(m_windowMovedLabel->font()).elidedText(m_displayData, Qt::ElideRight, 280));//显示省略号的字符串
-
-        movedWinSwitchLayout->addWidget(m_windowMovedLabel);
-        movedWinSwitchLayout->addStretch();
-        movedWinSwitchLayout->addWidget(m_windowMovedSwitch);
-        movedWinSwitchLayout->setContentsMargins(10, 0, 10, 0);
-        winEffectVLayout->addWidget(m_movedWinSwitchItem);
-        winEffectVLayout->setContentsMargins(0, 0, 0, 0);
-        DConfigWatcher::instance()->bind(DConfigWatcher::personalization, "effectMovewindowTranslucency", m_movedWinSwitchItem);
-        m_movedWinSwitchItem->setVisible(DConfigWatcher::instance()->getStatus(DConfigWatcher::personalization, "effectMovewindowTranslucency") != "Hidden");
-
         connect(m_transparentSlider->slider(), &dcc::widgets::DCCSlider::valueChanged, this,
                 &PersonalizationGeneral::requestSetOpacity);
         connect(m_transparentSlider->slider(), &dcc::widgets::DCCSlider::sliderMoved, this,
                 &PersonalizationGeneral::requestSetOpacity);
-        connect(m_cmbMiniEffect, &dcc::widgets::ComboxWidget::onIndexChanged, this,
-                &PersonalizationGeneral::requestSetMiniEffect);
 
         connect(m_wmSwitch, &DTK_WIDGET_NAMESPACE::DSwitchButton::clicked, this, [this](bool checked) {
                 if (!m_model) {
@@ -258,16 +226,8 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
                 qDebug() << "DSwitchButton::clicked:" << checked << ",m_model->is3DWm():" << m_model->is3DWm();
                 m_wmSwitch->setChecked(m_model->is3DWm());
                 Q_EMIT requestWindowSwitchWM(checked);
-                Q_EMIT requestSetMiniEffect(m_cmbMiniEffect->comboBox()->currentIndex());
-        });
-
-        connect(m_windowMovedSwitch,  &DTK_WIDGET_NAMESPACE::DSwitchButton::clicked, this, [this](bool checked) {
-            if (!m_model) {
-                return;
-            }
-            qDebug() << "DSwitchButton::clicked:" << checked << ",m_model->isMoveWindow():" << m_model->isMoveWindow();
-            m_windowMovedSwitch->setChecked(m_model->isMoveWindow());
-            Q_EMIT requestMovedWindowSwitchWM(checked);
+                if (m_cmbMiniEffect)
+                    Q_EMIT requestSetMiniEffect(m_cmbMiniEffect->comboBox()->currentIndex());
         });
 
         connect(this, &PersonalizationGeneral::windowMovedVisibleChanged, this, [this](bool value) {
@@ -279,7 +239,6 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
             }
         });
 
-        winEffectVLayout->addSpacing(10);
         m_winRoundSlider = new dcc::widgets::TitledSliderItem(tr("Rounded Corner"));
         m_winRoundSlider->addBackground();
         m_winRoundSlider->slider()->setOrientation(Qt::Horizontal);
@@ -294,8 +253,8 @@ PersonalizationGeneral::PersonalizationGeneral(QWidget *parent)
         sliderRound->setRange(0, 2);
         sliderRound->setTickInterval(1);
         sliderRound->setPageStep(1);
-        winEffectVLayout->addWidget(m_winRoundSlider);
-        winEffectVLayout->addStretch(20);
+        m_winEffectVLayout->addWidget(m_winRoundSlider);
+        m_winEffectVLayout->addStretch(20);
 
         connect(m_winRoundSlider->slider(), &dcc::widgets::DCCSlider::valueChanged, this, [=](int value){
             int val = value;
@@ -340,7 +299,77 @@ PersonalizationGeneral::~PersonalizationGeneral()
 {
     GSettingWatcher::instance()->erase("perssonalGeneralThemes", m_Themes);
     GSettingWatcher::instance()->erase("perssonalGeneralEffects", m_switchWidget);
-    DConfigWatcher::instance()->erase(DConfigWatcher::personalization, "effectMovewindowTranslucency", m_movedWinSwitchItem);
+    if (m_movedWinSwitchItem)
+        DConfigWatcher::instance()->erase(DConfigWatcher::personalization, "effectMovewindowTranslucency", m_movedWinSwitchItem);
+}
+
+void PersonalizationGeneral::onShowMiniEffect(const QString &option)
+{
+    if (!m_isShowWinEffect) {
+        m_isShowWinEffect = true;
+        m_winEffectVLayout->insertSpacing(4, 10);
+        m_cmbMiniEffect = new ComboxWidget();
+        m_cmbMiniEffect->setTitle(tr("Window Minimize Effect"));
+        m_cmbMiniEffect->addBackground();
+        if (option == "kwin4_effect_scale")
+            m_options << tr("Scale");
+        if (option == "magiclamp")
+            m_options << tr("Magic Lamp");
+        m_cmbMiniEffect->setComboxOption(m_options);
+        m_winEffectVLayout->insertWidget(5, m_cmbMiniEffect);
+        if (m_cmbMiniEffect) {
+            connect(m_cmbMiniEffect, &dcc::widgets::ComboxWidget::onIndexChanged, this,
+                    &PersonalizationGeneral::requestSetMiniEffect);
+        }
+    } else {
+        if (!m_options.contains(option)) {
+            if (option == "kwin4_effect_scale") {
+                m_options << tr("Scale");
+            }
+            if (option == "magiclamp") {
+                m_options << tr("Magic Lamp");
+            }
+            m_cmbMiniEffect->setComboxOption(m_options);
+        }
+    }
+}
+
+void PersonalizationGeneral::onShowWindowMovedSwitch()
+{
+    // 窗口移动时启用透明特效
+    m_winEffectVLayout->insertSpacing(m_isShowWinEffect ? 6 : 4, 10);
+    m_windowMovedSwitch = new DSwitchButton();
+    QHBoxLayout *movedWinSwitchLayout = new QHBoxLayout();
+    m_movedWinSwitchItem = new dcc::widgets::SettingsItem;
+    m_movedWinSwitchItem->setFixedHeight(MovedWindowWidgetHeight);
+    m_movedWinSwitchItem->addBackground();
+    m_movedWinSwitchItem->setLayout(movedWinSwitchLayout);
+
+    //用于记录原始内容长度，解决内容过长显示不全的问题
+    //~ contents_path /personalization/General
+    //~ child_page General
+    m_displayData = tr("Show transparency effects when a window is moved");
+    m_windowMovedLabel = new QLabel(m_displayData);
+    m_windowMovedLabel->setText(QFontMetrics(m_windowMovedLabel->font()).elidedText(m_displayData, Qt::ElideRight, 280));//显示省略号的字符串
+
+    movedWinSwitchLayout->addWidget(m_windowMovedLabel);
+    movedWinSwitchLayout->addStretch();
+    movedWinSwitchLayout->addWidget(m_windowMovedSwitch);
+    movedWinSwitchLayout->setContentsMargins(10, 0, 10, 0);
+    m_winEffectVLayout->insertWidget(m_isShowWinEffect ? 7 : 5, m_movedWinSwitchItem);
+    m_winEffectVLayout->setContentsMargins(0, 0, 0, 0);
+    DConfigWatcher::instance()->bind(DConfigWatcher::personalization, "effectMovewindowTranslucency", m_movedWinSwitchItem);
+    m_movedWinSwitchItem->setVisible(DConfigWatcher::instance()->getStatus(DConfigWatcher::personalization, "effectMovewindowTranslucency") != "Hidden");
+    if (m_windowMovedSwitch) {
+        connect(m_windowMovedSwitch,  &DTK_WIDGET_NAMESPACE::DSwitchButton::clicked, this, [this](bool checked) {
+            if (!m_model) {
+                return;
+            }
+            qDebug() << "DSwitchButton::clicked:" << checked << ",m_model->isMoveWindow():" << m_model->isMoveWindow();
+            m_windowMovedSwitch->setChecked(m_model->isMoveWindow());
+            Q_EMIT requestMovedWindowSwitchWM(checked);
+        });
+    }
 }
 
 void PersonalizationGeneral::setModel(dcc::personalization::PersonalizationModel *model)
@@ -357,13 +386,13 @@ void PersonalizationGeneral::setModel(dcc::personalization::PersonalizationModel
             m_wmSwitch->blockSignals(false);
         });
 
-        connect(model, &dcc::personalization::PersonalizationModel::moveWindowChanged, this,
-                [this](bool checked) {
-            m_windowMovedSwitch->blockSignals(true);
-            m_windowMovedSwitch->setChecked(checked);
-            m_windowMovedSwitch->blockSignals(false);
-        });
         if (m_windowMovedSwitch) {
+            connect(model, &dcc::personalization::PersonalizationModel::moveWindowChanged, this,
+                    [this](bool checked) {
+                m_windowMovedSwitch->blockSignals(true);
+                m_windowMovedSwitch->setChecked(checked);
+                m_windowMovedSwitch->blockSignals(false);
+            });
             m_windowMovedSwitch->setChecked(m_model->isMoveWindow());
         }
 
@@ -422,7 +451,8 @@ void PersonalizationGeneral::paintEvent(QPaintEvent *event)
 
 void PersonalizationGeneral::resizeEvent(QResizeEvent *event)
 {
-    m_windowMovedLabel->setText(QFontMetrics(m_windowMovedLabel->font()).elidedText(m_displayData, Qt::ElideRight, event->size().width() >= 430 ? 500 : 280));
+    if (m_windowMovedLabel)
+        m_windowMovedLabel->setText(QFontMetrics(m_windowMovedLabel->font()).elidedText(m_displayData, Qt::ElideRight, event->size().width() >= 430 ? 500 : 280));
     QWidget::resizeEvent(event);
 }
 
@@ -446,7 +476,8 @@ void PersonalizationGeneral::updateWMSwitcher(bool checked)
 
     if (m_transparentSlider) {
         m_transparentSlider->setVisible(checked || m_isWayland);
-        m_cmbMiniEffect->setVisible(checked || m_isWayland);
+        if (m_cmbMiniEffect)
+            m_cmbMiniEffect->setVisible(checked || m_isWayland);
     }
 
     if (m_winRoundSlider) {
@@ -501,7 +532,7 @@ void PersonalizationGeneral::onOpacityChanged(std::pair<int, double> value)
 
 void PersonalizationGeneral::onMiniEffectChanged(int index)
 {
-    if(index < m_cmbMiniEffect->comboBox()->count())
+    if(m_cmbMiniEffect && index < m_cmbMiniEffect->comboBox()->count())
         m_cmbMiniEffect->comboBox()->setCurrentIndex(index);
 }
 

--- a/src/frame/window/modules/personalization/personalizationgeneral.h
+++ b/src/frame/window/modules/personalization/personalizationgeneral.h
@@ -73,6 +73,9 @@ public:
     void setModel(dcc::personalization::PersonalizationModel *model);
     inline PerssonalizationThemeWidget *getThemeWidget() { return m_Themes; }
 
+    void onShowMiniEffect(const QString &option);
+    void onShowWindowMovedSwitch();
+
 protected:
     void paintEvent(QPaintEvent *event);
     void resizeEvent(QResizeEvent *event) override;
@@ -121,6 +124,9 @@ private:
     Dtk::Gui::DGuiApplicationHelper::ColorType m_themeType;
     bool m_isWayland;
     dcc::widgets::SettingsItem *m_movedWinSwitchItem;
+    QVBoxLayout *m_winEffectVLayout;
+    bool m_isShowWinEffect;
+    QStringList m_options;
 };
 }
 }

--- a/src/frame/window/modules/personalization/personalizationmodule.cpp
+++ b/src/frame/window/modules/personalization/personalizationmodule.cpp
@@ -138,6 +138,9 @@ void PersonalizationModule::showGenaralWidget()
     m_work->refreshTheme();
 
     PersonalizationGeneral *widget = new PersonalizationGeneral;
+    connect(m_work, &dcc::personalization::PersonalizationWork::requestShowMiniEffect, widget, &PersonalizationGeneral::onShowMiniEffect);
+    connect(m_work, &dcc::personalization::PersonalizationWork::requestShowWindowMovedSwitch, widget, &PersonalizationGeneral::onShowWindowMovedSwitch);
+    m_work->refreshEffectModule();
     widget->setVisible(false);
     widget->setAccessibleName("personalizationgeneral");
 


### PR DESCRIPTION
虚拟机中以上两种特效不支持，将不支持的功能模块隐藏

Log: 修复【虚拟机】【个性化】点击“移动窗口时启用透明特性”开关无响应，最小化效果为“魔灯”时无魔灯效果的问题
Bug: https://pms.uniontech.com/bug-view-163031.html
Influence: 控制中心特效
Change-Id: I52c8e5f7e9b00f2f0f9d778b9d3290682b5b7cea