### PR TITLE
fix: 控制中心域管用户能修改用户组

### DIFF
--- a/src/frame/modules/accounts/usermodel.cpp
+++ b/src/frame/modules/accounts/usermodel.cpp
@@ -4,6 +4,7 @@
 
 #include "usermodel.h"
 
+#include <QtDBus>
 #include <QDebug>
 
 using namespace dcc::accounts;
@@ -129,6 +130,27 @@ bool UserModel::getIsSecurityHighLever() const
 void UserModel::setIsSecurityHighLever(bool isSecurityHighLever)
 {
     m_isSecurityHighLever = isSecurityHighLever;
+}
+
+// 判断当前用户是否是域管账户
+bool UserModel::isDomainUser()
+{
+    QDBusInterface interface("com.deepin.udcp.iam",
+                             "/com/deepin/udcp/iam",
+                             "com.deepin.udcp.iam",
+                             QDBusConnection::systemBus());
+
+    if (!interface.isValid()) {
+        return false;
+    }
+
+    // 调用域管的接口获取当前用户的组，不为空为域管用户
+    QDBusReply<QStringList> reply = interface.call("GetUserGroups", m_currentUserName);
+    if (reply.error().type() == QDBusError::NoError && !reply.value().isEmpty()) {
+        return true;
+    }
+
+    return false;
 }
 
 #ifdef DCC_ENABLE_ADDOMAIN

--- a/src/frame/modules/accounts/usermodel.h
+++ b/src/frame/modules/accounts/usermodel.h
@@ -51,6 +51,7 @@ public:
     bool getIsSecurityHighLever() const;
     void setIsSecurityHighLever(bool isSecurityHighLever);
 
+    bool isDomainUser();
 Q_SIGNALS:
     void userAdded(User *user);
     void userRemoved(User *user);

--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -627,8 +627,8 @@ void AccountsDetailWidget::resizeEvent(QResizeEvent *event)
 
 void AccountsDetailWidget::initUserGroup(QVBoxLayout *layout)
 {
-    // 用户组入口，非专业版 且 非服务器 不显示
-    if (!IsProfessionalSystem && !IsServerSystem)
+    // 用户组入口，域管用户、非专业版、服务器版本不显示用户组
+    if (m_userModel->isDomainUser() || (!IsProfessionalSystem && !IsServerSystem))
         return;
 
     DViewItemAction *groupsEditAction = new DViewItemAction(Qt::AlignRight | Qt::AlignVCenter, QSize(14, 14), QSize(14, 14), true);

--- a/src/frame/window/modules/accounts/accountsmodule.cpp
+++ b/src/frame/window/modules/accounts/accountsmodule.cpp
@@ -264,7 +264,7 @@ void AccountsModule::initSearchData()
         m_frameProxy->setWidgetVisible(module, tr("Administrator"), true);
         m_frameProxy->setWidgetVisible(module, tr("Validity Days"), true);
         // 专业版或者服务器版本支持用户组搜索
-        m_frameProxy->setWidgetVisible(module, tr("Group"), IsProfessionalSystem || IsServerSystem);
+        m_frameProxy->setWidgetVisible(module, tr("Group"), !m_userModel->isDomainUser() && (IsProfessionalSystem || IsServerSystem));
     };
 
     connect(GSettingWatcher::instance(), &GSettingWatcher::notifyGSettingsChanged, this, [=](const QString &gsetting, const QString &state) {


### PR DESCRIPTION
域管用户不支持用户组编辑，隐藏用户组

Log: 修复控制中心域管用户能修改用户组的问题
Bug: https://pms.uniontech.com/bug-view-163513.html
Influence: 控制中心账户用户组
Change-Id: Ia6c470eb5dc4c5ec39fafd55c7534c45c65afe93