### PR TITLE
fix: 无主屏时，填充模式默认设置为""

### DIFF
--- a/src/frame/window/modules/display/displaymodule.cpp
+++ b/src/frame/window/modules/display/displaymodule.cpp
@@ -388,18 +388,20 @@ void DisplayModule::onRequestSetResolution(Monitor *monitor, const int mode)
     };
 
     tfunc(monitor, firstRes);
+    QString lastFillMode = "";
     if (m_displayModel->primaryMonitor() != nullptr) {
-        QString lastFillMode = m_displayModel->primaryMonitor()->currentFillMode();
-        //此处处理调用applyChanges的200ms延时, TimeoutDialog提前弹出的问题
-        QTimer::singleShot(300, monitor, [this, tfunc, monitor, lastRes,lastFillMode]{
-            if (showTimeoutDialog(monitor) == QDialog::Accepted) {
-                m_displayWorker->saveChanges();
-            } else {
-                tfunc(monitor, lastRes);
-                onSetFillMode(lastFillMode);
-            }
-        });
+        lastFillMode = m_displayModel->primaryMonitor()->currentFillMode();
     }
+    //此处处理调用applyChanges的200ms延时, TimeoutDialog提前弹出的问题
+    QTimer::singleShot(300, monitor, [this, tfunc, monitor, lastRes,lastFillMode]{
+        if (showTimeoutDialog(monitor) == QDialog::Accepted) {
+            m_displayWorker->saveChanges();
+        } else {
+            tfunc(monitor, lastRes);
+            onSetFillMode(lastFillMode);
+        }
+    });
+
 }
 
 void DisplayModule::onSetFillMode(QString currFullMode)


### PR DESCRIPTION
由于主屏为空，导致控制中心崩溃，2317dd4c修改导致无法弹窗保存，本提交修改无主屏时，填充模式默认设置为""

Log: 无主屏时，填充模式默认设置为""
Bug: https://pms.uniontech.com/bug-view-159801.html
Influence: 分辨率切换
Change-Id: I04aaf371b595fafbca5a5dbba36a9d60e9668403