### PR TITLE
fix: 修复进入开发者模式后重启时关机阻塞不显示导致注销问题

### DIFF
--- a/src/frame/window/modules/commoninfo/developermodewidget.cpp
+++ b/src/frame/window/modules/commoninfo/developermodewidget.cpp
@@ -157,10 +157,10 @@ void DeveloperModeWidget::setModel(CommonInfoModel *model)
             Q_UNUSED(str);
             if (idx == 1) {
                 DDBusSender()
-                .service("com.deepin.SessionManager")
-                .interface("com.deepin.SessionManager")
-                .path("/com/deepin/SessionManager")
-                .method("RequestReboot")
+                .service("com.deepin.dde.shutdownFront")
+                .interface("com.deepin.dde.shutdownFront")
+                .path("/com/deepin/dde/shutdownFront")
+                .method("Restart")
                 .call();
             }
         });


### PR DESCRIPTION
直接调用startdde的reboot，会导致有关机阻塞时注销；需要调用前端重启，会显示关机阻塞

Log: 修复进入开发者模式后重启时关机阻塞不显示导致注销问题
Bug: https://pms.uniontech.com/bug-view-147587.html
Influence: 进入开发者模式
Change-Id: I6a6f56035a23e94b4c6ba8e1b6d81623602da23c