### PR TITLE
fix: 控制中心蓝牙设备名称显示错误

### DIFF
--- a/src/frame/window/modules/bluetooth/detailpage.cpp
+++ b/src/frame/window/modules/bluetooth/detailpage.cpp
@@ -242,9 +242,16 @@ void DetailPage::onDeviceAliasChanged()
 {
     QString devAlias = m_editDevAlias->text();
     QString devName(m_device->name());
+    QString devAliasName(m_device->alias());
+
     if (devAlias.isEmpty()) {
-        m_editDevAlias->setPlaceholderText(m_device->name());
-        Q_EMIT requestSetDevAlias(m_device, devName);
+        // 当用户没有修改配对的蓝牙设备名称（编辑了但没有进行修改），显示之前配对的蓝牙设备名称
+        if (!devAliasName.isEmpty()) {
+            m_editDevAlias->setPlaceholderText(devAliasName);
+        } else {
+            m_editDevAlias->setPlaceholderText(devName);
+            Q_EMIT requestSetDevAlias(m_device, devName);
+        }
     } else if (devAlias != m_device->alias()) {
         Q_EMIT requestSetDevAlias(m_device, devAlias);
     }


### PR DESCRIPTION
当用户没有修改蓝牙名称时，显示之前配对的蓝牙设备名称

Log: 修复控制中心蓝牙设备名称显示错误的问题
Bug: https://pms.uniontech.com/bug-view-164595.html
Influence: 控制中心蓝牙设备名称显示
Change-Id: Idd0a4343dfe855f8f04f00c0e5bb68ad5fb49083