### PR TITLE
fix: 初始化获取当前是否开启窗口移动时启用透明特效改用异步, 且区分wayland和X11

### DIFF
--- a/src/frame/modules/personalization/personalizationwork.h
+++ b/src/frame/modules/personalization/personalizationwork.h
@@ -72,6 +72,7 @@ private:
     QList<QJsonObject> converToList(const QString &type, const QJsonArray &array);
     void addList(ThemeModel *model, const QString &type, const QJsonArray &array);
     void refreshWMState();
+    void refreshMoveWindowState();
     void refreshThemeByType(const QString &type);
     void refreshFontByType(const QString &type);
     void refreshOpacity(double opacity);
@@ -90,6 +91,7 @@ private:
     QMap<QString, ThemeModel*> m_themeModels;
     QMap<QString, FontModel*> m_fontModels;
     QGSettings *m_setting;
+    bool m_isWayland;
 };
 }
 }


### PR DESCRIPTION
1.窗管接口同步调用方式出现问题，不管是否设置成功都返回false，初始化调用isEffectLoaded方法，改用异步方式调用
2.wayland下默认支持特效，不能调用WMSwitcher接口判断

Log: 异步调用窗管接口
Influence: 打开控制中心第一次进入个性化
Bug: https://pms.uniontech.com/bug-view-164453.html
Change-Id: I40381fc6e2fc5afb6c70f7f7a4a47f9d821098e4