### PR TITLE
fix: 调整自定义时间保存按钮位置

### DIFF
--- a/src/frame/window/modules/datetime/datesettings.cpp
+++ b/src/frame/window/modules/datetime/datesettings.cpp
@@ -169,7 +169,7 @@ DateSettings::DateSettings(QWidget *parent)
     layout->addWidget(m_buttonTuple, 0, Qt::AlignBottom);
     TranslucentFrame *w = new TranslucentFrame;
     w->setLayout(layout);
-    setContentsMargins(0, 8, 0, 8);
+    setContentsMargins(0, 8, 0, 0);
     setContent(w);
 
     connect(m_autoSyncTimeSwitch, &SwitchWidget::checkedChanged, this, &DateSettings::requestSetAutoSyncdate);


### PR DESCRIPTION
自定义时间保存按钮位置到下边框间距过大，按设计调整成20像素

Log: 修复自定义时间保存按钮位置问题
Bug: https://pms.uniontech.com/bug-view-164699.html
Influence: 调整自定义时间保存按钮位置到下边框间距为20