### PR TITLE
fix: 控制中心系统音效列表标题间距显示异常

### DIFF
--- a/src/frame/window/modules/sound/soundeffectspage.cpp
+++ b/src/frame/window/modules/sound/soundeffectspage.cpp
@@ -65,7 +65,7 @@ SoundEffectsPage::SoundEffectsPage(QWidget *parent)
     m_effectList->setItemSpacing(1);
 
     QMargins itemMargins(m_effectList->itemMargins());
-    itemMargins.setLeft(14);
+    itemMargins.setLeft(4);
     m_effectList->setItemMargins(itemMargins);
 
     m_layout->addWidget(m_effectList, 1);


### PR DESCRIPTION
三级列表已经设置间隔为10，列表间隔设置为4即可（整体为14px）

Log: 修复控制中心系统音效列表标题间距显示异常的问题
Bug: https://pms.uniontech.com/bug-view-164789.html
Influence: 控制中心声音模块系统音效正常显示
Change-Id: I0fc754bc5cdc525a37d7cf1c75e008ca29551d37