### PR TITLE
fix: 控制中心“应用通知”标题字体显示异常

### DIFF
--- a/src/frame/window/modules/notification/notificationwidget.cpp
+++ b/src/frame/window/modules/notification/notificationwidget.cpp
@@ -69,6 +69,7 @@ NotificationWidget::NotificationWidget(NotificationModel *model, QWidget *parent
 
     //~ contents_path /notification/App Notifications
     m_appTitleLable = new QLabel(tr("App Notifications"));
+    DFontSizeManager::instance()->bind(m_appTitleLable, DFontSizeManager::T5, QFont::DemiBold);
     m_appTitleLable->setMargin(3);
     m_centralLayout->addWidget(m_appTitleLable);
     m_softwareListView->setResizeMode(QListView::Adjust);


### PR DESCRIPTION
应用通知标题需要加粗显示

Log: 修复控制中心“应用通知”标题字体显示异常的问题
Bug: https://pms.uniontech.com/bug-view-164715.html
Influence: 控制中心通知模块正常显示
Change-Id: Ie42e6f160b3f64f42801bfaacccadabe39e32da0