### PR TITLE
fix: 控制中心搜索列表显示错误

### DIFF
--- a/src/frame/window/modules/bluetooth/bluetoothmodule.cpp
+++ b/src/frame/window/modules/bluetooth/bluetoothmodule.cpp
@@ -186,7 +186,7 @@ void BluetoothModule::initSearchData()
          m_frameProxy->setModuleVisible(module, bBluetoothModel);
          setSearchState(withoutNames, powered && bBluetoothModel, first);
          setSearchState(allowFind, powered && bBluetoothModel, first);
-         setSearchState(myDevices, powered && bBluetoothModel, first);
+         setSearchState(myDevices, powered && bBluetoothModel && m_bluetoothModel->myDeviceVisible(), first);
          setSearchState(otherDevices, powered && bBluetoothModel, first);
          setSearchState(explain, !powered && bBluetoothModel, first);
      };


### PR DESCRIPTION
根据蓝牙“我的设备”的显示状态来确定其是否可以在搜索列表中搜到

Log: 修复控制中心控制中心搜索列表显示错误的问题
Bug: https://pms.uniontech.com/bug-view-164941.html
Influence: 控制中心搜索列表正常显示
Change-Id: Iea8e2e0a54d9c2e8d547bfec57b34287ece38703