### PR TITLE
fix: 修改系统时区删除按钮图标大小

### DIFF
--- a/src/frame/modules/datetime/timezoneitem.cpp
+++ b/src/frame/modules/datetime/timezoneitem.cpp
@@ -40,7 +40,7 @@ TimezoneItem::TimezoneItem(QFrame *parent)
     m_removeBtn->setObjectName("remove_button");
 
     m_removeBtn->setFixedSize(QSize(48, 48));
-    m_removeBtn->setIconSize(QSize(24, 24));
+    m_removeBtn->setIconSize(QSize(16, 16));
     m_removeBtn->setVisible(false);
 
     m_clock->setDrawTicks(false);


### PR DESCRIPTION
修改系统时区删除按钮图标大小，和系统语言列表中删除按钮大小保持一致

Log: 修复时区列表删除按钮大小不一致问题
Bug: https://pms.uniontech.com/bug-view-164805.html
Influence: 系统时区删除按钮图标大小和系统语言列表中删除按钮大小保持一致