### PR TITLE
fix: 将日期时间设置中的年月日字体调整为T8和60%灰度

### DIFF
--- a/src/frame/window/modules/datetime/datewidget.cpp
+++ b/src/frame/window/modules/datetime/datewidget.cpp
@@ -9,6 +9,8 @@
 #include <QHBoxLayout>
 #include <QMouseEvent>
 
+#include <DFontSizeManager>
+
 using namespace dcc::widgets;
 using namespace DCC_NAMESPACE;
 using namespace DCC_NAMESPACE::datetime;
@@ -36,6 +38,13 @@ DateWidget::DateWidget(Type type, int minimum, int maximum, QFrame *parent)
     m_lineEdit->setStyleSheet("background:transparent; border-width:0; border-style:outset");
     m_addBtn->setObjectName("DCC-Datetime-Datewidget-Add");
     m_reducedBtn->setObjectName("DCC-Datetime-Datewidget-Reduce");
+
+    DFontSizeManager::instance()->bind(m_label, DFontSizeManager::T8);
+    auto mpalette = this->palette();
+    QColor color = mpalette.color(QPalette::Text);
+    color.setAlpha(153);
+    mpalette.setColor(QPalette::Text, color);
+    m_label->setPalette(mpalette);
 
     m_label->setParent(m_lineEdit);
     m_label->move(0, 0);

--- a/src/frame/window/modules/datetime/datewidget.cpp
+++ b/src/frame/window/modules/datetime/datewidget.cpp
@@ -40,11 +40,11 @@ DateWidget::DateWidget(Type type, int minimum, int maximum, QFrame *parent)
     m_reducedBtn->setObjectName("DCC-Datetime-Datewidget-Reduce");
 
     DFontSizeManager::instance()->bind(m_label, DFontSizeManager::T8);
-    auto mpalette = this->palette();
-    QColor color = mpalette.color(QPalette::Text);
+    auto palette = this->palette();
+    QColor color = palette.color(QPalette::Text);
     color.setAlpha(153);
-    mpalette.setColor(QPalette::Text, color);
-    m_label->setPalette(mpalette);
+    palette.setColor(QPalette::Text, color);
+    m_label->setPalette(palette);
 
     m_label->setParent(m_lineEdit);
     m_label->move(0, 0);


### PR DESCRIPTION
按UI设计要求，将日期时间设置中的年月日字体调整为T8和60%灰度

Log: 按UI设计要求，将日期时间设置中的年月日字体调整为T8和60%灰度
Bug: https://pms.uniontech.com/bug-view-164777.html
Influence: 按UI设计要求，将日期时间设置中的年月日字体调整为T8和60%灰度