### PR TITLE
fix: 仅HDMI切换仅edp-1时控制中心退出

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -306,9 +306,7 @@ void MainWindow::setPrimaryScreen(QScreen *screen)
     updateWinsize();
     connect(m_primaryScreen, &QScreen::geometryChanged, this, &MainWindow::updateWinsize);
     // 主屏变化后，根据新主屏的分辨率移动窗口居中
-    connect(qApp, &QGuiApplication::primaryScreenChanged, this, [this] {
-        updateWinsize(m_primaryScreen->geometry());
-    });
+    connect(qApp, &QGuiApplication::primaryScreenChanged, this, &MainWindow::updateWinsize);
 }
 
 QScreen *MainWindow::primaryScreen() const
@@ -438,7 +436,7 @@ void MainWindow::initAllModule(const QString &m)
     qDebug() << QString("load search info with %1ms").arg(et.elapsed());
 }
 
-void MainWindow::updateWinsize(QRect rect)
+void MainWindow::updateWinsize()
 {
     if (!qApp->screens().contains(m_primaryScreen))
         return;

--- a/src/frame/window/mainwindow.h
+++ b/src/frame/window/mainwindow.h
@@ -116,7 +116,7 @@ private Q_SLOTS:
     void openManual();
 
 public Q_SLOTS:
-    void updateWinsize(QRect rect = QRect(0,0,0,0));
+    void updateWinsize();
 
 protected:
     void resizeEvent(QResizeEvent *event) override;


### PR DESCRIPTION
使用了空指针

Log: 修复仅HDMI切换仅edp-1时控制中心退出的问题
Bug: https://pms.uniontech.com/bug-view-165867.html
Influence: 切换显示模式
Change-Id: I09767be5e54c1b7de8a69d5020b7973db37cdcee