### PR TITLE
fix: 控制中心域管账户用户组显示错误

### DIFF
--- a/src/frame/modules/accounts/usermodel.cpp
+++ b/src/frame/modules/accounts/usermodel.cpp
@@ -133,7 +133,7 @@ void UserModel::setIsSecurityHighLever(bool isSecurityHighLever)
 }
 
 // 判断当前用户是否是域管账户
-bool UserModel::isDomainUser()
+bool UserModel::isDomainUser(const QString &userName)
 {
     QDBusInterface interface("com.deepin.udcp.iam",
                              "/com/deepin/udcp/iam",
@@ -145,7 +145,7 @@ bool UserModel::isDomainUser()
     }
 
     // 调用域管的接口获取当前用户的组，不为空为域管用户
-    QDBusReply<QStringList> reply = interface.call("GetUserGroups", m_currentUserName);
+    QDBusReply<QStringList> reply = interface.call("GetUserGroups", userName);
     if (reply.error().type() == QDBusError::NoError && !reply.value().isEmpty()) {
         return true;
     }

--- a/src/frame/modules/accounts/usermodel.h
+++ b/src/frame/modules/accounts/usermodel.h
@@ -51,7 +51,7 @@ public:
     bool getIsSecurityHighLever() const;
     void setIsSecurityHighLever(bool isSecurityHighLever);
 
-    bool isDomainUser();
+    bool isDomainUser(const QString &userName);
 Q_SIGNALS:
     void userAdded(User *user);
     void userRemoved(User *user);

--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -628,7 +628,7 @@ void AccountsDetailWidget::resizeEvent(QResizeEvent *event)
 void AccountsDetailWidget::initUserGroup(QVBoxLayout *layout)
 {
     // 用户组入口，域管用户、非专业版、服务器版本不显示用户组
-    if (m_userModel->isDomainUser() || (!IsProfessionalSystem && !IsServerSystem))
+    if (m_userModel->isDomainUser(m_curUser->name()) || (!IsProfessionalSystem && !IsServerSystem))
         return;
 
     DViewItemAction *groupsEditAction = new DViewItemAction(Qt::AlignRight | Qt::AlignVCenter, QSize(14, 14), QSize(14, 14), true);

--- a/src/frame/window/modules/accounts/accountsmodule.cpp
+++ b/src/frame/window/modules/accounts/accountsmodule.cpp
@@ -264,7 +264,7 @@ void AccountsModule::initSearchData()
         m_frameProxy->setWidgetVisible(module, tr("Administrator"), true);
         m_frameProxy->setWidgetVisible(module, tr("Validity Days"), true);
         // 专业版或者服务器版本支持用户组搜索
-        m_frameProxy->setWidgetVisible(module, tr("Group"), !m_userModel->isDomainUser() && (IsProfessionalSystem || IsServerSystem));
+        m_frameProxy->setWidgetVisible(module, tr("Group"), !m_userModel->isDomainUser(m_userModel->getCurrentUserName()) && (IsProfessionalSystem || IsServerSystem));
     };
 
     connect(GSettingWatcher::instance(), &GSettingWatcher::notifyGSettingsChanged, this, [=](const QString &gsetting, const QString &state) {


### PR DESCRIPTION
所有域管账户都不显示用户组，而不是只针对当前登录的用户

Log: 修复控制中心域管账户用户组显示错误的问题
Bug: https://pms.uniontech.com/bug-view-163513.html
Influence: 控制中心用户组显示
Change-Id: Ib0497b267218c6786509774e9d0d53cd07a3456c