### PR TITLE
Revert "fix: 修复【虚拟机】【个性化】点击“移动窗口时启用透明特性”开关无响应，最小化效果为“魔灯”时无魔灯效果的问题"

### DIFF
--- a/src/frame/modules/personalization/personalizationwork.cpp
+++ b/src/frame/modules/personalization/personalizationwork.cpp
@@ -405,53 +405,6 @@ void PersonalizationWork::refreshFontByType(const QString &type)
     connect(fontWatcher, &QDBusPendingCallWatcher::finished, this, &PersonalizationWork::onGetFontFinished);
 }
 
-void PersonalizationWork::refreshEffectModule()
-{
-    QDBusInterface effects("org.kde.KWin", "/Effects", "org.kde.kwin.Effects", QDBusConnection::sessionBus(), this);
-    if (effects.isValid()) {
-        QDBusPendingCall scaleEffectReply = effects.asyncCall("isEffectSupported", "kwin4_effect_scale");
-        QDBusPendingCallWatcher *scaleEffectWatcher = new QDBusPendingCallWatcher(scaleEffectReply, this);
-        connect(scaleEffectWatcher, &QDBusPendingCallWatcher::finished, [this, scaleEffectReply, scaleEffectWatcher] {
-            if (!scaleEffectReply.isError()) {
-                QDBusReply<bool> reply = scaleEffectReply.reply();
-                if (reply.value()) {
-                    Q_EMIT requestShowMiniEffect("kwin4_effect_scale");
-                }
-            } else {
-                qWarning() << "Failed to get kwin4_effect_scale state: " << scaleEffectReply.error().message();
-            }
-            scaleEffectWatcher->deleteLater();
-        });
-
-        QDBusPendingCall magiclampEffectReply = effects.asyncCall("isEffectSupported", "magiclamp");
-        QDBusPendingCallWatcher *magiclampEffectWatcher = new QDBusPendingCallWatcher(magiclampEffectReply, this);
-        connect(magiclampEffectWatcher, &QDBusPendingCallWatcher::finished, [this, magiclampEffectReply, magiclampEffectWatcher] {
-            if (!magiclampEffectReply.isError()) {
-                QDBusReply<bool> reply = magiclampEffectReply.reply();
-                if (reply.value()) {
-                    Q_EMIT requestShowMiniEffect("magiclamp");
-                }
-            } else {
-                qWarning() << "Failed to get magiclamp state: " << magiclampEffectReply.error().message();
-            }
-            magiclampEffectWatcher->deleteLater();
-        });
-
-        QDBusPendingCall translucencyEffectReply = effects.asyncCall("isEffectSupported", "kwin4_effect_translucency");
-        QDBusPendingCallWatcher *translucencyEffectWatcher = new QDBusPendingCallWatcher(translucencyEffectReply, this);
-        connect(translucencyEffectWatcher, &QDBusPendingCallWatcher::finished, [this, translucencyEffectReply, translucencyEffectWatcher] {
-            if (!translucencyEffectReply.isError()) {
-                QDBusReply<bool> reply = translucencyEffectReply.reply();
-                if (reply.value())
-                    Q_EMIT requestShowWindowMovedSwitch();
-            } else {
-                qWarning() << "Failed to get kwin4_effect_translucency state: " << translucencyEffectReply.error().message();
-            }
-            translucencyEffectWatcher->deleteLater();
-        });
-    }
-}
-
 void PersonalizationWork::refreshActiveColor(const QString &color)
 {
     m_model->setActiveColor(color);

--- a/src/frame/modules/personalization/personalizationwork.h
+++ b/src/frame/modules/personalization/personalizationwork.h
@@ -38,11 +38,6 @@ public:
     void onGetList();
     void refreshTheme();
     void refreshFont();
-    void refreshEffectModule();
-
-Q_SIGNALS:
-    void requestShowMiniEffect(const QString &option);
-    void requestShowWindowMovedSwitch();
 
 public Q_SLOTS:
     void setDefault(const QJsonObject &value);

--- a/src/frame/window/modules/personalization/personalizationgeneral.h
+++ b/src/frame/window/modules/personalization/personalizationgeneral.h
@@ -73,9 +73,6 @@ public:
     void setModel(dcc::personalization::PersonalizationModel *model);
     inline PerssonalizationThemeWidget *getThemeWidget() { return m_Themes; }
 
-    void onShowMiniEffect(const QString &option);
-    void onShowWindowMovedSwitch();
-
 protected:
     void paintEvent(QPaintEvent *event);
     void resizeEvent(QResizeEvent *event) override;
@@ -124,9 +121,6 @@ private:
     Dtk::Gui::DGuiApplicationHelper::ColorType m_themeType;
     bool m_isWayland;
     dcc::widgets::SettingsItem *m_movedWinSwitchItem;
-    QVBoxLayout *m_winEffectVLayout;
-    bool m_isShowWinEffect;
-    QStringList m_options;
 };
 }
 }

--- a/src/frame/window/modules/personalization/personalizationmodule.cpp
+++ b/src/frame/window/modules/personalization/personalizationmodule.cpp
@@ -138,9 +138,6 @@ void PersonalizationModule::showGenaralWidget()
     m_work->refreshTheme();
 
     PersonalizationGeneral *widget = new PersonalizationGeneral;
-    connect(m_work, &dcc::personalization::PersonalizationWork::requestShowMiniEffect, widget, &PersonalizationGeneral::onShowMiniEffect);
-    connect(m_work, &dcc::personalization::PersonalizationWork::requestShowWindowMovedSwitch, widget, &PersonalizationGeneral::onShowWindowMovedSwitch);
-    m_work->refreshEffectModule();
     widget->setVisible(false);
     widget->setAccessibleName("personalizationgeneral");
 


### PR DESCRIPTION
该修改存在较大问题,对于初始化以及connect信号槽连接时序都不对
因此导致第一次进去无法正常设置状态到界面

Log: 代码回退
Influence: 特效相关设置初始值失效
Bug: https://pms.uniontech.com/bug-view-166339.html This reverts commit 1199d94566c473ed81f9f7001ffc8c7b15f5b088.