### PR TITLE
fix: 控制中心域账户界面显示异常

### DIFF
--- a/src/frame/window/modules/accounts/accountsmodule.cpp
+++ b/src/frame/window/modules/accounts/accountsmodule.cpp
@@ -241,9 +241,10 @@ void AccountsModule::initSearchData()
 
     auto func_process_all = [=]() {
         //只存在二级页面，childpage为空，在判断是否加载数据时没有翻译，因此这个函数第二个参数不能添加翻译
+        bool isDomainUser = m_userModel->isDomainUser(m_userModel->getCurrentUserName());
         QString gsAccountUserModifypasswd = func_is_visible("accountUserModifypasswd").toString();
         gsettingsMap.insert("accountUserModifypasswd", gsAccountUserModifypasswd != "Hidden");
-        m_frameProxy->setWidgetVisible(module, tr("Change Password"), gsAccountUserModifypasswd != "Hidden");
+        m_frameProxy->setWidgetVisible(module, tr("Change Password"), gsAccountUserModifypasswd != "Hidden" && !isDomainUser);
 
         QString gsAccountUserDeleteaccount = func_is_visible("accountUserDeleteaccount").toString();
         gsettingsMap.insert("accountUserDeleteaccount", gsAccountUserDeleteaccount != "Hidden");
@@ -260,11 +261,11 @@ void AccountsModule::initSearchData()
         m_frameProxy->setWidgetVisible(module, tr("Create Account"), true);
         m_frameProxy->setDetailVisible(module, tr("Create Account"), tr("New Account"), true);
 
-        m_frameProxy->setWidgetVisible(module, tr("Account Settings"), true);
-        m_frameProxy->setWidgetVisible(module, tr("Administrator"), true);
-        m_frameProxy->setWidgetVisible(module, tr("Validity Days"), true);
+        m_frameProxy->setWidgetVisible(module, tr("Account Settings"), !isDomainUser);
+        m_frameProxy->setWidgetVisible(module, tr("Administrator"), !isDomainUser);
+        m_frameProxy->setWidgetVisible(module, tr("Validity Days"), !isDomainUser);
         // 专业版或者服务器版本支持用户组搜索
-        m_frameProxy->setWidgetVisible(module, tr("Group"), !m_userModel->isDomainUser(m_userModel->getCurrentUserName()) && (IsProfessionalSystem || IsServerSystem));
+        m_frameProxy->setWidgetVisible(module, tr("Group"), !isDomainUser && (IsProfessionalSystem || IsServerSystem));
     };
 
     connect(GSettingWatcher::instance(), &GSettingWatcher::notifyGSettingsChanged, this, [=](const QString &gsetting, const QString &state) {


### PR DESCRIPTION
域账户的相关信息（密码有效期，是否为管理员，重置密码，修改全名）等操作都是由域管服务器统一管理的
通过控制中心去修改相关信息，会造成本地账户的信息与域管信息不同步，会造成很多问题，故因此这些配置选项

Log: 修复控制中心域账户界面显示异常的问题
Bug: https://pms.uniontech.com/bug-view-166345.html
Influence: 控制中心账户页面正常显示
Change-Id: Ia40931a804bdce4a6b77efdc1f12a9d01e9c7b28