### PR TITLE
fix: 解决搜索数据过长显示不下的问题

### DIFF
--- a/src/frame/window/search/searchmodel.h
+++ b/src/frame/window/search/searchmodel.h
@@ -8,6 +8,7 @@
 
 #include <QStandardItemModel>
 #include <QSet>
+#include <QLabel>
 
 #include <memory>
 
@@ -45,6 +46,7 @@ class SearchModel : public QStandardItemModel {
     friend class SearchWidget;
 public:
     explicit SearchModel(QObject* parent = nullptr);
+    ~SearchModel();
 
 public:
     int getDataNum(QString source, char value);
@@ -61,6 +63,7 @@ public:
     void getJumpPath(QString &moduleName, QString &pageName, const QString &searchName);
     inline bool getDataUpdateCompleted() { return m_dataUpdateCompleted; }
     void addChildPageTrans(const QString &menu, const QString &tran);
+    QString getRealTxt(const QString &key) const;
 
 Q_SIGNALS:
     void notifyModuleSearch(QString, QString);
@@ -74,6 +77,7 @@ private:
     void appendChineseData(SearchBoxStruct::Ptr data);
     SearchBoxStruct::Ptr getModuleBtnString(QString value);
     bool specialProcessData(SearchBoxStruct::Ptr data);
+    QString getNormalText(QString value);
 
 private:
     QList<SearchBoxStruct::Ptr> m_originList;
@@ -96,6 +100,8 @@ private:
     QMap<QString, QString> m_transChildPageName;
     bool m_dataUpdateCompleted;
     QMap<QString, QString> m_transPlusData;
+    QLabel *m_calLenthLabel;
+    QMap<QString, QString> m_scaleTxtMap;
 };
 
 }// namespace search

--- a/src/frame/window/search/searchwidget.cpp
+++ b/src/frame/window/search/searchwidget.cpp
@@ -107,6 +107,7 @@ SearchWidget::SearchWidget(QWidget *parent)
             if (!jumpContentPathWidget(text())) {
                 //m_completer未关联部件时，currentCompletion只会获取到第一个选项并且不会在Edit中补全内容，需要通过popup()获取当前选择项并手动补全edit内容
                 QString currentCompletion = m_completer->popup()->currentIndex().data().toString();
+                currentCompletion = m_model->getRealTxt(currentCompletion);
                 //如果通过popup()未获取当前选择项,再通过currentCompletion获取第一个选项
                 if (m_completer->completionCount() > 0 && currentCompletion.isEmpty()) {
                     currentCompletion = m_completer->currentCompletion();
@@ -145,6 +146,7 @@ SearchWidget::~SearchWidget()
 void SearchWidget::onCompleterActivated(const QString &value)
 {
     qDebug() << Q_FUNC_INFO << value;
+    onSelectCompleterSacleData(value);
     Q_EMIT returnPressed();
 }
 
@@ -175,6 +177,22 @@ void SearchWidget::onSearchTextChange(const QString &text)
     Q_EMIT focusChanged(true);
     // 实现自动补全
     onAutoComplete(text);
+}
+
+// 处理显示数据过长替换为...结尾的数据，转换为真实数据设置到搜索框
+void SearchWidget::onSelectCompleterSacleData(QString text)
+{
+    if (!m_model || !m_completer)
+        return;
+
+    QString editTxt = m_completer->popup()->currentIndex().data().toString();
+    if (editTxt.contains("…")) {
+        QString value = m_model->getRealTxt(editTxt);
+        if (value != editTxt && value != "") {
+            qDebug() << Q_FUNC_INFO << " enter txt : "<< text << " , Real txt : " << value;
+            this->setText(value);
+        }
+    }
 }
 
 bool ddeCompleter::eventFilter(QObject *o, QEvent *e)

--- a/src/frame/window/search/searchwidget.h
+++ b/src/frame/window/search/searchwidget.h
@@ -54,6 +54,8 @@ private Q_SLOTS:
     void onCompleterActivated(const QString &value);
     void onAutoComplete(const QString &text);
     void onSearchTextChange(const QString &text);
+    void onSelectCompleterSacleData(QString text);
+
 Q_SIGNALS:
     void notifyModuleSearch(QString, QString);
 


### PR DESCRIPTION
1.搜索数据长度>315像素的时候，后面数据显示成...
2.鼠标点击或者键盘选中enter后，将...数据再恢复成真实数据，设置到搜索框并跳转

Log: 优化搜索数据过长显示问题
Influence: 搜索
Bug: https://pms.uniontech.com/bug-view-164951.html
Change-Id: I255cbeaa8a5d3aa34920b0c4f286692623343390