### PR TITLE
fix: 修复控制中心删除账户时的提示框删除字体颜色的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build*/
 
 .transifexrc
 lupdate.sh
+.cache/

--- a/src/frame/modules/accounts/removeuserdialog.cpp
+++ b/src/frame/modules/accounts/removeuserdialog.cpp
@@ -48,9 +48,8 @@ RemoveUserDialog::RemoveUserDialog(const User *user, QWidget *parent)
     box->setAccessibleName("Delete_Account_Checkbox");
     addContent(box, Qt::AlignTop);
 
-    QStringList buttons;
-    buttons << tr("Cancel") << tr("Delete");
-    addButtons(buttons);
+    addButton(tr("Cancel"));
+    addButton(tr("Delete"), false, DDialog::ButtonWarning);
 
     connect(box, &QCheckBox::toggled, [this, box] {
         m_deleteHome = box->checkState() == Qt::Checked;


### PR DESCRIPTION
按设计要求，删除操作的危险行为，不管活动色是什么，删除按钮文字改为用红色的

Log: 修复控制中心删除账户时的提示框删除字体颜色的问题
Task: https://pms.uniontech.com/task-view-208027.html
Influence: 账户删除按钮字体颜色
Change-Id: I58b71e684270ef90046818caa02f0235c71f44e7