### PR TITLE
fix: 控制中心蓝牙名称输入框提示错误

### DIFF
--- a/src/frame/window/modules/bluetooth/detailpage.cpp
+++ b/src/frame/window/modules/bluetooth/detailpage.cpp
@@ -253,6 +253,7 @@ void DetailPage::onDeviceAliasChanged()
             Q_EMIT requestSetDevAlias(m_device, devName);
         }
     } else if (devAlias != m_device->alias()) {
+        m_editDevAlias->setPlaceholderText(devAlias);
         Q_EMIT requestSetDevAlias(m_device, devAlias);
     }
 }


### PR DESCRIPTION
当修改了蓝牙配对的设备名称时，更新下输入框的提示

Log: 修复控制中心蓝牙名称输入框提示错误的问题
Bug: https://pms.uniontech.com/bug-view-166613.html
Influence: 控制中心蓝牙名称正常显示
Change-Id: Id408319262cc73ee93cd555caae4a3ce11b4167a