### PR TITLE
fix: 修复社区版-其他发行版【debian】点击更新模块，控制中心闪退的问题

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -476,12 +476,8 @@ void MainWindow::updateModuleVisible()
     m_hideModuleNames = m_moduleSettings->get(GSETTINGS_HIDE_MODULE).toStringList();
     for (auto i : m_modules) {
 
-        if (m_hideModuleNames.contains((i.first->name()))) {
+        if (m_hideModuleNames.contains((i.first->name())) || i.first->deviceUnavailabel() || !i.first->isAvailable()) {
             setModuleVisible(i.second, false);
-        } else if (i.first->deviceUnavailabel()) {
-            setModuleVisible(i.second, false);
-        } else if (i.first->isAvailable()) {
-            setModuleVisible(i.second, true);
         }
     }
 }


### PR DESCRIPTION
原因：其他发行版不支持更新模块，没有初始化更新模块，点击之后调用了对应的方法，导致崩溃
解决方案：其他发行版不支持更新，模块不应该显示出来

Log: 修复社区版-其他发行版【debian】点击更新模块，控制中心闪退的问题
Bug: https://pms.uniontech.com/bug-view-160653.html
Influence: 更新模块显示
Change-Id: I96fe1effd2bb7cd083b5bd5cf42273d93bf18399