### PR TITLE
fix: 控制中心自定义快捷键名称显示异常

### DIFF
--- a/src/frame/modules/keyboard/customedit.cpp
+++ b/src/frame/modules/keyboard/customedit.cpp
@@ -80,6 +80,18 @@ keyboard::CustomEdit::CustomEdit(ShortcutModel *model, QWidget *parent):
         }
         Q_EMIT CustomEdit::back();
     });
+    connect(m_name->dTextEdit(), &DLineEdit::textChanged, this, [=](const QString &text) {
+        okButton->setEnabled(true);
+
+        // 如果用户输入的快捷键名称和已有快捷键名称重复（冲突），置灰保存按钮
+        // 防止设置的快捷键名称和已有快捷键名称显示重复
+        for (auto info : model->infos()) {
+            if (info->name == text) {
+                okButton->setEnabled(false);
+                return;
+            }
+        }
+    });
     connect(pushbutton, &DIconButton::clicked, this, &CustomEdit::onOpenFile);
     connect(m_short, &CustomItem::requestUpdateKey, this, &CustomEdit::onUpdateKey);
     connect(okButton, &QPushButton::clicked, this, [this]{


### PR DESCRIPTION
当用户编辑自定义快捷键名称时，如果名称与已有快捷键名称重复，置灰保存按钮

Log: 修复控制中心自定义快捷键名称显示异常的问题
Bug: https://pms.uniontech.com/bug-view-110160.html
Influence: 控制中心快捷键显示
Change-Id: I0275f65e5fab41e8c808f2345caf8f0a4829466d