### PR TITLE
feat: 实现等保三级账户页面显示

### DIFF
--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -474,6 +474,8 @@ void AccountsDetailWidget::initSetting(QVBoxLayout *layout)
             m_modifyPassword->setEnabled(false);
             m_autoLogin->switchButton()->setEnabled(false);
             m_nopasswdLogin->switchButton()->setEnabled(false);
+            m_bindStatusLabel->setEnabled(false);
+            securityQuestionsButton->setEnabled(false);
         }
     }
     //修改密码状态判断
@@ -664,6 +666,11 @@ void AccountsDetailWidget::initUserGroup(QVBoxLayout *layout)
     QMargins listItemmargin( lvgroups->itemMargins());
     listItemmargin.setLeft(2);
     lvgroups->setItemMargins(listItemmargin);
+
+    // 开启等保三级后，只有sysadm账户可以修改用户组
+    if (m_userModel->getIsSecurityHighLever() && m_curLoginUser->securityLever() != SecurityLever::Sysadm) {
+        lvgroups->setEnabled(false);
+    }
 
     connect(lvgroups, &QListView::clicked, this, [ this ] {
         Q_EMIT requestShowUserGroups(m_curUser);

--- a/src/frame/window/modules/accounts/accountsdetailwidget.h
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.h
@@ -55,7 +55,7 @@ class AccountSpinBox : public DSpinBox
 public:
     explicit AccountSpinBox(QWidget *parent = nullptr);
 protected:
-    virtual QString textFromValue(int val) const;
+    virtual QString textFromValue(int val) const override;
     void focusInEvent(QFocusEvent *event) override;
     void focusOutEvent(QFocusEvent *event) override;
 };

--- a/src/frame/window/modules/accounts/usergroupspage.cpp
+++ b/src/frame/window/modules/accounts/usergroupspage.cpp
@@ -16,6 +16,7 @@ using namespace dcc::accounts;
 using namespace DCC_NAMESPACE::accounts;
 
 const QString Sudo = "sudo";
+const QString Root = "root";
 
 DWIDGET_USE_NAMESPACE
 
@@ -108,6 +109,13 @@ void UserGroupsPage::onGidChanged(const QString &gid)
             } else {
                 value = true;
             }
+
+            // 等保三级系统管理员不能修改自己的sudo和root组选项
+            if (m_userModel->getIsSecurityHighLever() &&
+                m_curUser->securityLever() == SecurityLever::Sysadm &&
+                (item->text() == Sudo || item->text() == Root)) {
+                value = false;
+            }
         } while (0);
         item->setEnabled(value);
     }
@@ -150,6 +158,13 @@ void UserGroupsPage::initData()
     for (QString item : userGroup) {
         GroupItem *it = new GroupItem(item);
         it->setCheckable(false);
+        // 开启等保后，原来的管理员账户统一显示标准用户（但是账户对应的sudo和root组其实还在）
+        // 需要将这两个选项隐藏，防止用户修改后与账户设置/管理员和账户类型显示不一致
+        if (m_userModel->getIsSecurityHighLever() &&
+            m_curUser->securityLever() != SecurityLever::Sysadm &&
+            (it->text() == Sudo || it->text() == Root)) {
+            continue;
+        }
         m_groupItemModel->appendRow(it);
     }
 


### PR DESCRIPTION
1.开启等保三级后，只有系统管理员(sysadm)有权限修改用户组页面；
2.针对原来的管理员账户，需要隐藏sudo和root组选项，与账户页面二级页面账户类型和三级页面账户设置/管理员保持一致

Log: 实现等保三级账户页面显示
Task: https://pms.uniontech.com/task-view-212851.html
Influence: 控制中心账户页面正常显示
Change-Id: I1eb7987c32397bb4e7bb6a7c7c2dd69cffc46666