### PR TITLE
fix: 域管用户账户页面安全问题显示异常

### DIFF
--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -384,10 +384,8 @@ void AccountsDetailWidget::initSetting(QVBoxLayout *layout)
     sqHLayout->addWidget(securityQuestionsButton, 0, Qt::AlignRight);
     securityQuestionsWidget->setVisible(false);
 
-    if (m_curUser->isCurrentUser())
+    if (m_curUser->isCurrentUser() && !isDomainUser)
         DConfigWatcher::instance()->bind(DConfigWatcher::accounts, "securityQuestions", securityQuestionsWidget);
-
-    securityQuestionsWidget->setVisible(!isDomainUser);
 
     connect(securityQuestionsButton, &QPushButton::clicked, this, [this] {
         Q_EMIT requestShowSecurityQuestionsSettings(m_curUser);


### PR DESCRIPTION
域管用户不绑定securityQuestions配置选项，即使用户修改了配置，也不显示该安全问题页面

Log: 修复账户页面安全问题显示异常的问题
Bug: https://pms.uniontech.com/bug-view-166345.html
Influence: 控制中心账户页面正常显示
Change-Id: Id7234a4fe2f5d510eb9b7d21f029045674946848