### PR TITLE
fix: 将时区地图中选择的坐标标识圆点颜色替换成系统活动色

### DIFF
--- a/src/frame/modules/datetime/datetimemodel.cpp
+++ b/src/frame/modules/datetime/datetimemodel.cpp
@@ -264,5 +264,10 @@ void DatetimeModel::setPositiveCurrencyFormat(const QString &value)
         Q_EMIT PositiveCurrencyFormatChanged(value);
     }
 }
+
+void DatetimeModel::setSystemActiveColor(const QString &color)
+{
+    m_systemActiveColor = color;
+}
 }
 }

--- a/src/frame/modules/datetime/datetimemodel.h
+++ b/src/frame/modules/datetime/datetimemodel.h
@@ -64,6 +64,7 @@ public:
     inline QString digitGroupingSymbol() const { return  m_digitGroupingSymbol; }
     inline QString negativeCurrencyFormat() const { return  m_negativeCurrencyFormat; }
     inline QString positiveCurrencyFormat() const { return  m_positiveCurrencyFormat; }
+    inline QString systemActiveColor() const { return  m_systemActiveColor; }
 
     void setWeekdayFormatType(int type);
     void setShortDateFormat(int type);
@@ -84,6 +85,7 @@ public:
     void setDigitGroupingSymbol(const QString &value);
     void setNegativeCurrencyFormat(const QString &value);
     void setPositiveCurrencyFormat(const QString &value);
+    void setSystemActiveColor(const QString &color);
 
 Q_SIGNALS:
     void NTPChanged(bool value);
@@ -146,6 +148,7 @@ private:
     QString m_digitGroupingSymbol{""};
     QString m_negativeCurrencyFormat{""};
     QString m_positiveCurrencyFormat{""};
+    QString m_systemActiveColor{""};
 };
 
 }

--- a/src/frame/modules/datetime/datetimework.cpp
+++ b/src/frame/modules/datetime/datetimework.cpp
@@ -21,6 +21,7 @@ DatetimeWork::DatetimeWork(DatetimeModel *model, QObject *parent)
     , m_model(model)
     , m_timedateInter(new Timedate("com.deepin.daemon.Timedate", "/com/deepin/daemon/Timedate", QDBusConnection::sessionBus(), this))
     , m_systemtimedatedInter(new Timedated("com.deepin.daemon.Timedated", "/com/deepin/daemon/Timedated", QDBusConnection::systemBus(), this))
+    , m_appearanceInter(new Appearance(Appearance::staticInterfaceName(), "/com/deepin/daemon/Appearance", QDBusConnection::sessionBus(), this))
 {
     m_timedateInter->setSync(false);
 
@@ -66,6 +67,8 @@ DatetimeWork::DatetimeWork(DatetimeModel *model, QObject *parent)
     connect(m_timedateInter, &Timedate::ShortTimeFormatChanged, m_model, &DatetimeModel::setShorTimeFormat);
     connect(m_timedateInter, &Timedate::LongTimeFormatChanged, m_model, &DatetimeModel::setLongTimeFormat);
     connect(m_timedateInter, &Timedate::WeekBeginsChanged, m_model, &DatetimeModel::setWeekStartDayFormat);
+    connect(m_appearanceInter, &Appearance::QtActiveColorChanged, m_model, &DatetimeModel::setSystemActiveColor);
+
     refreshNtpServerList();
     m_model->setNtpServerAddress(m_timedateInter->nTPServer());
     m_model->setTimeZoneInfo(m_timedateInter->timezone());
@@ -93,6 +96,7 @@ DatetimeWork::DatetimeWork(DatetimeModel *model, QObject *parent)
     m_model->setDigitGroupingSymbol(static_cast<QString>(formatInter.property("DigitGroupingSymbol").toString()));
     m_model->setNegativeCurrencyFormat(static_cast<QString>(formatInter.property("NegativeCurrencyFormat").toString()));
     m_model->setPositiveCurrencyFormat(static_cast<QString>(formatInter.property("PositiveCurrencyFormat").toString()));
+    m_model->setSystemActiveColor(m_appearanceInter->qtActiveColor());
 
     //关联属性信号变化
     QDBusConnection::sessionBus().connect("com.deepin.daemon.Format",

--- a/src/frame/modules/datetime/datetimework.h
+++ b/src/frame/modules/datetime/datetimework.h
@@ -9,6 +9,7 @@
 
 #include <com_deepin_daemon_timedate.h>
 #include <com_deepin_daemon_timedated.h>
+#include <com_deepin_daemon_appearance.h>
 
 #include <QObject>
 
@@ -17,6 +18,7 @@ namespace datetime {
 
 using Timedate = com::deepin::daemon::Timedate;
 using Timedated = com::deepin::daemon::Timedated;
+using Appearance = com::deepin::daemon::Appearance;
 
 class DatetimeWork : public QObject
 {
@@ -66,6 +68,7 @@ private:
     Timedate *m_timedateInter;
     Timedated *m_systemtimedatedInter;
     QStringList m_formatList;
+    Appearance *m_appearanceInter;
 };
 }
 }

--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
@@ -42,7 +42,7 @@ QPoint ZoneInfoToPosition(const ZoneInfo& zone, int map_width, int map_height) {
 
 TimezoneMap::TimezoneMap(QWidget* parent)
     : QFrame(parent),
-      m_appearanceInter(new Appearance(Appearance::staticInterfaceName(), "/com/deepin/daemon/Appearance", QDBusConnection::sessionBus(), this)),
+      m_systemActiveColor(QString("")),
       current_zone_(),
       total_zones_(GetZoneInfoList()),
       nearest_zones_() {
@@ -61,6 +61,15 @@ TimezoneMap::~TimezoneMap() {
 
 const QString TimezoneMap::getTimezone() const {
     return current_zone_.timezone;
+}
+
+void TimezoneMap::setSystemActiveColor(const QString &color)
+{
+    m_systemActiveColor = color;
+    const QPixmap dot_pixmap = getDotImage();
+    dot_->setPixmap(dot_pixmap);
+    dot_->setFixedSize(dot_pixmap.size());
+    update();
 }
 
 bool TimezoneMap::setTimezone(const QString &timezone)
@@ -234,13 +243,11 @@ void TimezoneMap::remark() {
 QPixmap TimezoneMap::getDotImage()
 {
     // 将地图上选中的点标识颜色替换成成系统活动色
-
     QPixmap sourcePixmap(kDotFile);
     QImage image = sourcePixmap.toImage();
 
-    if (m_appearanceInter->isValid()) {
-        QString strColor = m_appearanceInter->qtActiveColor();
-        QColor destColor = QColor(strColor);
+    if (!m_systemActiveColor.isEmpty()) {
+        QColor destColor = QColor(m_systemActiveColor);
 
         for (int w = 0; w < image.width(); ++w) {
             for (int h = 0; h < image.height(); ++h) {

--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.h
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.h
@@ -6,6 +6,11 @@
 #define INSTALLER_UI_WIDGETS_TIMEZONE_MAP_H
 
 #include <QFrame>
+
+#include <com_deepin_daemon_appearance.h>
+
+using Appearance = com::deepin::daemon::Appearance;
+
 class QLabel;
 class QListView;
 class QResizeEvent;
@@ -53,6 +58,9 @@ class TimezoneMap : public QFrame {
   // Mark current zone on the map.
   void remark();
 
+  // get dot image.
+  QPixmap getDotImage();
+
   // Currently selected/marked timezone.
   ZoneInfo current_zone_;
 
@@ -70,6 +78,8 @@ class TimezoneMap : public QFrame {
 
   // To display a list of zones on map.
   PopupMenu* popup_window_ = nullptr;
+
+  Appearance *m_appearanceInter;
 
  private Q_SLOTS:
   void onPopupWindowActivated(int index);

--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.h
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.h
@@ -7,10 +7,6 @@
 
 #include <QFrame>
 
-#include <com_deepin_daemon_appearance.h>
-
-using Appearance = com::deepin::daemon::Appearance;
-
 class QLabel;
 class QListView;
 class QResizeEvent;
@@ -33,6 +29,7 @@ class TimezoneMap : public QFrame {
 
   // Get current selected timezone, might be empty.
   const QString getTimezone() const;
+  void setSystemActiveColor(const QString &color);
 
  Q_SIGNALS:
   void timezoneUpdated(const QString& timezone);
@@ -79,7 +76,7 @@ class TimezoneMap : public QFrame {
   // To display a list of zones on map.
   PopupMenu* popup_window_ = nullptr;
 
-  Appearance *m_appearanceInter;
+  QString m_systemActiveColor;
 
  private Q_SLOTS:
   void onPopupWindowActivated(int index);

--- a/src/frame/modules/datetime/timezone_dialog/timezonechooser.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/timezonechooser.cpp
@@ -215,6 +215,7 @@ void TimeZoneChooser::setCurrentTimeZoneText(const QString &zone)
 void TimeZoneChooser::setMode(DatetimeModel *model)
 {
     m_model = model;
+    m_map->setSystemActiveColor(m_model->systemActiveColor());
 }
 
 void TimeZoneChooser::setMarkedTimeZone(const QString &timezone)


### PR DESCRIPTION
按UI设计要求，将时区地图中选择的坐标标识圆点颜色替换成系统活动色

Log: 修复修改系统时区主题适配问题
Bug: https://pms.uniontech.com/bug-view-171885.html
Influence: 图中选择的坐标标识圆点颜色替换成系统活动色