### PR TITLE
fix: 控制中心取消蓝牙配对焦点跳转异常

### DIFF
--- a/src/frame/window/modules/bluetooth/bluetoothwidget.cpp
+++ b/src/frame/window/modules/bluetooth/bluetoothwidget.cpp
@@ -135,6 +135,7 @@ void BluetoothWidget::updateWidget()
     vLayout->addStretch();
     m_tFrame->setLayout(vLayout);
     setContent(m_tFrame);
+    this->setFocus();
 }
 
 void BluetoothWidget::setVisibleState()


### PR DESCRIPTION
在每次去更新页面时，重新设置一下蓝牙页面的焦点

Log: 修复控制中心取消蓝牙配对焦点跳转异常的问题
Bug: https://pms.uniontech.com/bug-view-172115.html
Influence: 取消蓝牙配对时焦点不会自动跳转到搜索栏
Change-Id: Icb7cfa8c848a40580369d2ad63873e2120d02773