### PR TITLE
fix: 修复搜索"进入开发者模式"并跳转时打开错误页面的问题

### DIFF
--- a/src/frame/window/modules/commoninfo/commoninfomodule.cpp
+++ b/src/frame/window/modules/commoninfo/commoninfomodule.cpp
@@ -123,7 +123,7 @@ QStringList CommonInfoModule::availPage() const
     sl << "Boot Menu";
 
     if (!IsServerSystem && !IsCommunitySystem) {
-        sl << "User Experience Program" << "Developer Mode";
+        sl << "Developer Mode" << "User Experience Program";
     }
     sl.append(InsertPlugin::instance()->availPages(name()));
     return sl;


### PR DESCRIPTION
页面顺序初始化错误，导致无法正确跳转

Log: 修复控制中心，搜索进入开发者模式异常问题
Bug: https://pms.uniontech.com/bug-view-169845.html
Influence: 正常搜索并跳转进入开发者模式页面