### PR TITLE
fix: 修复KLUA切换扩展模式，副屏显示窗口显示在主屏的问题

### DIFF
--- a/src/frame/modules/display/monitor.cpp
+++ b/src/frame/modules/display/monitor.cpp
@@ -290,13 +290,15 @@ bool Monitor::hasRatefresh(const double r)
 
 QScreen *Monitor::getQScreen()
 {
-    auto screens = QGuiApplication::screens();
-
-    for(auto screen : screens) {
-        //x11下，qt获取的名字和后端给的名字一致 wayland下，qt获取的序列号中包含名称
-        if(screen->name() == name() || screen->model().contains(name()))
+    const auto screens = QGuiApplication::screens();
+    QScreen *res = nullptr;
+    for(const auto screen : screens) {
+        // x11下，qt获取的名字和后端给的名字一致 wayland下，qt获取的序列号中包含名称,优先获取名称完全一致的屏幕
+        // 例如eDP-1和DP-1，精准找到DP-1
+        if(screen->name() == name())
             return screen;
+        if(screen->model().contains(name()))
+            res = screen;
     }
-
-    return nullptr;
+    return res;
 }


### PR DESCRIPTION
屏幕获取错误

Log: 修复KLUA切换扩展模式，副屏显示窗口显示在主屏的问题
Bug: https://pms.uniontech.com/bug-view-170621.html
Influence: 控制中心显示模块
Change-Id: If41a7bd299821e024f5a1640f30a0bb298f79856