### PR TITLE
fix: 显示-多屏拓展模式设置顺序调整

### DIFF
--- a/src/frame/CMakeLists.txt
+++ b/src/frame/CMakeLists.txt
@@ -109,6 +109,7 @@ set(WINDOW_FILES
     window/modules/display/scalingwidget.cpp
     window/modules/display/resolutionwidget.cpp
     window/modules/display/brightnesswidget.cpp
+    window/modules/display/colortempwidget.cpp
     window/modules/display/rotatewidget.cpp
     window/modules/display/refreshratewidget.cpp
     window/modules/display/multiscreenwidget.cpp

--- a/src/frame/window/modules/display/brightnesswidget.cpp
+++ b/src/frame/window/modules/display/brightnesswidget.cpp
@@ -8,9 +8,7 @@
 #include "window/utils.h"
 #include "window/gsettingwatcher.h"
 
-#include "widgets/labels/tipslabel.h"
 #include "widgets/settingsheaderitem.h"
-#include "widgets/settingsgroup.h"
 #include "widgets/dccslider.h"
 #include "widgets/switchwidget.h"
 #include "widgets/titledslideritem.h"
@@ -20,7 +18,7 @@
 
 using namespace dcc::widgets;
 using namespace dcc::display;
-DWIDGET_USE_NAMESPACE;
+DWIDGET_USE_NAMESPACE
 
 namespace DCC_NAMESPACE {
 
@@ -36,15 +34,6 @@ BrightnessWidget::BrightnessWidget(QWidget *parent)
     , m_centralLayout(new QVBoxLayout(this))
     , m_autoLightSpacerItem(new QSpacerItem(0, 10))
     , m_autoLightMode(new SwitchWidget(this))
-    , m_colorSpacerItem(new QSpacerItem(0, 20))
-    , m_tempratureColorWidget(new QWidget(this))
-    , m_nightShift(new SwitchWidget(this))
-    , m_settingsGroup(new SettingsGroup(nullptr, SettingsGroup::GroupBackground))
-    , m_nightManual(new SwitchWidget(this))
-    , m_cctItem(new TitledSliderItem(QString(), this))
-    , m_nightShiftSpacerItem(new QSpacerItem(0, 10))
-    , m_nightTipsSpacerItem(new QSpacerItem(0, 6))
-    , m_nightManualSpacerItem(new QSpacerItem(0, 20))
 {
     m_centralLayout->setMargin(0);
     m_centralLayout->setSpacing(0);
@@ -52,7 +41,6 @@ BrightnessWidget::BrightnessWidget(QWidget *parent)
     //~ contents_path /display/Brightness
     m_brightnessTitle = new TitleLabel(tr("Brightness"), this);
     //~ contents_path /display/Color Temperature
-    m_tempratureColorTitle = new TitleLabel(tr("Color Temperature"), this);
     GSettingWatcher::instance()->bind("displayLightLighting", m_brightnessTitle);  // 使用GSettings来控制显示状态
     m_centralLayout->addWidget(m_brightnessTitle);
 
@@ -64,117 +52,23 @@ BrightnessWidget::BrightnessWidget(QWidget *parent)
     m_autoLightMode->setVisible(false);
     m_centralLayout->addWidget(m_autoLightMode);
 
-    m_centralLayout->addSpacerItem(m_colorSpacerItem);
-
-    m_centralLayout->addWidget(m_tempratureColorTitle);
-
-    //~ contents_path /display/Night Shift
-    m_nightShift->setTitle(tr("Night Shift"));
-    m_nightShift->addBackground();
-    m_centralLayout->addSpacerItem(m_nightShiftSpacerItem);
-    m_centralLayout->addWidget(m_nightShift);
-
-    m_nightTips = new DTipLabel(tr("The screen hue will be auto adjusted according to your location"), m_tempratureColorWidget);
-    m_tempratureColorWidget->setAccessibleName("BrightnessWidget_tempratureColor");
-    m_nightTips->setForegroundRole(DPalette::TextTips);
-    m_nightTips->setWordWrap(true);
-    m_nightTips->setAlignment(Qt::AlignTop | Qt::AlignLeft);
-    m_nightTips->adjustSize();
-    m_nightTips->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
-    m_nightTips->setContentsMargins(10, 0, 0, 0);
-    m_centralLayout->addSpacerItem(m_nightTipsSpacerItem);
-    m_centralLayout->addWidget(m_nightTips);
-
-    //~ contents_path /display/Change Color Temperature
-    m_nightManual->setTitle(tr("Change Color Temperature"));
-    m_cctItem->setAnnotations({tr("Cool"), "", tr("Warm")});
-    m_settingsGroup->appendItem(m_nightManual);
-    m_settingsGroup->appendItem(m_cctItem);
-    m_centralLayout->addSpacerItem(m_nightManualSpacerItem);
-    m_centralLayout->addWidget(m_settingsGroup);
-
-    m_tempratureColorWidget->setLayout(m_centralLayout);
-    GSettingWatcher::instance()->bind("displayColorTemperature", m_tempratureColorWidget);  // 使用GSettings来控制显示状态
-    m_centralLayout->addWidget(m_tempratureColorWidget);
     setLayout(m_centralLayout);
 }
 
-BrightnessWidget::~BrightnessWidget()
-{
-    GSettingWatcher::instance()->erase("displayColorTemperature");
-}
+BrightnessWidget::~BrightnessWidget() = default;
 
 void BrightnessWidget::setMode(DisplayModel *model)
 {
     m_displayModel = model;
 
     connect(m_autoLightMode, &SwitchWidget::checkedChanged, this, &BrightnessWidget::requestAmbientLightAdjustBrightness);
-    connect(m_displayModel, &DisplayModel::adjustCCTmodeChanged, this, &BrightnessWidget::setAdjustCCTmode);
-    connect(m_displayModel, &DisplayModel::redshiftVaildChanged, this, [=](const bool visible) {
-        if ("Hidden" != GSettingWatcher::instance()->getStatus("displayColorTemperature")) {
-            setColorTemperatureVisible(visible);
-        }
-    });
-    connect(m_nightManual, &SwitchWidget::checkedChanged, this, [=](const bool enable) {
-        if (enable) {
-            Q_EMIT requestSetMethodAdjustCCT(2);
-        } else {
-            Q_EMIT requestSetMethodAdjustCCT(0);
-        }
-    });
-    connect(m_nightShift, &SwitchWidget::checkedChanged, this, [=](const bool enable) {
-        if (enable) {
-            Q_EMIT requestSetMethodAdjustCCT(1);
-        } else {
-            Q_EMIT requestSetMethodAdjustCCT(0);
-        }
-    });
     connect(m_displayModel, &DisplayModel::autoLightAdjustVaildChanged, this, [=](const bool enable) {
         m_autoLightSpacerItem->changeSize(0, enable ? 10 : 0);
         m_autoLightMode->setVisible(enable);
     });
     connect(m_displayModel, &DisplayModel::autoLightAdjustSettingChanged, m_autoLightMode, &SwitchWidget::setChecked);
 
-    if ("Hidden" != GSettingWatcher::instance()->getStatus("displayColorTemperature")) {
-        m_autoLightSpacerItem->changeSize(0, model->autoLightAdjustIsValid() ? 10 : 0);
-        m_autoLightMode->setVisible(model->autoLightAdjustIsValid());
-        m_autoLightMode->setChecked(model->isAudtoLightAdjust());
-        setAdjustCCTmode(model->adjustCCTMode()); //0不调节色温  1  自动调节   2手动调节
-        setColorTemperatureVisible(model->redshiftIsValid());
-    } else {
-        setColorTemperatureVisible(false);
-    }
-
     addSlider();
-}
-
-void BrightnessWidget::setColorTemperatureVisible(bool visible)
-{
-    m_nightShiftSpacerItem->changeSize(0, visible ? 10 : 0);
-    m_nightTipsSpacerItem->changeSize(0, visible ? 6 : 0);
-    m_nightManualSpacerItem->changeSize(0, visible ? 20 : 0);
-    m_nightShift->setVisible(visible);
-    m_tempratureColorTitle->setVisible(visible);
-    m_tempratureColorWidget->setVisible(visible);
-    m_nightTips->setVisible(visible);
-    m_nightManual->setVisible(visible);
-    m_cctItem->setVisible(visible && m_displayModel->adjustCCTMode() == 2);
-}
-
-void BrightnessWidget::setAdjustCCTmode(int mode)
-{
-    m_nightShift->blockSignals(true);
-    m_nightManual->blockSignals(true);
-    m_nightShift->switchButton()->setChecked(mode == 1);
-    m_nightManual->switchButton()->setChecked(mode == 2);
-    m_cctItem->blockSignals(true);
-    //当布局器A中嵌套布局器B时，B中的控件隐藏时，需要先隐藏B再隐藏控件，消除控件闪动问题
-    m_settingsGroup->hide();
-    m_cctItem->setVisible(m_displayModel->adjustCCTMode() == 2);
-    m_settingsGroup->show();
-    m_cctItem->blockSignals(false);
-    m_nightShift->blockSignals(false);
-    m_nightManual->blockSignals(false);
 }
 
 void BrightnessWidget::showBrightness(Monitor *monitor)
@@ -188,8 +82,6 @@ void BrightnessWidget::showBrightness(Monitor *monitor)
         }
     }
     m_brightnessTitle->setVisible(bTitle);
-    //色温模块不显示的时候 设置空白区域高度为0
-    m_colorSpacerItem->changeSize(0, bTitle && ("Hidden" != GSettingWatcher::instance()->getStatus("displayColorTemperature")) && m_displayModel->redshiftIsValid() ? 20 : 0);
 }
 
 void BrightnessWidget::addSlider()
@@ -325,40 +217,6 @@ void BrightnessWidget::addSlider()
         m_centralLayout->insertWidget(1, brightnessSlideritem);
         m_monitorBrightnessMap[monList[i]] = brightnessSlideritem;
     }
-
-    DCCSlider *cctSlider = m_cctItem->slider();
-    cctSlider->setRange(0, 100);
-    cctSlider->setType(DCCSlider::Vernier);
-    cctSlider->setTickPosition(QSlider::TicksBelow);
-    cctSlider->setTickInterval(10);
-    cctSlider->setPageStep(1);
-    cctSlider->setValue(colorTemperatureToValue(m_displayModel->colorTemperature()));
-    connect(m_displayModel, &DisplayModel::colorTemperatureChanged, this, [=](int value) {
-        cctSlider->blockSignals(true);
-        cctSlider->setValue(colorTemperatureToValue(value));
-        cctSlider->blockSignals(false);
-    });
-
-    connect(cctSlider, &DCCSlider::valueChanged, this, [=](int pos) {
-        int kelvin = pos > 50 ? (6500 - (pos - 50) * 100) : (6500 + (50 - pos) * 300);
-        this->requestSetColorTemperature(kelvin);
-    });
-    connect(cctSlider, &DCCSlider::sliderMoved, this, [=](int pos) {
-        int kelvin = pos > 50 ? (6500 - (pos - 50) * 100) : (6500 + (50 - pos) * 300);
-        this->requestSetColorTemperature(kelvin);
-    });
-}
-
-int BrightnessWidget::colorTemperatureToValue(int kelvin)
-{
-    //色温范围有效值10000-25000  值越大，色温越冷，不开启色温时值为6500,超过18000基本看不出变化，小于1500色温实际效果没法看，无实际价值
-    //此处取有效至1500-21500
-    if (kelvin >= 6500)
-        return 50 - (kelvin - 6500) / 300;
-    else if (kelvin < 6500 && kelvin >= 1000)
-        return 50 - (kelvin - 6500) / 100;
-    else
-        return 0;
 }
 
 QString BrightnessWidget::brightnessToTickInterval(const double tb) const

--- a/src/frame/window/modules/display/brightnesswidget.h
+++ b/src/frame/window/modules/display/brightnesswidget.h
@@ -21,9 +21,7 @@ QT_END_NAMESPACE
 namespace dcc {
 
 namespace widgets {
-class TipsLabel;
 class SwitchWidget;
-class SettingsGroup;
 class TitledSliderItem;
 } // namespace widgets
 
@@ -47,20 +45,15 @@ public:
 
 public:
     void setMode(dcc::display::DisplayModel *model);
-    void setAdjustCCTmode(int mode);
     void showBrightness(dcc::display::Monitor *monitor = nullptr);
 
 Q_SIGNALS:
     void requestSetMonitorBrightness(dcc::display::Monitor *monitor, const double brightness);
     void requestAmbientLightAdjustBrightness(const bool able);
-    void requestSetColorTemperature(const int value);
-    void requestSetMethodAdjustCCT(const int mode);
 
 private:
     void addSlider();
-    int colorTemperatureToValue(int kelvin);
     QString brightnessToTickInterval(const double tb) const;
-    void setColorTemperatureVisible(bool visible);
 
 private:
     dcc::display::DisplayModel *m_displayModel;
@@ -69,17 +62,6 @@ private:
     TitleLabel *m_brightnessTitle;
     QSpacerItem *m_autoLightSpacerItem;
     dcc::widgets::SwitchWidget *m_autoLightMode;
-    QSpacerItem *m_colorSpacerItem;
-    QWidget *m_tempratureColorWidget;
-    TitleLabel *m_tempratureColorTitle;
-    dcc::widgets::SwitchWidget *m_nightShift;
-    DTK_WIDGET_NAMESPACE::DTipLabel *m_nightTips;
-    dcc::widgets::SettingsGroup *m_settingsGroup;
-    dcc::widgets::SwitchWidget *m_nightManual;
-    dcc::widgets::TitledSliderItem *m_cctItem;
-    QSpacerItem *m_nightShiftSpacerItem;
-    QSpacerItem *m_nightTipsSpacerItem;
-    QSpacerItem *m_nightManualSpacerItem;
 
     int m_miniScales = 0;
     QMap<dcc::display::Monitor *, QWidget *> m_monitorBrightnessMap;

--- a/src/frame/window/modules/display/colortempwidget.cpp
+++ b/src/frame/window/modules/display/colortempwidget.cpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "colortempwidget.h"
+#include "modules/display/displaymodel.h"
+#include "modules/display/monitor.h"
+#include "window/utils.h"
+#include "window/gsettingwatcher.h"
+
+#include "widgets/labels/tipslabel.h"
+#include "widgets/settingsheaderitem.h"
+#include "widgets/settingsgroup.h"
+#include "widgets/dccslider.h"
+#include "widgets/switchwidget.h"
+#include "widgets/titledslideritem.h"
+#include <QLabel>
+#include <QVBoxLayout>
+#include <DFontSizeManager>
+
+using namespace dcc::widgets;
+using namespace dcc::display;
+DWIDGET_USE_NAMESPACE
+
+namespace DCC_NAMESPACE {
+namespace display {
+
+const double BrightnessMaxScale = 100.0;
+const int PercentageNum = 100;
+const double DoubleZero = 0.01;
+
+ColorTempWidget::ColorTempWidget(QWidget *parent)
+    : QWidget(parent)
+    , m_displayModel(nullptr)
+    , m_centralLayout(new QVBoxLayout(this))
+    , m_tempratureColorWidget(new QWidget(this))
+    , m_nightShift(new SwitchWidget(this))
+    , m_settingsGroup(new SettingsGroup(nullptr, SettingsGroup::GroupBackground))
+    , m_nightManual(new SwitchWidget(this))
+    , m_cctItem(new TitledSliderItem(QString(), this))
+    , m_nightShiftSpacerItem(new QSpacerItem(0, 10))
+    , m_nightTipsSpacerItem(new QSpacerItem(0, 6))
+    , m_nightManualSpacerItem(new QSpacerItem(0, 20))
+{
+    m_centralLayout->setMargin(0);
+    m_centralLayout->setSpacing(0);
+
+    m_tempratureColorTitle = new TitleLabel(tr("Color Temperature"), this);
+
+    m_centralLayout->addWidget(m_tempratureColorTitle);
+
+    //~ contents_path /display/Night Shift
+    m_nightShift->setTitle(tr("Night Shift"));
+    m_nightShift->addBackground();
+    m_centralLayout->addSpacerItem(m_nightShiftSpacerItem);
+    m_centralLayout->addWidget(m_nightShift);
+
+    m_nightTips = new DTipLabel(tr("The screen hue will be auto adjusted according to your location"), m_tempratureColorWidget);
+    m_tempratureColorWidget->setAccessibleName("BrightnessWidget_tempratureColor");
+    m_nightTips->setForegroundRole(DPalette::TextTips);
+    m_nightTips->setWordWrap(true);
+    m_nightTips->setAlignment(Qt::AlignTop | Qt::AlignLeft);
+    m_nightTips->adjustSize();
+    m_nightTips->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
+    m_nightTips->setContentsMargins(10, 0, 0, 0);
+    m_centralLayout->addSpacerItem(m_nightTipsSpacerItem);
+    m_centralLayout->addWidget(m_nightTips);
+
+    //~ contents_path /display/Change Color Temperature
+    m_nightManual->setTitle(tr("Change Color Temperature"));
+    m_cctItem->setAnnotations({tr("Cool"), "", tr("Warm")});
+    m_settingsGroup->appendItem(m_nightManual);
+    m_settingsGroup->appendItem(m_cctItem);
+    m_centralLayout->addSpacerItem(m_nightManualSpacerItem);
+    m_centralLayout->addWidget(m_settingsGroup);
+
+    m_tempratureColorWidget->setLayout(m_centralLayout);
+    GSettingWatcher::instance()->bind("displayColorTemperature", m_tempratureColorWidget);  // 使用GSettings来控制显示状态
+    m_centralLayout->addWidget(m_tempratureColorWidget);
+    setLayout(m_centralLayout);
+}
+
+ColorTempWidget::~ColorTempWidget()
+{
+    GSettingWatcher::instance()->erase("displayColorTemperature");
+}
+
+void ColorTempWidget::setMode(DisplayModel *model)
+{
+    m_displayModel = model;
+
+    connect(m_displayModel, &DisplayModel::adjustCCTmodeChanged, this, &ColorTempWidget::setAdjustCCTmode);
+    connect(m_displayModel, &DisplayModel::redshiftVaildChanged, this, [=](const bool visible) {
+        if ("Hidden" != GSettingWatcher::instance()->getStatus("displayColorTemperature")) {
+            setColorTemperatureVisible(visible);
+        }
+    });
+    connect(m_nightManual, &SwitchWidget::checkedChanged, this, [=](const bool enable) {
+        if (enable) {
+            Q_EMIT requestSetMethodAdjustCCT(2);
+        } else {
+            Q_EMIT requestSetMethodAdjustCCT(0);
+        }
+    });
+    connect(m_nightShift, &SwitchWidget::checkedChanged, this, [=](const bool enable) {
+        if (enable) {
+            Q_EMIT requestSetMethodAdjustCCT(1);
+        } else {
+            Q_EMIT requestSetMethodAdjustCCT(0);
+        }
+    });
+
+    if ("Hidden" != GSettingWatcher::instance()->getStatus("displayColorTemperature")) {
+        setAdjustCCTmode(model->adjustCCTMode()); //0不调节色温  1  自动调节   2手动调节
+        setColorTemperatureVisible(model->redshiftIsValid());
+    } else {
+        setColorTemperatureVisible(false);
+    }
+
+    addSlider();
+}
+
+void ColorTempWidget::setAdjustCCTmode(int mode)
+{
+    m_nightShift->blockSignals(true);
+    m_nightManual->blockSignals(true);
+    m_nightShift->switchButton()->setChecked(mode == 1);
+    m_nightManual->switchButton()->setChecked(mode == 2);
+    m_cctItem->blockSignals(true);
+    //当布局器A中嵌套布局器B时，B中的控件隐藏时，需要先隐藏B再隐藏控件，消除控件闪动问题
+    m_settingsGroup->hide();
+    m_cctItem->setVisible(m_displayModel->adjustCCTMode() == 2);
+    m_settingsGroup->show();
+    m_cctItem->blockSignals(false);
+    m_nightShift->blockSignals(false);
+    m_nightManual->blockSignals(false);
+}
+
+void ColorTempWidget::addSlider()
+{
+    DCCSlider *cctSlider = m_cctItem->slider();
+    cctSlider->setRange(0, 100);
+    cctSlider->setType(DCCSlider::Vernier);
+    cctSlider->setTickPosition(QSlider::TicksBelow);
+    cctSlider->setTickInterval(10);
+    cctSlider->setPageStep(1);
+    cctSlider->setValue(colorTemperatureToValue(m_displayModel->colorTemperature()));
+    connect(m_displayModel, &DisplayModel::colorTemperatureChanged, this, [=](int value) {
+        cctSlider->blockSignals(true);
+        cctSlider->setValue(colorTemperatureToValue(value));
+        cctSlider->blockSignals(false);
+    });
+
+    connect(cctSlider, &DCCSlider::valueChanged, this, [=](int pos) {
+        int kelvin = pos > 50 ? (6500 - (pos - 50) * 100) : (6500 + (50 - pos) * 300);
+        this->requestSetColorTemperature(kelvin);
+    });
+    connect(cctSlider, &DCCSlider::sliderMoved, this, [=](int pos) {
+        int kelvin = pos > 50 ? (6500 - (pos - 50) * 100) : (6500 + (50 - pos) * 300);
+        this->requestSetColorTemperature(kelvin);
+    });
+}
+
+int ColorTempWidget::colorTemperatureToValue(int kelvin)
+{
+    //色温范围有效值10000-25000  值越大，色温越冷，不开启色温时值为6500,超过18000基本看不出变化，小于1500色温实际效果没法看，无实际价值
+    //此处取有效至1500-21500
+    if (kelvin >= 6500)
+        return 50 - (kelvin - 6500) / 300;
+    else if (kelvin < 6500 && kelvin >= 1000)
+        return 50 - (kelvin - 6500) / 100;
+    else
+        return 0;
+}
+
+void ColorTempWidget::setColorTemperatureVisible(bool visible)
+{
+    m_nightShiftSpacerItem->changeSize(0, visible ? 10 : 0);
+    m_nightTipsSpacerItem->changeSize(0, visible ? 6 : 0);
+    m_nightManualSpacerItem->changeSize(0, visible ? 20 : 0);
+    m_nightShift->setVisible(visible);
+    m_tempratureColorTitle->setVisible(visible);
+    m_tempratureColorWidget->setVisible(visible);
+    m_nightTips->setVisible(visible);
+    m_nightManual->setVisible(visible);
+    m_cctItem->setVisible(visible && m_displayModel->adjustCCTMode() == 2);
+}
+
+} // namespace display
+} // namespace DCC_NAMESPACE
+

--- a/src/frame/window/modules/display/colortempwidget.h
+++ b/src/frame/window/modules/display/colortempwidget.h
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2011 - 2022 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#ifndef COLORTEMPWIDGET_H
+#define COLORTEMPWIDGET_H
+
+#include "interface/namespace.h"
+#include "widgets/titlelabel.h"
+
+#include <DTipLabel>
+
+#include <QWidget>
+
+QT_BEGIN_NAMESPACE
+class QLabel;
+class QSpacerItem;
+class QVBoxLayout;
+QT_END_NAMESPACE
+
+namespace dcc {
+
+namespace widgets {
+class TipsLabel;
+class SwitchWidget;
+class SettingsGroup;
+class TitledSliderItem;
+} // namespace widgets
+
+namespace display {
+class Monitor;
+class DisplayModel;
+} // namespace display
+
+} // namespace dcc
+
+namespace DCC_NAMESPACE {
+namespace display {
+
+class ColorTempWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit ColorTempWidget(QWidget *parent = nullptr);
+    ~ColorTempWidget();
+
+public:
+    void setMode(dcc::display::DisplayModel *model);
+    void setAdjustCCTmode(int mode);
+
+Q_SIGNALS:
+    void requestSetColorTemperature(const int value);
+    void requestSetMethodAdjustCCT(const int mode);
+
+private:
+    void addSlider();
+    int colorTemperatureToValue(int kelvin);
+    void setColorTemperatureVisible(bool visible);
+
+private:
+    dcc::display::DisplayModel *m_displayModel;
+
+    QVBoxLayout *m_centralLayout;
+    QWidget *m_tempratureColorWidget;
+    TitleLabel *m_tempratureColorTitle;
+    dcc::widgets::SwitchWidget *m_nightShift;
+    DTK_WIDGET_NAMESPACE::DTipLabel *m_nightTips;
+    dcc::widgets::SettingsGroup *m_settingsGroup;
+    dcc::widgets::SwitchWidget *m_nightManual;
+    dcc::widgets::TitledSliderItem *m_cctItem;
+    QSpacerItem *m_nightShiftSpacerItem;
+    QSpacerItem *m_nightTipsSpacerItem;
+    QSpacerItem *m_nightManualSpacerItem;
+};
+
+} // namespace display
+} // namespace DCC_NAMESPACE
+
+#endif // COLORTEMPWIDGET_H

--- a/src/frame/window/modules/display/multiscreenwidget.h
+++ b/src/frame/window/modules/display/multiscreenwidget.h
@@ -7,6 +7,7 @@
 
 #include "interface/namespace.h"
 #include "widgets/titlelabel.h"
+#include <DTipLabel>
 
 class Resolution;
 
@@ -36,6 +37,7 @@ namespace DCC_NAMESPACE {
 
 namespace display {
 class BrightnessWidget;
+class ColorTempWidget;
 class ScalingWidget;
 class ResolutionWidget;
 class RefreshRateWidget;
@@ -109,6 +111,9 @@ private:
     ResolutionWidget *m_resolutionWidget;
     RefreshRateWidget *m_refreshRateWidget;
     RotateWidget *m_rotateWidget;
+    ColorTempWidget *m_colortempWidget;
+    DTK_WIDGET_NAMESPACE::DTipLabel *m_multiTips;
+    QSpacerItem *m_multiTipsSpacerItem;
 
     dcc::display::DisplayModel *m_model;
 


### PR DESCRIPTION
优化设置项顺序以及提供友好提示

Log: 显示-多屏拓展模式设置顺序调整
Task: https://pms.uniontech.com/task-view-212931.html
Influence: 调整主屏设置窗口的设置项顺序，并添加新文案