### PR TITLE
fix: 时区选择界面主题和地图颜色相反

### DIFF
--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
@@ -124,9 +124,11 @@ void TimezoneMap::resizeEvent(QResizeEvent* event) {
 
   QLabel *background_label = findChild<QLabel*>("background_label");
   if (background_label) {
-      QPixmap timezone_pixmap = loadPixmap(kTimezoneMapFile);
+      // kTimezoneMapFile_Light图片地图区域为黑色，其他区域为白色透明，与浅色主题界面保持一致
+      QPixmap timezone_pixmap = loadPixmap(kTimezoneMapFile_Light);
       if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
-          timezone_pixmap = loadPixmap(kTimezoneMapFile_Light);
+          // kTimezoneMapFile 图片地图区域为白色，其他空白区域为黑色，与深色主题界面保持一致
+          timezone_pixmap = loadPixmap(kTimezoneMapFile);
       }
       background_label->setPixmap(timezone_pixmap.scaled(event->size() * devicePixelRatioF(), Qt::KeepAspectRatio, Qt::FastTransformation));
   }
@@ -157,7 +159,12 @@ void TimezoneMap::initConnections() {
 void TimezoneMap::initUI() {
   QLabel* background_label = new QLabel(this);
   background_label->setObjectName("background_label");
-  QPixmap timezone_pixmap = loadPixmap(kTimezoneMapFile);
+  // kTimezoneMapFile_Light 地图区域为黑色，其他区域为白色透明，与浅色主题界面保持一致
+  QPixmap timezone_pixmap = loadPixmap(kTimezoneMapFile_Light);
+  if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::DarkType) {
+      // kTimezoneMapFile 地图区域为白色，其他空白区域为黑色，与深色主题界面保持一致
+      timezone_pixmap = loadPixmap(kTimezoneMapFile);
+  }
   Q_ASSERT(!timezone_pixmap.isNull());
   background_label->setPixmap(timezone_pixmap);
 

--- a/src/frame/modules/datetime/timezone_dialog/timezonechooser.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/timezonechooser.cpp
@@ -66,10 +66,11 @@ TimeZoneChooser::TimeZoneChooser(QWidget* parent)
     handle.setWindowRadius(18);
 
     m_blurEffect->setBlendMode(DBlurEffectWidget::BehindWindowBlend);
+    // 浅色主题时使用白色透明，让地图空白区域与界面保持一致，而深色主题时使用黑色透明与界面保持一致
     if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::LightType) {
-        m_blurEffect->setMaskColor(Qt::black);
-    } else {
         m_blurEffect->setMaskColor(Qt::white);
+    } else {
+        m_blurEffect->setMaskColor(Qt::black);
     }
 
     DDialogCloseButton *closeButton = new DDialogCloseButton;


### PR DESCRIPTION
时区选择界面主题和地图颜色相反,浅色主题时，选择界面为白色透明，地图区域为黑色透明；而深色主题时，选择界面为黑色透明，地图区域为白色透明

Log: 修复系统时区主题适配问题
Bug: https://pms.uniontech.com/bug-view-171885.html
Influence: 浅色主题时，选择界面为白色透明，地图区域为黑色透明；而深色主题时，选择界面为黑色透明，地图区域为白色透明