### PR TITLE
fix(audio): 修复概率无反馈音量问题

### DIFF
--- a/src/frame/modules/sound/soundworker.h
+++ b/src/frame/modules/sound/soundworker.h
@@ -91,6 +91,7 @@ private:
     SoundEffect *m_soundEffectInter;
     QPointer<Sink> m_defaultSink;
     QPointer<Source> m_defaultSource;
+    QPointer<Meter> m_defaultSourceMeter;
     QList<Sink*> m_sinks;
     QList<Source*> m_sources;
     SystemPowerInter *m_powerInter;


### PR DESCRIPTION
sources 属性和 default_source 属性变换信号存在时序问题，
可能 meter 建立的指向的是先前的 default_source，后面才收到
default_source 变换信号。

Log: 修复概率无反馈音量问题
Bug: https://pms.uniontech.com/bug-view-174101.html
Influence: 声音-输入-反馈