### PR TITLE
fix: 时区选择弹窗界面根据控制中心深浅主题变化而变化

### DIFF
--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.h
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.h
@@ -44,6 +44,7 @@ class TimezoneMap : public QFrame {
 
   // Hide tooltips when window is resized.
   void resizeEvent(QResizeEvent* event) override;
+  bool eventFilter(QObject *watcher, QEvent *event) override;
 
  private:
   void initConnections();
@@ -54,9 +55,6 @@ class TimezoneMap : public QFrame {
 
   // Mark current zone on the map.
   void remark();
-
-  // get dot image.
-  QPixmap getDotImage();
 
   // Currently selected/marked timezone.
   ZoneInfo current_zone_;


### PR DESCRIPTION
时区选择弹窗界面根据控制中心深浅主题变化而变化,原方案是替换颜色处理，但是在图形边缘有像素点替换不干净，形成了边框的效果，修改成重新使用活动色绘 制原点方式处理。

Log: 时区选择弹窗界面根据控制中心深浅主题变化而变化
Bug: https://pms.uniontech.com/bug-view-171885.html
Influence: 时区选择弹窗界面根据控制中心深浅主题变化而变化