### PR TITLE
fix: 根据当前状态设置添加系统语言按钮焦点策略

### DIFF
--- a/src/frame/window/modules/keyboard/systemlanguagewidget.cpp
+++ b/src/frame/window/modules/keyboard/systemlanguagewidget.cpp
@@ -80,18 +80,18 @@ SystemLanguageWidget::SystemLanguageWidget(KeyboardModel *model, QWidget *parent
     vLayout->addWidget(contentWidget);
     vLayout->setAlignment(Qt::AlignTop);
 
-    DFloatingButton *addSystemLanguage = new DFloatingButton(DStyle::SP_IncreaseElement, this);
-    addSystemLanguage->setObjectName("AddSystemLanguage");
+    m_addSystemLanguage = new DFloatingButton(DStyle::SP_IncreaseElement, this);
+    m_addSystemLanguage->setObjectName("AddSystemLanguage");
     QHBoxLayout *btnLayout = new QHBoxLayout;
     btnLayout->setMargin(0);
     btnLayout->setAlignment(Qt::AlignBottom | Qt::AlignHCenter);
-    btnLayout->addWidget(addSystemLanguage);
+    btnLayout->addWidget(m_addSystemLanguage);
     vLayout->addLayout(btnLayout);
     vLayout->setContentsMargins(10, 10, 10, 5);
     setLayout(vLayout);
 
     connect(m_langListview, &DListView::clicked, this, &SystemLanguageWidget::setCurLangChecked);
-    connect(addSystemLanguage, &DFloatingButton::clicked, this, &SystemLanguageWidget::onSystemLanguageAdded);
+    connect(m_addSystemLanguage, &DFloatingButton::clicked, this, &SystemLanguageWidget::onSystemLanguageAdded);
     connect(m_editSystemLang, &QPushButton::clicked, this, &SystemLanguageWidget::onEditClicked);
 
     connect(m_model, &KeyboardModel::curLocalLangChanged, this, [this](const QStringList &curLocalLang) {
@@ -191,6 +191,7 @@ void SystemLanguageWidget::onDefault(const QString &curLang)
 void SystemLanguageWidget::onSetCurLang(int value)
 {
     qDebug() << "m_langListview & m_editSystemLang" << value;
+    m_addSystemLanguage->setFocusPolicy(value ? Qt::NoFocus : Qt::TabFocus);
     m_langListview->setEnabled(!value);
     m_editSystemLang->setEnabled(!value);
 }

--- a/src/frame/window/modules/keyboard/systemlanguagewidget.h
+++ b/src/frame/window/modules/keyboard/systemlanguagewidget.h
@@ -11,6 +11,7 @@
 #include <DCommandLinkButton>
 
 #include <DListView>
+#include <DFloatingButton>
 
 #include <QWidget>
 
@@ -51,6 +52,7 @@ private:
     DTK_WIDGET_NAMESPACE::DListView *m_langListview;
     DCommandLinkButton *m_editSystemLang;
     SystemLanguageSettingWidget *m_settingWidget;
+    DFloatingButton *m_addSystemLanguage;
     bool m_bEdit{false};
 };
 }


### PR DESCRIPTION
根据当前状态设置添加系统语言按钮焦点策略

Log: 修复切换系统语言，系统语言+按钮展示Focus状态问题
Bug: https://pms.uniontech.com/bug-view-175149.html
Influence: 切换系统语言，系统语言+按钮不显示Focus状态