### PR TITLE
fix: 控制中心sudo用户组显示存在问题

### DIFF
--- a/src/frame/window/modules/accounts/usergroupspage.cpp
+++ b/src/frame/window/modules/accounts/usergroupspage.cpp
@@ -45,8 +45,9 @@ void UserGroupsPage::changeUserGroup(const QStringList &groups)
     int row_count = m_groupItemModel->rowCount();
     for (int i = 0; i < row_count; ++i) {
         QStandardItem *item = m_groupItemModel->item(i, 0);
-        item->setCheckState(item && groups.contains(item->text()) ? Qt::Checked : Qt::Unchecked);
-        item->setEnabled(item->text() != m_groupName);
+        if (item) {
+            item->setCheckState(groups.contains(item->text()) ? Qt::Checked : Qt::Unchecked);
+        }
     }
     m_groupItemModel->sort(0);
 }


### PR DESCRIPTION
当更新用户组时，不更新该选项的使能状态，只更新其选中状态

Log: 修复控制中心sudo用户组显示存在问题的问题
Bug: https://pms.uniontech.com/bug-view-176063.html
Influence: 控制中心用户组正常显示
Change-Id: If7fd136f308e1f9345abffdbf6aa18d1d5194ba3