### PR TITLE
fix: 规避复制模式无相同刷新率显示

### DIFF
--- a/src/frame/window/modules/display/refreshratewidget.cpp
+++ b/src/frame/window/modules/display/refreshratewidget.cpp
@@ -135,7 +135,7 @@ void RefreshRateWidget::initRefreshRate()
         }
 
         auto rate = mode.rate();
-        DStandardItem *item = new DStandardItem;
+        auto *item = new DStandardItem;
         auto ref = QString::number(rate, 'g', 4) + tr("Hz");
         if (Monitor::isSameResolution(mode, m_monitor->bestMode())) {
             if (Monitor::isSameRatefresh(mode, m_monitor->bestMode())) {
@@ -165,4 +165,9 @@ void RefreshRateWidget::initRefreshRate()
             Q_EMIT requestSetResolution(m_monitor, r);
         }
     });
+
+    if (m_refreshItemModel->rowCount() == 0) {
+        m_refreshLabel->setDisabled(true);
+        m_refreshCombox->setDisabled(true);
+    }
 }


### PR DESCRIPTION
可显示刷新率为空时,置灰相关UI

Log: 规避复制模式无相同刷新率显示
Bug: https://pms.uniontech.com/bug-view-124357.html
Influence: 刷新率显示
Change-Id: I6f265843c067c0ac6429191151595c40c071209c