### PR TITLE
fix(shortcut): 禁用快捷键名称显示控件的html标签解析功能

### DIFF
--- a/src/frame/modules/keyboard/shortcutitem.cpp
+++ b/src/frame/modules/keyboard/shortcutitem.cpp
@@ -38,6 +38,7 @@ ShortcutItem::ShortcutItem(QFrame *parent)
     m_title->setText("");
     m_title->setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
     m_title->setWordWrap(false);
+    m_title->setTextFormat(Qt::TextFormat::PlainText);
     m_title->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
 
     layout->addWidget(m_title);
@@ -208,7 +209,6 @@ void ShortcutItem::resizeEvent(QResizeEvent *event)
         m_title->setToolTip(m_info->name);
         QTimer::singleShot(0, this, &ShortcutItem::updateTitleSize);
     }
-    
 }
 
 bool ShortcutItem::eventFilter(QObject *watched, QEvent *event)


### PR DESCRIPTION
禁用快捷键名称显示控件的html标签解析功能

Log: 修复添加快捷键-名称未屏蔽富文本转义问题
Bug: https://pms.uniontech.com/bug-view-175179.html
Influence: 禁用快捷键名称显示控件的html标签解析功能