### PR TITLE
fix: 调整自定义快捷键显示项的边距，加高快捷键输入框高度

### DIFF
--- a/src/frame/modules/keyboard/customitem.cpp
+++ b/src/frame/modules/keyboard/customitem.cpp
@@ -22,7 +22,7 @@ CustomItem::CustomItem(QWidget *parent)
 {
     setMouseTracking(true);
     QHBoxLayout *layout = new QHBoxLayout();
-    layout->setContentsMargins(4, 4, 4, 4);
+    layout->setContentsMargins(4, 0, 4, 0);
     layout->setSpacing(2);
 
     m_title = new QLabel();


### PR DESCRIPTION
调整自定义快捷键显示项的边距，加高快捷键输入框高度

Log: 修复自定义快捷键创建页面中的“快捷键”输入框高度显示太小问题
Bug: https://pms.uniontech.com/bug-view-175607.html
Influence: “快捷键”输入框高度加高