### PR TITLE
fix: sw架构打包失败

### DIFF
--- a/src/frame/modules/sound/soundmodel.cpp
+++ b/src/frame/modules/sound/soundmodel.cpp
@@ -82,9 +82,7 @@ SoundModel::SoundModel(QObject *parent)
     , m_microphoneVolume(75)
     , m_maxUIVolume(0.0)
     , m_waitSoundReceiptTime(0)
-#ifndef DCC_DISABLE_FEEDBACK
     , m_microphoneFeedback(50)
-#endif
     , m_soundEffectMapBattery{}
     , m_inputVisibled(false)
     , m_outputVisibled(false)
@@ -185,15 +183,16 @@ void SoundModel::setMicrophoneVolume(double microphoneVolume)
         Q_EMIT microphoneVolumeChanged(microphoneVolume);
     }
 }
-#ifndef DCC_DISABLE_FEEDBACK
+
 void SoundModel::setMicrophoneFeedback(double microphoneFeedback)
 {
+#ifndef DCC_DISABLE_FEEDBACK
     if (!qFuzzyCompare(microphoneFeedback, m_microphoneFeedback)) {
         m_microphoneFeedback = microphoneFeedback;
         Q_EMIT microphoneFeedbackChanged(microphoneFeedback);
     }
-}
 #endif
+}
 
 void SoundModel::setPort(const Port *port)
 {

--- a/src/frame/modules/sound/soundmodel.h
+++ b/src/frame/modules/sound/soundmodel.h
@@ -128,10 +128,8 @@ public:
     inline double microphoneVolume() const { return m_microphoneVolume; }
     void setMicrophoneVolume(double microphoneVolume);
 
-#ifndef DCC_DISABLE_FEEDBACK
     inline double microphoneFeedback() const { return m_microphoneFeedback; }
     void setMicrophoneFeedback(double microphoneFeedback);
-#endif
 
     void setPort(const Port *port);
     void addPort(Port *port);
@@ -235,9 +233,7 @@ Q_SIGNALS:
     //声音输出设备是否可见
     void outputDevicesVisibleChanged(QString name, bool flag);
 
-#ifndef DCC_DISABLE_FEEDBACK
     void microphoneFeedbackChanged(double microphoneFeedback) const;
-#endif
     void portAdded(const Port *port);
     void portRemoved(const QString & portId, const uint &cardId, const Port::Direction &direction);
     void soundDeviceStatusChanged();
@@ -260,10 +256,7 @@ private:
     int m_waitSoundReceiptTime;
     QString m_speakerName;
     QString m_microphoneName;
-
-#ifndef DCC_DISABLE_FEEDBACK
     double m_microphoneFeedback;
-#endif
     QList<Port *> m_ports;
     QList<Port *> m_inputPorts;
     QList<Port *> m_outputPorts;


### PR DESCRIPTION
sw架构不支持麦克风功能，在方法内进行判断，避免在每个调用的地方都进行判断。

Log:
Task: https://pms.uniontech.com/task-view-226391.html
Influence: sw打包 & sw架构声音模块
Change-Id: I7b1c301ad2809cefc3793fdd0124df1d60415ac8