### PR TITLE
fix: 修复添加时区页面样式问题

### DIFF
--- a/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
+++ b/src/frame/modules/datetime/timezone_dialog/timezone_map.cpp
@@ -211,6 +211,7 @@ void TimezoneMap::initUI() {
   popup_window_ = new PopupMenu();
   popup_window_->hide();
 
+  this->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
   this->setContentsMargins(0, 0, 0, 0);
 }
 

--- a/src/frame/modules/datetime/timezone_dialog/timezonechooser.h
+++ b/src/frame/modules/datetime/timezone_dialog/timezonechooser.h
@@ -7,6 +7,7 @@
 
 #include <DBlurEffectWidget>
 #include <DSuggestButton>
+#include <DAbstractDialog>
 
 #include <QFrame>
 #include <QMap>
@@ -37,7 +38,7 @@ namespace dcc {
 namespace datetime {
 class DatetimeModel;
 
-class TimeZoneChooser : public QFrame
+class TimeZoneChooser : public DAbstractDialog
 {
     Q_OBJECT
 public:
@@ -49,7 +50,7 @@ public:
 
 Q_SIGNALS:
     void confirmed(const QString &zone);
-    void cancelled();
+   // void cancelled();
 
 public Q_SLOTS:
     void setMarkedTimeZone(const QString &timezone);
@@ -63,7 +64,7 @@ protected:
     void mouseMoveEvent(QMouseEvent *event) override;
 
 private:
-    QSize getFitSize() const;
+    QSize getScreenSize() const;
     int getFontSize() const;
     void setupSize();
 


### PR DESCRIPTION
1、使用系统统一的窗口关闭按钮
2、搜索框请使用透明度
3、定位tips背景的小尖角与矩形连接处颜色一致，没有黑线
4、取消确认按钮距离底部20px

Log: 修复添加时区页面样式问题
Bug: https://pms.uniontech.com/bug-view-171901.html
Influence: 修复添加时区页面样式问题