### PR TITLE
feat: 增加配置是否加载同步模块

### DIFF
--- a/configs/org.deepin.dde.control-center.json
+++ b/configs/org.deepin.dde.control-center.json
@@ -1,0 +1,16 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "showSyncModule": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "showSyncModule",
+            "description[zh_CN]": "是否显示控制中心内建同步模块",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+  }

--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -1489,7 +1489,6 @@ QString MainWindow::moduleDisplayName(const QString &module) const
     return find_it->second;
 }
 
-
 bool MainWindow::event(QEvent *event)
 {
     if(event->type() == QEvent::Show || event->type() == QEvent::Hide ){
@@ -1503,7 +1502,13 @@ bool MainWindow::showSyncModule()
     if (IsProfessionalSystem)
         return false;
 
-    QObject raii;
-    DConfig *config = DConfig::create("com.deepin.system.mil.dconfig", "com.deepin.system.mil.dconfig", QString(), &raii);
-    return !(config && config->keyList().contains("Use_mil") && config->value("Use_mil", 1).toInt());
+    QObject raii0;
+    DConfig *config0 = DConfig::create("org.deepin.dde.control-center", "org.deepin.dde.control-center", QString(), &raii0);
+    if (!(config0 && config0->keyList().contains("showSyncModule") && config0->value("showSyncModule",true).toBool())) {
+        return false;
+    }
+
+    QObject raii1;
+    DConfig *config1 = DConfig::create("com.deepin.system.mil.dconfig", "com.deepin.system.mil.dconfig", QString(), &raii1);
+    return !(config1 && config1->keyList().contains("Use_mil") && config1->value("Use_mil", 1).toInt());
 }


### PR DESCRIPTION
根据配置，选择是否加载控制中心同步模块，默认为true（专业版代码判断，不加载，军用版走专门配置）

Log: 增加配置是否加载同步模块
Task: https://pms.uniontech.com/task-view-229173.html
Influence: 同步模块
Change-Id: If00c4447d255982854126c4c748d54f4436d2c43