### PR TITLE
fix: 修复自定义快捷键名称重复无提示的问题

### DIFF
--- a/src/frame/window/modules/keyboard/customcontent.cpp
+++ b/src/frame/window/modules/keyboard/customcontent.cpp
@@ -106,6 +106,7 @@ CustomContent::CustomContent(ShortcutModel *model, QWidget *parent)
             }
         }
         m_buttonTuple->rightButton()->setEnabled(!exist);
+        m_shortCutNameEdit->setAlert(exist);
     });
 
     mainLayout->addWidget(m_shortCutCmdEdit);


### PR DESCRIPTION
经产品确认，增加红色背景

Log: 修复自定义快捷键名称重复无提示的问题
Bug: https://pms.uniontech.com/bug-view-174803.html
Influence: 自定义快捷键
Change-Id: If32c3f776132c394d739bd8ab5942a31eaa9ef40