### PR TITLE
fix: 修复自定义快捷键编辑页面，修改命令和快捷键后无法保存的问题

### DIFF
--- a/src/frame/modules/keyboard/customedit.cpp
+++ b/src/frame/modules/keyboard/customedit.cpp
@@ -82,15 +82,27 @@ keyboard::CustomEdit::CustomEdit(ShortcutModel *model, QWidget *parent):
     });
     connect(m_name->dTextEdit(), &DLineEdit::textChanged, this, [=](const QString &text) {
         okButton->setEnabled(true);
+        m_nameChanged = m_info->name != text;
 
         // 如果用户输入的快捷键名称和已有快捷键名称重复（冲突），置灰保存按钮
         // 防止设置的快捷键名称和已有快捷键名称显示重复
         for (auto info : model->infos()) {
-            if (info->name == text) {
+            if (info->name == text && m_nameChanged) {
+                m_nameRepeated = true;
                 okButton->setEnabled(false);
                 return;
             }
         }
+        m_nameRepeated = false;
+        okButton->setEnabled(!m_nameRepeated && (m_nameChanged || m_commandChanged || m_accelsChanged));
+    });
+    connect(m_command->dTextEdit(), &DLineEdit::textChanged, this, [=](const QString &text) {
+        m_commandChanged = m_info->command != text;
+        okButton->setEnabled(!m_nameRepeated && (m_nameChanged || m_commandChanged || m_accelsChanged));
+    });
+    connect(m_short, &CustomItem::changeAlert, this, [=] {
+        m_accelsChanged = m_info->accels != m_short->text();
+        okButton->setEnabled(!m_nameRepeated && (m_nameChanged || m_commandChanged || m_accelsChanged));
     });
     connect(pushbutton, &DIconButton::clicked, this, &CustomEdit::onOpenFile);
     connect(m_short, &CustomItem::requestUpdateKey, this, &CustomEdit::onUpdateKey);

--- a/src/frame/modules/keyboard/customedit.h
+++ b/src/frame/modules/keyboard/customedit.h
@@ -59,6 +59,10 @@ private:
     QLabel         *m_tip;
     ShortcutInfo *m_conflict;
     WaylandGrab *m_waylandGrab;
+    bool         m_nameChanged;
+    bool         m_nameRepeated;
+    bool         m_commandChanged;
+    bool         m_accelsChanged;
 };
 }
 }


### PR DESCRIPTION
自定义快捷键修改名称(名称不冲突)、命令或者键值都可以保存

Log: 修复自定义快捷键编辑页面，修改命令和快捷键后无法保存的问题
Bug: https://pms.uniontech.com/bug-view-175615.html
Influence: 自定义快捷键
Change-Id: Idd1b70b25fe5b4b5982bc4d939a127536f328fe9