### PR TITLE
fix: 显示密钥对话框关闭后，在开启起一个新的对话框

### DIFF
--- a/src/frame/window/modules/accounts/accountsdetailwidget.cpp
+++ b/src/frame/window/modules/accounts/accountsdetailwidget.cpp
@@ -601,8 +601,20 @@ void AccountsDetailWidget::initSecurityKey(QVBoxLayout *layout, bool isCurUser)
             return;
         }
         if (!m_securityKeyDisplayDialog) {
-            return;
+            m_securityKeyDisplayDialog = new SecurityKeyDisplayDialog(m_worker);
+            if (m_userModel)
+                m_securityKeyDisplayDialog->setCurrentAccount(m_userModel->getCurrentUserName());
         }
+        // Dialog弹框，确认/取消/关闭
+        connect(m_securityKeyDisplayDialog, &SecurityKeyDisplayDialog::notifySaveSecurityKey, securityKeySwitch, [=](const bool state) {
+            securityKeySwitch->setEnabled(true);
+            securityKeySwitch->setChecked(state);
+            if (state) {
+                m_securityKeyDisplayDialog->saveSecurityKey(m_userModel->getCurrentUserName());
+            }
+            m_securityKeyDisplayDialog->deleteLater();
+            m_securityKeyDisplayDialog = nullptr;
+        });
         securityKey->setEnabled(false);
         securityKeySwitch->setEnabled(!checked);
         if (checked) {
@@ -623,17 +635,10 @@ void AccountsDetailWidget::initSecurityKey(QVBoxLayout *layout, bool isCurUser)
             }
         } else {
             m_securityKeyDisplayDialog->clearSecurityKey();
+            m_securityKeyDisplayDialog->deleteLater();
+            m_securityKeyDisplayDialog = nullptr;
         }
         securityKey->setEnabled(true);
-    });
-
-    // Dialog弹框，确认/取消/关闭
-    connect(m_securityKeyDisplayDialog, &SecurityKeyDisplayDialog::notifySaveSecurityKey, securityKeySwitch, [=](const bool state) {
-        securityKeySwitch->setEnabled(true);
-        securityKeySwitch->setChecked(state);
-        if (state) {
-            m_securityKeyDisplayDialog->saveSecurityKey(m_userModel->getCurrentUserName());
-        }
     });
 
     // 只允许激活账户可开启


### PR DESCRIPTION
增加复制成功提示，关闭后开启起一个新的对话框，避免操作过快提示语不会消失

Log:
Bug: https://pms.uniontech.com/bug-view-175965.html
Influence: 对话框关闭再开启，重新new一个对话框对象
Change-Id: I4d2f66056764fd04a8a9c47ec548a174bf69c6c5