### PR TITLE
fix: 开启安全密钥，点击忘记密码也能打开重置密码框

### DIFF
--- a/src/frame/modules/accounts/accountsworker.cpp
+++ b/src/frame/modules/accounts/accountsworker.cpp
@@ -169,6 +169,11 @@ void AccountsWorker::getUUID(QString &uuid)
 
 void AccountsWorker::localBindCheck(dcc::accounts::User *user, const QString &uosid, const QString &uuid)
 {
+    //安全密钥开启了，则不需要检查后面流程
+    if (getSecurityKeyStatus()) {
+        Q_EMIT notifyDisplaySecurityKey();
+        return;
+    }
     QFutureWatcher<BindCheckResult> *watcher = new QFutureWatcher<BindCheckResult>(this);
     connect(watcher, &QFutureWatcher<BindCheckResult>::finished, [this, watcher] {
         BindCheckResult result = watcher->result();
@@ -362,6 +367,11 @@ const QString AccountsWorker::getActiveSessionName() const
         return "";
     }
     return m_login1SessionSelf->property("Name").toString();
+}
+
+bool AccountsWorker::getSecurityKeyStatus()
+{
+    return QString::compare(getSecurityKey(m_currentUserName), "") != 0;
 }
 
 void AccountsWorker::randomUserIcon(User *user)

--- a/src/frame/modules/accounts/accountsworker.h
+++ b/src/frame/modules/accounts/accountsworker.h
@@ -59,6 +59,7 @@ public:
     bool checkAuthorizationSync(const QString &path);
     bool getIsSessionActive() const;
     const QString getActiveSessionName() const;
+    bool getSecurityKeyStatus();
 
 Q_SIGNALS:
     void requestFrameAutoHide(const bool autoHide) const;
@@ -67,6 +68,7 @@ Q_SIGNALS:
     void requestMainWindowEnabled(const bool isEnabled) const;
     void localBindUbid(const QString &ubid);
     void localBindError(const QString &error);
+    void notifyDisplaySecurityKey(void);
     void showSafeyPage(const QString &errorTips);
 
 public Q_SLOTS:

--- a/src/frame/window/modules/accounts/accountsmodule.cpp
+++ b/src/frame/window/modules/accounts/accountsmodule.cpp
@@ -348,6 +348,10 @@ void AccountsModule::onShowPasswordPage(User *account)
     connect(w, &ModifyPasswdPage::requestCheckPwdLimitLevel, m_accountsWorker, &AccountsWorker::checkPwdLimitLevel);
     connect(m_accountsWorker, &AccountsWorker::localBindUbid, w, &ModifyPasswdPage::onLocalBindCheckUbid);
     connect(m_accountsWorker, &AccountsWorker::localBindError, w, &ModifyPasswdPage::onLocalBindCheckError);
+    connect(m_accountsWorker, &AccountsWorker::notifyDisplaySecurityKey, w, [=]() {
+        qInfo() << " [onNotifyDisplaySecurityKey] start reset-password-dialog.";
+        Q_EMIT w->requestStartResetPasswordExec(account);
+    });
 
     m_frameProxy->pushWidget(this, w);
     w->setVisible(true);

--- a/src/frame/window/modules/accounts/modifypasswdpage.cpp
+++ b/src/frame/window/modules/accounts/modifypasswdpage.cpp
@@ -423,10 +423,13 @@ void ModifyPasswdPage::onLocalBindCheckError(const QString &error)
     m_isBindCheckError = true;
     m_forgetPasswordBtn->setEnabled(true);
     QString tips;
+    qWarning() << Q_FUNC_INFO << error;
     if (error.contains("7500")) {
         tips = tr("System error");
     } else if (error.contains("7506")) {
         tips = tr("Network error");
+    } else {
+        tips = error;
     }
     if (!tips.isEmpty()) {
         DMessageManager::instance()->sendMessage(this,


### PR DESCRIPTION
开启安全密钥，忘记密码也需要开启重置密码框
说明：在关闭的时候能打开非控制中心操作，这个问题在另一个bug处理

Log:
Influence: 开启安全密钥，点击忘记密码
Bug: https://pms.uniontech.com/bug-view-177051.html
Change-Id: I3bf8111240b2c5be1bf1bb563ec43a79c785a4a6