### PR TITLE
fix: 检查结果为空时需要提示用户绑定UOS ID

### DIFF
--- a/src/frame/window/modules/accounts/modifypasswdpage.cpp
+++ b/src/frame/window/modules/accounts/modifypasswdpage.cpp
@@ -43,7 +43,6 @@ ModifyPasswdPage::ModifyPasswdPage(User *user, bool isCurrent, QWidget *parent)
     , m_forgetPasswordBtn(new DCommandLinkButton(tr("Forgot password?"), this))
     , m_passwordTipsEdit(new DLineEdit)
     , m_isCurrent(isCurrent)
-    , m_isBindCheckError(false)
     , m_localServer(new QLocalServer(this))
 {
     initWidget();
@@ -408,10 +407,10 @@ void ModifyPasswdPage::onSecurityQuestionsCheckReplied(const QList<int> &questio
 
 void ModifyPasswdPage::onLocalBindCheckUbid(const QString &ubid)
 {
+    // 检查结果返回ubid为空时需要提示用户绑定UOS ID
     if (!ubid.isEmpty()) {
-        m_isBindCheckError = false;
         Q_EMIT requestStartResetPasswordExec(m_curUser);
-    } else if (!m_isBindCheckError) {
+    } else {
         UnionIDBindReminderDialog dlg;
         dlg.exec();
         m_forgetPasswordBtn->setEnabled(true);
@@ -420,7 +419,6 @@ void ModifyPasswdPage::onLocalBindCheckUbid(const QString &ubid)
 
 void ModifyPasswdPage::onLocalBindCheckError(const QString &error)
 {
-    m_isBindCheckError = true;
     m_forgetPasswordBtn->setEnabled(true);
     QString tips;
     qWarning() << Q_FUNC_INFO << error;

--- a/src/frame/window/modules/accounts/modifypasswdpage.h
+++ b/src/frame/window/modules/accounts/modifypasswdpage.h
@@ -86,7 +86,6 @@ private:
     DCommandLinkButton *m_forgetPasswordBtn;
     DTK_WIDGET_NAMESPACE::DLineEdit *m_passwordTipsEdit;
     bool m_isCurrent;
-    bool m_isBindCheckError;
     QTimer m_enableBtnTimer;
     QLocalServer *m_localServer;
     QLocalSocket *m_client;


### PR DESCRIPTION
前一次结果错误时，设置m_isBindCheckError为True,再次检查时无法重置m_isBindCheckError状态，此时UBID为 空时无法提示用户绑定UOS ID

Log: 修复网络连接正常时无法提示用户绑定UOS ID问题
Bug: https://pms.uniontech.com/bug-view-154195.html
Influence: 网络恢复正常时可以正常提示用户绑定UOS ID