### PR TITLE
fix: 开启/关闭安全密钥开关，决定是否在reset-password-dialog是否显示安全密钥

### DIFF
--- a/src/reset-password-dialog/resetpassworddialog.h
+++ b/src/reset-password-dialog/resetpassworddialog.h
@@ -29,6 +29,12 @@ class ResetPasswordDialog : public DDialog
     Q_OBJECT
 
 public:
+    enum ResetPasswordType {
+        SecurityKey = 0,
+        UosID = 1,
+        Count,
+    };
+
     explicit ResetPasswordDialog(QRect screenGeometry, const QString &userName, const QString &appName, const int &fd);
     ~ResetPasswordDialog() {}
 
@@ -87,6 +93,7 @@ private:
     ResetPasswordWorker *m_resetPasswordWorker;
     QList<int> m_securityQuestions;
     SecurityKeyWidget *m_securityKeyWidget;
+    bool m_isValidSecurityKey;
 };
 
 class Manager : public QObject

--- a/src/reset-password-dialog/resetpasswordworker.cpp
+++ b/src/reset-password-dialog/resetpasswordworker.cpp
@@ -49,6 +49,17 @@ void ResetPasswordWorker::getSecurityKey(QString name)
     }
 }
 
+QString ResetPasswordWorker::getSecurityKeySync(QString name)
+{
+    QDBusReply<QString> reply = m_userQInter->call("GetSecretKey", QVariant::fromValue(name));
+    if (reply.isValid()) {
+        return reply.value();
+    } else {
+        qWarning() << "GetSecretKey failed:" << reply.error().message();
+    }
+    return "";
+}
+
 void ResetPasswordWorker::setPasswordHint(const QString &passwordHint)
 {
     auto reply = m_userInter->SetPasswordHint(passwordHint);

--- a/src/reset-password-dialog/resetpasswordworker.h
+++ b/src/reset-password-dialog/resetpasswordworker.h
@@ -33,6 +33,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void getSecurityQuestions();
     void getSecurityKey(QString name);
+    QString getSecurityKeySync(QString name);
     void setPasswordHint(const QString &passwordHint);
     void verifySecretQuestions(const QMap<int, QString> &securityQuestions);
     void asyncBindCheck();


### PR DESCRIPTION
开启安全密钥，重置密码页面显示安全密钥修改密码；
关闭安全密钥，重置密码页面不显示安全密钥修改密码；

Log:
Influence: 开启安全密钥，点击忘记密码
Bug: https://pms.uniontech.com/bug-view-177051.html
Change-Id: I87f90cb390dd91189ebb218e1390f409a0daa0b3