### PR TITLE
fix: 修复当人脸识别设备正常时，接入虹膜识别设备后，控制中心生物识别模块消失

### DIFF
--- a/src/frame/modules/authentication/charamangerworker.cpp
+++ b/src/frame/modules/authentication/charamangerworker.cpp
@@ -141,10 +141,9 @@ QString CharaMangerWorker::getControlCenterDbusSender()
 
 void CharaMangerWorker::predefineDriverInfo(const QString &driverInfo)
 {
+    m_model->setFaceDriverVaild(false);
+    m_model->setIrisDriverVaild(false);
     if (driverInfo.isNull()) {
-        // 处理界面显示空设备
-        m_model->setFaceDriverVaild(false);
-        m_model->setIrisDriverVaild(false);
         return;
     }
     QStringList faceDriverNames;
@@ -160,17 +159,12 @@ void CharaMangerWorker::predefineDriverInfo(const QString &driverInfo)
         // 可用人脸driverName
         if (it.value() & FACE_CHARA) {
             faceDriverNames.append(it.key());
+            m_model->setFaceDriverVaild(true);
         }
 
         if (it.value() & IRIS_CHARA) {
             irisDriverNames.append(it.key());
-        }
-
-        if (it.value() == 0) {
-            // 处理界面显示空设备
-            m_model->setFaceDriverVaild(false);
-            m_model->setIrisDriverVaild(false);
-            return;
+            m_model->setIrisDriverVaild(true);
         }
     }
 


### PR DESCRIPTION
当某个生物识别设备type未0时（即拔出设备后），不应屏蔽所有生物识别模块

Log: 修复当人脸识别设备正常时，接入虹膜识别设备后，控制中心生物识别模块消失
Influence: 控制中心生物识别模块
Bug: https://pms.uniontech.com/task-view-231313.html
Change-Id: I3072787ec0291854e0add7e8f2cbacfbaa6b33ee