### PR TITLE
chore: dde-control-center build failed

### DIFF
--- a/src/develop-tool/CMakeLists.txt
+++ b/src/develop-tool/CMakeLists.txt
@@ -35,6 +35,7 @@ set(SRCS
 find_package(PkgConfig REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5DBus REQUIRED)
+find_package(DtkCore REQUIRED)
 
 pkg_check_modules(DFrameworkDBus REQUIRED dframeworkdbus)
 
@@ -42,11 +43,13 @@ add_executable(${BIN_NAME} ${SRCS})
 target_include_directories(${BIN_NAME} PUBLIC
     ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
     ${PROJECT_BINARY_DIR}
+    ${DtkCore_INCLUDE_DIRS}
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE
     ${Qt5Widgets_LIBRARIES}
     ${Qt5DBus_LIBRARIES}
+    ${DtkCore_LIBRARIES}
 )
 
 # bin


### PR DESCRIPTION
解决控制中心编译找不到DtkCore

Log: 控制中心github编译找不到DtkCore
Influence: github编译
Bug: https://pms.uniontech.com/bug-view-178821.html
Change-Id: Id347a5569b38b6bdbd1892c22c14b92c50c4b885