### PR TITLE
fix: 修复控制中心搜索“触控板”无触控板开关选项的问题

### DIFF
--- a/src/frame/window/modules/mouse/mousemodule.cpp
+++ b/src/frame/window/modules/mouse/mousemodule.cpp
@@ -253,6 +253,7 @@ void MouseModule::initSearchData()
     auto func_touchpad_changed = [ = ](bool tpadExist) {
         bool bTouchpad = func_is_visible("mouseTouch") && tpadExist;
         m_frameProxy->setWidgetVisible(module, touchpad, bTouchpad);
+        m_frameProxy->setDetailVisible(module, touchpad, tr("Touchpad"), bTouchpad);
         m_frameProxy->setDetailVisible(module, touchpad, tr("Pointer Speed"), bTouchpad);
         m_frameProxy->setDetailVisible(module, touchpad, tr("Tap to Click"), bTouchpad);
         m_frameProxy->setDetailVisible(module, touchpad, tr("Natural Scrolling"), bTouchpad);


### PR DESCRIPTION
搜索加入触控板选项

Log: 修复控制中心搜索“触控板”无触控板开关选项的问题
Bug: https://pms.uniontech.com/bug-view-178947.html
Influence: 触控板搜索
Change-Id: Ib19a53e7df94724d011caf05c4b04aa444778dcf