### PR TITLE
fix: 一级侧边导航栏不需要保留上下边距

### DIFF
--- a/src/frame/window/mainwindow.cpp
+++ b/src/frame/window/mainwindow.cpp
@@ -913,7 +913,7 @@ void MainWindow::resetNavList(bool isIconMode)
         m_moduleName.clear();
     } else {
         //The second page will Covered with fill blank areas
-        m_navView->setViewportMargins(QMargins(10, 10, 10, 10));
+        m_navView->setViewportMargins(QMargins(10, 0, 10, 0));
         m_navView->setViewMode(QListView::ListMode);
         m_navView->setMinimumWidth(first_widget_min_width);
         m_navView->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);


### PR DESCRIPTION
按UI设计的要求，一级侧边导航栏不需要保留上下边距

Log: 修复侧边栏滚动区域过小问题
Bug: https://pms.uniontech.com/bug-view-179559.html
Influence: 一级侧边导航栏不需要保留上下边距