### PR TITLE
fix: 修复禁用USB指纹仪后再次添加指纹，控制中心直接挂死问题

### DIFF
--- a/src/frame/modules/authentication/fingermodel.h
+++ b/src/frame/modules/authentication/fingermodel.h
@@ -55,6 +55,7 @@ Q_SIGNALS:
     void enrollResult(EnrollResult enrollRes);
 
     void lockedChanged(bool locked);
+    void claimFailed();
 
 private:
     QString m_userName;

--- a/src/frame/window/modules/authentication/addfingedialog.cpp
+++ b/src/frame/window/modules/authentication/addfingedialog.cpp
@@ -103,6 +103,7 @@ void AddFingeDialog::setFingerModel(FingerModel *model)
     connect(m_model, &FingerModel::enrollFailed, this, &AddFingeDialog::enrollFailed);
     connect(m_model, &FingerModel::enrollDisconnected, this, &AddFingeDialog::enrollDisconnected);
     connect(m_model, &FingerModel::enrollRetry, this, &AddFingeDialog::enrollRetry);
+    connect(m_model, &FingerModel::claimFailed, this, &AddFingeDialog::claimFailed);
     connect(m_model, &FingerModel::lockedChanged, this, [=](bool locked) {
         if (locked) {
 //            close();
@@ -161,6 +162,13 @@ void AddFingeDialog::enrollFailed(QString title, QString msg)
     m_timer->stop();
     Q_EMIT requestStopEnroll(m_username);
 }
+
+void AddFingeDialog::claimFailed()
+{
+    m_fingeWidget->setStatueMsg(tr("The device is unavailabl"), tr(""), true);
+    m_spaceWidget->setVisible(true);
+}
+
 void AddFingeDialog::enrollDisconnected()
 {
     Q_EMIT requestStopEnroll(m_username);

--- a/src/frame/window/modules/authentication/addfingedialog.h
+++ b/src/frame/window/modules/authentication/addfingedialog.h
@@ -48,6 +48,7 @@ public:
     void enrollFocusOut();
     void enrollOverTime();
     void enrollRetry(QString title, QString msg);
+    void claimFailed();
 
 private:
     void initWidget();

--- a/src/frame/window/modules/authentication/fingerdetailwidget.cpp
+++ b/src/frame/window/modules/authentication/fingerdetailwidget.cpp
@@ -149,15 +149,22 @@ void FingerDetailWidget::showAddFingeDialog(const QString &name, const QString &
             dlg->setFocus();
             dlg->activateWindow();
         } else if (res == FingerModel::Enroll_Failed) {
-            qDebug() << "FingerModel::Enroll_Failed";
+            qWarning() << "FingerModel::Enroll_Failed";
             Q_EMIT requestStopEnroll(name);
             if (m_disclaimer != nullptr) {
                 closeFingerDisclaimer();
             }
             dlg->deleteLater();
         } else if (res == FingerModel::Enroll_AuthFailed) {
-            qDebug() << "FingerModel::Enroll_AuthFailed";
+            qWarning() << "FingerModel::Enroll_AuthFailed";
             dlg->deleteLater();
+        }else if (res == FingerModel::Enroll_ClaimFailed) {
+            qWarning() << "FingerModel::Enroll_ClaimFailed";
+            dlg->setFingerModel(m_model);
+            dlg->setWindowFlags(Qt::Dialog | Qt::Popup | Qt::WindowStaysOnTopHint);
+            dlg->show();
+            dlg->setFocus();
+            dlg->activateWindow();
         }
     });
 


### PR DESCRIPTION
未处理claim失败导致控制中心卡死

Log: 指纹录入失败处理
Bug: https://pms.uniontech.com/bug-view-179805.html
Influence: 指纹录入
Change-Id: I5503d8996f98eaa2380199f0f8982806bd939fd4