### PR TITLE
feat: 个性化增加滚动条设置,添加dconfig和处理搜索数据

### DIFF
--- a/configs/org.deepin.dde.control-center.personalization.json
+++ b/configs/org.deepin.dde.control-center.personalization.json
@@ -23,6 +23,17 @@
             "description": "",
             "permissions": "readwrite",
             "visibility": "private"
+        },
+        "scrollbarPolicyStatus": {
+            "value": "Enabled",
+            "serial": 0,
+            "flags": [],
+            "name": "scrollbarPolicyStatus",
+            "name[zh_CN]": "滚动条显示策略的状态",
+            "description[zh_CN]": "滚动条显示策略的状态",
+            "description": "",
+            "permissions": "readwrite",
+            "visibility": "private"
         }
     }
   }

--- a/src/frame/window/modules/personalization/personalizationgeneral.cpp
+++ b/src/frame/window/modules/personalization/personalizationgeneral.cpp
@@ -389,6 +389,8 @@ PersonalizationGeneral::PersonalizationGeneral(dcc::personalization::Personaliza
         }
     });
 
+    DConfigWatcher::instance()->bind(DConfigWatcher::personalization, "scrollbarPolicyStatus", m_cmbScrollBarPolicy);
+
     m_centralLayout->addStretch(20);
 
     QScrollArea *scrollArea = new QScrollArea;

--- a/src/frame/window/modules/personalization/personalizationmodule.cpp
+++ b/src/frame/window/modules/personalization/personalizationmodule.cpp
@@ -249,6 +249,7 @@ void PersonalizationModule::initSearchData()
 
     auto func_general_changed = [ = ](bool bGeneral) {
         bool bEffects = func_is_visible("perssonalGeneralEffects");
+        bool bScrollbarPolicy = func_is_visible("scrollbarPolicyStatus");
         bool is3DWm = m_model->is3DWm();
 
         m_frameProxy->setWidgetVisible(module, general, bGeneral);
@@ -261,6 +262,7 @@ void PersonalizationModule::initSearchData()
         m_frameProxy->setDetailVisible(module, general, tr("Transparency"), bGeneral && bEffects && is3DWm);
         m_frameProxy->setDetailVisible(module, general, tr("Window Minimize Effect"), bGeneral && bEffects && is3DWm && (m_model->getIsEffectSupportScale() || m_model->getIsEffectSupportMagiclamp()));
         m_frameProxy->setDetailVisible(module, general, tr("Show transparency effects when a window is moved"), bGeneral && bEffects && is3DWm && m_model->getIsEffectSupportMoveWindow() && func_isdconf_visible("effectMovewindowTranslucency"));
+        m_frameProxy->setDetailVisible(module, general, tr("Scroll Bars"), bGeneral && bScrollbarPolicy);
     };
 
     auto func_icontheme_changed = [ = ](bool bIconTheme) {
@@ -325,7 +327,9 @@ void PersonalizationModule::initSearchData()
 
         bool bGeneral = func_is_visible("personalizationGeneral");
         bool bEffects = func_is_visible("perssonalGeneralEffects");
+        bool bScrollbarPolicy = func_is_visible("scrollbarPolicyStatus");
         m_frameProxy->setDetailVisible(module, general, tr("Show transparency effects when a window is moved"), bGeneral && bEffects && m_model->is3DWm() && m_model->getIsEffectSupportMoveWindow() && func_isdconf_visible("effectMovewindowTranslucency"));
+        m_frameProxy->setDetailVisible(module, general, tr("Scroll Bars"), bGeneral && bScrollbarPolicy);
         m_frameProxy->updateSearchData(module);
     });
 


### PR DESCRIPTION
1、增加滚动条显示策略功能是否可用的dconfig配置
2、处理滚动条显示策略的搜索数据

Log: 个性化增加滚动条设置
Task: https://pms.uniontech.com/task-view-212919.html
Influence: 个性化增加滚动条设置