### PR TITLE
fix: 修复添加虹膜时点击下一步，添加虹膜数据弹框未消失问题

### DIFF
--- a/src/frame/window/modules/authentication/addirisinfodialog.cpp
+++ b/src/frame/window/modules/authentication/addirisinfodialog.cpp
@@ -142,6 +142,7 @@ void AddIrisInfoDialog::initConnect()
 
 void AddIrisInfoDialog::refreshInfoStatusDisplay(CharaMangerModel::AddInfoState state)
 {
+    this->show();
     m_irisInfo->updateState(state);
     m_state = state;
     switch (state) {

--- a/src/frame/window/modules/authentication/irisdetailwidget.cpp
+++ b/src/frame/window/modules/authentication/irisdetailwidget.cpp
@@ -119,6 +119,7 @@ void IrisDetailWidget::onShowAddIrisDialog(const QString &driverName, const int 
 
     // 点击下一步开始录入
     connect(irisDlg, &AddIrisInfoDialog::requestInputIris, this, [ = ](){
+        irisDlg->hide();
         Q_EMIT requestEnrollStart(driverName, charaType, charaName);
     });
 


### PR DESCRIPTION
调用录入前需要隐藏回话,返回后再继续展示

Log: 虹膜录入优化
Bug: https://pms.uniontech.com/bug-view-181933.html
Influence: 虹膜录入
Change-Id: I57b7860940f618718537d58e51af02b4af982e3d