### PR TITLE
fix: 选择系统语言后需要处理界面焦点

### DIFF
--- a/src/frame/window/modules/keyboard/systemlanguagewidget.cpp
+++ b/src/frame/window/modules/keyboard/systemlanguagewidget.cpp
@@ -194,4 +194,5 @@ void SystemLanguageWidget::onSetCurLang(int value)
     m_addSystemLanguage->setFocusPolicy(value ? Qt::NoFocus : Qt::TabFocus);
     m_langListview->setEnabled(!value);
     m_editSystemLang->setEnabled(!value);
+    setFocus();
 }


### PR DESCRIPTION
m_langListview在setEnabled(false)后m_langListview会失去焦点，此时焦点会自动跳转到其他部件， 需要手动处理下焦点

Log: 修复添加系统语言时，勾选新增系统语言后焦点偏移到返回按钮上问题
Bug: https://pms.uniontech.com/bug-view-180165.html
Influence: 焦点不会偏移到返回按钮上