### PR TITLE
fix: 修复 GetModules 接口冷启动时返回空列表

### DIFF
--- a/src/frame/main.cpp
+++ b/src/frame/main.cpp
@@ -102,6 +102,8 @@ int main(int argc, char *argv[])
     DCC_NAMESPACE::ControlCenterDBusAdaptor adaptor(&mw);
     DCC_NAMESPACE::DBusControlCenterGrandSearchService grandSearchadAptor(&mw);
 
+    mw.loadModules(!(parser.isSet(showOption) && parser.isSet(dbusOption)));
+
     QDBusConnection conn = QDBusConnection::sessionBus();
     if (!conn.registerService("org.deepin.dde.ControlCenter1") ||
         !conn.registerObject("/org/deepin/dde/ControlCenter1", &mw)) {
@@ -109,7 +111,7 @@ int main(int argc, char *argv[])
         if (!parser.isSet(showOption))
             return -1;
     }
-    mw.loadModules(!(parser.isSet(showOption) && parser.isSet(dbusOption)));
+
     if (!reqPage.isEmpty()) {
         adaptor.ShowPage(reqPage);
     }


### PR DESCRIPTION
将初始化 module 放在 DBus 导出之前

Log: 修复 GetModules 接口冷启动时返回空列表