### PR TITLE
chore: fix DCC_DISABLE_LANGUAGE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,9 +20,11 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -Wall -Werror=return-type")
 # plugins can be disabled and their options
 # plugin-authentication : DISABLE_AUTHENTICATION
 # plugin-update : DISABLE_UPDATE
+# plugin-keyboard: DISABLE_LANGUAGE to disable language panel
 
 option(DISABLE_AUTHENTICATION "disable build authentication plugins" OFF)
 option(DISABLE_UPDATE "disable build update plugins" OFF)
+option(DISABLE_LANGUAGE "disable lanugage settings in control center" OFF)
 
 # asan 自己有内存泄露，暂不使用
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -721,7 +723,9 @@ if (BUILD_PLUDIN)
         "src/plugin-keyboard/operation/*.cpp"
         "src/plugin-keyboard/operation/qrc/keyboard.qrc"
     )
-
+    if (DISABLE_LANGUAGE)
+      add_definitions(-DDCC_DISABLE_LANUGAGE)
+    endif()
     add_library(${KeyBoard_Name} MODULE
         ${KEYBOARD_SRCS}
     )

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -37,6 +37,7 @@ build() {
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DDISABLE_UPDATE=ON \
         -DDISABLE_AUTHENTICATION=ON \
+        -DDISABLE_LANGUAGE=ON \
         -DCMAKE_INSTALL_LIBDIR=/usr/lib
   ninja
 }

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -87,7 +87,6 @@ void KeyboardWorker::refreshShortcut()
             SLOT(onRequestShortcut(QDBusPendingCallWatcher*)));
 }
 
-#ifndef DCC_DISABLE_LANGUAGE
 void KeyboardWorker::refreshLang()
 {
     m_keyboardDBusProxy->blockSignals(false);
@@ -96,7 +95,6 @@ void KeyboardWorker::refreshLang()
     else
         onLangSelectorServiceFinished();
 }
-#endif
 
 void KeyboardWorker::windowSwitch()
 {
@@ -752,7 +750,6 @@ void KeyboardWorker::setLayout(const QString &value)
     m_keyboardDBusProxy->setCurrentLayout(value);
 }
 
-#ifndef DCC_DISABLE_LANGUAGE
 void KeyboardWorker::setLang(const QString &value)
 {
     Q_EMIT requestSetAutoHide(false);
@@ -806,4 +803,3 @@ void KeyboardWorker::deleteLang(const QString &value)
         watcher->deleteLater();
     });
 }
-#endif

--- a/src/plugin-keyboard/window/keyboardmodule.cpp
+++ b/src/plugin-keyboard/window/keyboardmodule.cpp
@@ -7,8 +7,10 @@
 #include "kblayoutsettingwidget.h"
 #include "keyboardlayoutdialog.h"
 #include "shortcutsettingwidget.h"
+#ifndef DCC_DISABLE_LANUGAGE
 #include "systemlanguagewidget.h"
 #include "systemlanguagesettingdialog.h"
+#endif
 #include "widgets/settingshead.h"
 #include "operation/keyboardwork.h"
 #include "operation/keyboardmodel.h"
@@ -64,11 +66,13 @@ ModuleObject *KeyboardPlugin::module()
     moduleKeyBoard->appendChild(kBLayoutSettingModule);
     moduleInterface->appendChild(moduleKeyBoard);
 
+#ifndef DCC_DISABLE_LANUGAGE
     //二级菜单--系统语言
     ModuleObject *moduleSystemLanguageSetting = new PageModule("keyboardLanguage", tr("Language"));
     SystemLanguageSettingModule *systemLanguageSettingModule = new SystemLanguageSettingModule(moduleInterface->model(), moduleInterface->worker());
     moduleSystemLanguageSetting->appendChild(systemLanguageSettingModule);
     moduleInterface->appendChild(moduleSystemLanguageSetting);
+#endif
 
     //二级菜单--快捷键
     ShortCutSettingMenuModule *moduleShortCutSetting = new ShortCutSettingMenuModule("keyboardShortcuts", tr("Shortcuts"));
@@ -181,6 +185,7 @@ QWidget *KBLayoutSettingModule::page()
     return w;
 }
 
+#ifndef DCC_DISABLE_LANUGAGE
 QWidget *SystemLanguageSettingModule::page()
 {
     m_worker->refreshLang();
@@ -207,6 +212,7 @@ void SystemLanguageSettingModule::onAddLocale(const QModelIndex &index)
     QVariant var = index.data(SystemLanguageSettingDialog::KeyRole);
     m_worker->addLang(var.toString());
 }
+#endif
 
 QWidget *ShortCutSettingModule::page()
 {

--- a/src/plugin-keyboard/window/keyboardmodule.h
+++ b/src/plugin-keyboard/window/keyboardmodule.h
@@ -87,6 +87,7 @@ private:
     KeyboardWorker *m_worker;
 };
 
+#ifndef DCC_DISABLE_LANUGAGE
 class SystemLanguageSettingModule : public ModuleObject
 {
     Q_OBJECT
@@ -103,6 +104,7 @@ private:
     KeyboardModel *m_model;
     KeyboardWorker *m_worker;
 };
+#endif
 
 class ShortCutSettingMenuModule : public PageModule
 {


### PR DESCRIPTION
Log: add option DISABLE_LANGUAGE

deepin上的language选项有时候会调用dpkg,除了对后端修改以外，源码中本来就有宏禁用这一选项，然而原本的宏根本没有作用，所以对应的修改了下

resolve: https://github.com/linuxdeepin/developer-center/issues/3733