### PR TITLE
fix: 控制中心电池管理的设置丢失

### DIFF
--- a/src/plugin-power/window/usebatterymodule.cpp
+++ b/src/plugin-power/window/usebatterymodule.cpp
@@ -321,7 +321,8 @@ void UseBatteryModule::initUI()
         [] (ModuleObject *module) -> QWidget*{
             DSwitchButton *powerShowTimeToFull = new DSwitchButton();
             // depend dock dconfig setting "showtimetofull"
-            DConfig *cfgDock = DConfig::create("org.deepin.dde.dock1", "org.deepin.dde.dock1", QString(), powerShowTimeToFull);
+            DConfig *cfgDock = DConfig::create("dde-dock", "org.deepin.dde.dock.power", QString(), powerShowTimeToFull);
+            powerShowTimeToFull->setChecked(cfgDock->value("showtimetofull").toBool());
             connect(powerShowTimeToFull, &DSwitchButton::checkedChanged, powerShowTimeToFull, [cfgDock, powerShowTimeToFull] (){
                 // 保存设置值
                 if (!cfgDock->value("showtimetofull").isNull()) {


### PR DESCRIPTION
关联了错误的配置选项，导致修改对应选项未生效

Log: 修复控制中心电池管理的设置丢失的问题
resolve: https://github.com/linuxdeepin/developer-center/issues/3768
Influence: 控制中心电池管理/任务栏电池信息显示