### PR TITLE
fix: the size of scrollarea will not adjust to window

### DIFF
--- a/src/plugin-keyboard/window/kblayoutsettingwidget.cpp
+++ b/src/plugin-keyboard/window/kblayoutsettingwidget.cpp
@@ -43,7 +43,6 @@ KBLayoutSettingWidget::KBLayoutSettingWidget(QWidget *parent)
     m_kbLayoutListView->setModel(m_kbLayoutModel);
     m_kbLayoutListView->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_kbLayoutListView->setBackgroundType(DStyledItemDelegate::BackgroundType::ClipCornerBackground);
-    m_kbLayoutListView->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
     m_kbLayoutListView->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     m_kbLayoutListView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_kbLayoutListView->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);

--- a/src/plugin-keyboard/window/keyboardmodule.cpp
+++ b/src/plugin-keyboard/window/keyboardmodule.cpp
@@ -60,6 +60,7 @@ ModuleObject *KeyboardPlugin::module()
     //键盘布局
     KBLayoutSettingModule *kBLayoutSettingModule = new KBLayoutSettingModule(moduleInterface->model(), moduleInterface->worker());
     kBLayoutSettingModule->setName("keyboardLayout");
+    kBLayoutSettingModule->setDisplayName(tr("keyboard Layout"));
     kBLayoutSettingModule->setDescription(tr("Keyboard Layout"));
     kBLayoutSettingModule->addContentText(tr("Keyboard Layout"));
 

--- a/src/plugin-keyboard/window/systemlanguagewidget.cpp
+++ b/src/plugin-keyboard/window/systemlanguagewidget.cpp
@@ -45,7 +45,6 @@ SystemLanguageWidget::SystemLanguageWidget(KeyboardModel *model, QWidget *parent
     m_langListview->setAccessibleName("SystemLanguageWidget_langListview");
     m_langListview->setEditTriggers(QAbstractItemView::NoEditTriggers);
     m_langListview->setBackgroundType(DStyledItemDelegate::BackgroundType::ClipCornerBackground);
-    m_langListview->setSizeAdjustPolicy(QAbstractScrollArea::AdjustToContents);
     m_langListview->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Preferred);
     m_langListview->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_langListview->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);


### PR DESCRIPTION
这个flag在控制中心里面是没有意义的。本来这个页面就不应该嵌套，但是设计上在title加了和下面有关联的信号，那就很难办了。。所以还是直接移除flag

resolve: https://github.com/linuxdeepin/developer-center/issues/3725