### PR TITLE
fix: sidenav width not restore when return to home

### DIFF
--- a/src/frame/mainmodule.cpp
+++ b/src/frame/mainmodule.cpp
@@ -128,6 +128,7 @@ public:
             m_view->clearSelection();
             m_sidebarWidget->setVisible(false);
 #ifdef USE_SIDEBAR
+            m_mainWindow->setSidebarWidth(100);
             m_mainWindow->setSidebarExpanded(false);
             m_mainWindow->setSidebarVisible(false);
 #endif


### PR DESCRIPTION
从子模块返回主页时，没有恢复sidenav的宽度，导致标题栏阴影宽度未恢复
close linuxdeepin/developer-center#3586