### PR TITLE
feat: use a timeout to load sync plugin

### DIFF
--- a/src/frame/pluginmanager.h
+++ b/src/frame/pluginmanager.h
@@ -8,8 +8,7 @@
 
 #include <QFuture>
 #include <QObject>
-
-#include <optional>
+#include <QVector>
 
 class QPluginLoader;
 
@@ -54,8 +53,8 @@ private:
 
     QList<PluginData> m_datas;  // cache for other plugin
     ModuleObject *m_rootModule; // root module from MainWindow
-    bool m_loadAllFinished;
     QFuture<PluginData> m_future;
+    QVector<QString> m_pluginsStatus;
 };
 
 } // namespace DCC_NAMESPACE


### PR DESCRIPTION
set 5 sec timeout for if plugin cannot construct

resolve: https://github.com/linuxdeepin/developer-center/issues/3949

遇到了插件初始化无法完成的问题。。如果是真同步的话 -d就永远启动不了了。所以添加超时检查