### PR TITLE
feat: 控制中心支持用户头像个性化配置

### DIFF
--- a/src/plugin-accounts/window/accountsmodule.cpp
+++ b/src/plugin-accounts/window/accountsmodule.cpp
@@ -39,7 +39,7 @@
 #include <DSysInfo>
 #include <DDesktopServices>
 #include <DFloatingButton>
-
+#include <DBlurEffectWidget>
 
 #include <polkit-qt5-1/PolkitQt1/Authority>
 
@@ -570,16 +570,17 @@ void AccountsModule::onModifyIcon()
     QWidget *w = qobject_cast<QWidget *>(sender());
     if (!w)
         return;
-    AvatarListDialog *avatarListDialog = new AvatarListDialog(m_curUser, w);
-    avatarListDialog->deleteLater();
-    if (avatarListDialog->exec() == QDialog::Accepted) {
-        QString avatarpath = avatarListDialog->getAvatarPath();
-        if (!m_curUser) {
-            return;
-        }
-        if (!avatarpath.isEmpty() && avatarpath != m_curUser->currentAvatar())
-            m_worker->setAvatar(m_curUser, avatarpath);
-    }
+
+    AvatarListDialog *avatarListDialog = new AvatarListDialog(m_curUser);
+    avatarListDialog->show();
+    QPoint globalPos = w->mapToGlobal(QPoint(0, 0));
+    int x = globalPos.x() + w->width() / 2 - avatarListDialog->width() / 2 - 40;
+    int y = globalPos.y() + w->height() / 2 - avatarListDialog->height() / 2 + 80;
+    avatarListDialog->move(x, y);
+
+    connect(avatarListDialog, &AvatarListDialog::requestSaveAvatar, this, [this](const QString &path){
+        m_worker->setAvatar(m_curUser, path);
+    });
 }
 
 void AccountsModule::setCurrentUser(User *user)

--- a/src/plugin-accounts/window/avatarcropbox.cpp
+++ b/src/plugin-accounts/window/avatarcropbox.cpp
@@ -1,0 +1,52 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "avatarcropbox.h"
+
+#include <QPainter>
+
+#define CropBoxSize 120
+
+using namespace DCC_NAMESPACE;
+
+AvatarCropBox::AvatarCropBox(QWidget *parent)
+    : QWidget(parent)
+    , m_backgroundColor(parent->palette().color(QPalette::Window))
+{
+    setFixedSize(190, 190);
+}
+
+AvatarCropBox::~AvatarCropBox()
+{
+
+}
+
+void AvatarCropBox::setBackgroundColor(QColor color)
+{
+    m_backgroundColor = color;
+
+    repaint();
+}
+
+void AvatarCropBox::paintEvent(QPaintEvent *event)
+{
+    Q_UNUSED(event);
+
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+
+    auto rect = parentWidget()->rect();
+
+    QPainterPath border,cropBox;
+
+    border.setFillRule(Qt::WindingFill);
+    border.addRect(rect);
+
+    cropBox.setFillRule(Qt::WindingFill);
+    auto adjustSize = (rect.width() - CropBoxSize) / 2;
+    cropBox.addRoundedRect(rect.adjusted(adjustSize, adjustSize, -adjustSize, -adjustSize), 10, 10);
+
+    QPainterPath endPath = border.subtracted(cropBox);
+    p.fillPath(endPath, m_backgroundColor);
+}

--- a/src/plugin-accounts/window/avatarcropbox.h
+++ b/src/plugin-accounts/window/avatarcropbox.h
@@ -1,0 +1,30 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include "interface/namespace.h"
+
+#include <QWidget>
+#include <QColor>
+#include <QPainterPath>
+
+namespace DCC_NAMESPACE {
+
+class AvatarCropBox : public QWidget
+{
+    Q_OBJECT
+public:
+    AvatarCropBox(QWidget *parent=nullptr);
+    ~AvatarCropBox();
+
+    void setBackgroundColor(QColor color);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QColor m_backgroundColor;
+};
+
+} // DCC_NAMESPACE

--- a/src/plugin-accounts/window/avataritemdelegate.cpp
+++ b/src/plugin-accounts/window/avataritemdelegate.cpp
@@ -21,8 +21,11 @@
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
-AvatarItemDelegate::AvatarItemDelegate(QObject *parent)
+#define CustomAvatarRole 4
+
+AvatarItemDelegate::AvatarItemDelegate(const int role, QObject *parent)
     : QStyledItemDelegate(parent)
+    , m_role(role)
 {
 }
 
@@ -37,8 +40,9 @@ void AvatarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
 
     QStyleOptionViewItem opt(option);
     initStyleOption(&opt, index);
-    auto style = opt.widget->style();
-    opt.rect = opt.rect.adjusted(8, 8, -8, -8);
+    QStyle *style = option.widget ? option.widget->style() : QApplication::style();
+
+    opt.rect = opt.rect.adjusted(4, 4, -4, -4);
 
     auto pm = static_cast<QStyle::PixelMetric>(DStyle::PM_FocusBorderWidth);
     int borderWidth = style->pixelMetric(pm, &opt, nullptr);
@@ -64,6 +68,7 @@ void AvatarItemDelegate::paint(QPainter *painter, const QStyleOptionViewItem &op
         rect.moveCenter(QRect(opt.rect).center());
         painter->setPen(Qt::NoPen);
         painter->setBrush(dh.getColor(&opt, QPalette::Button));
+
         painter->drawRoundedRect(opt.rect.marginsRemoved(margins), 8, 8);
 
         //画+号

--- a/src/plugin-accounts/window/avataritemdelegate.h
+++ b/src/plugin-accounts/window/avataritemdelegate.h
@@ -29,12 +29,15 @@ class AvatarItemDelegate : public QStyledItemDelegate
     Q_OBJECT
 
 public:
-    explicit AvatarItemDelegate(QObject *parent = nullptr);
+    explicit AvatarItemDelegate(const int role, QObject *parent = nullptr);
 
     // painting
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
 
     // set item size
     QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
+private:
+    int m_role;
 };
 } // DCC_NAMESPACE

--- a/src/plugin-accounts/window/avatarlistframe.h
+++ b/src/plugin-accounts/window/avatarlistframe.h
@@ -1,0 +1,175 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include "interface/namespace.h"
+#include "avatarlistview.h"
+#include "widgets/accessibleinterface.h"
+
+#include <DFrame>
+#include <QScrollArea>
+
+DWIDGET_BEGIN_NAMESPACE
+class DSlider;
+DWIDGET_END_NAMESPACE
+
+QT_BEGIN_NAMESPACE
+class QLabel;
+class QPoint;
+class QColor;
+class QTimer;
+class QFileDialog;
+QT_END_NAMESPACE
+
+namespace DCC_NAMESPACE {
+
+class AvatarCropBox;
+class AvatarListView;
+
+enum Role {
+    Person,
+    Animal,
+    Illustration,
+    Expression,
+    Custom,
+    AvatarAdd
+};
+
+enum Type {
+    Dimensional, // 立体风格
+    Flat //平面风格
+};
+
+class AvatarListFrame : public QFrame {
+    Q_OBJECT
+public:
+    struct AvatarRoleItem
+    {
+        int role;
+        int type;
+        QString path;
+        bool isLoader;
+
+        AvatarRoleItem(const int &_role, const int &_type, const QString&_path, const bool &_isLoader)
+            : role(_role)
+            , type(_type)
+            , path(_path)
+            , isLoader(_isLoader)
+        {
+        }
+    };
+    explicit AvatarListFrame(const int &role , QWidget *parent = nullptr);
+    virtual ~AvatarListFrame() =default;
+
+    inline int getCurrentRole() { return m_role; }
+    inline int getCurrentType() { return m_type; }
+    inline AvatarListView *getCurrentListView() { return m_currentAvatarLsv; }
+    QString getAvatarPath() const;
+
+    bool isExistCustomAvatar(const QString &path);
+
+public Q_SLOTS:
+    void updateListView(const int &role, const int &type);
+
+private:
+    QString getCurrentAvatarPath(const int role, const int type);
+
+private:
+    int m_role;
+    int m_type;
+    AvatarListView *m_avatarDimensionalLsv;
+    AvatarListView *m_avatarFlatLsv;
+    AvatarListView *m_currentAvatarLsv;
+};
+
+class CustomAddAvatarWidget : public AvatarListFrame {
+    Q_OBJECT
+public:
+    explicit CustomAddAvatarWidget(const int &role , QWidget *parent = nullptr);
+    virtual ~CustomAddAvatarWidget();
+
+protected:
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragLeaveEvent(QDragLeaveEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+    bool eventFilter(QObject *object, QEvent *event) override;
+    void paintEvent(QPaintEvent *event) override;
+
+Q_SIGNALS:
+    void requestUpdateCustomWidget(const QString &path);
+
+private:
+    void saveCustomAvatar(const QString &path);
+
+private:
+    QFileDialog *m_fd;
+    Dtk::Widget::DFrame *m_addAvatarFrame;
+    QLabel *m_addAvatarLabel;
+    QLabel *m_hintLabel;
+    QRect m_acceptableRect;
+    QColor m_currentBkColor;
+    QColor m_dragEnterBkColor;
+    QColor m_dragLeaveBkColor;
+};
+
+class CustomAvatarView : public QWidget{
+    Q_OBJECT
+
+public:
+    CustomAvatarView(const QString &avatarPath, QWidget *parent = nullptr);
+    ~CustomAvatarView();
+
+    void setAvatarPath(const QString &avatarPath);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+    void mousePressEvent(QMouseEvent *event) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void mouseReleaseEvent(QMouseEvent *event) override;
+
+Q_SIGNALS:
+    void enableAvatarScaledItem(const bool enabled);
+    void requestSaveCustomAvatar(const QString &path);
+
+public Q_SLOTS:
+    void startAvatarModify();
+    void endAvatarModify();
+    void setZoomValue(const int value);
+    QString getCroppedImage();
+
+private:
+    int m_xPtInterval = 0;
+    int m_yPtInterval = 0;
+    int m_offset = 0;
+    int m_currentScaledValue = 0;
+    bool m_Pressed = false;
+    QTimer *m_autoExitTimer;
+    QImage m_image;
+    AvatarCropBox *m_cropBox;
+    qreal m_zoomValue = 1.0;
+    QPoint m_OldPos;
+    QString m_path;
+
+private slots:
+    void onZoomInImage(void);
+    void onZoomOutImage(void);
+    void onPresetImage(void);
+};
+
+class CustomAvatarWidget : public AvatarListFrame {
+    Q_OBJECT
+public:
+    explicit CustomAvatarWidget(const int &role , QWidget *parent = nullptr);
+    ~CustomAvatarWidget() override=default;
+
+    void enableAvatarScaledItem(bool enabled);
+
+    inline CustomAvatarView *getCustomAvatarView() { return m_avatarView; }
+
+private:
+    Dtk::Widget::DSlider *m_avatarScaledItem;
+    CustomAvatarView *m_avatarView;
+};
+
+} // DCC_NAMESPACE

--- a/src/plugin-accounts/window/avatarlistview.cpp
+++ b/src/plugin-accounts/window/avatarlistview.cpp
@@ -1,0 +1,331 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+#include "avatarlistview.h"
+#include "avataritemdelegate.h"
+#include "widgets/accessibleinterface.h"
+
+#include <QWidget>
+#include <QListView>
+#include <QStandardItemModel>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QPixmap>
+#include <QDir>
+#include <QLabel>
+#include <QFileInfo>
+#include <QDebug>
+#include <QFileInfoList>
+#include <QFileDialog>
+#include <QStandardPaths>
+#include <QRandomGenerator>
+#include <QDateTime>
+
+#include <DConfig>
+
+const int MaxAvatarSize = 20;
+const int CustomAvatarType = 4;
+const int MaxCustomAvatarSize = 4;
+
+DWIDGET_USE_NAMESPACE
+DCORE_USE_NAMESPACE
+using namespace DCC_NAMESPACE;
+
+SET_FORM_ACCESSIBLE(AvatarListView,"AvatarListView")
+AvatarListView::AvatarListView(const int &role, const int &type, const QString &path, QWidget *parent)
+    : DListView(parent)
+    , m_currentAvatarRole(role)
+    , m_currentAvatarType(type)
+    , m_path(path)
+    , m_avatarItemModel(new QStandardItemModel(this))
+    , m_avatarItemDelegate(new AvatarItemDelegate(role, this))
+    , m_avatarSize(QSize(80, 80))
+    , m_fd(new QFileDialog(this))
+    , m_dconfig(DConfig::create("org.deepin.dde.control-center", QStringLiteral("org.deepin.dde.control-center.accounts"), QString(), this))
+{
+    initWidgets();
+    connect(this, &DListView::clicked, this, &AvatarListView::onItemClicked);
+    connect(m_fd, &QFileDialog::finished, this, [=](int result) {
+        if (result == QFileDialog::Accepted) {
+            const QString path = m_fd->selectedFiles().first();
+
+            QFileInfo info(path);
+
+            m_dconfig->setValue("avatarPath", info.absolutePath());
+
+            int row = -1;
+            for (int i = 1; i <= m_avatarItemModel->rowCount(); ++i) {
+                if (path == m_avatarItemModel->index(i, 0).data(AvatarListView::SaveAvatarRole)) {
+                    row = i;
+                    break;
+                }
+            }
+
+            if (row == -1) {
+                return addCustomAvatar(path, false);
+            }
+
+            onItemClicked(m_avatarItemModel->index(row, 0));
+        }
+    });
+}
+
+AvatarListView::~AvatarListView()
+{
+    if (m_fd)
+        m_fd->deleteLater();
+
+    if (m_avatarItemModel) {
+        m_avatarItemModel->clear();
+        m_avatarItemModel->deleteLater();
+        m_avatarItemModel = nullptr;
+    }
+    if (m_avatarItemDelegate) {
+        m_avatarItemDelegate->deleteLater();
+        m_avatarItemDelegate = nullptr;
+    }
+}
+
+QString AvatarListView::getCustomAvatarPath()
+{
+    auto homeDir = QStandardPaths::standardLocations(QStandardPaths::HomeLocation);
+    auto path = homeDir.first() + QString("/.local/share/icons/");
+
+    return path;
+}
+
+void AvatarListView::initWidgets()
+{
+    m_fd->setAccessibleName("QFileDialog");
+
+    setViewMode(ViewMode::IconMode);
+    setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+    setContentsMargins(0, 0, 0, 0);
+    setSpacing(2);
+    setItemAlignment(Qt::AlignTop);
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
+    setDragDropMode(QAbstractItemView::NoDragDrop);
+    setDragEnabled(false);
+    setResizeMode(DListView::Adjust);
+    setFrameShape(QFrame::NoFrame);
+    setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+    setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
+
+    setItemDelegate(m_avatarItemDelegate);
+    setModel(m_avatarItemModel);
+
+    addItemFromDefaultDir(m_path);
+
+    m_fd->setModal(true);
+    m_fd->setNameFilter(tr("Images") + "(*.png *.bmp *.jpg *.jpeg)");
+}
+
+void AvatarListView::addLastItem()
+{
+    DStandardItem *item = new DStandardItem();
+    item->setAccessibleText("LastItem");
+    item->setData(m_avatarSize, Qt::SizeHintRole);
+    item->setData("", AvatarListView::SaveAvatarRole);
+    item->setData(true, AvatarListView::AddAvatarRole);
+    m_avatarItemModel->appendRow(item);
+
+    if (m_avatarItemModel->rowCount() > MaxCustomAvatarSize + 1) {
+        item->setEnabled(false);
+    }
+}
+
+QStandardItem *AvatarListView::getCustomAvatar()
+{
+    QStandardItem *item = m_avatarItemModel->item(1);
+    // 默认项MaxAvatarSize个，添加项一个
+    if (m_avatarItemModel->rowCount() < MaxCustomAvatarSize + 1) {
+        if (m_updateItem) {
+            m_updateItem = false;
+            return m_avatarItemModel->item(m_currentSelectIndex.row());
+        }
+
+        item = new QStandardItem();
+        if (m_currentSelectIndex.isValid())
+            m_avatarItemModel->item(m_currentSelectIndex.row())->setCheckState(Qt::Unchecked);
+        m_avatarItemModel->insertRow(1, item);
+    }
+    return item;
+}
+
+void AvatarListView::addItemFromDefaultDir(const QString &path)
+{
+    auto avatarPath = path;
+    if (m_currentAvatarRole == CustomAvatarType) {
+        avatarPath = getCustomAvatarPath();
+    }
+    QDir dir(avatarPath);
+    QStringList hideList;
+    hideList << "default.png"
+             << "guest.png";
+    QStringList filters;
+    filters << "*.png" << "*.jpg" << "*.jpeg";       // 设置过滤类型
+    dir.setNameFilters(filters); // 设置文件名的过滤
+    QFileInfoList list = dir.entryInfoList();
+
+    // 根据文件名进行排序
+    std::sort(list.begin(),
+              list.end(),
+              [&](const QFileInfo &fileinfo1, const QFileInfo &fileinfo2) {
+                  return fileinfo1.baseName() < fileinfo2.baseName();
+              });
+
+    if (m_currentAvatarRole == 	CustomAvatarType && !list.isEmpty()) {
+        addLastItem();
+    }
+
+    for (int i = 0; i < MaxAvatarSize && i < list.size(); ++i) {
+        if (hideList.contains(list.at(i).fileName())) {
+            continue;
+        }
+
+        QString iconPath = list.at(i).filePath();
+
+        DStandardItem *item = new DStandardItem();
+        item->setBackgroundRole(QPalette::ColorRole::Highlight);
+        item->setAccessibleText(iconPath);
+        auto ratio = devicePixelRatioF();
+
+        auto pxPath = iconPath;
+        auto px = QPixmap(pxPath).scaled(QSize(74, 74) * ratio,
+                                         Qt::KeepAspectRatio,
+                                         Qt::FastTransformation);
+        px.setDevicePixelRatio(ratio);
+
+        item->setData(QVariant::fromValue(px), Qt::DecorationRole);
+        item->setData(QVariant::fromValue(iconPath), AvatarListView::SaveAvatarRole);
+        item->setData(m_avatarSize, Qt::SizeHintRole);
+        m_avatarItemModel->appendRow(item);
+    }
+}
+
+void AvatarListView::setCurrentAvatarUnChecked()
+{
+    if (m_currentSelectIndex.isValid()) {
+        m_avatarItemModel->setData(m_currentSelectIndex, Qt::Unchecked, Qt::CheckStateRole);
+    }
+}
+
+void AvatarListView::requestUpdateCustomAvatar(const QString &path)
+{
+    addCustomAvatar(path, true);
+}
+
+bool AvatarListView::isExistCustomAvatar()
+{
+    auto path = getCustomAvatarPath();
+
+    QDir dir(path);
+
+    if (dir.entryInfoList().isEmpty()) {
+        return false;
+    }
+
+    return true;
+}
+
+void AvatarListView::addCustomAvatar(const QString &path, bool isFirst)
+{
+    if (m_avatarItemModel->rowCount() > MaxCustomAvatarSize + 1) {
+        return;
+    }
+
+    if (isFirst) {
+        addLastItem();
+    }
+
+    QStandardItem *item = getCustomAvatar();
+    item->setAccessibleText(path);
+    auto ratio = devicePixelRatioF();
+    auto px = QPixmap(path).scaled(QSize(74, 74) * ratio,
+                                   Qt::KeepAspectRatio,
+                                   Qt::FastTransformation);
+    px.setDevicePixelRatio(ratio);
+
+    item->setData(QVariant::fromValue(px), Qt::DecorationRole);
+    item->setData(QVariant::fromValue(path), AvatarListView::SaveAvatarRole);
+    item->setData(m_avatarSize, Qt::SizeHintRole);
+
+    if (m_currentSelectIndex.isValid())
+        m_avatarItemModel->item(m_currentSelectIndex.row())->setCheckState(Qt::Unchecked);
+
+    if (m_avatarItemModel->item(m_currentSelectIndex.row())) {
+        m_avatarItemModel->item(m_currentSelectIndex.row())->setCheckState(Qt::Checked);
+        m_avatarItemModel->item(m_currentSelectIndex.row())
+                ->setData(QVariant::fromValue(path), AvatarListView::SaveAvatarRole);
+    }
+
+    Q_EMIT requestUpdateListView(m_currentAvatarRole, m_currentAvatarType);
+}
+
+void AvatarListView::onItemClicked(const QModelIndex &index)
+{
+    if (index.data(Qt::CheckStateRole) == Qt::Checked)
+        return;
+    const QString filePath = index.data(SaveAvatarRole).toString();
+    if (filePath.isEmpty()) {
+        QString dir = m_dconfig->value("avatarPath").toString();
+        if (dir.isEmpty() || !QDir(dir).exists()) {
+            QStringList directory =
+                    QStandardPaths::standardLocations(QStandardPaths::PicturesLocation);
+            if (!directory.isEmpty()) {
+                m_fd->setDirectory(directory.first());
+            }
+        } else {
+            m_fd->setDirectory(dir);
+        }
+        m_fd->show();
+    } else {
+        if(m_currentSelectIndex.isValid())
+            m_avatarItemModel->item(m_currentSelectIndex.row())->setCheckState(Qt::Unchecked);
+
+        m_currentSelectIndex = index;
+        m_avatarItemModel->item(m_currentSelectIndex.row())->setCheckState(Qt::Checked);
+        m_avatarItemModel->item(m_currentSelectIndex.row())->setData(QVariant::fromValue(filePath), AvatarListView::SaveAvatarRole);
+        Q_EMIT requestUpdateListView(m_currentAvatarRole, m_currentAvatarType);
+    }
+}
+
+void AvatarListView::saveAvatar(const QString &oldPath, const QString &path)
+{
+    m_updateItem = true;
+    QFileInfo info(path);
+    QFile::remove(getAvatarPath());
+
+    addCustomAvatar(path, false);
+}
+
+QString AvatarListView::getCurrentSelectAvatar() const
+{
+    return m_currentSelectIndex.data(AvatarListView::SaveAvatarRole).toString();
+}
+
+QString AvatarListView::getAvatarPath() const
+{
+    auto index = QRandomGenerator::global()->bounded(20);
+    if (!m_currentSelectIndex.isValid())
+        return QString();
+
+    index = m_currentSelectIndex.row();
+    auto idx = m_avatarItemModel->index(index, 0);
+    return m_avatarItemModel->data(idx, SaveAvatarRole).toString();
+}
+
+void AvatarListView::setAvatarSize(const QSize &size)
+{
+    if (m_avatarSize == size)
+        return;
+
+    m_avatarSize = size;
+
+    auto count = m_avatarItemModel->rowCount();
+    for (auto i = 0; i < count; ++i) {
+        auto idx = m_avatarItemModel->index(i, 0);
+        m_avatarItemModel->setData(idx, m_avatarSize, Qt::SizeHintRole);
+    }
+}

--- a/src/plugin-accounts/window/avatarlistview.h
+++ b/src/plugin-accounts/window/avatarlistview.h
@@ -1,0 +1,86 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef AVATARLISVIEW_H
+#define AVATARLISVIEW_H
+
+#include "interface/namespace.h"
+
+#include <DListView>
+
+#include <QWidget>
+
+QT_BEGIN_NAMESPACE
+class QVBoxLayout;
+class QLabel;
+class QListView;
+class QStandardItemModel;
+class QModelIndex;
+class QFileDialog;
+QT_END_NAMESPACE
+
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
+
+namespace DCC_NAMESPACE {
+class AvatarItemDelegate;
+
+class AvatarListView : public DTK_WIDGET_NAMESPACE::DListView
+{
+    Q_OBJECT
+public:
+    enum ItemRole {
+        AddAvatarRole = Dtk::UserRole + 1,
+        SaveAvatarRole,
+    };
+
+public:
+    AvatarListView(const int &role, const int &type, const QString &path, QWidget *parent = nullptr);
+    virtual ~AvatarListView();
+
+    inline int getCurrentListViewRole() { return m_currentAvatarRole; }
+    inline int getCurrentListViewType() { return m_currentAvatarType; }
+    inline QSize avatarSize() const { return m_avatarSize; }
+
+    void addCustomAvatar(const QString &path, bool isFirst);
+    void addLastItem();
+    void setAvatarSize(const QSize &size);
+    void saveAvatar(const QString &oldPath, const QString &path);
+    void addItemFromDefaultDir(const QString &path);
+    bool isExistCustomAvatar();
+
+    QString getCustomAvatarPath();
+    QString getAvatarPath() const;
+    QString getCurrentSelectAvatar() const;
+
+Q_SIGNALS:
+    void requestUpdateListView(const int &role, const int &type);
+
+public Q_SLOTS:
+    void setCurrentAvatarChecked(const QString &avatar);
+    void setCurrentAvatarUnChecked();
+    void requestUpdateCustomAvatar(const QString &path);
+
+private:
+    void initWidgets();
+    QStandardItem *getCustomAvatar();
+
+private Q_SLOTS:
+    void onItemClicked(const QModelIndex &index);
+
+private:
+    bool m_updateItem = false;
+    int m_currentAvatarRole;
+    int m_currentAvatarType;
+    QString m_path;
+    QStandardItemModel *m_avatarItemModel;
+    AvatarItemDelegate *m_avatarItemDelegate;
+    QSize m_avatarSize;
+    QModelIndex m_currentSelectIndex;
+    QFileDialog *m_fd;
+    DTK_CORE_NAMESPACE::DConfig *m_dconfig;
+};
+}
+
+#endif //AVATARLISVIEW_H

--- a/src/plugin-accounts/window/avatarlistwidget.h
+++ b/src/plugin-accounts/window/avatarlistwidget.h
@@ -4,86 +4,74 @@
 #pragma once
 
 #include "interface/namespace.h"
+#include "avatarlistframe.h"
+#include "avatarlistview.h"
 #include "src/plugin-accounts/operation/user.h"
 
 #include <DListView>
+#include <DBlurEffectWidget>
+#include <QWidget>
+#include <QLabel>
+#include <QScrollArea>
+#include <QHBoxLayout>
+
 #include <DDialog>
 
-#include <QWidget>
-
-QT_BEGIN_NAMESPACE
-class QVBoxLayout;
-class QLabel;
-class QListView;
-class QStandardItemModel;
-class QModelIndex;
-class QFileDialog;
-QT_END_NAMESPACE
-
-DCORE_BEGIN_NAMESPACE
-class DConfig;
-DCORE_END_NAMESPACE
+DWIDGET_BEGIN_NAMESPACE
+class DFrame;
+DWIDGET_END_NAMESPACE
 
 namespace DCC_NAMESPACE {
-class AvatarItemDelegate;
-class AvatarListWidget : public DTK_WIDGET_NAMESPACE::DListView
+class CustomAddAvatarWidget;
+class CustomAvatarWidget;
+class AvatarListDialog : public Dtk::Widget::DBlurEffectWidget
 {
     Q_OBJECT
 public:
-    enum ItemRole {
-        AddAvatarRole = Dtk::UserRole + 1,
-        SaveAvatarRole,
+    // 头像选择项
+struct AvatarItem
+{
+    QString name;
+    QString icon;
+    int role;
+    bool isLoader;
+
+    AvatarItem(const QString &_name, const QString &_icon, const int &_role, const bool &_isLoader)
+        : name(_name)
+        , icon(_icon)
+        , role(_role)
+        , isLoader(_isLoader)
+    {
+    }
+};
+    enum AvatarItemRole {
+        AvatarItemNameRole = DTK_NAMESPACE::UserRole + 1,
+        AvatarItemIconRole
     };
 
-public:
-    AvatarListWidget(User *usr, QWidget *parent = nullptr);
-    virtual ~AvatarListWidget();
-public:
-    void addItemFromDefaultDir();
-    void addLastItem();
-    QString getAvatarPath() const;
-    inline QSize avatarSize() const { return m_avatarSize; }
-    void setAvatarSize(const QSize &size);
-
-Q_SIGNALS:
-    void requestSetAvatar(const QString &avatarPath);
-    void requestAddNewAvatar(User *user, const QString &file);
-    void requesRetract();
-
-public Q_SLOTS:
-    void setCurrentAvatarChecked(const QString &avatar);
-    void refreshCustomAvatar(const QString &str);
-
-private Q_SLOTS:
-    void onItemClicked(const QModelIndex &index);
-
-private:
-    void initWidgets();
-    QString getUserAddedCustomPicPath(const QString &usrName);
-    QStandardItem *getCustomAvatar();
-
-private:
-    User *m_curUser{nullptr};
-    QVBoxLayout *m_mainContentLayout;
-    QStandardItemModel *m_avatarItemModel;
-    AvatarItemDelegate *m_avatarItemDelegate;
-    QSize m_avatarSize;
-    QModelIndex m_currentSelectIndex;
-    bool m_displayLastItem;
-    QFileDialog *m_fd;
-    DTK_CORE_NAMESPACE::DConfig *m_dconfig;
-};
-
-class AvatarListDialog : public DTK_WIDGET_NAMESPACE::DDialog
-{
-    Q_OBJECT
-public:
-    AvatarListDialog(User *usr, QWidget *parent = nullptr);
+    AvatarListDialog(User *usr);
     virtual ~AvatarListDialog();
 
     QString getAvatarPath() const;
 
+protected:
+    void mousePressEvent(QMouseEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *e) override;
+    void mouseReleaseEvent(QMouseEvent *e) override;
+
+Q_SIGNALS:
+    void requestSaveAvatar(const QString &avatarPath);
+
 private:
-    AvatarListWidget *m_avatarList;
+    User *m_curUser{nullptr};
+    QHBoxLayout *m_mainContentLayout;
+    QVBoxLayout *m_leftContentLayout;
+    QVBoxLayout *m_rightContentLayout;
+    DTK_WIDGET_NAMESPACE::DListView *m_avatarSelectItem;
+    QStandardItemModel *m_avatarSelectItemModel;
+    AvatarListFrame *m_currentSelectAvatarWidget;
+    QMap <int, AvatarListFrame *> m_avatarFrames;
+    QPoint m_lastPos;
+    QScrollArea *m_avatarArea;
 };
 }

--- a/src/plugin-accounts/window/createaccountpage.cpp
+++ b/src/plugin-accounts/window/createaccountpage.cpp
@@ -408,7 +408,7 @@ void CreateAccountPage::createUser()
     }
 
     //如果用户没有选图像
-    auto avatarPaht = AvatarListWidget(m_newUser).getAvatarPath();
+    auto avatarPaht = AvatarListFrame(0,0).getAvatarPath();
     m_newUser->setCurrentAvatar(avatarPaht);
     m_newUser->setName(m_nameEdit->dTextEdit()->lineEdit()->text().simplified());
     m_newUser->setFullname(m_fullnameEdit->dTextEdit()->lineEdit()->text());


### PR DESCRIPTION
使用新的账户头像资源,支持用户头像个性化配置

Log: 实现控制中心个性化头像定制功能
Resolve: https://github.com/linuxdeepin/developer-center/issues/3796
Influence: 控制中心账户头像设置