### PR TITLE
feat: 控制中心跨端协同连接方向显示异常

### DIFF
--- a/src/plugin-display/operation/displayworker.cpp
+++ b/src/plugin-display/operation/displayworker.cpp
@@ -528,19 +528,21 @@ void DisplayWorker::machinesAdded(const QString &path)
     MachineDBusProxy *interProxy = new MachineDBusProxy(path, this);
     Machine *machine = new Machine(this);
 
-    connect(interProxy, &MachineDBusProxy::IpChanged, machine, &Machine::setIP);
+    connect(interProxy, &MachineDBusProxy::IPChanged, machine, &Machine::setIP);
     connect(interProxy, &MachineDBusProxy::NameChanged, machine, &Machine::setName);
     connect(interProxy, &MachineDBusProxy::ConnectedChanged, machine, &Machine::setConnected);
     connect(interProxy, &MachineDBusProxy::DeviceSharingChanged, machine, &Machine::setDeviceSharing);
     connect(interProxy, &MachineDBusProxy::disconnectStatusChanged, machine, &Machine::setDisconnectStatus);
-    connect(interProxy, &MachineDBusProxy::directionChanged, machine, &Machine::setDirection);
+    connect(interProxy, &MachineDBusProxy::DirectionChanged, machine, &Machine::setDirection);
+
     machine->setPath(path);
-    machine->setIP(interProxy->IP());
+    machine->setIP(interProxy->ip());
     machine->setName(interProxy->name());
     machine->setConnected(interProxy->connected());
     machine->setDeviceSharing(interProxy->deviceSharing());
-    machine->setUUID(interProxy->UUID());
+    machine->setUUID(interProxy->uuid());
     machine->setDirection(interProxy->direction());
+
     // 标记历史设备
     const QList<QString> &historyDev = m_displayInter->CooperatedMachines();
     for (auto &hisdevPath : historyDev) {

--- a/src/plugin-display/operation/machine.cpp
+++ b/src/plugin-display/operation/machine.cpp
@@ -59,7 +59,7 @@ void Machine::setDeviceSharing(const bool deviceSharing)
 
 void Machine::setDisconnectStatus(bool status)
 {
-    Q_EMIT disconnnectStatusChanged(status);
+    Q_EMIT disconnectStatusChanged(status);
 }
 
 void Machine::setHistoryStates(bool isHistory)

--- a/src/plugin-display/operation/machine.h
+++ b/src/plugin-display/operation/machine.h
@@ -42,7 +42,7 @@ Q_SIGNALS:
     void nameChanged(const QString& name);
     void IPChanged(const QString& Ip);
     void deviceSharingChanged(bool deviceSharing);
-    void disconnnectStatusChanged(bool status);
+    void disconnectStatusChanged(bool status);
     void historyStatusChanged(bool status);
     void directionChanged(const quint16& dir);
 

--- a/src/plugin-display/operation/machinedbusproxy.cpp
+++ b/src/plugin-display/operation/machinedbusproxy.cpp
@@ -8,6 +8,9 @@
 #include <QDBusReply>
 #include <QDebug>
 
+const static QString PropertiesInterface = "org.freedesktop.DBus.Properties";
+const static QString PropertiesChanged = "PropertiesChanged";
+
 MachineDBusProxy::MachineDBusProxy(QString cooperationMachinePath, QObject *parent)
     : QObject(parent)
     , m_cooperationMachinePath(cooperationMachinePath)
@@ -16,9 +19,11 @@ MachineDBusProxy::MachineDBusProxy(QString cooperationMachinePath, QObject *pare
     const static QString CooperationInterface = "org.deepin.dde.Cooperation1.Machine";
 
     m_dBusMachineInter = new DCC_NAMESPACE::DCCDBusInterface(CooperationService, m_cooperationMachinePath, CooperationInterface, QDBusConnection::sessionBus(), this);
+    QDBusConnection dbusConnection = m_dBusMachineInter->connection();
+    dbusConnection.connect(CooperationService, m_cooperationMachinePath, PropertiesInterface, PropertiesChanged, this, SLOT(onPropertiesChanged(QDBusMessage)));
 }
 
-QString MachineDBusProxy::IP()
+QString MachineDBusProxy::ip()
 {
     return qvariant_cast<QString>(m_dBusMachineInter->property("IP"));
 }
@@ -33,7 +38,7 @@ bool MachineDBusProxy::connected()
     return qvariant_cast<bool>(m_dBusMachineInter->property("Connected"));
 }
 
-QString MachineDBusProxy::UUID()
+QString MachineDBusProxy::uuid()
 {
     return qvariant_cast<QString>(m_dBusMachineInter->property("UUID"));
 }

--- a/src/plugin-display/operation/machinedbusproxy.h
+++ b/src/plugin-display/operation/machinedbusproxy.h
@@ -21,8 +21,8 @@ class MachineDBusProxy : public QObject
 public:
     explicit MachineDBusProxy(QString cooperationMachinePath, QObject *parent = nullptr);
 
-    Q_PROPERTY(QString IP READ IP NOTIFY IpChanged)
-    QString IP();
+    Q_PROPERTY(QString IP READ ip NOTIFY IPChanged)
+    QString ip();
 
     Q_PROPERTY(QString Name READ name NOTIFY NameChanged)
     QString name();
@@ -30,13 +30,13 @@ public:
     Q_PROPERTY(bool Connected READ connected NOTIFY ConnectedChanged)
     bool connected();
 
-    Q_PROPERTY(QString UUID READ UUID NOTIFY UuidChanged)
-    QString UUID();
+    Q_PROPERTY(QString UUID READ uuid NOTIFY UUIDChanged)
+    QString uuid();
 
     Q_PROPERTY(bool DeviceSharing READ deviceSharing NOTIFY DeviceSharingChanged)
     bool deviceSharing(); // 默认设备
 
-    Q_PROPERTY(int Direction READ direction NOTIFY directionChanged)
+    Q_PROPERTY(int Direction READ direction NOTIFY DirectionChanged)
     quint16 direction();
 
     void disconnect();
@@ -46,13 +46,14 @@ public:
     void stopDeviceSharing();
 
 Q_SIGNALS:
-    void IpChanged(const QString& ip);
+    void IPChanged(const QString& ip);
     void NameChanged(const QString& name);
-    void ConnectedChanged(bool connecteded);
-    void UuidChanged(const QString& uuid);
+    void ConnectedChanged(bool connected);
+    void UUIDChanged(const QString& uuid);
     void DeviceSharingChanged(bool cooperating);
+    void DirectionChanged(int dir);
+
     void disconnectStatusChanged(bool);
-    void directionChanged(quint16 dir);
 
 private slots:
     void onPropertiesChanged(const QDBusMessage &message);

--- a/src/plugin-display/window/collaborativelinkwidget.cpp
+++ b/src/plugin-display/window/collaborativelinkwidget.cpp
@@ -216,7 +216,7 @@ void CollaborativeLinkWidget::addMachine(Machine *machine)
         cooperationStatusChanged(deviceSharing);
     });
 
-    connect(machine, &Machine::disconnnectStatusChanged, m_deviceCombox, [this](bool status) {
+    connect(machine, &Machine::disconnectStatusChanged, m_deviceCombox, [this](bool status) {
         m_currentMachineDevcice = nullptr;
         cooperationStatusChanged(false);
     });


### PR DESCRIPTION
需要绑定PropertiesChanged去更新对应的界面显示

Log: 修复控制中心跨端协同连接方向显示异常的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3703
Influence: 控制中心显示界面跨端协同