### PR TITLE
fix: appendconsole add twice

### DIFF
--- a/src/frame/main.cpp
+++ b/src/frame/main.cpp
@@ -37,9 +37,6 @@ int main(int argc, char *argv[])
     app->setOrganizationName("deepin");
     app->setApplicationName("dde-control-center");
 
-    DLogManager::registerJournalAppender();
-    DLogManager::registerConsoleAppender();
-
     // take care of command line options
     QCommandLineOption showOption(QStringList() << "s"
                                                 << "show",
@@ -97,6 +94,7 @@ int main(int argc, char *argv[])
         return -1;
     }
 
+    DLogManager::registerJournalAppender();
     DLogManager::registerConsoleAppender();
     DLogManager::registerFileAppender();
 


### PR DESCRIPTION
Before I want to add registerJournalAppender, but I also have do registerConsoleAppender, then console is registered twice, this will append to console twice, make the log unreadable, this pr fix it

Log: fix appendconsole add twice