### PR TITLE
fix: 控制中心用户头像显示异常

### DIFF
--- a/src/plugin-accounts/window/avatarlistframe.h
+++ b/src/plugin-accounts/window/avatarlistframe.h
@@ -28,13 +28,6 @@ namespace DCC_NAMESPACE {
 class AvatarCropBox;
 class AvatarListView;
 
-enum Role { Person, Animal, Illustration, Expression, Custom, AvatarAdd };
-
-enum Type {
-    Dimensional, // 立体风格
-    Flat         // 平面风格
-};
-
 class AvatarListFrame : public QFrame
 {
     Q_OBJECT
@@ -62,9 +55,7 @@ public:
     virtual ~AvatarListFrame() = default;
 
     inline int getCurrentRole() { return m_role; }
-
-    inline int getCurrentType() { return m_type; }
-
+    inline QString getCurrentPath() { return m_path; }
     inline AvatarListView *getCurrentListView() { return m_currentAvatarLsv; }
 
     QString getAvatarPath() const;
@@ -72,14 +63,14 @@ public:
     bool isExistCustomAvatar(const QString &path);
 
 public Q_SLOTS:
-    void updateListView(const int &role, const int &type);
+    void updateListView(bool isSave, const int &role, const int &type);
 
 private:
     QString getCurrentAvatarPath(const int role, const int type);
 
 private:
     int m_role;
-    int m_type;
+    QString m_path;
     AvatarListView *m_avatarDimensionalLsv;
     AvatarListView *m_avatarFlatLsv;
     AvatarListView *m_currentAvatarLsv;
@@ -121,7 +112,7 @@ class CustomAvatarView : public QWidget
     Q_OBJECT
 
 public:
-    explicit CustomAvatarView(const QString &avatarPath, QWidget *parent = nullptr);
+    explicit CustomAvatarView(QWidget *parent = nullptr);
     ~CustomAvatarView();
 
     void setAvatarPath(const QString &avatarPath);

--- a/src/plugin-accounts/window/avatarlistview.h
+++ b/src/plugin-accounts/window/avatarlistview.h
@@ -26,6 +26,13 @@ DCORE_END_NAMESPACE
 namespace DCC_NAMESPACE {
 class AvatarItemDelegate;
 
+enum Role { Person, Animal, Illustration, Expression, Custom, AvatarAdd };
+
+enum Type {
+    Dimensional, // 立体风格
+    Flat         // 平面风格
+};
+
 class AvatarListView : public DTK_WIDGET_NAMESPACE::DListView
 {
     Q_OBJECT
@@ -42,28 +49,24 @@ public:
                    QWidget *parent = nullptr);
     virtual ~AvatarListView();
 
-    inline int getCurrentListViewRole() { return m_currentAvatarRole; }
-
-    inline int getCurrentListViewType() { return m_currentAvatarType; }
-
+    inline int getCurrentListViewRole() const { return m_currentAvatarRole; }
+    inline int getCurrentListViewType() const { return m_currentAvatarType; }
     inline QSize avatarSize() const { return m_avatarSize; }
 
     void addCustomAvatar(const QString &path, bool isFirst);
     void addLastItem();
-    void saveAvatar(const QString &oldPath, const QString &path);
+    void saveAvatar(const QString &path);
     void addItemFromDefaultDir(const QString &path);
-    bool isExistCustomAvatar();
 
-    QString getCustomAvatarPath();
     QString getAvatarPath() const;
-    QString getCurrentSelectAvatar() const;
 
 Q_SIGNALS:
-    void requestUpdateListView(const int &role, const int &type);
+    void requestUpdateListView(bool isSave, const int &role, const int &type);
 
 public Q_SLOTS:
     void setCurrentAvatarChecked(const QString &avatar);
     void setCurrentAvatarUnChecked();
+    void requestAddCustomAvatar(const QString &path);
     void requestUpdateCustomAvatar(const QString &path);
 
 private:
@@ -75,6 +78,7 @@ private Q_SLOTS:
 
 private:
     bool m_updateItem = false;
+    bool m_save = false;
     int m_currentAvatarRole;
     int m_currentAvatarType;
     QString m_path;

--- a/src/plugin-accounts/window/avatarlistwidget.h
+++ b/src/plugin-accounts/window/avatarlistwidget.h
@@ -61,6 +61,9 @@ protected:
     void mouseMoveEvent(QMouseEvent *e) override;
     void mouseReleaseEvent(QMouseEvent *e) override;
 
+private:
+    CustomAvatarWidget *getCustomAvatarWidget();
+
 Q_SIGNALS:
     void requestSaveAvatar(const QString &avatarPath);
 


### PR DESCRIPTION
1. 用户自定义头像保存路径改由dde-system-daemon去保存, 防止登录界面获取不到用户头像
2. 修改用户自定义头像的保存逻辑(默认替换原来的头像)

Log: 修复控制中心用户头像显示异常的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/4041
Influence: 控制中心账户头像显示