### PR TITLE
chore: 优化控制中心用户头像显示

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -42,7 +42,7 @@ build() {
         -DDISABLE_AUTHENTICATION=ON \
         -DDISABLE_LANGUAGE=ON \
         -DCMAKE_INSTALL_LIBDIR=/usr/lib \
-        -DCMAKE_INSTALL_LOCALSTATEDIR=var
+        -DCMAKE_INSTALL_LOCALSTATEDIR=/var
   ninja
 }
 

--- a/src/plugin-accounts/window/avatarlistframe.cpp
+++ b/src/plugin-accounts/window/avatarlistframe.cpp
@@ -35,7 +35,7 @@ const QString IllustrationDimensionalPath = QStringLiteral("lib/AccountsService/
 const QString EmojiDimensionalPath = QStringLiteral("lib/AccountsService/icons/emoji/dimensional");
 
 // 用户自定义图像存放路径
-const QString AvatarCustomPath = QStringLiteral("lib/AccountsService/icons/custom");
+const QString AvatarCustomPath = QStringLiteral("lib/AccountsService/icons/local");
 
 #define BORDER_BOX_SIZE 190
 #define AVATAR_ICON_SIZE 140
@@ -68,25 +68,26 @@ struct AvatarItem
     }
 };
 
-AvatarListFrame::AvatarListFrame(const int &role, QWidget *parent)
+AvatarListFrame::AvatarListFrame(User * user, const int &role, QWidget *parent)
     : QFrame(parent)
     , m_role(role)
     , m_avatarDimensionalLsv(nullptr)
     , m_avatarFlatLsv(nullptr)
     , m_currentAvatarLsv(nullptr)
 {
-    const QString personDimensionPath = QString("/%1/%2").arg(VarDirectory).arg(PersonDimensionalPath);
-    const QString personFlatPath = QString("/%1/%2").arg(VarDirectory).arg(PersonFlatPath);
-    const QString animalDimensionPath = QString("/%1/%2").arg(VarDirectory).arg(AnimalDimensionalPath);
-    const QString illustrationDimensionPath = QString("/%1/%2").arg(VarDirectory).arg(IllustrationDimensionalPath);
-    const QString emojiDimensionPath = QString("/%1/%2").arg(VarDirectory).arg(EmojiDimensionalPath);
-    const QString customAvatarPath = QString("/%1/%2").arg(VarDirectory).arg(AvatarCustomPath);
+    const QString personDimensionPath = QString("%1/%2").arg(VarDirectory).arg(PersonDimensionalPath);
+    const QString personFlatPath = QString("%1/%2").arg(VarDirectory).arg(PersonFlatPath);
+    const QString animalDimensionPath = QString("%1/%2").arg(VarDirectory).arg(AnimalDimensionalPath);
+    const QString illustrationDimensionPath = QString("%1/%2").arg(VarDirectory).arg(IllustrationDimensionalPath);
+    const QString emojiDimensionPath = QString("%1/%2").arg(VarDirectory).arg(EmojiDimensionalPath);
+    const QString customAvatarPath = QString("%1/%2").arg(VarDirectory).arg(AvatarCustomPath);
 
     setFrameStyle(QFrame::NoFrame);
     setContentsMargins(0, 0, 0, 0);
     if (role == Role::Custom) {
         m_path = customAvatarPath;
-        m_currentAvatarLsv = new AvatarListView(role, Type::Dimensional, customAvatarPath);
+        m_currentAvatarLsv = new AvatarListView(user, role, Type::Dimensional, customAvatarPath);
+        m_currentAvatarLsv->setCurrentAvatarChecked(user->currentAvatar());
         return;
     }
 
@@ -116,10 +117,12 @@ AvatarListFrame::AvatarListFrame(const int &role, QWidget *parent)
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->setContentsMargins(0, 0, 0, 0);
 
-    auto addAvatar = [this, mainLayout](const AvatarRoleItem &item) {
-        m_currentAvatarLsv = new AvatarListView(item.role, item.type, item.path);
+    auto addAvatar = [this, mainLayout, user](const AvatarRoleItem &item) {
+        m_currentAvatarLsv = new AvatarListView(user, item.role, item.type, item.path);
         item.type == Type::Dimensional ? m_avatarDimensionalLsv = m_currentAvatarLsv
                                        : m_avatarFlatLsv = m_currentAvatarLsv;
+
+        m_currentAvatarLsv->setCurrentAvatarChecked(user->currentAvatar());
 
         QHBoxLayout *hBoxLayout = new QHBoxLayout;
         hBoxLayout->addWidget(m_currentAvatarLsv, Qt::AlignCenter);
@@ -192,8 +195,8 @@ void AvatarListFrame::updateListView(bool isSave, const int &role, const int &ty
     }
 }
 
-CustomAddAvatarWidget::CustomAddAvatarWidget(const int &role, QWidget *parent)
-    : AvatarListFrame(role, parent)
+CustomAddAvatarWidget::CustomAddAvatarWidget(User *user, const int &role, QWidget *parent)
+    : AvatarListFrame(user, role, parent)
     , m_fd(new QFileDialog(this))
     , m_addAvatarFrame(new DFrame(this))
     , m_addAvatarLabel(new QLabel(this))
@@ -569,8 +572,8 @@ void CustomAvatarView::onPresetImage(void)
     this->update();
 }
 
-CustomAvatarWidget::CustomAvatarWidget(const int &role, QWidget *parent)
-    : AvatarListFrame(role, parent)
+CustomAvatarWidget::CustomAvatarWidget(User *user, const int &role, QWidget *parent)
+    : AvatarListFrame(user, role, parent)
     , m_avatarScaledItem(new DSlider(Qt::Horizontal, this))
     , m_avatarView(new CustomAvatarView(this))
 {

--- a/src/plugin-accounts/window/avatarlistframe.h
+++ b/src/plugin-accounts/window/avatarlistframe.h
@@ -51,7 +51,7 @@ public:
         }
     };
 
-    explicit AvatarListFrame(const int &role, QWidget *parent = nullptr);
+    explicit AvatarListFrame(User * user, const int &role, QWidget *parent = nullptr);
     virtual ~AvatarListFrame() = default;
 
     inline int getCurrentRole() { return m_role; }
@@ -80,7 +80,7 @@ class CustomAddAvatarWidget : public AvatarListFrame
 {
     Q_OBJECT
 public:
-    explicit CustomAddAvatarWidget(const int &role, QWidget *parent = nullptr);
+    explicit CustomAddAvatarWidget(User *user, const int &role, QWidget *parent = nullptr);
     virtual ~CustomAddAvatarWidget();
 
 protected:
@@ -156,7 +156,7 @@ class CustomAvatarWidget : public AvatarListFrame
 {
     Q_OBJECT
 public:
-    explicit CustomAvatarWidget(const int &role, QWidget *parent = nullptr);
+    explicit CustomAvatarWidget(User *user, const int &role, QWidget *parent = nullptr);
     ~CustomAvatarWidget() override = default;
 
     void enableAvatarScaledItem(bool enabled);

--- a/src/plugin-accounts/window/avatarlistview.cpp
+++ b/src/plugin-accounts/window/avatarlistview.cpp
@@ -31,7 +31,7 @@ DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
-AvatarListView::AvatarListView(const int &role,
+AvatarListView::AvatarListView(User *user, const int &role,
                                const int &type,
                                const QString &path,
                                QWidget *parent)
@@ -43,6 +43,7 @@ AvatarListView::AvatarListView(const int &role,
     , m_avatarItemDelegate(new AvatarItemDelegate(this))
     , m_avatarSize(QSize(80, 80))
     , m_fd(new QFileDialog(this))
+    , m_curUser(user)
     , m_dconfig(DConfig::create("org.deepin.dde.control-center",
                                 QStringLiteral("org.deepin.dde.control-center.accounts"),
                                 QString(),
@@ -185,6 +186,13 @@ void AvatarListView::addItemFromDefaultDir(const QString &path)
         }
 
         QString iconPath = list.at(i).filePath();
+
+        if (m_currentAvatarRole == Custom) {
+            // 过滤掉非当前用户自定义头像
+            if (!iconPath.contains(m_curUser->name() + "-")) {
+                continue;
+            }
+        }
 
         DStandardItem *item = new DStandardItem();
         item->setBackgroundRole(QPalette::ColorRole::Highlight);

--- a/src/plugin-accounts/window/avatarlistview.h
+++ b/src/plugin-accounts/window/avatarlistview.h
@@ -5,6 +5,7 @@
 #define AVATARLISVIEW_H
 
 #include "interface/namespace.h"
+#include "src/plugin-accounts/operation/user.h"
 
 #include <DListView>
 
@@ -43,7 +44,7 @@ public:
     };
 
 public:
-    AvatarListView(const int &role,
+    AvatarListView(User *user, const int &role,
                    const int &type,
                    const QString &path,
                    QWidget *parent = nullptr);
@@ -87,6 +88,7 @@ private:
     QSize m_avatarSize;
     QModelIndex m_currentSelectIndex;
     QFileDialog *m_fd;
+    User *m_curUser;
     DTK_CORE_NAMESPACE::DConfig *m_dconfig;
 };
 } // namespace DCC_NAMESPACE

--- a/src/plugin-accounts/window/avatarlistwidget.cpp
+++ b/src/plugin-accounts/window/avatarlistwidget.cpp
@@ -80,10 +80,10 @@ AvatarListDialog::AvatarListDialog(User *usr)
             m_avatarSelectItemModel->appendRow(avatarItem);
 
             if (item.role == Role::Custom) {
-                m_avatarFrames[AvatarAdd] = new CustomAddAvatarWidget(Role::Custom, this);
-                m_avatarFrames[Role::Custom] = new CustomAvatarWidget(Role::Custom, this);
+                m_avatarFrames[AvatarAdd] = new CustomAddAvatarWidget(m_curUser, Role::Custom, this);
+                m_avatarFrames[Role::Custom] = new CustomAvatarWidget(m_curUser, Role::Custom, this);
             } else {
-                m_avatarFrames[item.role] = new AvatarListFrame(item.role, this);
+                m_avatarFrames[item.role] = new AvatarListFrame(m_curUser, item.role, this);
             }
         }
     }
@@ -120,7 +120,6 @@ AvatarListDialog::AvatarListDialog(User *usr)
 
         auto listView = iter.value()->getCurrentListView();
         if (listView && listView->getCurrentListViewRole() != Role::AvatarAdd) {
-            listView->setCurrentAvatarChecked(m_curUser->currentAvatar());
             connect(listView,
                     &AvatarListView::requestUpdateListView,
                     this,
@@ -147,12 +146,19 @@ AvatarListDialog::AvatarListDialog(User *usr)
                                 connect(m_curUser,
                                         &User::currentAvatarChanged,
                                         this,
-                                        [this](const auto &path) {
-                                            getCustomAvatarWidget()->getCurrentListView()->requestUpdateCustomAvatar(path);
-                                            getCustomAvatarWidget()->getCustomAvatarView()->setAvatarPath(
-                                                    m_avatarFrames[Custom]
-                                                            ->getCurrentListView()
-                                                            ->getAvatarPath());
+                                        [this](const QString &path) {
+                                            if (path.contains(
+                                                        m_avatarFrames[Custom]->getCurrentPath())) {
+                                                getCustomAvatarWidget()
+                                                        ->getCurrentListView()
+                                                        ->requestUpdateCustomAvatar(path);
+                                                getCustomAvatarWidget()
+                                                        ->getCustomAvatarView()
+                                                        ->setAvatarPath(
+                                                                m_avatarFrames[Custom]
+                                                                        ->getCurrentListView()
+                                                                        ->getAvatarPath());
+                                            }
                                         });
 
                                 return;

--- a/src/plugin-accounts/window/avatarlistwidget.h
+++ b/src/plugin-accounts/window/avatarlistwidget.h
@@ -6,7 +6,6 @@
 #include "avatarlistframe.h"
 #include "avatarlistview.h"
 #include "interface/namespace.h"
-#include "src/plugin-accounts/operation/user.h"
 
 #include <DBlurEffectWidget>
 #include <DDialog>


### PR DESCRIPTION
多用户时,每个用户只显示当前用户定义的图片

Log: 优化控制中心用户头像显示
Resolve: https://github.com/linuxdeepin/developer-center/issues/4041
Influence: 控制中心账户头像显示