### PR TITLE
fix: 控制中心新建用户时闪退

### DIFF
--- a/src/plugin-accounts/window/avatarlistframe.cpp
+++ b/src/plugin-accounts/window/avatarlistframe.cpp
@@ -91,27 +91,29 @@ AvatarListFrame::AvatarListFrame(User * user, const int &role, QWidget *parent)
         return;
     }
 
+    const QString &name = user->name();
+
     QList<AvatarRoleItem> items = {
         AvatarRoleItem{ Role::Person,
                         Type::Dimensional,
                         personDimensionPath,
-                        isExistCustomAvatar(personDimensionPath) },
+                        isExistCustomAvatar(personDimensionPath, name) },
         AvatarRoleItem{ Role::Person,
                         Type::Flat,
                         personFlatPath,
-                        isExistCustomAvatar(personFlatPath) },
+                        isExistCustomAvatar(personFlatPath, name) },
         AvatarRoleItem{ Role::Animal,
                         Type::Dimensional,
                         animalDimensionPath,
-                        isExistCustomAvatar(animalDimensionPath) },
+                        isExistCustomAvatar(animalDimensionPath, name) },
         AvatarRoleItem{ Role::Illustration,
                         Type::Dimensional,
                         illustrationDimensionPath,
-                        isExistCustomAvatar(illustrationDimensionPath) },
+                        isExistCustomAvatar(illustrationDimensionPath, name) },
         AvatarRoleItem{ Role::Expression,
                         Type::Dimensional,
                         emojiDimensionPath,
-                        isExistCustomAvatar(emojiDimensionPath) },
+                        isExistCustomAvatar(emojiDimensionPath, name) },
     };
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
@@ -167,13 +169,28 @@ QString AvatarListFrame::getAvatarPath() const
     return m_currentAvatarLsv->getAvatarPath();
 }
 
-bool AvatarListFrame::isExistCustomAvatar(const QString &path)
+bool AvatarListFrame::isExistCustomAvatar(const QString &path, const QString &userName)
 {
-    QDir info(path);
+    QDir dir(path);
     QStringList filters{ "*.png", "*.jpg", ".jpeg", ".bmp" }; // 设置过滤类型
-    info.setNameFilters(filters);                             // 设置文件名的过滤
+    dir.setNameFilters(filters);
 
-    return !info.entryInfoList().isEmpty();
+    QFileInfoList list = dir.entryInfoList();
+
+    if (m_role != Custom) {
+        return !list.isEmpty();
+    }
+
+    // 自定义账户页面检查是否存在当前用户自定义头像
+    auto res = std::find_if(list.cbegin(), list.cend(), [ userName ](const QFileInfo &info)->bool{
+        return info.filePath().contains(userName + "-");
+    });
+
+    if (res != list.cend()) {
+        return true;
+    }
+
+    return false;
 }
 
 void AvatarListFrame::updateListView(bool isSave, const int &role, const int &type)

--- a/src/plugin-accounts/window/avatarlistframe.h
+++ b/src/plugin-accounts/window/avatarlistframe.h
@@ -60,7 +60,7 @@ public:
 
     QString getAvatarPath() const;
 
-    bool isExistCustomAvatar(const QString &path);
+    bool isExistCustomAvatar(const QString &path, const QString &userName);
 
 public Q_SLOTS:
     void updateListView(bool isSave, const int &role, const int &type);

--- a/src/plugin-accounts/window/avatarlistview.cpp
+++ b/src/plugin-accounts/window/avatarlistview.cpp
@@ -76,7 +76,7 @@ AvatarListView::AvatarListView(User *user, const int &role,
             }
 
             if (row == -1) {
-                return addCustomAvatar(path, false);
+                return addCustomAvatar(path);
             }
 
             onItemClicked(m_avatarItemModel->index(row, 0));
@@ -176,8 +176,17 @@ void AvatarListView::addItemFromDefaultDir(const QString &path)
                   return fileinfo1.baseName() < fileinfo2.baseName();
               });
 
-    if (m_currentAvatarRole == Role::Custom && !list.isEmpty()) {
-        addLastItem();
+    const auto &name = m_curUser->name();
+    // 当前用户有自定义用户头像时, 需要添加用户添加按钮, 否则不需要添加
+    if (m_currentAvatarRole == Custom) {
+        auto res =
+                std::find_if(list.cbegin(), list.cend(), [name](const QFileInfo &info) -> bool {
+                    return info.filePath().contains(name + "-");
+                });
+
+        if (res != list.cend()) {
+            addLastItem();
+        }
     }
 
     for (int i = 0; i < MaxAvatarSize && i < list.size(); ++i) {
@@ -189,7 +198,7 @@ void AvatarListView::addItemFromDefaultDir(const QString &path)
 
         if (m_currentAvatarRole == Custom) {
             // 过滤掉非当前用户自定义头像
-            if (!iconPath.contains(m_curUser->name() + "-")) {
+            if (!iconPath.contains(name + "-")) {
                 continue;
             }
         }
@@ -221,7 +230,8 @@ void AvatarListView::setCurrentAvatarUnChecked()
 
 void AvatarListView::requestAddCustomAvatar(const QString &path)
 {
-    addCustomAvatar(path, true);
+    addLastItem();
+    addCustomAvatar(path);
 }
 
 void AvatarListView::requestUpdateCustomAvatar(const QString &path)
@@ -235,13 +245,9 @@ void AvatarListView::requestUpdateCustomAvatar(const QString &path)
                       AvatarListView::SaveAvatarRole);
 }
 
-void AvatarListView::addCustomAvatar(const QString &path, bool isFirst)
+void AvatarListView::addCustomAvatar(const QString &path)
 {
     m_save = true;
-
-    if (isFirst) {
-        addLastItem();
-    }
 
     QStandardItem *item = getCustomAvatar();
     item->setAccessibleText(path);
@@ -297,7 +303,7 @@ void AvatarListView::saveAvatar(const QString &path)
 {
     m_updateItem = true;
 
-    addCustomAvatar(path, false);
+    addCustomAvatar(path);
 }
 
 QString AvatarListView::getAvatarPath() const

--- a/src/plugin-accounts/window/avatarlistview.h
+++ b/src/plugin-accounts/window/avatarlistview.h
@@ -54,7 +54,7 @@ public:
     inline int getCurrentListViewType() const { return m_currentAvatarType; }
     inline QSize avatarSize() const { return m_avatarSize; }
 
-    void addCustomAvatar(const QString &path, bool isFirst);
+    void addCustomAvatar(const QString &path);
     void addLastItem();
     void saveAvatar(const QString &path);
     void addItemFromDefaultDir(const QString &path);

--- a/src/plugin-accounts/window/avatarlistwidget.cpp
+++ b/src/plugin-accounts/window/avatarlistwidget.cpp
@@ -176,7 +176,7 @@ AvatarListDialog::AvatarListDialog(User *usr)
     connect(m_avatarSelectItem, &DListView::clicked, this, [this, avatarSelectWidget](auto &index) {
         // 如果没有添加自定义头像, 显示自定义添加图像页面
         if (!m_avatarFrames[Custom]->isExistCustomAvatar(
-                    m_avatarFrames[Custom]->getCurrentPath())) {
+                    m_avatarFrames[Custom]->getCurrentPath(), m_curUser->name())) {
             if (index.row() == 3) {
                 avatarSelectWidget->setCurrentIndex(index.row() + 1);
                 m_currentSelectAvatarWidget = m_avatarFrames[Custom];

--- a/src/plugin-accounts/window/createaccountpage.cpp
+++ b/src/plugin-accounts/window/createaccountpage.cpp
@@ -431,9 +431,8 @@ void CreateAccountPage::createUser()
         }
     }
 
-    // 如果用户没有选图像
-    auto avatarPaht = AvatarListFrame(0, 0).getAvatarPath();
-    m_newUser->setCurrentAvatar(avatarPaht);
+    // 如果用户没有选图像, 则从系统头像中随机选择一张图像
+    m_accountWorker->randomUserIcon(m_newUser);
     m_newUser->setName(m_nameEdit->dTextEdit()->lineEdit()->text().simplified());
     m_newUser->setFullname(m_fullnameEdit->dTextEdit()->lineEdit()->text());
     m_newUser->setPassword(m_passwdEdit->lineEdit()->text());


### PR DESCRIPTION
新建用户时, 从系统头像中随机选择一张, 不从头像列表中去选择,防止数据异常导致程序崩溃

Log: 修复控制中心新建用户时闪退的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/4107
Influence: 控制中心账户创建