### PR TITLE
chore: 优化账户头像设置

### DIFF
--- a/src/plugin-accounts/window/avatarlistframe.cpp
+++ b/src/plugin-accounts/window/avatarlistframe.cpp
@@ -25,8 +25,6 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
-const QString VarDirectory = QStringLiteral(VARDIRECTORY);
-
 // 系统用户头像存放路径
 const QString PersonDimensionalPath = QStringLiteral("lib/AccountsService/icons/human/dimensional");
 const QString PersonFlatPath = QStringLiteral("lib/AccountsService/icons/human/flat");

--- a/src/plugin-accounts/window/avatarlistview.cpp
+++ b/src/plugin-accounts/window/avatarlistview.cpp
@@ -26,6 +26,8 @@
 
 const int MaxAvatarSize = 20;
 const int MaxCustomAvatarSize = 4;
+const QString VarDirectory = QStringLiteral(VARDIRECTORY);
+const QString DefaultAvatar = QStringLiteral("lib/AccountsService/icons/animal/dimensional/raccoon.png");
 
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
@@ -322,8 +324,15 @@ void AvatarListView::setCurrentAvatarChecked(const QString &avatar)
         return;
 
     QString currentAvatar = avatar;
-    if (avatar.startsWith("file://"))
-        currentAvatar = QUrl(avatar).toLocalFile();
+    const QString urlPre = "file://";
+    // 如果是默认的头像, 需要将路径换成实际的路径
+    if (currentAvatar.contains("default")) {
+        const auto defaultAvatar = QString("%1%2/%3").arg(urlPre).arg(VarDirectory).arg(DefaultAvatar);
+        currentAvatar = defaultAvatar;
+    }
+
+    if (currentAvatar.startsWith(urlPre))
+        currentAvatar = QUrl(currentAvatar).toLocalFile();
 
     if (!QFile(currentAvatar).exists())
         return;

--- a/src/plugin-accounts/window/avatarlistwidget.cpp
+++ b/src/plugin-accounts/window/avatarlistwidget.cpp
@@ -239,6 +239,9 @@ AvatarListDialog::AvatarListDialog(User *usr)
         const QString path = getAvatarPath();
         if (!path.isEmpty() && path != m_curUser->currentAvatar()) {
             Q_EMIT requestSaveAvatar(path);
+
+            // 成功设置头像后关闭窗口
+            close();
         }
     });
     connect(cancelButton, &QPushButton::clicked, this, &AvatarListDialog::close);


### PR DESCRIPTION
1. 默认头像路径(一个软链接)和实际头像路径不一样, 需要替换成实际的头像路径
2. 用户设置头像成功后关闭窗口

Log: 优化控制中心账户头像设置
Influence: 控制中心账户头像正常设置和显示