### PR TITLE
fix: plugin load with -d cannot load dbus in time

### DIFF
--- a/src/frame/pluginmanager.h
+++ b/src/frame/pluginmanager.h
@@ -45,7 +45,6 @@ public Q_SLOTS:
 Q_SIGNALS:
     void loadedModule(const PluginData &data);
     void loadAllFinished();
-    void requestForceContinue();
 
 private:
     ModuleObject *findModule(ModuleObject *module, const QString &name);


### PR DESCRIPTION
use eventloop, it will enter eventloop before load dbus, so back to thread sleep, and some plugin maybe take loog time to load, set notify time to 10 second

Log: adjust plugin load logic