### PR TITLE
chore: when all plugins is loaded, but watcher is not finished

### DIFF
--- a/src/frame/pluginmanager.cpp
+++ b/src/frame/pluginmanager.cpp
@@ -215,7 +215,7 @@ void PluginManager::loadModules(ModuleObject *root, bool async, const QStringLis
     if (!async) {
         for (int i = 0; i < 50; i++) {
             QThread::msleep(100);
-            if (watcher->isFinished()) {
+            if (m_pluginsStatus.isEmpty()) {
                 break;
             }
         }


### PR DESCRIPTION
Log: adjust logic of plugin load