### PR TITLE
fix: remove batteryPercentageChange signal

### DIFF
--- a/src/plugin-power/operation/powerdbusproxy.h
+++ b/src/plugin-power/operation/powerdbusproxy.h
@@ -4,6 +4,7 @@
 #ifndef POWERDBUSPROXY_H
 #define POWERDBUSPROXY_H
 
+#include <qdbusargument.h>
 #include <QObject>
 class QDBusInterface;
 class QDBusMessage;
@@ -114,11 +115,18 @@ signals:
     void PowerSavingModeEnabledChanged(bool value) const;
     void HasBatteryChanged(bool value) const;
     void PowerSavingModeAutoWhenBatteryLowChanged(bool value) const;
-    void BatteryPercentageChanged(const QVariantMap &battery) const;
     void PowerSavingModeBrightnessDropPercentChanged(uint value) const;
     void ModeChanged(const QString &value) const;
     void BatteryCapacityChanged(double value) const;
 
+    // unused signals
+    void BatteryPercentageChanged(const QDBusArgument &) const;
+    void BatteryPercentageChanged(double value) const;
+    void BatteryTimeToEmptyChanged(const qulonglong &) const;
+    void BatteryTimeToFullChanged(const qulonglong &) const;
+    void BatteryStatusChanged(const QDBusArgument &) const;
+    void BatteryStatusChanged(uint) const;
+    void OnBatteryChanged(bool) const;
 public slots:
     // SystemPower
     void SetMode(const QString &mode);

--- a/src/plugin-power/operation/powerdbusproxy.h
+++ b/src/plugin-power/operation/powerdbusproxy.h
@@ -113,8 +113,8 @@ signals:
     void PowerSavingModeAutoChanged(bool value) const;
     void PowerSavingModeEnabledChanged(bool value) const;
     void HasBatteryChanged(bool value) const;
-    void BatteryPercentageChanged(double value) const;
     void PowerSavingModeAutoWhenBatteryLowChanged(bool value) const;
+    void BatteryPercentageChanged(const QVariantMap &battery) const;
     void PowerSavingModeBrightnessDropPercentChanged(uint value) const;
     void ModeChanged(const QString &value) const;
     void BatteryCapacityChanged(double value) const;

--- a/src/plugin-power/operation/powermodel.cpp
+++ b/src/plugin-power/operation/powermodel.cpp
@@ -162,15 +162,6 @@ void PowerModel::setHaveBettary(bool haveBettary)
     Q_EMIT haveBettaryChanged(haveBettary);
 }
 
-void PowerModel::setBatteryPercentage(double batteryPercentage)
-{
-    if (!getDoubleCompare(batteryPercentage, m_batteryPercentage))
-        return;
-
-    m_batteryPercentage = batteryPercentage;
-
-    Q_EMIT batteryPercentageChanged(batteryPercentage);
-}
 
 bool PowerModel::getDoubleCompare(const double value1, const double value2)
 {

--- a/src/plugin-power/operation/powermodel.h
+++ b/src/plugin-power/operation/powermodel.h
@@ -66,7 +66,6 @@ public:
         return m_haveBettary;
     }
     void setHaveBettary(bool haveBettary);
-    void setBatteryPercentage(double batteryPercentage);
 
     bool getDoubleCompare(const double value1, const double value2);
 
@@ -141,7 +140,6 @@ Q_SIGNALS:
     void haveBettaryChanged(bool haveBettary);
     void batteryLockScreenDelayChanged(const int batteryLockScreenTime);
     void powerLockScreenDelayChanged(const int powerLockScreenTime);
-    void batteryPercentageChanged(double batteryPercentage);
     //------------------------sp2 add-------------------------------
     void powerSavingModeAutoWhenQuantifyLowChanged(const bool state);
     void powerSavingModeAutoChanged(const bool state);

--- a/src/plugin-power/operation/powerworker.cpp
+++ b/src/plugin-power/operation/powerworker.cpp
@@ -38,7 +38,6 @@ PowerWorker::PowerWorker(PowerModel *model, QObject *parent)
     connect(m_powerDBusProxy, &PowerDBusProxy::PowerSavingModeEnabledChanged, m_powerModel, &PowerModel::setPowerSaveMode);
 
     connect(m_powerDBusProxy, &PowerDBusProxy::HasBatteryChanged, m_powerModel, &PowerModel::setHaveBettary);
-    connect(m_powerDBusProxy, &PowerDBusProxy::BatteryPercentageChanged, m_powerModel, &PowerModel::setBatteryPercentage);
 
     //--------------------sp2 add----------------------------
     connect(m_powerDBusProxy, &PowerDBusProxy::PowerSavingModeAutoWhenBatteryLowChanged, m_powerModel, &PowerModel::setPowerSavingModeAutoWhenQuantifyLow);

--- a/src/plugin-power/window/powerplugin.cpp
+++ b/src/plugin-power/window/powerplugin.cpp
@@ -59,8 +59,6 @@ PowerModule::PowerModule(QObject *parent)
     m_model->setShutdown(true);
 #endif
     connect(m_model, &PowerModel::haveBettaryChanged, this, &PowerModule::onBatteryChanged);
-    connect(m_model, &PowerModel::batteryPercentageChanged, this, &PowerModule::onBatteryPercentageChanged);
-
     //-------------------------------------------
     if (!IsServerSystem) {
         appendChild(new GeneralModule(m_model, m_work, this));
@@ -87,27 +85,6 @@ void PowerModule::onBatteryChanged(const bool &state)
         removeChild(m_useBattery);
         m_useBattery->deleteLater();
         m_useBattery = nullptr;
-    }
-}
-//done: 遗留问题，控制中心不应该发电量低通知
-void PowerModule::onBatteryPercentageChanged(const double value)
-{
-    if (!m_model->getDoubleCompare(m_nBatteryPercentage, value)) {
-        m_nBatteryPercentage = value;
-
-        QString remindData = "";
-        if (m_model->getDoubleCompare(value, 20.0)
-            || m_model->getDoubleCompare(value, 15.0)
-            || m_model->getDoubleCompare(value, 10.0)) {
-            remindData = tr("Battery low, please plug in");
-        } else if (m_model->getDoubleCompare(value, 5.0)) {
-            remindData = tr("Battery critically low");
-        }
-
-        //send system info
-        if ("" != remindData) {
-            Dtk::Core::DUtil::DNotifySender(remindData.toLatin1().data());
-        }
     }
 }
 


### PR DESCRIPTION
batteryPercentageChange signal send a Map{String, double}, but here set as double, so it receive warning in qt, and check the code, it should not receive the signal, because control center should not check the battery percentage change, and emit low battery notify

Log: remove batteryPercentageChange signal