### PR TITLE
fix: bluetooth will active again if enter page

### DIFF
--- a/src/plugin-bluetooth/window/bluetoothmodule.cpp
+++ b/src/plugin-bluetooth/window/bluetoothmodule.cpp
@@ -39,12 +39,6 @@ BluetoothModule::BluetoothModule(QObject *parent)
     updateWidget();
 }
 
-void BluetoothModule::active()
-{
-    for (auto &&module : m_valueMap)
-        module->active();
-}
-
 void BluetoothModule::deactive()
 {
     for (auto &&adapter : m_valueMap.keys())

--- a/src/plugin-bluetooth/window/bluetoothmodule.h
+++ b/src/plugin-bluetooth/window/bluetoothmodule.h
@@ -24,7 +24,6 @@ class BluetoothModule : public DCC_NAMESPACE::PageModule
 public:
     explicit BluetoothModule(QObject *parent = nullptr);
     ~BluetoothModule() override { }
-    void active() override;
     void deactive() override;
     bool hasDevice();
 


### PR DESCRIPTION
Log: not always active bluetooth, only when user active manually

这个问题困扰我好久了，每次点击页面bluetooth都重新跑了