### PR TITLE
sync enum in common.h

### DIFF
--- a/src/plugin-update/operation/common.h
+++ b/src/plugin-update/operation/common.h
@@ -38,7 +38,7 @@ enum UpdatesStatus {
     Checking,
     Updated,
     UpdatesAvailable,
-    Updateing,
+    Updating,
     Downloading,
     DownloadPaused,
     Downloaded,
@@ -47,11 +47,11 @@ enum UpdatesStatus {
     UpdateSucceeded,
     UpdateFailed,
     NeedRestart,
-    WaitRecoveryBackup,
+    WaitForRecoveryBackup,
     RecoveryBackingup,
     RecoveryBackingSuccessed,
     RecoveryBackupFailed,
-    NoAtive
+    Inactive
 };
 
 enum UpdateErrorType {

--- a/src/plugin-update/operation/updatemodel.h
+++ b/src/plugin-update/operation/updatemodel.h
@@ -59,19 +59,20 @@ public:
         Checking,
         Updated,
         UpdatesAvailable,
+        Updating,
         Downloading,
         DownloadPaused,
         Downloaded,
+        AutoDownloaded,
         Installing,
         UpdateSucceeded,
         UpdateFailed,
         NeedRestart,
-        NoNetwork,
-        NoSpace,
-        DeependenciesBrokenError,
+        WaitForRecoveryBackup,
         RecoveryBackingup,
         RecoveryBackingSuccessed,
-        RecoveryBackupFailed
+        RecoveryBackupFailed,
+        Inactive
     };
     Q_ENUM(ModelUpdatesStatus)
 

--- a/src/plugin-update/operation/updatework.cpp
+++ b/src/plugin-update/operation/updatework.cpp
@@ -616,7 +616,7 @@ void UpdateWorker::distUpgrade(ClassifyUpdateType updateType)
             m_updateInter->CleanJob(job->id());
             deleteJob(job);
         }
-        m_model->setClassifyUpdateTypeStatus(updateType, UpdatesStatus::WaitRecoveryBackup);
+        m_model->setClassifyUpdateTypeStatus(updateType, UpdatesStatus::WaitForRecoveryBackup);
         return;
     }
     if (m_backupStatus == BackupStatus::Backuped) {
@@ -834,7 +834,7 @@ void UpdateWorker::setDownloadJob(const QString &jobPath, ClassifyUpdateType upd
         setUpdateInfo();
     }
 
-    m_model->setStatus(UpdatesStatus::Updateing, __LINE__);
+    m_model->setStatus(UpdatesStatus::Updating, __LINE__);
     QPointer<UpdateJobDBusProxy> job = new UpdateJobDBusProxy(jobPath, this);
     switch (updateType) {
     case ClassifyUpdateType::SystemUpdate:
@@ -889,7 +889,7 @@ void UpdateWorker::setDownloadJob(const QString &jobPath, ClassifyUpdateType upd
 void UpdateWorker::setDistUpgradeJob(const QString &jobPath, ClassifyUpdateType updateType)
 {
     QMutexLocker locker(&m_mutex);
-    m_model->setStatus(UpdatesStatus::Updateing, __LINE__);
+    m_model->setStatus(UpdatesStatus::Updating, __LINE__);
     QPointer<UpdateJobDBusProxy> job = new UpdateJobDBusProxy(jobPath, this);
     switch (updateType) {
     case ClassifyUpdateType::SystemUpdate:
@@ -1439,7 +1439,7 @@ void UpdateWorker::checkUpdatablePackages(const QMap<QString, QStringList> &upda
 // 可进行原子更新
 void UpdateWorker::backupToAtomicUpgrade()
 {
-    m_model->setStatus(UpdatesStatus::Updateing, __LINE__);
+    m_model->setStatus(UpdatesStatus::Updating, __LINE__);
     m_model->setClassifyUpdateTypeStatus(m_backupingClassifyType, UpdatesStatus::RecoveryBackingup);
     /*
         "{"SubmissionTime":"1653034897","SystemVersion":"UOS-V23-2000-107","SubmissionType":0,"UUID":"02eb924f-4f35-4880-b839-096c3a65f525","Note":"系统更新"}"
@@ -1563,7 +1563,7 @@ void UpdateWorker::handleAtomicStateChanged(int operate,
 void UpdateWorker::onAtomicUpdateFinshed(bool successed)
 {
     auto requestUpdate = [=](ClassifyUpdateType type) -> bool {
-        if (m_model->getClassifyUpdateStatus(type) == UpdatesStatus::WaitRecoveryBackup
+        if (m_model->getClassifyUpdateStatus(type) == UpdatesStatus::WaitForRecoveryBackup
             || m_model->getClassifyUpdateStatus(type) == UpdatesStatus::RecoveryBackingup
             || m_model->getClassifyUpdateStatus(type) == UpdatesStatus::RecoveryBackingSuccessed) {
             distUpgrade(type);

--- a/src/plugin-update/window/updatectrlwidget.cpp
+++ b/src/plugin-update/window/updatectrlwidget.cpp
@@ -285,7 +285,7 @@ void UpdateCtrlWidget::setStatus(const UpdatesStatus &status)
 
     qDebug() << " ========= UpdateCtrlWidget::setStatus  " << status;
     if (m_model->systemActivation() == UiActiveState::Unauthorized || m_model->systemActivation() == UiActiveState::TrialExpired) {
-        m_status = NoAtive;
+        m_status = Inactive;
     }
 
     Q_EMIT notifyUpdateState(m_status);
@@ -332,7 +332,7 @@ void UpdateCtrlWidget::setStatus(const UpdatesStatus &status)
         m_checkUpdateItem->setSystemVersion(m_systemVersion);
         showCheckButton(tr("Check for Updates"));
         break;
-    case UpdatesStatus::NoAtive:
+    case UpdatesStatus::Inactive:
         m_resultItem->setVisible(true);
         m_resultItem->setSuccess(ShowStatus::NoActive);
         break;
@@ -346,7 +346,7 @@ void UpdateCtrlWidget::setStatus(const UpdatesStatus &status)
     case UpdatesStatus::UpdatesAvailable:
         onChangeUpdatesAvailableStatus();
         break;
-    case UpdatesStatus::Updateing:
+    case UpdatesStatus::Updating:
         showUpdateInfo();
         onRequestRefreshSize();
         onRequestRefreshWidget();
@@ -409,7 +409,7 @@ void UpdateCtrlWidget::setProgressValue(const double value)
 
 void UpdateCtrlWidget::setLowBattery(const bool &lowBattery)
 {
-    if (m_status == UpdatesStatus::Updateing || m_status == UpdatesStatus::UpdatesAvailable) {
+    if (m_status == UpdatesStatus::Updating || m_status == UpdatesStatus::UpdatesAvailable) {
         bool activation = false;
         const UiActiveState value = m_model->systemActivation();
         if (UiActiveState::Authorized == value || UiActiveState::TrialAuthorized == value || UiActiveState::AuthorizedLapse == value) {

--- a/src/plugin-update/window/updateplugin.cpp
+++ b/src/plugin-update/window/updateplugin.cpp
@@ -81,7 +81,7 @@ void UpdateModule::active()
             syncUpdatablePackagesChanged(false);
         } else {
             UpdatesStatus status = m_model->status();
-            if (status == UpdatesStatus::UpdatesAvailable || status == UpdatesStatus::Updateing || status == UpdatesStatus::Downloading || status == UpdatesStatus::DownloadPaused || status == UpdatesStatus::Downloaded ||
+            if (status == UpdatesStatus::UpdatesAvailable || status == UpdatesStatus::Updating || status == UpdatesStatus::Downloading || status == UpdatesStatus::DownloadPaused || status == UpdatesStatus::Downloaded ||
                     status == UpdatesStatus::Installing || status == UpdatesStatus::RecoveryBackingup || status == UpdatesStatus::RecoveryBackingSuccessed || m_model->getUpdatablePackages()) {
                 syncUpdatablePackagesChanged(true);
             }

--- a/src/plugin-update/window/widgets/updatesettingitem.cpp
+++ b/src/plugin-update/window/widgets/updatesettingitem.cpp
@@ -158,7 +158,7 @@ void UpdateSettingItem::setStatus(const UpdatesStatus &status)
         m_controlWidget->setProgressText(tr("The newest system installed, restart to take effect"));
         m_controlWidget->showButton(false);
         break;
-    case UpdatesStatus::WaitRecoveryBackup:
+    case UpdatesStatus::WaitForRecoveryBackup:
         m_controlWidget->showUpdateProcess(true);
         m_controlWidget->setProgressText(tr("Waiting"));
         m_controlWidget->setButtonStatus(ButtonStatus::invalid);


### PR DESCRIPTION
sync enum in common.h

the ModelUpdatesStatus is used to print log, should always be sync with
UpdateStatus in common.h, but seems it has long time no update, make
there is something error with the log, and there exists some typo both
in UpdateStatus and UpdateStatus, so also fix the typo
