### PR TITLE
fix(power): missing choices in power plugin

### DIFF
--- a/src/plugin-power/window/usebatterymodule.cpp
+++ b/src/plugin-power/window/usebatterymodule.cpp
@@ -368,7 +368,8 @@ void UseBatteryModule::updateComboxActionList()
         m_Options.append({ tr("Hibernate"), 2 });
     }
     m_Options.append({ tr("Turn off the monitor"), 3 });
-    m_Options.append({ tr("Do nothing"), 4 });
+    m_Options.append({ tr("Show the shutdown Interface"), 4 });
+    m_Options.append({ tr("Do nothing"), 5 });
 }
 
 QString UseBatteryModule::delayToLiteralString(const int delay) const

--- a/src/plugin-power/window/useelectricmodule.cpp
+++ b/src/plugin-power/window/useelectricmodule.cpp
@@ -248,5 +248,6 @@ void UseElectricModule::updateComboxActionList()
         m_comboxOptions.append({ tr("Hibernate"), 2 });
     }
     m_comboxOptions.append({ tr("Turn off the monitor"), 3 });
-    m_comboxOptions.append({ tr("Do nothing"), 4 });
+    m_comboxOptions.append({ tr("Show the shutdown Interface"), 4 });
+    m_comboxOptions.append({ tr("Do nothing"), 5 });
 }


### PR DESCRIPTION
in dde-daemon, there is 6 choices about ppower when lid is closed and etc, in dde-control-center, there is only 5, one is missing

Log: add missing choices in power plugin

resolve: https://github.com/linuxdeepin/developer-center/issues/4469

翻译需要同步dde-daemon那边的