### PR TITLE
chore: avoid use hardcode path in dbus services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,12 @@ install(FILES ${QM_FILES} DESTINATION ${TRANSLATE_INSTALL_DIR})
 install(FILES misc/dde-control-center.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)
 
 #service
-install(FILES misc/org.deepin.dde.ControlCenter1.service DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/services)
+configure_file(
+    ${CMAKE_SOURCE_DIR}/misc/org.deepin.dde.ControlCenter1.service.in 
+    ${CMAKE_CURRENT_BINARY_DIR}/org.deepin.dde.ControlCenter1.service 
+    @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.deepin.dde.ControlCenter1.service 
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/dbus-1/services)
 
 # dev files
 file(GLOB HEADERS "include/*")

--- a/misc/org.deepin.dde.ControlCenter1.service
+++ b/misc/org.deepin.dde.ControlCenter1.service
@@ -1,3 +1,0 @@
-[D-BUS Service]
-Name=org.deepin.dde.ControlCenter1
-Exec=/usr/bin/dde-control-center -d

--- a/misc/org.deepin.dde.ControlCenter1.service.in
+++ b/misc/org.deepin.dde.ControlCenter1.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.deepin.dde.ControlCenter1
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/dde-control-center -d


### PR DESCRIPTION
Log: avoid use hardcode path in dbus services