### PR TITLE
chore(tabview): tabview mouse event override

### DIFF
--- a/src/interface/hlistmodule.cpp
+++ b/src/interface/hlistmodule.cpp
@@ -55,10 +55,6 @@ public:
         QObject::connect(parentWidget, &QObject::destroyed, m_layout, [this]() { m_layout = nullptr; });
 
         m_view = new TabView;
-        QHBoxLayout* titlebarLayout = new QHBoxLayout;
-        titlebarLayout->addStretch();
-        titlebarLayout->addWidget(m_view);
-        titlebarLayout->addStretch();
 
         TabItemDelegate *delegate = new TabItemDelegate(m_view);
         ModuleDataModel *model = new ModuleDataModel(m_view);
@@ -69,7 +65,7 @@ public:
         m_view->setModel(model);
         m_view->setItemDelegate(delegate);
 
-        m_layout->addLayout(titlebarLayout);
+        m_layout->addWidget(m_view);
 
         auto onClicked = [](const QModelIndex &index) {
             ModuleObject *obj = static_cast<ModuleObject *>(index.internalPointer());

--- a/src/interface/tabview.cpp
+++ b/src/interface/tabview.cpp
@@ -521,3 +521,8 @@ void TabView::wheelEvent(QWheelEvent *e)
     QApplication::sendEvent(horizontalScrollBar(), e);
     e->setAccepted(true);
 }
+
+void TabView::mouseMoveEvent(QMouseEvent *event)
+{
+    QWidget::mouseMoveEvent(event);
+}

--- a/src/interface/tabview.h
+++ b/src/interface/tabview.h
@@ -53,6 +53,7 @@ protected:
     void paintEvent(QPaintEvent *e) override;
     bool viewportEvent(QEvent *event) override;
     void wheelEvent(QWheelEvent *e) override;
+    void mouseMoveEvent(QMouseEvent *event) override;
 
 private:
     TabViewPrivate *const d_ptr;


### PR DESCRIPTION
allow tabview can be drag, not use stretch, because stretch will make scrollarea display abnormal

Log: override mouseMoveEvent in tabview