### PR TITLE
fix: Wrong focus when switching keyboard's language

### DIFF
--- a/src/plugin-keyboard/window/systemlanguagewidget.cpp
+++ b/src/plugin-keyboard/window/systemlanguagewidget.cpp
@@ -191,8 +191,7 @@ void SystemLanguageWidget::onDefault(const QString &curLang)
 void SystemLanguageWidget::onSetCurLang(int value)
 {
     qDebug() << "m_langListview & m_editSystemLang" << value;
-    m_langListview->setEnabled(!value);
-    m_editSystemLang->setEnabled(!value);
+    setEnabled(!value);
 }
 
 void SystemLanguageWidget::addSystemLanguage()


### PR DESCRIPTION
  Disable it's parent widget instead of children widgets.

Issue: https://github.com/linuxdeepin/developer-center/issues/4700