### PR TITLE
fix: 控制中心电源模块使用电池显示为空

### DIFF
--- a/src/plugin-power/window/usebatterymodule.cpp
+++ b/src/plugin-power/window/usebatterymodule.cpp
@@ -25,7 +25,7 @@ DCORE_USE_NAMESPACE
 const static QMap<int, int> g_sldLowBatteryMap = { { 0, 10 }, { 1, 15 }, { 2, 20 }, { 3, 25 } };
 
 UseBatteryModule::UseBatteryModule(PowerModel *model, PowerWorker *work, QObject *parent)
-    : PageModule("onBattery", "", tr("On Battery"), QIcon::fromTheme("dcc_battery"), parent)
+    : PageModule("onBattery", tr("On Battery"), tr("On Battery"), QIcon::fromTheme("dcc_battery"), parent)
     , m_model(model)
     , m_work(work)
     , m_annos({ "1m", "5m", "10m", "15m", "30m", "1h", tr("Never") })


### PR DESCRIPTION
设置UseBatteryModule displayName

Log: 修复控制中心电源模块使用电池显示为空的问题
Influence: 控制中心电源模块正常显示
Resolve: https://github.com/linuxdeepin/developer-center/issues/4781