### PR TITLE
fix: add miss separator for kZoneTabFile

### DIFF
--- a/src/plugin-datetime/window/widgets/timezone.cpp
+++ b/src/plugin-datetime/window/widgets/timezone.cpp
@@ -31,7 +31,7 @@ const QString tzDirPath = std::visit([] {
 
 // Absolute path to zone.tab file.
 const QString kZoneTabFile = std::visit([] {
-    return tzDirPath + "/zone1970.tab";
+    return tzDirPath + QDir::separator() + "/zone1970.tab";
 });
 
 // Absolute path to backward timezone file.


### PR DESCRIPTION
Log: add miss separator for kZoneTabFile