### PR TITLE
fix: opening the Control Center in the launcher or right-clicking to open the Control Center fails

### DIFF
--- a/src/frame/controlcenterdbusadaptor.cpp
+++ b/src/frame/controlcenterdbusadaptor.cpp
@@ -60,7 +60,7 @@ void ControlCenterDBusAdaptor::Hide()
 void ControlCenterDBusAdaptor::Show()
 {
     if (parent()->isMinimized() || !parent()->isVisible())
-        parent()->show();
+        parent()->showNormal();
 
     parent()->activateWindow();
 }


### PR DESCRIPTION
fix: opening the Control Center in the launcher or right-clicking to open the Control Center fails

log: Turn off window effects and minimize Control Center to the taskbar

Issue: https://github.com/linuxdeepin/developer-center/issues/5105