### PR TITLE
chore: init device Comboox enable state

### DIFF
--- a/src/plugin-display/window/collaborativelinkwidget.cpp
+++ b/src/plugin-display/window/collaborativelinkwidget.cpp
@@ -122,6 +122,7 @@ void CollaborativeLinkWidget::setModel(DisplayModel *model)
 
     connect(model, &DisplayModel::deviceSharingSwitchChanged, m_deviceSwitch, &SwitchWidget::setChecked);
     m_deviceSwitch->setChecked(m_displayModel->DeviceSharingSwitch());
+    m_deviceCombox->setEnabled(m_deviceSwitch->checked());
     m_directionComboxItem->setVisible(m_displayModel->DeviceSharingSwitch());
 
     refreshRowItem();


### PR DESCRIPTION
init enable state

如果初始化时本来就是未打开的情况，combobox也应该是disabled, 这个时候connection还未连接