### PR TITLE
chore: not init filedialog in constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -958,6 +958,7 @@ if (BUILD_PLUDIN)
     )
 
     target_include_directories(${Display_Name} PUBLIC
+        src/plugin-display
         ${Display_Includes}
     )
 

--- a/src/plugin-display/window/collaborativelinkwidget.h
+++ b/src/plugin-display/window/collaborativelinkwidget.h
@@ -7,8 +7,6 @@
 #include <DComboBox>
 #include <QStandardItem>
 #include <QWidget>
-#include "interface/plugininterface.h"
-#include "cooperationsettingsdialog.h"
 #include "treecombox.h"
 
 QT_BEGIN_NAMESPACE
@@ -79,7 +77,6 @@ private:
     QStandardItemModel *m_deviceComboxModel;
     TreeCombox *m_deviceCombox;
     QPushButton *m_deviceButton;
-    CooperationSettingsDialog *m_moreSettingsDialog;
 
     // 连接方向
     DCC_NAMESPACE::SettingsItem *m_directionComboxItem;


### PR DESCRIPTION
DFileChooserEdit need a QFileChooser, so just exec a dialog when needed

Log: