### PR TITLE
fix: listview is not in the center of the widget

### DIFF
--- a/src/plugin-commoninfo/window/bootwidget.cpp
+++ b/src/plugin-commoninfo/window/bootwidget.cpp
@@ -3,8 +3,8 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "bootwidget.h"
 #include "commonbackgrounditem.h"
+
 #include "pwqualitymanager.h"
-#include "src/plugin-commoninfo/operation/commoninfowork.h"
 #include "src/plugin-commoninfo/operation/commoninfomodel.h"
 #include "src/frame/utils.h"
 
@@ -34,6 +34,12 @@ Q_DECLARE_METATYPE(QMargins)
 const QMargins ListViewItemMargin(10, 8, 10, 8);
 const QVariant VListViewItemMargin = QVariant::fromValue(ListViewItemMargin);
 
+constexpr static int LISTVIEW_ITEM_SPACING = 3;
+constexpr static int LISTVIEW_ITEM_HEIGHT = 32;
+constexpr static int LISTVIEW_ITEM_HEIGHT_WITH_SPACING = LISTVIEW_ITEM_SPACING + LISTVIEW_ITEM_HEIGHT;
+constexpr static int LISTVIEW_MAX_HEIGHT = 350;
+constexpr static int MAX_BACKGROUND_HEIGHT = LISTVIEW_MAX_HEIGHT + LISTVIEW_ITEM_HEIGHT_WITH_SPACING;
+
 using namespace DCC_NAMESPACE;
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
@@ -51,7 +57,7 @@ BootWidget::BootWidget(QWidget *parent)
     m_listLayout->addSpacing(10);
     m_listLayout->setMargin(0);
 
-    m_bootList = new DListView(this);
+    m_bootList = new CommonInfoListView(this);
     m_bootList->setAccessibleName("List_bootlist");
     m_bootList->setAutoScroll(false);
     m_bootList->setFrameShape(QFrame::NoFrame);
@@ -65,6 +71,13 @@ BootWidget::BootWidget(QWidget *parent)
     m_bootList->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_bootList->setVerticalScrollBarPolicy(Qt::ScrollBarAsNeeded);
     m_bootList->setMinimumWidth(240);
+    m_bootList->setItemSpacing(LISTVIEW_ITEM_SPACING);
+
+    QSize itemSize = m_bootList->itemSize();
+    itemSize.setHeight(LISTVIEW_ITEM_HEIGHT);
+    m_bootList->setItemSize(itemSize);
+
+    m_bootList->setMaxShowHeight(LISTVIEW_MAX_HEIGHT);
     m_bootList->setWordWrap(true);
 
     DPalette dp = DPaletteHelper::instance()->palette(m_bootList);
@@ -253,11 +266,11 @@ void BootWidget::setEntryList(const QStringList &list)
 void BootWidget::setBootList()
 {
     int cout = m_bootList->count();
-    int height = (cout + 2) * 35;
+    int height = (cout + 2) * LISTVIEW_ITEM_HEIGHT;
 
-    m_listLayout->addWidget(m_bootList);
+    m_listLayout->addWidget(m_bootList, Qt::AlignCenter);
     m_listLayout->addSpacing(15);
-    m_background->setFixedHeight(height + 35 > 350 ? 350 : height + 35);
+    m_background->setFixedHeight(std::min(height + LISTVIEW_ITEM_HEIGHT , MAX_BACKGROUND_HEIGHT));
 }
 
 void BootWidget::onCurrentItem(const QModelIndex &curIndex)

--- a/src/plugin-commoninfo/window/bootwidget.h
+++ b/src/plugin-commoninfo/window/bootwidget.h
@@ -4,6 +4,7 @@
 #pragma once
 #include "interface/namespace.h"
 
+#include "commoninfolistview.h"
 #include <DListView>
 
 class QVBoxLayout;
@@ -58,7 +59,7 @@ private:
     DTK_WIDGET_NAMESPACE::DTipLabel *m_grubVerifyLbl;  // grub 验证提示
     DTK_WIDGET_NAMESPACE::DCommandLinkButton *m_grubModifyPasswdLink; // grub修改密码
     DTK_WIDGET_NAMESPACE::DDialog *m_grubEditAuthDialog = nullptr; // grub修改密码输入框
-    DTK_WIDGET_NAMESPACE::DListView *m_bootList; // 启动项目列表
+    CommonInfoListView *m_bootList; // 启动项目列表
     QLabel *m_updatingLabel;    // Updating标签
     CommonBackgroundItem *m_background;          // 背景项
     QVBoxLayout *m_listLayout;

--- a/src/plugin-commoninfo/window/commonbackgrounditem.cpp
+++ b/src/plugin-commoninfo/window/commonbackgrounditem.cpp
@@ -142,13 +142,32 @@ void CommonBackgroundItem::updateBackground(const QPixmap &pixmap)
 {
     if (pixmap.isNull())
         return;
-    qDebug() << pixmap;
+
     m_basePixmap = pixmap;
 
-    auto ratio = devicePixelRatioF();
-    m_background = m_basePixmap.scaled(size() * ratio,
+    QSize pixmapSize = m_basePixmap.size();
+    QSize showSize = size();
+    QSize finalSize = ((float)showSize.width() / (float)pixmapSize.width()) * pixmapSize;
+    qreal ratio = devicePixelRatioF();
+
+    auto previewPixmap = m_basePixmap.scaled(finalSize,
                                        Qt::IgnoreAspectRatio,
-                                       Qt::FastTransformation);
+                                       Qt::SmoothTransformation);
+
+
+    if (previewPixmap.size().height() <= showSize.height()) {
+        m_background = previewPixmap;
+    } else {
+        qreal centerHeight = (float)previewPixmap.size().height() / 2;
+        qreal offsetHeight = (float)showSize.height() / 2;
+
+        qreal start_y = centerHeight - offsetHeight;
+
+        qreal start_x = 0;
+
+        m_background = previewPixmap.copy(QRect(start_x, start_y, showSize.width(), showSize.height()));
+    }
+
     m_background.setDevicePixelRatio(ratio);
     update();
 }

--- a/src/plugin-commoninfo/window/commoninfolistview.cpp
+++ b/src/plugin-commoninfo/window/commoninfolistview.cpp
@@ -1,0 +1,33 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "commoninfolistview.h"
+
+CommonInfoListView::CommonInfoListView(QWidget *parent)
+    : DTK_WIDGET_NAMESPACE::DListView(parent)
+    , m_maxheight(std::nullopt)
+{
+
+}
+
+void CommonInfoListView::setMaxShowHeight(int height)
+{
+    m_maxheight = height;
+}
+
+void CommonInfoListView::updateGeometries()
+{
+    DListView::updateGeometries();
+    if (model()->rowCount() == 0) {
+        return;
+    }
+    QRect r = rectForIndex(model()->index(model()->rowCount() - 1, 0));
+    QMargins margins = viewportMargins();
+
+    int height = r.y() + r.height() + margins.top() + margins.bottom() + 1;
+
+    if (!m_maxheight.has_value() || m_maxheight.value() > height) {
+        setFixedHeight(height);
+    }
+}

--- a/src/plugin-commoninfo/window/commoninfolistview.h
+++ b/src/plugin-commoninfo/window/commoninfolistview.h
@@ -1,0 +1,24 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <DListView>
+
+#include <optional>
+
+class CommonInfoListView : public DTK_WIDGET_NAMESPACE::DListView
+{
+    Q_OBJECT
+public:
+    explicit CommonInfoListView(QWidget *parent = nullptr);
+
+    void setMaxShowHeight(int height);
+
+protected slots:
+    void updateGeometries() override;
+
+private:
+    std::optional<int> m_maxheight;
+};


### PR DESCRIPTION
set the listview size is the same as item count, and put it in the center.

And in commonbackgrounditem, not resize the image directly, keep the full shape of the origin image, final clip the center part as the shown image

Log:

Issue 没有找到。。我记得有的，而且我也不太爽这个地方