### PR TITLE
chore: split plymouth scale setting

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfomodel.cpp
+++ b/src/plugin-commoninfo/operation/commoninfomodel.cpp
@@ -1,7 +1,8 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
-//SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include "commoninfomodel.h"
+
 #include <QDebug>
 
 using namespace DCC_NAMESPACE;
@@ -9,8 +10,13 @@ using namespace DCC_NAMESPACE;
 CommonInfoModel::CommonInfoModel(QObject *parent)
     : QObject(parent)
     , m_bootDelay(false)
+    , m_themeEnabled(false)
+    , m_updating(false)
+    , m_joinUeProgram(false)
+    , m_activation(false)
+    , m_plymouthscale(0)
+    , m_plymouththeme(QString())
 {
-
 }
 
 void CommonInfoModel::setEntryLists(const QStringList &list)
@@ -104,7 +110,6 @@ void CommonInfoModel::setActivation(bool value)
     }
 }
 
-
 QPixmap CommonInfoModel::background() const
 {
     return m_background;
@@ -125,4 +130,18 @@ bool CommonInfoModel::ueProgram() const
 bool CommonInfoModel::developerModeState() const
 {
     return m_developerModeState;
+}
+
+void CommonInfoModel::setPlymouthScale(int scale)
+{
+    m_plymouthscale = scale;
+
+    Q_EMIT plymouthScaleChanged(scale);
+}
+
+void CommonInfoModel::setPlymouthTheme(const QString &themeName)
+{
+    m_plymouththeme = themeName;
+
+    Q_EMIT plymouthThemeChanged(themeName);
 }

--- a/src/plugin-commoninfo/operation/commoninfomodel.h
+++ b/src/plugin-commoninfo/operation/commoninfomodel.h
@@ -29,6 +29,8 @@ public:
     inline bool isLogin() const { return m_isLogin; }
     inline bool isActivate() const { return m_activation; }
     void setActivation(bool value);
+    inline int plymouthScale() const { return m_plymouthscale; }
+    inline QString plymouthTheme() const { return m_plymouththeme; }
 
 Q_SIGNALS:
     void bootDelayChanged(const bool enabled) const;
@@ -42,6 +44,8 @@ Q_SIGNALS:
     void developerModeStateChanged(const bool enable) const;
     void isLoginChenged(bool log) const;
     void LicenseStateChanged(bool state);
+    void plymouthScaleChanged(int scale);
+    void plymouthThemeChanged(const QString &themeName);
 
 public Q_SLOTS:
     void setBootDelay(bool bootDelay);
@@ -53,6 +57,8 @@ public Q_SLOTS:
     void setUeProgram(const bool ueProgram); // for user experience program
     void setDeveloperModeState(const bool state);
     void setIsLogin(const bool log);
+    void setPlymouthScale(int scale);
+    void setPlymouthTheme(const QString &themeName);
 
 private:
     bool m_bootDelay;
@@ -67,5 +73,7 @@ private:
     bool m_developerModeState{false}; // for developer mode state
     bool m_isLogin{false};
     bool m_activation;
+    int m_plymouthscale;
+    QString m_plymouththeme;
 };
 } // namespace DCC_NAMESPACE

--- a/src/plugin-commoninfo/operation/commoninfoproxy.cpp
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.cpp
@@ -36,8 +36,9 @@ const QString &NotificationService = QStringLiteral("org.deepin.dde.Notification
 const QString &NotificationPath = QStringLiteral("/org/deepin/dde/Notification1");
 const QString &NotificationInterface = QStringLiteral("org.deepin.dde.Notification");
 
-const QString &PropertiesInterface = QStringLiteral("org.freedesktop.DBus.Properties");
-const QString &PropertiesChanged = QStringLiteral("PropertiesChanged");
+const QString &PlyMouthScaleService = QStringLiteral("org.deepin.dde.Daemon1");
+const QString &PlyMouthScalePath = QStringLiteral("/org/deepin/dde/Daemon1");
+const QString &PlyMouthScaleInterface = QStringLiteral("org.deepin.dde.Daemon1");
 
 CommonInfoProxy::CommonInfoProxy(QObject *parent)
     : QObject(parent)
@@ -48,7 +49,10 @@ CommonInfoProxy::CommonInfoProxy(QObject *parent)
     , m_licenseInter(new DDBusInterface(LicenseService, LicensePath, LicenseInterface, QDBusConnection::systemBus(), this))
     , m_userexperienceInter(new DDBusInterface(UserexperienceService, UserexperiencePath, UserexperienceInterface, QDBusConnection::sessionBus(), this))
     , m_notificationInter(new DDBusInterface(NotificationService, NotificationPath, NotificationInterface, QDBusConnection::sessionBus(), this))
+    , m_grubScaleInter(new DDBusInterface(PlyMouthScaleService, PlyMouthScalePath, PlyMouthScaleInterface, QDBusConnection::systemBus(), this))
 {
+    // in this function, it will wait for 50 seconds finall return
+    m_grubScaleInter->setTimeout(50000);
 }
 
 bool CommonInfoProxy::IsLogin()
@@ -148,6 +152,11 @@ void CommonInfoProxy::EnableUser(const QString &username, const QString &passwor
         }
         watcher->deleteLater();
     });
+}
+
+QDBusPendingCall CommonInfoProxy::SetScalePlymouth(int scale)
+{
+    return m_grubScaleInter->asyncCallWithArgumentList("ScalePlymouth", { scale });
 }
 
 QString CommonInfoProxy::Background()

--- a/src/plugin-commoninfo/operation/commoninfoproxy.h
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "interface/namespace.h"
+#include <QDBusReply>
 #include <QObject>
 #include <DDBusInterface>
 
@@ -60,6 +61,8 @@ public:
     // notification
     void Notify(const QString &in0, const uint in1, const QString &in2, const QString &in3, const QString &in4,
                 const QStringList &in5, const QVariantMap &in6, const int in7);
+    // groubScale
+    QDBusPendingCall SetScalePlymouth(int scale);
 
 Q_SIGNALS: // SIGNALS
     // deepin id
@@ -93,4 +96,5 @@ private:
     DDBusInterface *m_licenseInter;
     DDBusInterface *m_userexperienceInter;
     DDBusInterface *m_notificationInter;
+    DDBusInterface *m_grubScaleInter;
 };

--- a/src/plugin-commoninfo/operation/commoninfowork.h
+++ b/src/plugin-commoninfo/operation/commoninfowork.h
@@ -21,6 +21,8 @@ public:
     virtual ~CommonInfoWork();
 
     void active();
+    QPixmap getPlymouthFilePixmap();
+    bool isSettingPlymouth() { return m_scaleIsSetting; }
 
 public Q_SLOTS:
     void setBootDelay(bool value);
@@ -34,9 +36,14 @@ public Q_SLOTS:
     void setEnableDeveloperMode(bool enabled);
     void login();
     void deepinIdErrorSlot(int code, const QString &msg);
+    void setPlymouthFactor(int factor);
+
+Q_SIGNALS:
+    void settingScaling(bool);
 
 private:
     QString passwdEncrypt(const QString &password);
+    std::pair<int, QString> getPlyMouthInformation();
 
 private:
     CommonInfoModel *m_commomModel;
@@ -44,5 +51,6 @@ private:
     QProcess *m_process = nullptr;
     QString m_title;
     QString m_content;
+    bool m_scaleIsSetting;
 };
 } // namespace DCC_NAMESPACE

--- a/src/plugin-commoninfo/window/commoninfomodule.cpp
+++ b/src/plugin-commoninfo/window/commoninfomodule.cpp
@@ -1,19 +1,29 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
-//SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include "commoninfomodule.h"
-#include "interface/pagemodule.h"
-#include "src/plugin-commoninfo/operation/commoninfomodel.h"
-#include "src/plugin-commoninfo/operation/commoninfowork.h"
-#include "src/frame/utils.h"
 
 #include "bootwidget.h"
-#include "userexperienceprogramwidget.h"
+#include "dcclistview.h"
 #include "developermodewidget.h"
+#include "interface/pagemodule.h"
+#include "moduleobject.h"
+#include "plymouthdisplay.h"
+#include "src/frame/utils.h"
+#include "src/plugin-commoninfo/operation/commoninfomodel.h"
+#include "src/plugin-commoninfo/operation/commoninfowork.h"
+#include "userexperienceprogramwidget.h"
+#include "widgets/itemmodule.h"
 
-#include <DSysInfo>
+#include <qstandarditemmodel.h>
+
 #include <DIconTheme>
+#include <DSysInfo>
+#include <DTipLabel>
+
 #include <QApplication>
+
+using Dtk::Widget::DStandardItem;
 
 using namespace DCC_NAMESPACE;
 DGUI_USE_NAMESPACE
@@ -45,32 +55,45 @@ QString CommonInfoPlugin::name() const
 }
 
 ModuleObject *CommonInfoPlugin::module()
-{   
-    //一级菜单--通用设置
+{
+    // 一级菜单--通用设置
     CommonInfoModule *moduleInterface = new CommonInfoModule();
     moduleInterface->setName("commoninfo");
     moduleInterface->setDisplayName(tr("General Settings"));
     moduleInterface->setIcon(DIconTheme::findQIcon("dcc_nav_commoninfo"));
 
-    //二级菜单--启动菜单
+    // 二级菜单--启动菜单
     ModuleObject *moduleBootMenu = new PageModule("bootMenu", tr("Boot Menu"));
-    BootModule *bootModule = new BootModule(moduleInterface->model(), moduleInterface->worker(), moduleBootMenu);
+    BootModule *bootModule =
+            new BootModule(moduleInterface->model(), moduleInterface->worker(), moduleBootMenu);
     moduleBootMenu->appendChild(bootModule);
     moduleInterface->appendChild(moduleBootMenu);
 
+    moduleInterface->appendChild(
+            new PlyMouthModule(moduleInterface->model(), moduleInterface->worker()));
+
     // 服务器版/社区版
     if (!IS_SERVER_SYSTEM && !IS_COMMUNITY_SYSTEM && DSysInfo::isDeepin()) {
-        if (DSysInfo::uosEditionType() != DSysInfo::UosEuler || DSysInfo::uosEditionType() != DSysInfo::UosEnterpriseC) {
-            //二级菜单--开发者模式
-            ModuleObject *moduleDeveloperMode = new PageModule("developerMode", tr("Developer Mode"));
-            DeveloperModeModule *developerModeModule = new DeveloperModeModule(moduleInterface->model(), moduleInterface->worker(), moduleBootMenu);
+        if (DSysInfo::uosEditionType() != DSysInfo::UosEuler
+            || DSysInfo::uosEditionType() != DSysInfo::UosEnterpriseC) {
+            // 二级菜单--开发者模式
+            ModuleObject *moduleDeveloperMode =
+                    new PageModule("developerMode", tr("Developer Mode"));
+            DeveloperModeModule *developerModeModule =
+                    new DeveloperModeModule(moduleInterface->model(),
+                                            moduleInterface->worker(),
+                                            moduleBootMenu);
             moduleDeveloperMode->appendChild(developerModeModule);
             moduleInterface->appendChild(moduleDeveloperMode);
         }
 
-        //二级菜单--用户体验计划
-        ModuleObject *moduleUserExperienceProgram = new PageModule("userExperienceProgram", tr("User Experience Program"));
-        UserExperienceProgramModule *userExperienceProgramModule = new UserExperienceProgramModule(moduleInterface->model(), moduleInterface->worker(), moduleBootMenu);
+        // 二级菜单--用户体验计划
+        ModuleObject *moduleUserExperienceProgram =
+                new PageModule("userExperienceProgram", tr("User Experience Program"));
+        UserExperienceProgramModule *userExperienceProgramModule =
+                new UserExperienceProgramModule(moduleInterface->model(),
+                                                moduleInterface->worker(),
+                                                moduleBootMenu);
         moduleUserExperienceProgram->appendChild(userExperienceProgramModule);
         moduleInterface->appendChild(moduleUserExperienceProgram);
     }
@@ -98,7 +121,10 @@ QWidget *UserExperienceProgramModule::page()
 {
     UserExperienceProgramWidget *w = new UserExperienceProgramWidget();
     w->setModel(m_model);
-    connect(w, &UserExperienceProgramWidget::enableUeProgram, m_worker, &CommonInfoWork::setUeProgram);
+    connect(w,
+            &UserExperienceProgramWidget::enableUeProgram,
+            m_worker,
+            &CommonInfoWork::setUeProgram);
     connect(w, &UserExperienceProgramWidget::destroyed, m_worker, &CommonInfoWork::closeUeProgram);
     return w;
 }
@@ -109,7 +135,7 @@ QWidget *BootModule::page()
     w->setModel(m_model);
     connect(w, &BootWidget::bootdelay, m_worker, &CommonInfoWork::setBootDelay);
     connect(w, &BootWidget::enableTheme, m_worker, &CommonInfoWork::setEnableTheme);
-    connect(w, &BootWidget::enableGrubEditAuth, m_worker, [this, w](bool value){
+    connect(w, &BootWidget::enableGrubEditAuth, m_worker, [this, w](bool value) {
         if (value) {
             w->showGrubEditAuthPasswdDialog(false);
         } else {
@@ -122,4 +148,84 @@ QWidget *BootModule::page()
 
     w->setGrubEditAuthVisible(m_model->isShowGrubEditAuth());
     return w;
+}
+
+PlyMouthModule::PlyMouthModule(CommonInfoModel *model, CommonInfoWork *work, QObject *parent)
+    : PageModule("plymouthAnimation", tr("Boot Animation"), parent)
+    , m_model(model)
+    , m_work(work)
+{
+    appendChild(new ItemModule("", "", this, &PlyMouthModule::initPlyMouthDisplay, false));
+    appendChild(new ItemModule("plymouthScale",
+                               "",
+                               this,
+                               &PlyMouthModule::initPlymouthScale,
+                               false));
+}
+
+QWidget *PlyMouthModule::initPlyMouthDisplay(ModuleObject *module)
+{
+    auto displayItem = new PlyMouthDisplayItem;
+
+    displayItem->setLogoPixmap(m_work->getPlymouthFilePixmap());
+    connect(m_model, &CommonInfoModel::plymouthThemeChanged, displayItem, [displayItem, this] {
+        displayItem->setLogoPixmap(m_work->getPlymouthFilePixmap());
+    });
+
+    return displayItem;
+}
+
+QWidget *PlyMouthModule::initPlymouthScale(ModuleObject *module)
+{
+    Q_UNUSED(module)
+    DCCListView *plymouthView = new DCCListView;
+    QStandardItemModel *plymouthModel = new QStandardItemModel;
+
+    DStandardItem *smallOne = new DStandardItem;
+    smallOne->setData(tr("Small Size"), Qt::DisplayRole);
+    smallOne->setData(1, Dtk::UserRole);
+
+    DStandardItem *bingOne = new DStandardItem;
+    bingOne->setData(tr("Big Size"), Qt::DisplayRole);
+    bingOne->setData(2, Dtk::UserRole);
+
+    plymouthModel->appendRow(smallOne);
+    plymouthModel->appendRow(bingOne);
+
+    plymouthView->setModel(plymouthModel);
+
+    auto plymouthValueViewChanged = [plymouthView, plymouthModel](int scale) {
+        if (scale == 0 || scale > 2) {
+            return;
+        }
+        int row = scale - 1;
+        plymouthView->setCurrentIndex(plymouthModel->index(row, 0));
+        for (int i = 0; i < 2; ++i) {
+            auto item = plymouthModel->item(i);
+            item->setCheckState(row == i ? Qt::Checked : Qt::Unchecked);
+        }
+    };
+    plymouthValueViewChanged(m_model->plymouthScale());
+
+    auto handleDisableChanged = [plymouthModel](bool disable) {
+        for (int i = 0; i < 2; ++i) {
+            auto item = plymouthModel->item(i);
+            item->setEnabled(!disable);
+        }
+    };
+
+    handleDisableChanged(m_work->isSettingPlymouth());
+
+    connect(m_model,
+            &CommonInfoModel::plymouthScaleChanged,
+            plymouthView,
+            plymouthValueViewChanged);
+
+    connect(m_work, &CommonInfoWork::settingScaling, plymouthView, handleDisableChanged);
+
+    connect(plymouthView, &QListView::clicked, m_work, [this](const QModelIndex &index) {
+        int scale = index.row() + 1;
+        m_work->setPlymouthFactor(scale);
+    });
+    return plymouthView;
 }

--- a/src/plugin-commoninfo/window/commoninfomodule.h
+++ b/src/plugin-commoninfo/window/commoninfomodule.h
@@ -1,12 +1,13 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
 //
-//SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
-#include "interface/namespace.h"
 #include "interface/hlistmodule.h"
+#include "interface/namespace.h"
 #include "interface/plugininterface.h"
+#include "pagemodule.h"
 
 #include <QObject>
 
@@ -34,6 +35,7 @@ public:
     virtual void active() override;
 
     CommonInfoWork *worker() { return m_worker; }
+
     CommonInfoModel *model() { return m_model; }
 
 private:
@@ -41,26 +43,58 @@ private:
     CommonInfoModel *m_model;
 };
 
-
 class DeveloperModeModule : public ModuleObject
 {
     Q_OBJECT
 public:
-    explicit DeveloperModeModule(CommonInfoModel *model, CommonInfoWork *worker, QObject *parent = nullptr)
-        : ModuleObject(parent), m_model(model), m_worker(worker) {}
+    explicit DeveloperModeModule(CommonInfoModel *model,
+                                 CommonInfoWork *worker,
+                                 QObject *parent = nullptr)
+        : ModuleObject(parent)
+        , m_model(model)
+        , m_worker(worker)
+    {
+    }
+
     virtual QWidget *page() override;
+
 private:
     CommonInfoModel *m_model;
     CommonInfoWork *m_worker;
+};
+
+class PlyMouthModule : public PageModule
+{
+    Q_OBJECT
+public:
+    explicit PlyMouthModule(CommonInfoModel *model,
+                            CommonInfoWork *worker,
+                            QObject *parent = nullptr);
+
+private slots:
+    QWidget *initPlymouthScale(ModuleObject *module);
+    QWidget *initPlyMouthDisplay(ModuleObject *module);
+
+private:
+    CommonInfoModel *m_model;
+    CommonInfoWork *m_work;
 };
 
 class UserExperienceProgramModule : public ModuleObject
 {
     Q_OBJECT
 public:
-    explicit UserExperienceProgramModule(CommonInfoModel *model, CommonInfoWork *worker, QObject *parent = nullptr)
-        : ModuleObject(parent), m_model(model), m_worker(worker) {}
+    explicit UserExperienceProgramModule(CommonInfoModel *model,
+                                         CommonInfoWork *worker,
+                                         QObject *parent = nullptr)
+        : ModuleObject(parent)
+        , m_model(model)
+        , m_worker(worker)
+    {
+    }
+
     virtual QWidget *page() override;
+
 private:
     CommonInfoModel *m_model;
     CommonInfoWork *m_worker;
@@ -71,10 +105,17 @@ class BootModule : public ModuleObject
     Q_OBJECT
 public:
     explicit BootModule(CommonInfoModel *model, CommonInfoWork *worker, QObject *parent = nullptr)
-        : ModuleObject(parent), m_model(model), m_worker(worker) {}
+        : ModuleObject(parent)
+        , m_model(model)
+        , m_worker(worker)
+    {
+    }
+
     virtual QWidget *page() override;
+
 private:
     CommonInfoModel *m_model;
     CommonInfoWork *m_worker;
 };
+
 } // namespace DCC_NAMESPACE

--- a/src/plugin-commoninfo/window/plymouthdisplay.cpp
+++ b/src/plugin-commoninfo/window/plymouthdisplay.cpp
@@ -1,0 +1,46 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "plymouthdisplay.h"
+
+#include <qpainterpath.h>
+
+#include <QPaintEvent>
+#include <QPainter>
+
+using namespace DCC_NAMESPACE;
+
+static constexpr int ItemHeight = 200;
+static constexpr qreal Radius = 8.0;
+
+PlyMouthDisplayItem::PlyMouthDisplayItem(QWidget *parent)
+    : QWidget(parent)
+    , m_logo(QPixmap())
+{
+    setMinimumHeight(ItemHeight);
+}
+
+void PlyMouthDisplayItem::paintEvent(QPaintEvent *event)
+{
+    QWidget::paintEvent(event);
+    QPainter painter(this);
+    painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
+
+    QPainterPath path;
+    path.addRoundedRect(rect(), Radius, Radius);
+    painter.fillPath(path, Qt::black);
+
+    if (m_logo.isNull()) {
+        return;
+    }
+    qreal x = (rect().width() - m_logo.width()) / 2.0;
+    qreal y = (rect().height() - m_logo.height()) / 2.0;
+    painter.drawPixmap(x, y, m_logo);
+}
+
+void PlyMouthDisplayItem::setLogoPixmap(const QPixmap &pix)
+{
+    m_logo = pix;
+    update();
+}

--- a/src/plugin-commoninfo/window/plymouthdisplay.h
+++ b/src/plugin-commoninfo/window/plymouthdisplay.h
@@ -1,0 +1,28 @@
+//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+#include "interface/namespace.h"
+
+#include <QObject>
+#include <QWidget>
+#include <QPixmap>
+
+namespace DCC_NAMESPACE {
+class PlyMouthDisplayItem : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit PlyMouthDisplayItem(QWidget *parent = nullptr);
+
+public slots:
+    void setLogoPixmap(const QPixmap &pix);
+
+protected:
+    void paintEvent(QPaintEvent *event) override;
+
+private:
+    QPixmap m_logo;
+};
+} // namespace DCC_NAMESPACE

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -839,6 +839,18 @@
         <source>Signature verification failed, unable to get root access</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Start setting the new boot animation, please wait for a minute</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Setting new boot animation finished</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The settings will be applied after rebooting the system</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>dccV23::CreateAccountPage</name>
@@ -1551,6 +1563,21 @@
     </message>
     <message>
         <source>plugins cannot loaded in time</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dccV23::PlyMouthModule</name>
+    <message>
+        <source>Boot Animation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Small Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Big Size</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -837,6 +837,18 @@
         <source>Signature verification failed, unable to get root access</source>
         <translation>签名验证失败，无法进入开发者模式</translation>
     </message>
+    <message>
+        <source>Start setting the new boot animation, please wait for a minute</source>
+        <translation>开始设置启动新动画，请稍等一会儿</translation>
+    </message>
+    <message>
+        <source>Setting new boot animation finished</source>
+        <translation>新的启动动画设置完成</translation>
+    </message>
+    <message>
+        <source>The settings will be applied after rebooting the system</source>
+        <translation>新的设置会在重启系统后生效</translation>
+    </message>
 </context>
 <context>
     <name>dccV23::CreateAccountPage</name>
@@ -1550,6 +1562,21 @@
     <message>
         <source>plugins cannot loaded in time</source>
         <translation>插件没有及时加载</translation>
+    </message>
+</context>
+<context>
+    <name>dccV23::PlyMouthModule</name>
+    <message>
+        <source>Boot Animation</source>
+        <translation>启动动画</translation>
+    </message>
+    <message>
+        <source>Small Size</source>
+        <translation>小尺寸</translation>
+    </message>
+    <message>
+        <source>Big Size</source>
+        <translation>大尺寸</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
计划是不在设置缩放时候设置plymouth, 将这个操作从startdde移除，控制中心单独做个模块去直接调用。不应该在设置屏幕缩放时候去设置动画跑一遍内核命令，当前行为感觉会对其他发行版的用户造成困扰