### PR TITLE
feat: use DIconTheme::findQIcon

### DIFF
--- a/docs/v23-dcc-interface.zh_CN.md
+++ b/docs/v23-dcc-interface.zh_CN.md
@@ -189,7 +189,7 @@ ModuleObject *Test1Plugin::module()
 }
 
 Test1ModuleObject::Test1ModuleObject()
-    : HListModule("firstmenu", tr("主菜单"), tr("我是主菜单"), QIcon::fromTheme("preferences-system"))
+    : HListModule("firstmenu", tr("主菜单"), tr("我是主菜单"), DIconTheme::findQIcon("preferences-system"))
 {
     // 根节点继承于HListModule
     //-----------正常树构建----------
@@ -288,7 +288,7 @@ QString Plugin::name() const
 ModuleObject* Plugin::module()
 {
     //-----------创建根节点----------
-    ModuleObject *moduleRoot = new ModuleObject("menu3", tr("菜单3"), tr("我是菜单3"), QIcon::fromTheme("preferences-system"), this);
+    ModuleObject *moduleRoot = new ModuleObject("menu3", tr("菜单3"), tr("我是菜单3"), DIconTheme::findQIcon("preferences-system"), this);
     moduleRoot->setChildType(ModuleObject::ChildType::Page);
 
     for (int j = 0; j < 4; j++) {
@@ -302,8 +302,8 @@ ModuleObject* Plugin::module()
 
 QString Plugin::follow() const
 {
-    // 注意这里返回的是上级的url
-    return QStringLiteral("firstmenu");
+    // 注意这里返回的是上级的url
+    return QStringLiteral("firstmenu");
 }
 
 QString Plugin::location() const

--- a/src/frame/listitemdelegate.cpp
+++ b/src/frame/listitemdelegate.cpp
@@ -18,6 +18,7 @@
 #include <DStyle>
 #include <DStyledItemDelegate>
 #include <DGuiApplicationHelper>
+#include <DIconTheme>
 
 #if DTK_VERSION >= DTK_VERSION_CHECK(5, 6, 0, 0)
 #    define USE_DCIICON
@@ -180,7 +181,7 @@ void ListItemDelegate::drawDecoration(QPainter *painter, const QStyleOptionViewI
             icon = iconVar.value<QIcon>();
         } else if (iconVar.type() == QVariant::String) {
             const QString &iconstr = iconVar.toString();
-            icon = QIcon::fromTheme(iconstr);
+            icon = DIconTheme::findQIcon(iconstr);
             if (icon.isNull())
                 icon = QIcon(iconstr);
         }

--- a/src/frame/main.cpp
+++ b/src/frame/main.cpp
@@ -11,12 +11,14 @@
 #include <DApplicationSettings>
 #include <DDBusSender>
 #include <DLog>
+#include <DIconTheme>
 
 #include <QIcon>
 #include <QScreen>
 #include <QStringList>
 
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
 constexpr QSize MainWindowStartSize(QSize(1000, 600));
@@ -112,8 +114,8 @@ int main(int argc, char *argv[])
     app->setAttribute(Qt::AA_UseHighDpiPixmaps);
     app->loadTranslator();
     app->setStyle("chameleon");
-    app->setProductIcon(QIcon::fromTheme("preferences-system"));
-    app->setWindowIcon(QIcon::fromTheme("preferences-system"));
+    app->setProductIcon(DIconTheme::findQIcon("preferences-system"));
+    app->setWindowIcon(DIconTheme::findQIcon("preferences-system"));
 
     DApplicationSettings settings;
 

--- a/src/frame/mainwindow.cpp
+++ b/src/frame/mainwindow.cpp
@@ -22,6 +22,7 @@
 #include <DPushButton>
 #include <DTitlebar>
 #include <DWidgetUtil>
+#include <DIconTheme>
 
 #include <QColor>
 #include <QDBusConnection>
@@ -41,6 +42,7 @@
 #include <QTimer>
 
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
@@ -208,7 +210,7 @@ void MainWindow::initUI()
     m_backwardBtn->setAccessibleName("backwardbtn");
 
     titlebar()->addWidget(m_backwardBtn, Qt::AlignLeft | Qt::AlignVCenter);
-    titlebar()->setIcon(QIcon::fromTheme("preferences-system"));
+    titlebar()->setIcon(DIconTheme::findQIcon("preferences-system"));
 
     connect(m_backwardBtn, &DIconButton::clicked, this, &MainWindow::toHome);
 

--- a/src/frame/searchwidget.cpp
+++ b/src/frame/searchwidget.cpp
@@ -19,6 +19,7 @@
 #ifdef USE_DCIICON
 #    include <DDciIcon>
 #    include <DGuiApplicationHelper>
+#    include <DIconTheme>
 DGUI_USE_NAMESPACE
 #endif
 
@@ -161,7 +162,7 @@ void DccCompleterStyledItemDelegate::paint(QPainter *painter, const QStyleOption
             icon = iconVar.value<QIcon>();
         } else if (iconVar.type() == QVariant::String) {
             const QString &iconstr = iconVar.toString();
-            icon = QIcon::fromTheme(iconstr);
+            icon = DIconTheme::findQIcon(iconstr);
             if (icon.isNull())
                 icon = QIcon(iconstr);
         }

--- a/src/interface/moduledatamodel.cpp
+++ b/src/interface/moduledatamodel.cpp
@@ -6,12 +6,14 @@
 #include "interface/moduleobject.h"
 
 #include <dstyleoption.h>
+#include <DIconTheme>
 
 #include <QSignalMapper>
 
 #include <algorithm>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 
 ModuleDataModel::ModuleDataModel(QObject *parent)
     : QAbstractItemModel(parent)
@@ -60,7 +62,7 @@ QVariant ModuleDataModel::data(const QModelIndex &index, int role) const
     case Qt::DecorationRole: {
         auto icon = data->icon();
         if (icon.type() == QVariant::String) {
-            return QIcon::fromTheme(icon.toString());
+            return DIconTheme::findQIcon(icon.toString());
         }
         return data->icon();
     }

--- a/src/plugin-accounts/window/accountsmodule.cpp
+++ b/src/plugin-accounts/window/accountsmodule.cpp
@@ -41,6 +41,7 @@
 #include <DDesktopServices>
 #include <DFloatingButton>
 #include <DBlurEffectWidget>
+#include <DIconTheme>
 
 #include <polkit-qt5-1/PolkitQt1/Authority>
 
@@ -49,6 +50,7 @@
 
 using namespace DCC_NAMESPACE;
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 QString AccountsPlugin::name() const
@@ -99,7 +101,7 @@ void AccountSpinBox::focusOutEvent(QFocusEvent *event)
 }
 ///////////////////////////////////////
 AccountsModule::AccountsModule(QObject *parent)
-    : PageModule("accounts", tr("Users"), tr("User management") , QIcon::fromTheme("dcc_nav_accounts"), parent)
+    : PageModule("accounts", tr("Users"), tr("User management") , DIconTheme::findQIcon("dcc_nav_accounts"), parent)
     , m_model(nullptr)
     , m_worker(nullptr)
     , m_curLoginUser(nullptr)
@@ -367,7 +369,7 @@ QWidget *AccountsModule::initFullNameIcon(ModuleObject *module)
 {
     DToolButton *fullNameBtn = new DToolButton();
     fullNameBtn->setAccessibleName("fullName_btn");
-    fullNameBtn->setIcon(QIcon::fromTheme("dcc_edit"));
+    fullNameBtn->setIcon(DIconTheme::findQIcon("dcc_edit"));
     fullNameBtn->setIconSize(QSize(12, 12));
     //点击用户全名编辑按钮
     connect(fullNameBtn, &DIconButton::clicked, module, [this]() {
@@ -472,7 +474,7 @@ QWidget *AccountsModule::initName(ModuleObject *module)
     Q_UNUSED(module)
     QWidget *w = new QWidget();
     QLabel *shortnameBtn = new QLabel();
-    shortnameBtn->setPixmap(QIcon::fromTheme("dcc_avatar").pixmap(12, 12));
+    shortnameBtn->setPixmap(DIconTheme::findQIcon("dcc_avatar").pixmap(12, 12));
     QLabel *shortName = new QLabel();
     shortName->setEnabled(false);
     auto updateName = [shortName](User *user, User *oldUser) {
@@ -779,7 +781,7 @@ void AccountsModule::updateFullnameVisible(uint32_t flag, bool state)
 void AccountsModule::onShowSafetyPage(const QString &errorTips)
 {
     DDialog dlg("", errorTips, nullptr);
-    dlg.setIcon(QIcon::fromTheme("preferences-system"));
+    dlg.setIcon(DIconTheme::findQIcon("preferences-system"));
     dlg.addButton(tr("Go to Settings"));
     dlg.addButton(tr("Cancel"), true, DDialog::ButtonWarning);
     connect(this, &AccountsModule::deactivated, &dlg, &DDialog::close);
@@ -808,7 +810,7 @@ void AccountsModule::onLoginModule(ModuleObject *module)
                 m_worker->setAutoLogin(m_curUser, autoLogin);
             } else {
                 DDialog *tipDialog = new DDialog(qobject_cast<QWidget *>(sender()));
-                tipDialog->setIcon(QIcon::fromTheme("dialog-warning"));
+                tipDialog->setIcon(DIconTheme::findQIcon("dialog-warning"));
                 tipDialog->setModal(true);
                 tipDialog->setAttribute(Qt::WA_DeleteOnClose);
                 tipDialog->addButton(tr("OK"));

--- a/src/plugin-accounts/window/avatarlistframe.cpp
+++ b/src/plugin-accounts/window/avatarlistframe.cpp
@@ -7,6 +7,7 @@
 #include "avatarcropbox.h"
 
 #include <DSlider>
+#include <DIconTheme>
 
 #include <QColor>
 #include <QDateTime>
@@ -24,6 +25,8 @@
 #include <QTimer>
 #include <QVBoxLayout>
 #include <QWidget>
+
+DGUI_USE_NAMESPACE
 
 const QString VarDirectory = QStringLiteral(VARDIRECTORY);
 
@@ -229,7 +232,7 @@ CustomAddAvatarWidget::CustomAddAvatarWidget(User *user, const int &role, QWidge
     m_addAvatarFrame->setAcceptDrops(true);
     m_addAvatarFrame->installEventFilter(this);
 
-    m_addAvatarLabel->setPixmap(QIcon::fromTheme("dcc_user_add_icon").pixmap(60, 60));
+    m_addAvatarLabel->setPixmap(DIconTheme::findQIcon("dcc_user_add_icon").pixmap(60, 60));
     m_addAvatarLabel->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
 
     m_hintLabel->setText(

--- a/src/plugin-accounts/window/avatarlistwidget.cpp
+++ b/src/plugin-accounts/window/avatarlistwidget.cpp
@@ -10,6 +10,7 @@
 #include <DDialog>
 #include <DDialogCloseButton>
 #include <DStyle>
+#include <DIconTheme>
 
 #include <QDebug>
 #include <QDir>
@@ -26,6 +27,7 @@
 #include <QVBoxLayout>
 #include <QWidget>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
@@ -83,7 +85,7 @@ AvatarListDialog::AvatarListDialog(User *usr, AccountsWorker *worker, QWidget *p
         if (item.isLoader) {
             DStandardItem *avatarItem = new DStandardItem(item.name);
             avatarItem->setFontSize(DFontSizeManager::SizeType::T5);
-            avatarItem->setIcon(QIcon::fromTheme(item.icon));
+            avatarItem->setIcon(DIconTheme::findQIcon(item.icon));
             avatarItem->setData(item.role, AvatarItemNameRole);
             m_avatarSelectItemModel->appendRow(avatarItem);
 

--- a/src/plugin-accounts/window/unionidbindreminderdialog.cpp
+++ b/src/plugin-accounts/window/unionidbindreminderdialog.cpp
@@ -4,15 +4,17 @@
 #include "unionidbindreminderdialog.h"
 #include <QPushButton>
 #include <DDBusSender>
+#include <DIconTheme>
 
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 UnionIDBindReminderDialog::UnionIDBindReminderDialog(QWidget *parent)
     : DDialog(tr("The user account is not linked to Union ID"),
               tr("To reset passwords, you should authenticate your Union ID first. Click \"Go to Link\" to finish the settings."))
 {
     setParent(parent);
-    setIcon(QIcon::fromTheme("dialog-warning"));
+    setIcon(DIconTheme::findQIcon("dialog-warning"));
     QStringList buttons;
     buttons << tr("Cancel");
     addButtons(buttons);

--- a/src/plugin-adapterv20tov23/moduleinterface.h
+++ b/src/plugin-adapterv20tov23/moduleinterface.h
@@ -9,6 +9,10 @@
 #include <QIcon>
 #include <QWidget>
 
+#include <DIconTheme>
+
+DGUI_USE_NAMESPACE
+
 //struct ModuleMetadata {
 //    QString icon;
 //    QString title;
@@ -70,7 +74,7 @@ public:
     /// \return
     ///
     virtual QIcon icon() const {
-        return QIcon::fromTheme(QString("dcc_nav_%1").arg(name()));
+        return DIconTheme::findQIcon(QString("dcc_nav_%1").arg(name()));
     }
 
     ///

--- a/src/plugin-authentication/window/authenticationplugin.cpp
+++ b/src/plugin-authentication/window/authenticationplugin.cpp
@@ -9,6 +9,9 @@
 #include "faceiddetailwidget.h"
 #include "fingerdetailwidget.h"
 #include "irisdetailwidget.h"
+#include <DIconTheme>
+
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 QString AuthenticationPlugin::name() const
 {
@@ -59,7 +62,7 @@ QString AuthenticationPlugin::location() const
 }
 
 AuthenticationModule::AuthenticationModule(QObject *parent)
-    : HListModule("authentication", tr("Biometric Authentication"), QString(), QIcon::fromTheme("dcc_nav_authentication"), parent)
+    : HListModule("authentication", tr("Biometric Authentication"), QString(), DIconTheme::findQIcon("dcc_nav_authentication"), parent)
     , m_model(new CharaMangerModel(this))
     , m_work(new CharaMangerWorker(m_model, this))
 {

--- a/src/plugin-authentication/window/faceiddetailwidget.cpp
+++ b/src/plugin-authentication/window/faceiddetailwidget.cpp
@@ -9,9 +9,12 @@
 #include <DApplicationHelper>
 #include <DFontSizeManager>
 #include <DTipLabel>
+#include <DIconTheme>
 
 #include <QBoxLayout>
 #include <QLabel>
+
+DGUI_USE_NAMESPACE
 
 FaceidDetailWidget::FaceidDetailWidget(CharaMangerModel *model, QWidget *parent)
     : QWidget (parent)
@@ -54,10 +57,10 @@ void FaceidDetailWidget::initFaceidShow()
     connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
         this, [=](Dtk::Gui::DGuiApplicationHelper::ColorType themeType) {
         Q_UNUSED(themeType);
-        m_pNotDevice->setPixmap(QIcon::fromTheme(getDisplayPath()).pixmap(64, 64));
+        m_pNotDevice->setPixmap(DIconTheme::findQIcon(getDisplayPath()).pixmap(64, 64));
     });
 
-    m_pNotDevice->setPixmap(QIcon::fromTheme(getDisplayPath()).pixmap(64, 64));
+    m_pNotDevice->setPixmap(DIconTheme::findQIcon(getDisplayPath()).pixmap(64, 64));
     m_pNotDevice->setAlignment(Qt::AlignHCenter);
 
     // 设置高亮字体

--- a/src/plugin-authentication/window/fingerdetailwidget.cpp
+++ b/src/plugin-authentication/window/fingerdetailwidget.cpp
@@ -8,6 +8,7 @@
 #include <DApplicationHelper>
 #include <DFontSizeManager>
 #include <DTipLabel>
+#include <DIconTheme>
 
 #include <QVBoxLayout>
 #include <QLabel>
@@ -16,6 +17,7 @@
 #include <QSize>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 FingerDetailWidget::FingerDetailWidget(QWidget *parent)
@@ -74,10 +76,10 @@ void FingerDetailWidget::initNotFingerDevice()
     connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
     this, [ = ](Dtk::Gui::DGuiApplicationHelper::ColorType themeType) {
         Q_UNUSED(themeType);
-        pNotDevice->setPixmap(QIcon::fromTheme(getDisplayPath()).pixmap(64, 64));
+        pNotDevice->setPixmap(DIconTheme::findQIcon(getDisplayPath()).pixmap(64, 64));
 
     });
-    pNotDevice->setPixmap(QIcon::fromTheme(getDisplayPath()).pixmap(64, 64));
+    pNotDevice->setPixmap(DIconTheme::findQIcon(getDisplayPath()).pixmap(64, 64));
     pNotDevice->setAlignment(Qt::AlignHCenter);
 
 

--- a/src/plugin-authentication/window/irisdetailwidget.cpp
+++ b/src/plugin-authentication/window/irisdetailwidget.cpp
@@ -8,9 +8,12 @@
 #include <DApplicationHelper>
 #include <DFontSizeManager>
 #include <DTipLabel>
+#include <DIconTheme>
 
 #include <QBoxLayout>
 #include <QLabel>
+
+DGUI_USE_NAMESPACE
 
 IrisDetailWidget::IrisDetailWidget(CharaMangerModel *model, QWidget *parent)
     : QWidget (parent)
@@ -50,10 +53,10 @@ void IrisDetailWidget::initIrisShow()
     connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
         this, [=](Dtk::Gui::DGuiApplicationHelper::ColorType themeType) {
         Q_UNUSED(themeType);
-        m_pNotDevice->setPixmap(QIcon::fromTheme(getDisplayPath()).pixmap(64, 64));
+        m_pNotDevice->setPixmap(DIconTheme::findQIcon(getDisplayPath()).pixmap(64, 64));
     });
 
-    m_pNotDevice->setPixmap(QIcon::fromTheme(getDisplayPath()).pixmap(64, 64));
+    m_pNotDevice->setPixmap(DIconTheme::findQIcon(getDisplayPath()).pixmap(64, 64));
     m_pNotDevice->setAlignment(Qt::AlignHCenter);
 
     // 设置高亮字体

--- a/src/plugin-authentication/window/widgets/authenticationinfoitem.cpp
+++ b/src/plugin-authentication/window/widgets/authenticationinfoitem.cpp
@@ -14,8 +14,10 @@
 #include <DIconButton>
 #include <DLineEdit>
 #include <DStyleHelper>
+#include <DIconTheme>
 
 using namespace DCC_NAMESPACE;
+
 DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
@@ -31,7 +33,7 @@ AuthenticationInfoItem::AuthenticationInfoItem(QWidget *parent)
 {
     setFixedHeight(36);
 
-    m_editBtn->setIcon(QIcon::fromTheme("dcc_edit"));
+    m_editBtn->setIcon(DIconTheme::findQIcon("dcc_edit"));
     m_editBtn->setFlat(true);//设置背景透明
     m_editBtn->setVisible(false);
 

--- a/src/plugin-authentication/window/widgets/face/addfaceinfodialog.cpp
+++ b/src/plugin-authentication/window/widgets/face/addfaceinfodialog.cpp
@@ -7,8 +7,9 @@
 
 #include <DTitlebar>
 #include <DFontSizeManager>
-
 #include <DSuggestButton>
+#include <DIconTheme>
+
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QPushButton>
@@ -17,6 +18,7 @@
 #include <QDebug>
 #include <QDialog>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
@@ -67,7 +69,7 @@ void AddFaceInfoDialog::initWidget()
 
     // 人脸图片
     m_facePic = new QLabel(this);
-    m_facePic->setPixmap(QIcon::fromTheme(getFacePicture()).pixmap(128,128));
+    m_facePic->setPixmap(DIconTheme::findQIcon(getFacePicture()).pixmap(128,128));
 
     // 提示信息
     m_resultTips = new QLabel(this);
@@ -162,7 +164,7 @@ void AddFaceInfoDialog::responseEnrollInfoState(CharaMangerModel::AddInfoState s
 {
     m_currentState = state;
 
-    m_facePic->setPixmap(QIcon::fromTheme(getFacePicture()).pixmap(128, 128));
+    m_facePic->setPixmap(DIconTheme::findQIcon(getFacePicture()).pixmap(128, 128));
     if (m_currentState == CharaMangerModel::AddInfoState::StartState) {
         m_resultTips->hide();
 

--- a/src/plugin-authentication/window/widgets/finger/fingedisclaimer.cpp
+++ b/src/plugin-authentication/window/widgets/finger/fingedisclaimer.cpp
@@ -8,6 +8,7 @@
 #include <DTitlebar>
 #include <DFontSizeManager>
 #include <DSuggestButton>
+#include <DIconTheme>
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -18,6 +19,7 @@
 #include <QDialog>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 FingerDisclaimer::FingerDisclaimer(QWidget *parent)
@@ -66,7 +68,7 @@ void FingerDisclaimer::initWidget()
     titleIcon->setTitle(tr("Add Fingerprint"));
 
     m_fingerPic = new QLabel(this);
-    m_fingerPic->setPixmap(QIcon::fromTheme(getFacePicture()).pixmap(128, 128));
+    m_fingerPic->setPixmap(DIconTheme::findQIcon(getFacePicture()).pixmap(128, 128));
 
     // 提示信息
     m_resultTips = new QLabel(this);

--- a/src/plugin-bluetooth/window/adaptermodule.cpp
+++ b/src/plugin-bluetooth/window/adaptermodule.cpp
@@ -13,6 +13,7 @@
 #include <DListView>
 #include <DSwitchButton>
 #include <DSpinner>
+#include <DIconTheme>
 
 #include <QDBusConnection>
 #include <QDBusInterface>
@@ -25,6 +26,7 @@
 #include <QCheckBox>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 AdapterModule::AdapterModule(const BluetoothAdapter *adapter, BluetoothModel *model, BluetoothWorker *work, QObject *parent)
@@ -197,7 +199,7 @@ void AdapterModule::initAnonymousCheckBox(QWidget *w)
 
     DIconButton *refreshBtn = new DIconButton(w);
     refreshBtn->setFixedSize(36, 36);
-    refreshBtn->setIcon(QIcon::fromTheme("dcc_refresh"));
+    refreshBtn->setIcon(DIconTheme::findQIcon("dcc_refresh"));
     refreshBtn->setVisible(!m_adapter->discovering());
 
     QHBoxLayout *phlayoutShowAnonymous = new QHBoxLayout;

--- a/src/plugin-bluetooth/window/bluetoothdevicemodel.cpp
+++ b/src/plugin-bluetooth/window/bluetoothdevicemodel.cpp
@@ -8,6 +8,7 @@
 
 #include <DDesktopServices>
 #include <DSpinner>
+#include <DIconTheme>
 
 #include <QApplication>
 #include <QLineEdit>
@@ -16,6 +17,7 @@
 #include <QStyleOptionViewItem>
 #include <QWidget>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 struct BluetoothDeviceItemAction
@@ -171,9 +173,9 @@ QVariant BluetoothDeviceModel::data(const QModelIndex &index, int role) const
         return device->alias().isEmpty() ? device->name() : device->alias();
     case Qt::DecorationRole:
         if (!device->deviceType().isEmpty())
-            return QIcon::fromTheme(device->deviceType());
+            return DIconTheme::findQIcon(device->deviceType());
         else
-            return QIcon::fromTheme(QString("bluetooth_other"));
+            return DIconTheme::findQIcon(QString("bluetooth_other"));
     case Dtk::RightActionListRole:
         return m_data.at(row)->item->data(role);
     default:

--- a/src/plugin-bluetooth/window/bluetoothmodule.cpp
+++ b/src/plugin-bluetooth/window/bluetoothmodule.cpp
@@ -14,12 +14,15 @@
 #include <QApplication>
 #include <QLoggingCategory>
 
+#include <DIconTheme>
+DGUI_USE_NAMESPACE
+
 Q_LOGGING_CATEGORY(DdcBluetoothModule, "dcc-bluetooth-module")
 
 using namespace DCC_NAMESPACE;
 
 BluetoothModule::BluetoothModule(QObject *parent)
-    : PageModule("bluetooth", tr("Bluetooth"), tr("Bluetooth device manager"), QIcon::fromTheme("dcc_nav_bluetooth"), parent)
+    : PageModule("bluetooth", tr("Bluetooth"), tr("Bluetooth device manager"), DIconTheme::findQIcon("dcc_nav_bluetooth"), parent)
 {
     m_model = new BluetoothModel(this);
     m_work = new BluetoothWorker(m_model, this);

--- a/src/plugin-bluetooth/window/pincodedialog.cpp
+++ b/src/plugin-bluetooth/window/pincodedialog.cpp
@@ -4,7 +4,9 @@
 #include "pincodedialog.h"
 
 #include <QLabel>
+#include <DIconTheme>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 static QList<PinCodeDialog *> Instances;
@@ -14,7 +16,7 @@ PinCodeDialog::PinCodeDialog(const QString &pinCode, const bool &cancelable)
     , m_pinCodeLabel(new QLabel)
 {
     setTitle(tr("The PIN for connecting to the Bluetooth device is:"));
-    setIcon(QIcon::fromTheme("notification-bluetooth-connected"));
+    setIcon(DIconTheme::findQIcon("notification-bluetooth-connected"));
 
     m_pinCodeLabel->setObjectName("PinCodeText");
     addContent(m_pinCodeLabel, Qt::AlignTop | Qt::AlignCenter);

--- a/src/plugin-bluetooth/window/titleedit.cpp
+++ b/src/plugin-bluetooth/window/titleedit.cpp
@@ -10,7 +10,9 @@
 #include <QHBoxLayout>
 #include <DLineEdit>
 #include <DDesktopServices>
+#include <DIconTheme>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 using namespace DCC_NAMESPACE;
@@ -28,7 +30,7 @@ TitleEdit::TitleEdit(QWidget *parent)
     mainlayout->addWidget(m_lineEdit);
     mainlayout->addSpacing(5);
     DToolButton *editWidget = new DToolButton(this);
-    editWidget->setIcon(QIcon::fromTheme("dcc_edit"));
+    editWidget->setIcon(DIconTheme::findQIcon("dcc_edit"));
     mainlayout->addWidget(editWidget);
     mainlayout->addStretch();
     mainlayout->setMargin(0);

--- a/src/plugin-commoninfo/window/commoninfomodule.cpp
+++ b/src/plugin-commoninfo/window/commoninfomodule.cpp
@@ -12,9 +12,11 @@
 #include "developermodewidget.h"
 
 #include <DSysInfo>
+#include <DIconTheme>
 #include <QApplication>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
 CommonInfoModule::CommonInfoModule(QObject *parent)
@@ -48,7 +50,7 @@ ModuleObject *CommonInfoPlugin::module()
     CommonInfoModule *moduleInterface = new CommonInfoModule();
     moduleInterface->setName("commoninfo");
     moduleInterface->setDisplayName(tr("General Settings"));
-    moduleInterface->setIcon(QIcon::fromTheme("dcc_nav_commoninfo"));
+    moduleInterface->setIcon(DIconTheme::findQIcon("dcc_nav_commoninfo"));
 
     //二级菜单--启动菜单
     ModuleObject *moduleBootMenu = new PageModule("bootMenu", tr("Boot Menu"));

--- a/src/plugin-commoninfo/window/developermodedialog.cpp
+++ b/src/plugin-commoninfo/window/developermodedialog.cpp
@@ -10,6 +10,7 @@
 #include <DTitlebar>
 #include <DWindowCloseButton>
 #include <DTextBrowser>
+#include <DIconTheme>
 
 #include <QVBoxLayout>
 #include <QHBoxLayout>
@@ -25,6 +26,7 @@
 #include <QJsonDocument>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 DeveloperModeDialog::DeveloperModeDialog(QObject *parent)
@@ -48,7 +50,7 @@ DeveloperModeDialog::DeveloperModeDialog(QObject *parent)
     titleIcon->setAccessibleName("DeveloperModeDialog_titleIcon");
     titleIcon->setFrameStyle(QFrame::NoFrame);//无边框
     titleIcon->setBackgroundTransparent(true);//透明
-    titleIcon->setIcon(QIcon::fromTheme("preferences-system"));
+    titleIcon->setIcon(DIconTheme::findQIcon("preferences-system"));
     titleHBoxLayout->addWidget(titleIcon, Qt::AlignTop);
     titleIcon->setMenuVisible(false);
     titleIcon->setTitle("");

--- a/src/plugin-datetime/window/datetimeplugin.cpp
+++ b/src/plugin-datetime/window/datetimeplugin.cpp
@@ -9,10 +9,12 @@
 #include "timesettingmodule.h"
 #include "timezonemodule.h"
 
+#include <DIconTheme>
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
 DatetimeModule::DatetimeModule(QObject *parent)
-    : HListModule("datetime", tr("Date and Time"), QIcon::fromTheme("dcc_nav_datetime"), parent)
+    : HListModule("datetime", tr("Date and Time"), DIconTheme::findQIcon("dcc_nav_datetime"), parent)
     , m_model(nullptr)
 {
     m_model = new DatetimeModel(this);

--- a/src/plugin-datetime/window/regionanddatemodule.cpp
+++ b/src/plugin-datetime/window/regionanddatemodule.cpp
@@ -16,11 +16,13 @@
 #include <DFontSizeManager>
 #include <DIconButton>
 #include <DTipLabel>
+#include <DIconTheme>
 
 #include <QDateTime>
 #include <QGridLayout>
 #include <QPushButton>
 
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 using Dtk::Widget::DFontSizeManager;
 using Dtk::Widget::DIconButton;
@@ -255,7 +257,7 @@ RegionSettingBtn::RegionSettingBtn(const QString &region, QWidget *parent)
     center->addStretch();
 
     DIconButton *right = new DIconButton;
-    right->setIcon(QIcon::fromTheme("go-next"));
+    right->setIcon(DIconTheme::findQIcon("go-next"));
     connect(right, &QPushButton::clicked, this, &RegionSettingBtn::clicked);
     center->addWidget(right);
 

--- a/src/plugin-datetime/window/widgets/clock.cpp
+++ b/src/plugin-datetime/window/widgets/clock.cpp
@@ -7,6 +7,9 @@
 #include <QPainterPath>
 #include <QIcon>
 #include <QTimer>
+#include <DIconTheme>
+
+DGUI_USE_NAMESPACE
 
 static const QSize clockSize = QSize(224, 224);
 static const QSize pointSize = QSize(145, 15);
@@ -33,7 +36,7 @@ Clock::~Clock()
 
 QPixmap Clock::getPixmap(const QString &name, const QSize size)
 {
-    const QIcon &icon = QIcon::fromTheme(name);
+    const QIcon &icon = DIconTheme::findQIcon(name);
     const qreal ratio = devicePixelRatioF();
     QPixmap pixmap = icon.pixmap(size * ratio).scaled(size * ratio, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
     QPainter p(&pixmap);

--- a/src/plugin-defaultapp/window/defappdetailwidget.cpp
+++ b/src/plugin-defaultapp/window/defappdetailwidget.cpp
@@ -12,6 +12,7 @@
 #include <DFloatingButton>
 #include <DListView>
 #include <DStyle>
+#include <DIconTheme>
 
 #include <QVBoxLayout>
 #include <QDebug>
@@ -23,6 +24,7 @@
 
 Q_LOGGING_CATEGORY(DdcDefaultDetailWidget, "dcc-default-detailwidget")
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 DefappDetailWidget::DefappDetailWidget(DefAppWorker::DefaultAppsCategory category, QWidget *parent)
@@ -103,7 +105,7 @@ QIcon DefappDetailWidget::getAppIcon(const QString &appIcon, const QSize &size)
 {
     QIcon icon(appIcon);
     if (icon.pixmap(size).isNull())
-        icon = QIcon::fromTheme(appIcon, QIcon::fromTheme("application-x-desktop"));
+        icon = DIconTheme::findQIcon(appIcon, DIconTheme::findQIcon("application-x-desktop"));
 
     const qreal ratio = devicePixelRatioF();
     QPixmap pixmap = icon.pixmap(size * ratio).scaled(size * ratio, Qt::KeepAspectRatio, Qt::SmoothTransformation);

--- a/src/plugin-defaultapp/window/defappplugin.cpp
+++ b/src/plugin-defaultapp/window/defappplugin.cpp
@@ -11,10 +11,12 @@
 
 #include <DFloatingButton>
 #include <DStyle>
+#include <DIconTheme>
 
 #include <QApplication>
 #include <QVBoxLayout>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
@@ -110,7 +112,7 @@ QString DefAppPlugin::location() const
 }
 
 DefAppModule::DefAppModule(QObject *parent)
-    : VListModule("defapp", tr("Default Applications"), QIcon::fromTheme("dcc_nav_defapp"), parent)
+    : VListModule("defapp", tr("Default Applications"), DIconTheme::findQIcon("dcc_nav_defapp"), parent)
     , m_model(new DefAppModel(this))
     , m_work(new DefAppWorker(m_model, this))
     , m_defApps(nullptr)

--- a/src/plugin-display/window/brightnesswidget.cpp
+++ b/src/plugin-display/window/brightnesswidget.cpp
@@ -8,11 +8,13 @@
 #include "widgets/dccslider.h"
 
 #include <DFontSizeManager>
+#include <DIconTheme>
 
 #include <QLabel>
 #include <QVBoxLayout>
 #include <QSpacerItem>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
@@ -191,8 +193,8 @@ void BrightnessWidget::addSlider()
             slider->setRange(miniScale, int(BrightnessMaxScale));
             slider->setType(DCCSlider::Vernier);
             slider->setTickPosition(QSlider::TicksBelow);
-            slider->setLeftIcon(QIcon::fromTheme("dcc_brightnesslow"));
-            slider->setRightIcon(QIcon::fromTheme("dcc_brightnesshigh"));
+            slider->setLeftIcon(DIconTheme::findQIcon("dcc_brightnesslow"));
+            slider->setRightIcon(DIconTheme::findQIcon("dcc_brightnesshigh"));
             slider->setIconSize(QSize(24, 24));
             slider->setTickInterval(int((BrightnessMaxScale - miniScale) / 5.0));
             slider->setValue(int(brightness * BrightnessMaxScale));
@@ -242,8 +244,8 @@ void BrightnessWidget::addSlider()
             slider->setRange(m_miniScales, maxBacklight);
             slider->setType(DCCSlider::Vernier);
             slider->setTickPosition(QSlider::TicksBelow);
-            slider->setLeftIcon(QIcon::fromTheme("dcc_brightnesslow"));
-            slider->setRightIcon(QIcon::fromTheme("dcc_brightnesshigh"));
+            slider->setLeftIcon(DIconTheme::findQIcon("dcc_brightnesslow"));
+            slider->setRightIcon(DIconTheme::findQIcon("dcc_brightnesshigh"));
             slider->setIconSize(QSize(24, 24));
             slider->setTickInterval(1);
             slider->setValue(int((brightness + DoubleZero) * maxBacklight));

--- a/src/plugin-display/window/collaborativelinkwidget.cpp
+++ b/src/plugin-display/window/collaborativelinkwidget.cpp
@@ -15,6 +15,7 @@
 
 #include <DComboBox>
 #include <DStandardItem>
+#include <DIconTheme>
 
 #include <QBoxLayout>
 #include <QComboBox>
@@ -25,6 +26,7 @@
 #include <QWidgetAction>
 
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
 CollaborativeLinkWidget::CollaborativeLinkWidget(QWidget *parent)
@@ -68,7 +70,7 @@ void CollaborativeLinkWidget::initUI()
     QLabel *devLabel = new QLabel(this);
     devLabel->setText(tr("Connect to"));
     m_deviceButton->setFixedWidth(36);
-    m_deviceButton->setIcon(QIcon::fromTheme("dcc_break"));
+    m_deviceButton->setIcon(DIconTheme::findQIcon("dcc_break"));
     m_deviceButton->setEnabled(false);
 
     m_deviceCombox->setModel(m_deviceComboxModel);
@@ -274,7 +276,7 @@ void CollaborativeLinkWidget::initDirectionItem()
     QStringList textList { tr("On the top"), tr("On the right"), tr("On the bottom"), tr("On the left")};
 
     for (int idx = 0; idx < dirList.size(); idx++) {
-        m_directionCombox->addItem(QIcon::fromTheme(QString("dcc_display_%1").arg(dirList[idx])), textList[idx]);
+        m_directionCombox->addItem(DIconTheme::findQIcon(QString("dcc_display_%1").arg(dirList[idx])), textList[idx]);
     }
 }
 

--- a/src/plugin-display/window/displaymodule.cpp
+++ b/src/plugin-display/window/displaymodule.cpp
@@ -16,11 +16,13 @@
 #include "operation/displayworker.h"
 
 #include <DMainWindow>
+#include <DIconTheme>
 
 #include <QApplication>
 #include <QDesktopWidget>
 #include <QVBoxLayout>
 
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
 QString DisplayPlugin::name() const
@@ -35,7 +37,7 @@ ModuleObject * DisplayPlugin::module()
     moduleInterface->setName("display");
     moduleInterface->setDisplayName(tr("Display"));
     moduleInterface->setDescription(tr("Light, resolution, scaling and etc"));
-    moduleInterface->setIcon(QIcon::fromTheme("dcc_nav_display"));
+    moduleInterface->setIcon(DIconTheme::findQIcon("dcc_nav_display"));
 
     DisplayModule *displayModule = new DisplayModule(moduleInterface);
     moduleInterface->appendChild(displayModule);

--- a/src/plugin-display/window/monitorcontrolwidget.cpp
+++ b/src/plugin-display/window/monitorcontrolwidget.cpp
@@ -9,14 +9,16 @@
 #include <QVBoxLayout>
 #include <QPushButton>
 #include <QIcon>
+#include <DIconTheme>
 
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
 MonitorControlWidget::MonitorControlWidget(int activateHeight, QWidget *parent)
     : QFrame(parent)
     , m_screensGround(new MonitorsGround(activateHeight,this))
-    , m_recognize(new QPushButton(QIcon::fromTheme("dcc_recognize"), tr("Identify")))
-    , m_gather(new QPushButton(QIcon::fromTheme("dcc_gather"), tr("Gather Windows")))
+    , m_recognize(new QPushButton(DIconTheme::findQIcon("dcc_recognize"), tr("Identify")))
+    , m_gather(new QPushButton(DIconTheme::findQIcon("dcc_gather"), tr("Gather Windows")))
     , m_effectiveReminder(new QLabel(this))
 {
     m_screensGround->setAccessibleName("screensGround");

--- a/src/plugin-display/window/secondaryscreendialog.cpp
+++ b/src/plugin-display/window/secondaryscreendialog.cpp
@@ -14,6 +14,7 @@
 #include "operation/displaymodel.h"
 
 #include <DFontSizeManager>
+#include <DIconTheme>
 
 #include <QGuiApplication>
 #include <QVBoxLayout>
@@ -21,6 +22,7 @@
 #include <QKeyEvent>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 const int ComboxWidth = 200;
@@ -121,8 +123,8 @@ void SecondaryScreenDialog::setModel(DisplayModel *model, Monitor *monitor)
             slider->setRange(miniScale, int(BrightnessMaxScale));
             slider->setType(DCCSlider::Vernier);
             slider->setTickPosition(QSlider::TicksBelow);
-            slider->setLeftIcon(QIcon::fromTheme("dcc_brightnesslow"));
-            slider->setRightIcon(QIcon::fromTheme("dcc_brightnesshigh"));
+            slider->setLeftIcon(DIconTheme::findQIcon("dcc_brightnesslow"));
+            slider->setRightIcon(DIconTheme::findQIcon("dcc_brightnesshigh"));
             slider->setIconSize(QSize(24, 24));
             slider->setTickInterval(int((BrightnessMaxScale - miniScale) / 5.0));
             slider->setValue(int(brightness * BrightnessMaxScale));
@@ -169,8 +171,8 @@ void SecondaryScreenDialog::setModel(DisplayModel *model, Monitor *monitor)
             slider->setRange(m_miniScales, maxBacklight);
             slider->setType(DCCSlider::Vernier);
             slider->setTickPosition(QSlider::TicksBelow);
-            slider->setLeftIcon(QIcon::fromTheme("dcc_brightnesslow"));
-            slider->setRightIcon(QIcon::fromTheme("dcc_brightnesshigh"));
+            slider->setLeftIcon(DIconTheme::findQIcon("dcc_brightnesslow"));
+            slider->setRightIcon(DIconTheme::findQIcon("dcc_brightnesshigh"));
             slider->setIconSize(QSize(24, 24));
             slider->setTickInterval(1);
             slider->setValue(int((brightness + DoubleZero) * maxBacklight));

--- a/src/plugin-display/window/timeoutdialog.cpp
+++ b/src/plugin-display/window/timeoutdialog.cpp
@@ -4,6 +4,8 @@
 
 
 #include "timeoutdialog.h"
+#include <DIconTheme>
+DGUI_USE_NAMESPACE
 
 TimeoutDialog::TimeoutDialog(const int timeout, QString messageModel, QWidget *parent)
     : DDialog(parent)
@@ -18,7 +20,7 @@ TimeoutDialog::TimeoutDialog(const int timeout, QString messageModel, QWidget *p
         m_messageModel = tr("Settings will be reverted in %1s.");
     }
     setMessage(m_messageModel.arg(m_timeout));
-    setIcon(QIcon::fromTheme("preferences-system"));
+    setIcon(DIconTheme::findQIcon("preferences-system"));
 
     addButton(tr("Revert"), true, DDialog::ButtonRecommend);
     addButton(tr("Save"));

--- a/src/plugin-keyboard/window/keyboardmodule.cpp
+++ b/src/plugin-keyboard/window/keyboardmodule.cpp
@@ -21,10 +21,12 @@
 #include "interface/pagemodule.h"
 
 #include <DFloatingButton>
+#include <DIconTheme>
 
 #include <QApplication>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 class KeyboardFloatingButton : public DFloatingButton
@@ -45,7 +47,7 @@ ModuleObject *KeyboardPlugin::module()
     KeyboardModule *moduleInterface = new KeyboardModule();
     moduleInterface->setName("keyboard");
     moduleInterface->setDisplayName(tr("Keyboard and Language"));
-    moduleInterface->setIcon(QIcon::fromTheme("dcc_nav_keyboard"));
+    moduleInterface->setIcon(DIconTheme::findQIcon("dcc_nav_keyboard"));
 
     //二级菜单--键盘
     ModuleObject *moduleKeyBoard = new PageModule("keyboardGeneral", tr("Keyboard"));

--- a/src/plugin-keyboard/window/shortcutitem.cpp
+++ b/src/plugin-keyboard/window/shortcutitem.cpp
@@ -6,6 +6,7 @@
 #include "keylabel.h"
 
 #include <DStyle>
+#include <DIconTheme>
 
 #include <QLabel>
 #include <QMouseEvent>
@@ -15,6 +16,7 @@
 
 using namespace DCC_NAMESPACE;
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 ShortcutItem::ShortcutItem(QFrame *parent)
     : SettingsItem(parent)
@@ -40,7 +42,7 @@ ShortcutItem::ShortcutItem(QFrame *parent)
     layout->setAlignment(m_title, Qt::AlignLeft);
 
     m_editBtn = new DIconButton(this);
-    m_editBtn->setIcon(QIcon::fromTheme("dcc_edit"));
+    m_editBtn->setIcon(DIconTheme::findQIcon("dcc_edit"));
     m_editBtn->hide();
     m_editBtn->setFixedSize(16, 16);
     m_editBtn->setAccessibleName("EDIT_SHORTCUT_BUTTON");

--- a/src/plugin-mouse/window/mousemodule.cpp
+++ b/src/plugin-mouse/window/mousemodule.cpp
@@ -14,6 +14,8 @@
 
 #include <QDebug>
 #include <QApplication>
+#include <DIconTheme>
+DGUI_USE_NAMESPACE
 
 using namespace DCC_NAMESPACE;
 
@@ -45,7 +47,7 @@ ModuleObject *MousePlugin::module()
     MouseModule *moduleInterface = new MouseModule();
     moduleInterface->setName("mouse");
     moduleInterface->setDisplayName(tr("Mouse"));
-    moduleInterface->setIcon(QIcon::fromTheme("dcc_nav_mouse"));
+    moduleInterface->setIcon(DIconTheme::findQIcon("dcc_nav_mouse"));
 
     //二级菜单--通用
     ModuleObject *moduleGeneral = new PageModule("mouseGeneral", tr("General"));

--- a/src/plugin-notification/window/notificationmodule.cpp
+++ b/src/plugin-notification/window/notificationmodule.cpp
@@ -16,9 +16,11 @@
 #include <QBoxLayout>
 #include <QFile>
 #include <QSvgRenderer>
+#include <DIconTheme>
 
 Q_DECLARE_METATYPE(QMargins)
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 
 QString NotificationPlugin::name() const
 {
@@ -44,7 +46,7 @@ NotificationModule::NotificationModule(QObject *parent)
 {
     setName("notification");
     setDisplayName(tr("Notification"));
-    setIcon(QIcon::fromTheme("dcc_nav_notification"));
+    setIcon(DIconTheme::findQIcon("dcc_nav_notification"));
     if (m_model) {
         delete m_model;
     }
@@ -88,7 +90,7 @@ void NotificationModule::initUi()
 void NotificationModule::onAppListAdded(AppItemModel *item)
 {
     QString softName = item->getAppName();
-    QIcon icon = QIcon::fromTheme(item->getIcon());
+    QIcon icon = DIconTheme::findQIcon(item->getIcon());
     m_appNameList.append(softName);
     PageModule *newpage = new PageModule(softName, softName, icon, nullptr);
     newpage->appendChild(new ItemModule(

--- a/src/plugin-personalization-dock/window/dockplugin.cpp
+++ b/src/plugin-personalization-dock/window/dockplugin.cpp
@@ -16,6 +16,7 @@
 #include <DListView>
 #include <DStyle>
 #include <DGuiApplicationHelper>
+#include <DIconTheme>
 
 #include <QApplication>
 #include <QScreen>
@@ -27,6 +28,7 @@
 #include <QStyle>
 #include <QCheckBox>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 using namespace DCC_NAMESPACE;
@@ -133,9 +135,9 @@ QIcon DockModuleObject::getIcon(const DockItemInfo &dockItemInfo) const
 
     QIcon icon(pixmap);
     if (icon.isNull())
-        icon = QIcon::fromTheme(pluginIconMap.value(dockItemInfo.name));
+        icon = DIconTheme::findQIcon(pluginIconMap.value(dockItemInfo.name));
     if (icon.isNull())
-        icon = QIcon::fromTheme("dcc_dock_plug_in");
+        icon = DIconTheme::findQIcon("dcc_dock_plug_in");
 
     return icon;
 }

--- a/src/plugin-personalization/window/personalizationdesktopmodule.cpp
+++ b/src/plugin-personalization/window/personalizationdesktopmodule.cpp
@@ -13,11 +13,13 @@
 
 #include <DSwitchButton>
 #include <DSysInfo>
+#include <DIconTheme>
 
 #include <QComboBox>
 
 using namespace DCC_NAMESPACE;
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 PersonalizationDesktopModule::PersonalizationDesktopModule(PersonalizationModel *model,
@@ -89,8 +91,8 @@ QWidget *PersonalizationDesktopModule::initTransparentEffect(ModuleObject *modul
     transparentSlider->setObjectName("Transparency");
 
     // 设计效果图变更：增加左右图标
-    transparentSlider->setLeftIcon(QIcon::fromTheme("transparency_low"));
-    transparentSlider->setRightIcon(QIcon::fromTheme("transparency_high"));
+    transparentSlider->setLeftIcon(DIconTheme::findQIcon("transparency_low"));
+    transparentSlider->setRightIcon(DIconTheme::findQIcon("transparency_high"));
     transparentSlider->setIconSize(QSize(24, 24));
     DCCSlider *slider = transparentSlider->slider();
     slider->setAccessibleName("transparency");
@@ -145,8 +147,8 @@ QWidget *PersonalizationDesktopModule::initRoundEffect(ModuleObject *module)
     winRoundSlider->slider()->setOrientation(Qt::Horizontal);
     winRoundSlider->setObjectName("winRoundSlider");
     winRoundSlider->setIconSize(QSize(32, 32));
-    winRoundSlider->setLeftIcon(QIcon::fromTheme("round_low"));
-    winRoundSlider->setRightIcon(QIcon::fromTheme("round_high"));
+    winRoundSlider->setLeftIcon(DIconTheme::findQIcon("round_low"));
+    winRoundSlider->setRightIcon(DIconTheme::findQIcon("round_high"));
 
     DCCSlider *sliderRound = winRoundSlider->slider();
     sliderRound->setType(DCCSlider::Vernier);

--- a/src/plugin-personalization/window/personalizationplugin.cpp
+++ b/src/plugin-personalization/window/personalizationplugin.cpp
@@ -9,7 +9,9 @@
 #include "personalizationdesktopmodule.h"
 
 #include <QLabel>
+#include <DIconTheme>
 
+DGUI_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
 const QString gsetting_showSuspend = "showSuspend";
@@ -17,7 +19,7 @@ const QString gsetting_showHiberante = "showHibernate";
 const QString gsetting_showShutdown = "showShutdown";
 
 PersonalizationModule::PersonalizationModule(QObject *parent)
-    : HListModule("personalization", tr("Personalization"), QIcon::fromTheme("dcc_nav_personalization"), parent)
+    : HListModule("personalization", tr("Personalization"), DIconTheme::findQIcon("dcc_nav_personalization"), parent)
     , m_model(nullptr)
     , m_nBatteryPercentage(100.0)
     , m_useElectric(nullptr)

--- a/src/plugin-personalization/window/personalizationthememodule.cpp
+++ b/src/plugin-personalization/window/personalizationthememodule.cpp
@@ -19,6 +19,7 @@
 #include <DGuiApplicationHelper>
 #include <DLabel>
 #include <DStyle>
+#include <DIconTheme>
 
 #include <QCheckBox>
 #include <QColorDialog>
@@ -31,6 +32,7 @@
 #include <QToolButton>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
@@ -239,7 +241,7 @@ QWidget *PersonalizationThemeModule::initThemeTitle(ModuleObject *module)
     layout->addWidget(leftWidget);
 
     //    QToolButton *button = new QToolButton();
-    //    button->setIcon(QIcon::fromTheme("help"));
+    //    button->setIcon(DIconTheme::findQIcon("help"));
     //    button->setFixedSize(24, 24);
     //    layout->addWidget(button);
     //    layout->addStretch();
@@ -456,8 +458,8 @@ QWidget *PersonalizationThemeModule::initFontSize(ModuleObject *module)
               << "20";
     fontSizeSlider->setAnnotations(annotions);
     fontSizeSlider->setIconSize(QSize(24, 24));
-    fontSizeSlider->setLeftIcon(QIcon::fromTheme("fontsize_decrease"));
-    fontSizeSlider->setRightIcon(QIcon::fromTheme("fontsize_increase"));
+    fontSizeSlider->setLeftIcon(DIconTheme::findQIcon("fontsize_decrease"));
+    fontSizeSlider->setRightIcon(DIconTheme::findQIcon("fontsize_increase"));
 
     DCCSlider *slider = fontSizeSlider->slider();
     slider->setOrientation(Qt::Horizontal);

--- a/src/plugin-power/window/generalmodule.cpp
+++ b/src/plugin-power/window/generalmodule.cpp
@@ -16,16 +16,18 @@
 #include <DComboBox>
 #include <DListView>
 #include <DSwitchButton>
+#include <DIconTheme>
 
 #define BALANCE "balance"         // 平衡模式
 #define PERFORMANCE "performance" // 高性能模式
 #define POWERSAVE "powersave"     // 节能模式
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 GeneralModule::GeneralModule(PowerModel *model, PowerWorker *work, QObject *parent)
-    : PageModule("general", tr("General"), QIcon::fromTheme("dcc_general_purpose"), parent)
+    : PageModule("general", tr("General"), DIconTheme::findQIcon("dcc_general_purpose"), parent)
     , m_model(model)
     , m_work(work)
 {

--- a/src/plugin-power/window/powerplugin.cpp
+++ b/src/plugin-power/window/powerplugin.cpp
@@ -11,15 +11,17 @@
 #include "utils.h"
 
 #include <QLabel>
+#include <DIconTheme>
 
 using namespace DCC_NAMESPACE;
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 const QString gsetting_showSuspend = "showSuspend";
 const QString gsetting_showHiberante = "showHibernate";
 const QString gsetting_showShutdown = "showShutdown";
 
 PowerModule::PowerModule(QObject *parent)
-    : HListModule("power", tr("Power"), QIcon::fromTheme("dcc_nav_power"), parent)
+    : HListModule("power", tr("Power"), DIconTheme::findQIcon("dcc_nav_power"), parent)
     , m_model(nullptr)
     , m_nBatteryPercentage(100.0)
     , m_useElectric(nullptr)

--- a/src/plugin-power/window/usebatterymodule.cpp
+++ b/src/plugin-power/window/usebatterymodule.cpp
@@ -15,17 +15,19 @@
 #include "widgets/dccslider.h"
 
 #include <DConfig>
+#include <DIconTheme>
 
 #include <QLayout>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
 const static QMap<int, int> g_sldLowBatteryMap = { { 0, 10 }, { 1, 15 }, { 2, 20 }, { 3, 25 } };
 
 UseBatteryModule::UseBatteryModule(PowerModel *model, PowerWorker *work, QObject *parent)
-    : PageModule("onBattery", tr("On Battery"), tr("On Battery"), QIcon::fromTheme("dcc_battery"), parent)
+    : PageModule("onBattery", tr("On Battery"), tr("On Battery"), DIconTheme::findQIcon("dcc_battery"), parent)
     , m_model(model)
     , m_work(work)
     , m_annos({ "1m", "5m", "10m", "15m", "30m", "1h", tr("Never") })

--- a/src/plugin-power/window/useelectricmodule.cpp
+++ b/src/plugin-power/window/useelectricmodule.cpp
@@ -13,13 +13,15 @@
 #include "itemmodule.h"
 
 #include <DComboBox>
+#include <DIconTheme>
 
 using namespace DCC_NAMESPACE;
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
 UseElectricModule::UseElectricModule(PowerModel *model, PowerWorker *work, QObject *parent)
-    : PageModule("pluggedIn", tr("Plugged In"), QIcon::fromTheme("dcc_using_electric"), parent)
+    : PageModule("pluggedIn", tr("Plugged In"), DIconTheme::findQIcon("dcc_using_electric"), parent)
     , m_model(model)
     , m_work(work)
 {

--- a/src/plugin-privacy/operation/privacyplugin.cpp
+++ b/src/plugin-privacy/operation/privacyplugin.cpp
@@ -16,7 +16,7 @@
 using namespace DCC_NAMESPACE;
 
 PrivacyModule::PrivacyModule(QObject *parent)
-    : VListModule("privacyAndSecurity", tr("Privacy and Security"), tr("Privacy and Security"), QIcon::fromTheme("dcc_nav_privacy"),parent)
+    : VListModule("privacyAndSecurity", tr("Privacy and Security"), tr("Privacy and Security"), DIconTheme::findQIcon("dcc_nav_privacy"),parent)
     , m_model(new PrivacySecurityModel(this))
     , m_work(new PrivacySecurityWorker(m_model, this))
 {

--- a/src/plugin-privacy/window/servicesettingsmodule.cpp
+++ b/src/plugin-privacy/window/servicesettingsmodule.cpp
@@ -64,7 +64,7 @@ void ServiceSettingsModule::initSwitchWidget(DCC_NAMESPACE::SwitchWidget *titleS
 {
     QPixmap pixmap;
     QSize size(42,42);
-    QIcon icon = QIcon::fromTheme(m_currentServiceDate.icon);
+    QIcon icon = DIconTheme::findQIcon(m_currentServiceDate.icon);
     pixmap = icon.pixmap(size);
     titleSwitch->setTitle(m_currentServiceDate.name);
     QLabel *iconLabel = new QLabel;
@@ -117,7 +117,7 @@ void ServiceSettingsModule::initListView(Dtk::Widget::DListView *settingsGrp)
 
             // 图标
             auto leftAction = new DViewItemAction(Qt::AlignVCenter, size, size, true);
-            leftAction->setIcon(QIcon::fromTheme("application-x-desktop"));
+            leftAction->setIcon(DIconTheme::findQIcon("application-x-desktop"));
             item->setActionList(Qt::Edge::LeftEdge, {leftAction});
 
             auto rightAction = new DViewItemAction(Qt::AlignVCenter, size, size, true);

--- a/src/plugin-sound/window/microphonepage.cpp
+++ b/src/plugin-sound/window/microphonepage.cpp
@@ -17,6 +17,7 @@
 #include <DGuiApplicationHelper>
 #include <DApplication>
 #include <QDBusPendingReply>
+#include <DIconTheme>
 
 #include <QHBoxLayout>
 #include <QVBoxLayout>
@@ -30,6 +31,7 @@
 #include <QDBusInterface>
 #include <sounddbusproxy.h>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
@@ -311,8 +313,8 @@ void MicrophonePage::initSlider()
     slider2->setEnabled(false);
     slider2->setType(DCCSlider::Vernier);
     slider2->setTickPosition(QSlider::NoTicks);
-    slider2->setLeftIcon(QIcon::fromTheme("dcc_feedbacklow"));
-    slider2->setRightIcon(QIcon::fromTheme("dcc_feedbackhigh"));
+    slider2->setLeftIcon(DIconTheme::findQIcon("dcc_feedbacklow"));
+    slider2->setRightIcon(DIconTheme::findQIcon("dcc_feedbackhigh"));
     slider2->setIconSize(QSize(24, 24));
     slider2->setTickInterval(1);
     slider2->setPageStep(1);

--- a/src/plugin-sound/window/soundeffectspage.cpp
+++ b/src/plugin-sound/window/soundeffectspage.cpp
@@ -10,6 +10,7 @@
 
 #include <DIconButton>
 #include <DListView>
+#include <DIconTheme>
 
 #include <QLabel>
 #include <QListView>
@@ -21,6 +22,7 @@
 #include <QVBoxLayout>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 const int AnimationDuration = 5000;
@@ -113,7 +115,7 @@ void SoundEffectsPage::startPlay(const QModelIndex &index)
     aniAction->setVisible(true);
     connect(m_aniTimer, &QTimer::timeout, this, [=] {
         auto aniIdx = (m_aniDuration / intervalal) % 3 + 1;
-        auto icon = QIcon::fromTheme("dcc_volume" + QString::number(aniIdx));
+        auto icon = DIconTheme::findQIcon("dcc_volume" + QString::number(aniIdx));
         aniAction->setIcon(icon);
 
         m_aniDuration += intervalal;

--- a/src/plugin-sound/window/soundplugin.cpp
+++ b/src/plugin-sound/window/soundplugin.cpp
@@ -3,6 +3,8 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include <QApplication>
 #include <DFontSizeManager>
+#include <DIconTheme>
+
 #include "widgets/titlelabel.h"
 #include "interface/pagemodule.h"
 #include "soundplugin.h"
@@ -13,6 +15,7 @@
 #include "soundeffectspage.h"
 #include "devicemanagespage.h"
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 using namespace DCC_NAMESPACE;
 
@@ -68,7 +71,7 @@ QString SoundPlugin::location() const
 }
 
 SoundModule::SoundModule(QObject *parent)
-    : HListModule("sound", tr("Sound"), QIcon::fromTheme("dcc_nav_sound"), parent)
+    : HListModule("sound", tr("Sound"), DIconTheme::findQIcon("dcc_nav_sound"), parent)
     , m_model(new SoundModel(this))
     , m_work(new SoundWorker(m_model, this))
 {

--- a/src/plugin-systeminfo/window/hostnameitem.cpp
+++ b/src/plugin-systeminfo/window/hostnameitem.cpp
@@ -9,6 +9,7 @@
 
 #include <DDesktopServices>
 #include <DLabel>
+#include <DIconTheme>
 
 #include <QDir>
 #include <QEvent>
@@ -16,6 +17,7 @@
 #include <QToolButton>
 #include <QValidator>
 
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 // if there is lid, it is laptop
@@ -109,14 +111,14 @@ void HostNameItem::initUI()
     hostNameLayout->setSpacing(0);
     hostNameLayout->setMargin(0);
     m_computerLabel->setAlignment(Qt::AlignTop | Qt::AlignHCenter);
-    m_computerLabel->setPixmap(QIcon::fromTheme(m_iconName).pixmap(200, 200));
+    m_computerLabel->setPixmap(DIconTheme::findQIcon(m_iconName).pixmap(200, 200));
 
     hostNameLayout->addWidget(m_computerLabel);
 
     QHBoxLayout *editHostLayout = new QHBoxLayout;
     m_hostNameLabel->setForegroundRole(DPalette::TextTips);
 
-    m_hostNameBtn->setIcon(QIcon::fromTheme("dcc_edit"));
+    m_hostNameBtn->setIcon(DIconTheme::findQIcon("dcc_edit"));
     m_hostNameBtn->setIconSize(QSize(12, 12));
     m_hostNameBtn->setFixedSize(36, 36);
 
@@ -151,7 +153,7 @@ void HostNameItem::initUI()
             &DGuiApplicationHelper::themeTypeChanged,
             this,
             [this] {
-                m_computerLabel->setPixmap(QIcon::fromTheme(m_iconName).pixmap(200, 200));
+                m_computerLabel->setPixmap(DIconTheme::findQIcon(m_iconName).pixmap(200, 200));
             });
 }
 

--- a/src/plugin-systeminfo/window/logoitem.cpp
+++ b/src/plugin-systeminfo/window/logoitem.cpp
@@ -9,6 +9,9 @@
 #include <QImageReader>
 #include <QLabel>
 
+#include <DIconTheme>
+DGUI_USE_NAMESPACE
+
 #define FRAME_WIDTH 408
 #define NAVBAR_WIDTH 56
 
@@ -47,7 +50,7 @@ void LogoItem::setDescription(bool isVisible)
 
 void LogoItem::setLogo(const QString &logo)
 {
-    m_logo->setPixmap(QIcon::fromTheme(logo).pixmap(100, 20));
+    m_logo->setPixmap(DIconTheme::findQIcon(logo).pixmap(100, 20));
 }
 
 const QString LogoItem::logo()

--- a/src/plugin-systeminfo/window/systeminfomodule.cpp
+++ b/src/plugin-systeminfo/window/systeminfomodule.cpp
@@ -29,6 +29,8 @@
 #include <QtConcurrent>
 
 #include <functional>
+#include <DIconTheme>
+DGUI_USE_NAMESPACE
 
 const QString PLATFORM_NAME = std::visit([]() -> QString {
     QString platformname = QGuiApplication::platformName();
@@ -102,21 +104,21 @@ void SystemInfoModule::initChildModule()
     moduleAboutPc->appendChild(copyrightBottom);
 
     // 二级菜单--协议与隐私政策
-    ModuleObject *moduleAgreement = new VListModule("agreement", tr("Agreements and Privacy Policy"), QIcon::fromTheme("dcc_version"), this);
+    ModuleObject *moduleAgreement = new VListModule("agreement", tr("Agreements and Privacy Policy"), DIconTheme::findQIcon("dcc_version"), this);
 
     // 三级菜单--协议与隐私政策-版本协议
-    ModuleObject *moduleEdition = new PageModule("editionLicense", tr("Edition License"), QIcon::fromTheme("dcc_version"), moduleAgreement);
+    ModuleObject *moduleEdition = new PageModule("editionLicense", tr("Edition License"), DIconTheme::findQIcon("dcc_version"), moduleAgreement);
     moduleEdition->appendChild(new WidgetModule<VersionProtocolWidget>("editionLicense", tr("Edition License"), this, &SystemInfoModule::initGnuLicenseModule));
     moduleAgreement->appendChild(moduleEdition);
     if (auto licensepath = DCC_LICENSE::isEndUserAgreementExist(); licensepath.exist) {
         m_model->setEndUserAgreementPath(licensepath.path);
         // 三级菜单--协议与隐私政策-最终用户许可协议
-        ModuleObject *moduleUserAgreement = new PageModule("endUserLicenseAgreement", tr("End User License Agreement"), QIcon::fromTheme("dcc_protocol"), moduleAgreement);
+        ModuleObject *moduleUserAgreement = new PageModule("endUserLicenseAgreement", tr("End User License Agreement"), DIconTheme::findQIcon("dcc_protocol"), moduleAgreement);
         moduleUserAgreement->appendChild(new WidgetModule<UserLicenseWidget>("endUserLicenseAgreement", tr("End User License Agreement"), this, &SystemInfoModule::initUserLicenseModule));
         moduleAgreement->appendChild(moduleUserAgreement);
     }
     // 三级菜单--协议与隐私政策-隐私政策
-    ModuleObject *modulePolicy = new PageModule("privacyPolicy", tr("Privacy Policy"), QIcon::fromTheme("dcc_privacy_policy"), moduleAgreement);
+    ModuleObject *modulePolicy = new PageModule("privacyPolicy", tr("Privacy Policy"), DIconTheme::findQIcon("dcc_privacy_policy"), moduleAgreement);
     modulePolicy->appendChild(new WidgetModule<PrivacyPolicyWidget>());
     moduleAgreement->appendChild(modulePolicy);
 
@@ -313,7 +315,7 @@ ModuleObject *SystemInfoPlugin::module()
     SystemInfoModule *moduleInterface = new SystemInfoModule();
     moduleInterface->setName("systeminfo");
     moduleInterface->setDisplayName(tr("System Info"));
-    moduleInterface->setIcon(QIcon::fromTheme("dcc_nav_systeminfo"));
+    moduleInterface->setIcon(DIconTheme::findQIcon("dcc_nav_systeminfo"));
 
     return moduleInterface;
 }

--- a/src/plugin-touchscreen/window/touchscreenmodule.cpp
+++ b/src/plugin-touchscreen/window/touchscreenmodule.cpp
@@ -9,15 +9,17 @@
 #include "buttontuple.h"
 
 #include <DPushButton>
+#include <DIconTheme>
 
 #include <QComboBox>
 #include <QPushButton>
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 TouchScreenModule::TouchScreenModule(QObject *parent)
-    : PageModule("touchscreen", tr("Touch Screen"), tr("Touch Screen"), QIcon::fromTheme("dcc_nav_touchscreen"), parent)
+    : PageModule("touchscreen", tr("Touch Screen"), tr("Touch Screen"), DIconTheme::findQIcon("dcc_nav_touchscreen"), parent)
 {
     m_model  = new TouchScreenModel(this);
     init();

--- a/src/plugin-update/window/updateplugin.cpp
+++ b/src/plugin-update/window/updateplugin.cpp
@@ -14,12 +14,14 @@
 #include "widgets/switchwidget.h"
 
 #include <DFontSizeManager>
+#include <DIconTheme>
 
 #include <QLoggingCategory>
 
 Q_LOGGING_CATEGORY(DdcUpdatePlugin, "dcc-update-plugin")
 
 using namespace DCC_NAMESPACE;
+DGUI_USE_NAMESPACE
 DWIDGET_USE_NAMESPACE
 
 QString UpdatePlugin::name() const
@@ -54,7 +56,7 @@ QString UpdatePlugin::location() const
 }
 
 UpdateModule::UpdateModule(QObject *parent)
-    : HListModule("update", tr("Updates"), QIcon::fromTheme("dcc_nav_update"), parent)
+    : HListModule("update", tr("Updates"), DIconTheme::findQIcon("dcc_nav_update"), parent)
     , m_model(new UpdateModel(this))
     , m_work(new UpdateWorker(m_model, this))
 {

--- a/src/plugin-update/window/widgets/loadingitem.cpp
+++ b/src/plugin-update/window/widgets/loadingitem.cpp
@@ -8,7 +8,9 @@
 #include <QIcon>
 #include <QPainter>
 #include <DSysInfo>
+#include <DIconTheme>
 
+DGUI_USE_NAMESPACE
 DCORE_USE_NAMESPACE
 
 LoadingItem::LoadingItem(QFrame *parent)
@@ -91,7 +93,7 @@ void LoadingItem::setImageOrTextVisible(bool state)
 
     QString path = "";
     if (state) {
-        m_labelImage->setPixmap(QIcon::fromTheme("icon_success").pixmap({128, 128}));
+        m_labelImage->setPixmap(DIconTheme::findQIcon("icon_success").pixmap({128, 128}));
     } else {
         m_labelImage->setPixmap(QIcon(":/icons/deepin/builtin/icons/dcc_checking_update.svg").pixmap({128, 128}));
     }

--- a/src/plugin-update/window/widgets/updatecontrolpanel.cpp
+++ b/src/plugin-update/window/widgets/updatecontrolpanel.cpp
@@ -11,10 +11,13 @@
 #include <DProgressBar>
 #include <DSysInfo>
 #include <DFontSizeManager>
+#include <DIconTheme>
+
 #include <QVBoxLayout>
 
 using namespace DCC_NAMESPACE;
 DWIDGET_USE_NAMESPACE
+    DGUI_USE_NAMESPACE
 
 updateControlPanel::updateControlPanel(QWidget *parent)
     : SettingsItem(parent)
@@ -82,13 +85,13 @@ void updateControlPanel::setButtonIcon(ButtonStatus status)
 {
     switch (status) {
     case ButtonStatus::start:
-        m_startButton->setIcon(QIcon::fromTheme("dcc_start"));
+        m_startButton->setIcon(DIconTheme::findQIcon("dcc_start"));
         break;
     case ButtonStatus::pause:
-        m_startButton->setIcon(QIcon::fromTheme("dcc_pause"));
+        m_startButton->setIcon(DIconTheme::findQIcon("dcc_pause"));
         break;
     case ButtonStatus::retry:
-        m_startButton->setIcon(QIcon::fromTheme("dcc_retry"));
+        m_startButton->setIcon(DIconTheme::findQIcon("dcc_retry"));
         break;
     default:
         m_startButton->setIcon(static_cast<QStyle::StandardPixmap>(-1));
@@ -301,7 +304,7 @@ void updateControlPanel::initUi()
     buttonLay->addWidget(m_updateButton, 0, Qt::AlignRight | Qt::AlignTop);
     buttonLay->setContentsMargins(0, 0, 8, 0);
 
-    m_startButton->setIcon(QIcon::fromTheme("dcc_start"));
+    m_startButton->setIcon(DIconTheme::findQIcon("dcc_start"));
     m_startButton->setIconSize(QSize(32, 32));
     m_startButton->setFlat(true);//设置背景透明
     m_startButton->setFixedSize(32, 32);

--- a/src/plugin-wacom/window/wacommodule.cpp
+++ b/src/plugin-wacom/window/wacommodule.cpp
@@ -11,6 +11,7 @@
 #include "widgets/dccslider.h"
 
 #include <DSlider>
+#include <DIconTheme>
 
 #include <QComboBox>
 #include <QLoggingCategory>
@@ -20,9 +21,10 @@ Q_LOGGING_CATEGORY(DdcWacomModule, "dcc-wacom-module")
 
 using namespace DCC_NAMESPACE;
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 WacomModule::WacomModule(QObject *parent)
-    : PageModule("wacom", tr("Drawing Tablet") , tr("Drawing Tablet"), QIcon::fromTheme("dcc_nav_wacom"), parent)
+    : PageModule("wacom", tr("Drawing Tablet") , tr("Drawing Tablet"), DIconTheme::findQIcon("dcc_nav_wacom"), parent)
     , m_model(new WacomModel(this))
 {
     connect(m_model, &WacomModel::ExistChanged, this, [this](bool exist){

--- a/src/widgets/moduleobjectitem.cpp
+++ b/src/widgets/moduleobjectitem.cpp
@@ -5,6 +5,7 @@
 
 #include <DStyleOption>
 #include <DStyledItemDelegate>
+#include <DIconTheme>
 
 #include <QApplication>
 
@@ -14,6 +15,7 @@
 
 using namespace DCC_NAMESPACE;
 DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 namespace DCC_NAMESPACE {
 class ModuleObjectItemPrivate
@@ -102,7 +104,7 @@ void ModuleObjectItem::setRightIcon(DStyle::StandardPixmap st, int index)
 
 void ModuleObjectItem::setRightIcon(const QString &icon, int index)
 {
-    QIcon ico = QIcon::fromTheme(icon);
+    QIcon ico = DIconTheme::findQIcon(icon);
     if (ico.isNull())
         ico = QIcon(icon);
 


### PR DESCRIPTION
Find QIcon from name without relying on platform(theme) plugins, e.g dde-qt5integration dde-qt5xcb-plugin.

Replacing QIcon::fromTheme.

Issue: https://github.com/linuxdeepin/developer-center/issues/4112