### PR TITLE
fix: can not change boot entry when current boot entry is not in the boot list

### DIFF
--- a/src/plugin-commoninfo/window/bootwidget.cpp
+++ b/src/plugin-commoninfo/window/bootwidget.cpp
@@ -281,8 +281,7 @@ void BootWidget::onCurrentItem(const QModelIndex &curIndex)
 
     // 获取当前被选项
     QString selectedText = m_curSelectedIndex.data().toString();
-    if (selectedText.isEmpty())
-        return;
+    // NOTE: If the type of current selected boot entry is submenu whitch is not shown in current boot list, do not care, and do the set action
     if (curText != selectedText) {
         Q_EMIT defaultEntry(curText);
     }


### PR DESCRIPTION
移除了："判断当前默认启动项是否在启动列表中，如果不在则直接返回" 的代码
Issue: https://github.com/linuxdeepin/developer-center/issues/5863
Log: 修复当前默认启动项不在控制中心-通用-启动菜单列表中时，无法通过点击修改默认启动项的问题