### PR TITLE
chore: 规范港澳台地区名称

### DIFF
--- a/translations/datetime_country_zh_CN.ts
+++ b/translations/datetime_country_zh_CN.ts
@@ -831,7 +831,7 @@
     </message>
     <message>
         <source>Hong Kong</source>
-        <translation>香港</translation>
+        <translation>中国香港</translation>
     </message>
     <message>
         <source>Japan</source>
@@ -855,11 +855,11 @@
     </message>
     <message>
         <source>Macao</source>
-        <translation>澳门</translation>
+        <translation>中国澳门</translation>
     </message>
     <message>
         <source>Taiwan</source>
-        <translation>台湾</translation>
+        <translation>中国台湾</translation>
     </message>
     <message>
         <source>Afghanistan</source>


### PR DESCRIPTION
香港 -> 中国香港， 澳门 -> 中国澳门， 台湾 -> 中国台湾
Issue: https://github.com/linuxdeepin/developer-center/issues/5997
Log: 规范港澳台地区名称