### PR TITLE
fix: crash when setting default application

### DIFF
--- a/src/plugin-defaultapp/operation/defappworker.cpp
+++ b/src/plugin-defaultapp/operation/defappworker.cpp
@@ -231,7 +231,7 @@ void DefAppWorker::getDefaultAppFinished(const QString &mimeKey, const QString &
         return app.Id == id;
     });
 
-    if (it != items.end()) {
+    if (it != items.cend()) {
         category->setDefault(*it);
         category->setCategory(mimeKey);
     }


### PR DESCRIPTION
Finding result should be compared to cend to see if successful. Or
it would be a invalid iterator.

Log: fix crash when setting default application
