### PR TITLE
fix: mainwindow lost focus when switch module

### DIFF
--- a/src/plugin-accounts/window/accountsmodule.cpp
+++ b/src/plugin-accounts/window/accountsmodule.cpp
@@ -60,7 +60,7 @@ QString AccountsPlugin::name() const
 
 ModuleObject *AccountsPlugin::module()
 {
-    return new AccountsModule();
+    return new AccountsModule(this);
 }
 
 QString AccountsPlugin::location() const
@@ -219,10 +219,25 @@ bool AccountsModule::isSystemAdmin(User *user)
     return user->userType() == User::UserType::Administrator;
 }
 
+static QWidget *findAncestorWidget(const QObject *obj)
+{
+    while (obj) {
+        if (QWidget *w = qobject_cast<QWidget *>(obj->parent()))
+            return w;
+        obj = obj->parent();
+    }
+
+    return nullptr;
+}
+
 QWidget *AccountsModule::initAccountsList(ModuleObject *module)
 {
     Q_UNUSED(module)
-    AccountsListView *userlistView = new AccountsListView();
+
+    QWidget *pw = findAncestorWidget(this);
+    AccountsListView *userlistView = new AccountsListView(pw);
+    userlistView->parentWidget();
+
     userlistView->setMaximumHeight(90);
     userlistView->setFrameShape(QFrame::NoFrame);
     QPalette pa = userlistView->palette();
@@ -267,7 +282,6 @@ QWidget *AccountsModule::initCreateAccount(ModuleObject *module)
     createBtn->setFixedSize(50, 50);
     createBtn->setToolTip(tr("Create User"));
     createBtn->setAccessibleName(tr("Create User"));
-    createBtn->setVisible(true);
     connect(createBtn, &QPushButton::clicked, this, &AccountsModule::onCreateAccount);
     return createBtn;
 }

--- a/src/plugin-update/window/widgets/updatecontrolpanel.cpp
+++ b/src/plugin-update/window/widgets/updatecontrolpanel.cpp
@@ -29,7 +29,7 @@ updateControlPanel::updateControlPanel(QWidget *parent)
     , m_updateButton(new DCommandLinkButton("", this))
     , m_showMoreBUtton(new DCommandLinkButton("", this))
     , m_startButton(new DIconButton(this))
-    , m_Progess(new DProgressBar)
+    , m_Progess(new DProgressBar(this))
     , m_buttonStatus(ButtonStatus::invalid)
     , m_progressType(UpdateDProgressType::InvalidType)
     , m_currentValue(0)
@@ -315,7 +315,6 @@ void updateControlPanel::initUi()
     m_Progess->setRange(0, 100);
     m_Progess->setAlignment(Qt::AlignRight);
     m_Progess->setFixedWidth(100);
-    m_Progess->setVisible(true);
 
     m_progressLabel->setVisible(false);
     DFontSizeManager::instance()->bind(m_progressLabel, DFontSizeManager::T10);


### PR DESCRIPTION
plugin create widget without parent and show will take focus

Issue: https://github.com/linuxdeepin/developer-center/issues/5693