### PR TITLE
fix: red point/badge not clear

### DIFF
--- a/src/frame/mainmodule.cpp
+++ b/src/frame/mainmodule.cpp
@@ -174,6 +174,12 @@ public:
                          });
         m_view = createListView(parentWidget);
         m_sidebarWidget = createListView(parentWidget, true);
+        QObject::connect(q, &MainModule::moduleDataChanged, q, [this, q](){
+            if (auto model = dynamic_cast<ModuleDataModel*>(m_sidebarWidget->model())) {
+                auto index = model->index(q->currentModule());
+                model->dataChanged(index, index);
+            }
+        });
 #ifdef USE_SIDEBAR
         m_mainWindow->setSidebarWidget(m_sidebarWidget);
 #endif

--- a/src/interface/moduledatamodel.cpp
+++ b/src/interface/moduledatamodel.cpp
@@ -157,6 +157,12 @@ void ModuleDataModel::setModuleObject(ModuleObject *const module)
                 Q_UNUSED(state)
                 onDataChanged(tmpChild);
             });
+    // emit moduleDataChanged if module data changed(e.g. setBadge)
+    connect(m_parentObject, &ModuleObject::moduleDataChanged, this, [this]() {
+        if (auto mainModule = dynamic_cast<ModuleObject *>(m_parentObject->parent())) {
+            mainModule->moduleDataChanged();
+        }
+    });
 }
 
 QModelIndex ModuleDataModel::index(ModuleObject *module) const

--- a/src/plugin-update/operation/updatework.cpp
+++ b/src/plugin-update/operation/updatework.cpp
@@ -1458,6 +1458,8 @@ void UpdateWorker::onClassityInstallStatusChanged(const ClassifyUpdateType type,
         cleanLastoreJob(job);
     } else if (value == "succeed") {
         m_model->setClassifyUpdateTypeStatus(type, UpdatesStatus::UpdateSucceeded);
+        // update updateState ==> setBadge(false)
+        m_model->isUpdatablePackages(false);
     } else if (value == "end") {
         if (checkUpdateSuccessed()) {
             m_model->setStatus(UpdatesStatus::UpdateSucceeded);


### PR DESCRIPTION
update state when we got succeed status
moduleDataChanged ==> dataChanged ==> update(index)

Issue: https://github.com/linuxdeepin/developer-center/issues/5795