### PR TITLE
fix: atom upgrade status should not store

### DIFF
--- a/src/plugin-update/operation/updatedbusproxy.cpp
+++ b/src/plugin-update/operation/updatedbusproxy.cpp
@@ -292,7 +292,7 @@ void UpdateDBusProxy::commit(const QString &commitDate)
     m_atomicUpgradeInter->asyncCallWithArgumentList(QStringLiteral("Commit"), argumentList);
 }
 
-bool UpdateDBusProxy::running()
+bool UpdateDBusProxy::atomBackupIsRunning()
 {
     return qvariant_cast<bool>(m_atomicUpgradeInter->property("HasAmbientLightSensor"));
 }

--- a/src/plugin-update/operation/updatedbusproxy.h
+++ b/src/plugin-update/operation/updatedbusproxy.h
@@ -86,8 +86,8 @@ public:
 
     // Atomic Upgrade
     void commit(const QString &commitDate);
-    Q_PROPERTY(bool Running READ running NOTIFY RunningChanged)
-    bool running();
+
+    bool atomBackupIsRunning();
 
 signals:
     // updater

--- a/src/plugin-update/operation/updatemodel.cpp
+++ b/src/plugin-update/operation/updatemodel.cpp
@@ -58,7 +58,6 @@ UpdateModel::UpdateModel(QObject *parent)
     , m_autoCheckUpdateCircle(0)
     , m_isUpdatablePackages(false)
     , m_testingChannelStatus(TestingChannelStatus::DeActive)
-    , m_atomicBackingUp(false)
     , m_linglongAutoUpdateActived(false)
 {
 
@@ -616,16 +615,6 @@ int32_t UpdateModel::submissionType()
 QString UpdateModel::UUID()
 {
     return "02eb924f-4f35-4880-b839-096c3a65f525";
-}
-
-void UpdateModel::setAtomicBackingUp(bool atomicBackingUp)
-{
-    if (m_atomicBackingUp == atomicBackingUp)
-        return;
-
-    m_atomicBackingUp = atomicBackingUp;
-
-    Q_EMIT atomicBackingUpChanged(atomicBackingUp);
 }
 
 QString UpdateModel::utcDateTime2LocalDate(const QString &utcDateTime)

--- a/src/plugin-update/operation/updatemodel.h
+++ b/src/plugin-update/operation/updatemodel.h
@@ -212,10 +212,6 @@ public:
     int32_t submissionType();
     QString UUID();
 
-    inline bool atomicBackingUp() const { return m_atomicBackingUp; }
-
-    void setAtomicBackingUp(bool atomicBackingUp);
-
     QString utcDateTime2LocalDate(const QString &utcDateTime);
     // Testing Channel
     TestingChannelStatus getTestingChannelStatus() const;
@@ -270,8 +266,6 @@ Q_SIGNALS:
     void updateNotifyChanged(const bool notify);
     void updatablePackagesChanged(const bool isUpdatablePackages);
 
-    // Atomic Upgrade
-    void atomicBackingUpChanged(const bool atomicBackingUp);
     // Testing Channel
     void TestingChannelStatusChanged(const TestingChannelStatus &status);
 
@@ -327,7 +321,6 @@ private:
 
     TestingChannelStatus m_testingChannelStatus;
 
-    bool m_atomicBackingUp;
     bool m_linglongAutoUpdateActived;
 };
 

--- a/src/plugin-update/operation/updatework.cpp
+++ b/src/plugin-update/operation/updatework.cpp
@@ -171,8 +171,6 @@ void UpdateWorker::init()
         QMap<QString, QStringList> updatablePackages = m_updateInter->classifiedUpdatablePackages();
         checkUpdatablePackages(updatablePackages);
     });
-    connect(m_updateInter, &UpdateDBusProxy::RunningChanged,
-            m_model, &UpdateModel::setAtomicBackingUp);
 
     connect(m_updateInter, &UpdateDBusProxy::ClassifiedUpdatablePackagesChanged,
             this, &UpdateWorker::onClassifiedUpdatablePackagesChanged);
@@ -251,7 +249,6 @@ void UpdateWorker::activate()
     m_model->setAutoCheckUpdates(m_updateInter->autoCheckUpdates());
     m_model->setUpdateMode(m_updateInter->updateMode());
     m_model->setUpdateNotify(m_updateInter->updateNotify());
-    m_model->setAtomicBackingUp(m_updateInter->running());
 
     setOnBattery(m_updateInter->onBattery());
     setBatteryPercentage(m_updateInter->batteryPercentage());
@@ -709,7 +706,7 @@ void UpdateWorker::distUpgrade(ClassifyUpdateType updateType)
                            << " == start Atomic Upgrade == ";
     // 条件不足 1. 分区空间 就是 state = -2    2.  分区格式不支持仓库存储（忽略） 3.
     // 第二更新后的失败更新
-    if (!m_model->atomicBackingUp()) {
+    if (!m_updateInter->atomBackupIsRunning()) {
         backupToAtomicUpgrade();
     } else {
         // 系统环境配置不满足,则直接跳到下一步下载数据


### PR DESCRIPTION
it will exist when it thought it should, and once upgrade, it will be invoked just once

Issue: https://github.com/linuxdeepin/developer-center/issues/6443 Log: