### PR TITLE
fix: when current text is empty, still can set info

### DIFF
--- a/src/plugin-commoninfo/window/bootwidget.cpp
+++ b/src/plugin-commoninfo/window/bootwidget.cpp
@@ -276,8 +276,6 @@ void BootWidget::setBootList()
 void BootWidget::onCurrentItem(const QModelIndex &curIndex)
 {
     QString curText = curIndex.data().toString();
-    if (curText.isEmpty())
-        return;
 
     // 获取当前被选项
     QString selectedText = m_curSelectedIndex.data().toString();


### PR DESCRIPTION
Issue: https://github.com/develop-center-issues/5863 Log: