### PR TITLE
fix: version info data source not consistent

### DIFF
--- a/src/plugin-update/window/updatectrlwidget.h
+++ b/src/plugin-update/window/updatectrlwidget.h
@@ -50,8 +50,8 @@ public:
     ~UpdateCtrlWidget();
 
     void initConnect();
-    void setModel(UpdateModel *model);
-    void setSystemVersion(const QString &version);
+    void initModel();
+    void updateSystemVersionLabel();
 
     UpdateErrorType updateJobErrorMessage() const;
     void setUpdateJobErrorMessage(const UpdateErrorType &updateJobErrorMessage);
@@ -131,7 +131,7 @@ private:
     QPushButton *m_CheckAgainBtn;
     QLabel *m_lastCheckAgainTimeTip;
 
-    DTK_WIDGET_NAMESPACE::DLabel *m_versrionTip;
+    DTK_WIDGET_NAMESPACE::DLabel *m_versionTip;
 
     DTK_WIDGET_NAMESPACE::DSpinner *m_spinner;
     DTK_WIDGET_NAMESPACE::DLabel *m_updateTipsLab;

--- a/src/plugin-update/window/updateplugin.cpp
+++ b/src/plugin-update/window/updateplugin.cpp
@@ -109,32 +109,12 @@ QWidget *checkUpdateModule::page()
 {
     UpdateWidget *updateWidget = new UpdateWidget;
     updateWidget->setModel(m_model, m_worker);
-    if (m_model->systemActivation() == UiActiveState::Authorized || m_model->systemActivation() == UiActiveState::TrialAuthorized || m_model->systemActivation() == UiActiveState::AuthorizedLapse) {
-        updateWidget->setSystemVersion(m_model->systemVersionInfo());
-    }
     connect(updateWidget, &UpdateWidget::requestLastoreHeartBeat, m_worker, &UpdateWorker::onRequestLastoreHeartBeat);
-
-#ifndef DISABLE_ACTIVATOR
-    if (m_model->systemActivation() == UiActiveState::Authorized || m_model->systemActivation() == UiActiveState::TrialAuthorized || m_model->systemActivation() == UiActiveState::AuthorizedLapse) {
-        updateWidget->setSystemVersion(m_model->systemVersionInfo());
-    }
-#endif
-
-#ifndef DISABLE_ACTIVATOR
-    connect(m_model, &UpdateModel::systemActivationChanged, this, [ = ](UiActiveState systemactivation) {
-        if (systemactivation == UiActiveState::Authorized || systemactivation == UiActiveState::TrialAuthorized || systemactivation == UiActiveState::AuthorizedLapse) {
-            if (updateWidget)
-                updateWidget->setSystemVersion(m_model->systemVersionInfo());
-        }
-    });
-#endif
-
     connect(updateWidget, &UpdateWidget::requestUpdates, m_worker, &UpdateWorker::distUpgrade);
     connect(updateWidget, &UpdateWidget::requestUpdateCtrl, m_worker, &UpdateWorker::OnDownloadJobCtrl);
     connect(updateWidget, &UpdateWidget::requestOpenAppStroe, m_worker, &UpdateWorker::onRequestOpenAppStore);
     connect(updateWidget, &UpdateWidget::requestFixError, m_worker, &UpdateWorker::onFixError);
     updateWidget->displayUpdateContent(UpdateWidget::UpdateType::UpdateCheck);
-
     return updateWidget;
 }
 

--- a/src/plugin-update/window/updatewidget.h
+++ b/src/plugin-update/window/updatewidget.h
@@ -43,7 +43,7 @@ public:
     ~UpdateWidget();
 
     void setModel(const UpdateModel *model, const UpdateWorker *work);
-    void setSystemVersion(QString version);
+    void updateSystemVersionLabel();
     void displayUpdateContent(UpdateType index);
 
 private:

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -736,53 +736,6 @@
     </message>
 </context>
 <context>
-    <name>dccV23::CollaborativeLinkWidget</name>
-    <message>
-        <source>Multi-Screen Collaboration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>PC Collaboration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Connect to</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Select a device for collaboration</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Device Orientation</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>On the top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>On the right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>On the bottom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>On the left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>My Devices</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Other Devices</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>dccV23::CommonInfoPlugin</name>
     <message>
         <source>General Settings</source>
@@ -3489,10 +3442,6 @@ UnionTech Software is committed to research and improve the security, accuracy a
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Current Edition</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Updating...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3534,6 +3483,10 @@ UnionTech Software is committed to research and improve the security, accuracy a
     </message>
     <message>
         <source>Please ensure sufficient power to restart, and don&apos;t power off or unplug your machine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Current Edition</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -734,53 +734,6 @@
     </message>
 </context>
 <context>
-    <name>dccV23::CollaborativeLinkWidget</name>
-    <message>
-        <source>Multi-Screen Collaboration</source>
-        <translation>电脑协同设置</translation>
-    </message>
-    <message>
-        <source>PC Collaboration</source>
-        <translation>电脑协同</translation>
-    </message>
-    <message>
-        <source>Connect to</source>
-        <translation>连接设备</translation>
-    </message>
-    <message>
-        <source>Select a device for collaboration</source>
-        <translation>请选择协同设备</translation>
-    </message>
-    <message>
-        <source>Device Orientation</source>
-        <translation>连接方向</translation>
-    </message>
-    <message>
-        <source>On the top</source>
-        <translation>屏幕上方</translation>
-    </message>
-    <message>
-        <source>On the right</source>
-        <translation>屏幕右侧</translation>
-    </message>
-    <message>
-        <source>On the bottom</source>
-        <translation>屏幕下方</translation>
-    </message>
-    <message>
-        <source>On the left</source>
-        <translation>屏幕左侧</translation>
-    </message>
-    <message>
-        <source>My Devices</source>
-        <translation>我的设备</translation>
-    </message>
-    <message>
-        <source>Other Devices</source>
-        <translation>其他设备</translation>
-    </message>
-</context>
-<context>
     <name>dccV23::CommonInfoPlugin</name>
     <message>
         <source>General Settings</source>
@@ -3501,10 +3454,6 @@ UnionTech Software is committed to research and improve the security, accuracy a
         <translation>检测到有更新可用</translation>
     </message>
     <message>
-        <source>Current Edition</source>
-        <translation>当前版本</translation>
-    </message>
-    <message>
         <source>Updating...</source>
         <translation>更新中...</translation>
     </message>
@@ -3547,6 +3496,10 @@ UnionTech Software is committed to research and improve the security, accuracy a
     <message>
         <source>Please ensure sufficient power to restart, and don&apos;t power off or unplug your machine</source>
         <translation>请确保重启后有充足的电源，并不要关机或者拔出电源</translation>
+    </message>
+    <message>
+        <source>Current Edition</source>
+        <translation>当前版本</translation>
     </message>
     <message>
         <source>Size</source>


### PR DESCRIPTION
Version info for update widget and update ctrl widget is not consistent.
Use version info from model instead.

Log: fix version info data source not consistent
Issue: https://github.com/linuxdeepin/developer-center/issues/7253
