### PR TITLE
fix: the plymouth page displays incorrectly

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -333,7 +333,7 @@ std::pair<int, QString> CommonInfoWork::getPlyMouthInformation()
 
     QString themeName = settings.value("Daemon/Theme").toString();
 
-    static QStringList ScaleLowDpiThemeNames = {"deepin-ssd-logo", "uos-ssd-logo"};
+    static QStringList ScaleLowDpiThemeNames = {"deepin-logo", "deepin-ssd-logo", "uos-ssd-logo"};
     static QStringList ScaleHighDpiThemeNames = {"deepin-hidpi-logo", "deepin-hidpi-ssd-logo", "uos-hidpi-ssd-logo"};
     if (ScaleLowDpiThemeNames.contains(themeName)) {
         return {1, themeName};


### PR DESCRIPTION
* 加入 deepin-logo、deepin-hidpi-logo 支持

Issues: linuxdeepin/developer-center#6249