### PR TITLE
fix: grand search can not search dcc modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,9 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/DdeControlCenterConfig.cmake
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/org.deepin.dde.controlcenter.metainfo.xml
         DESTINATION ${CMAKE_INSTALL_DATADIR}/metainfo)
 
+#dde-grand-search-daemon conf
+install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/misc/org.deepin.dde-grand-search.dde-control-center-setting.conf
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/dde-grand-search-daemon/plugins/searcher)
 #-------------------------ut-dcc-interface-------------------------
 if (UNITTEST)
     set(UT_Interface_Name ut-dcc-interface)

--- a/debian/dde-control-center.install
+++ b/debian/dde-control-center.install
@@ -6,3 +6,4 @@ usr/share/dsg/
 usr/share/metainfo
 usr/share/applications/
 usr/share/dbus-1/
+usr/lib/*/dde-grand-search-daemon/plugins/searcher/*

--- a/misc/org.deepin.dde-grand-search.dde-control-center-setting.conf
+++ b/misc/org.deepin.dde-grand-search.dde-control-center-setting.conf
@@ -1,0 +1,7 @@
+[Grand Search]
+Name=org.deepin.dde-grand-search.dde-control-center-setting
+Mode=Trigger
+DBusService=org.deepin.dde.ControlCenter1
+DBusAddress=/org/deepin/dde/ControlCenter1
+DBusInterface=org.deepin.dde.ControlCenter1.GrandSearch
+InterfaceVersion=1.0

--- a/src/frame/mainwindow.cpp
+++ b/src/frame/mainwindow.cpp
@@ -59,8 +59,9 @@ const QString HeightConfig = QStringLiteral("height");
 const QString HideConfig = QStringLiteral("hideModule");
 const QString DisableConfig = QStringLiteral("disableModule");
 const QString ControlCenterIcon = QStringLiteral("preferences-system");
+// 这个只有 com.xx 全局搜索才翻译设置
 const QString ControlCenterGroupName =
-        "org.deepin.dde-grand-search.group.dde-control-center-setting";
+        "com.deepin.dde-grand-search.group.dde-control-center-setting";
 
 MainWindow::MainWindow(QWidget *parent)
     : DMainWindow(parent)


### PR DESCRIPTION
add grand search daemon config file

Issue: https://github.com/linuxdeepin/developer-center/issues/7333