### PR TITLE
fix: ui flash when switching power subpage

### DIFF
--- a/src/plugin-power/operation/powerdbusproxy.cpp
+++ b/src/plugin-power/operation/powerdbusproxy.cpp
@@ -345,8 +345,7 @@ bool PowerDBusProxy::CanHibernate()
 bool PowerDBusProxy::login1ManagerCanSuspend()
 {
     QList<QVariant> argumentList;
-    QDBusPendingReply<QString> reply = m_login1ManagerInter->asyncCallWithArgumentList(QStringLiteral("CanSuspend"), argumentList);
-    reply.waitForFinished();
+    QDBusPendingReply<QString> reply = m_login1ManagerInter->callWithArgumentList(QDBus::BlockWithGui, QStringLiteral("CanSuspend"), argumentList);
     return reply.value().contains("yes");
 }
 


### PR DESCRIPTION
set the parameter to BlockWithGui when calling the dbus interface

Issue: https://github.com/linuxdeepin/developer-center/issues/7171