### PR TITLE
fix: flash appears when switching beteen  power's subpages

### DIFF
--- a/src/plugin-power/operation/powerdbusproxy.cpp
+++ b/src/plugin-power/operation/powerdbusproxy.cpp
@@ -352,7 +352,6 @@ bool PowerDBusProxy::login1ManagerCanSuspend()
 bool PowerDBusProxy::login1ManagerCanHibernate()
 {
     QList<QVariant> argumentList;
-    QDBusPendingReply<QString> reply = m_login1ManagerInter->asyncCallWithArgumentList(QStringLiteral("CanHibernate"), argumentList);
-    reply.waitForFinished();
+    QDBusPendingReply<QString> reply = m_login1ManagerInter->callWithArgumentList(QDBus::BlockWithGui, QStringLiteral("CanHibernate"), argumentList);
     return reply.value().contains("yes");
 }


### PR DESCRIPTION
set the parameter to BlockWithGui when calling the dbus interface

Issue: https://github.com/linuxdeepin/developer-center/issues/7171