### PR TITLE
fix: flash appear when switching subpages of the power module

### DIFF
--- a/src/plugin-power/window/usebatterymodule.cpp
+++ b/src/plugin-power/window/usebatterymodule.cpp
@@ -360,10 +360,10 @@ void UseBatteryModule::updateComboxActionList()
     if (m_model->getShutdown()) {
         m_Options.append({ tr("Shut down"), 0 });
     }
-    if (m_work->getCurCanSuspend()) {
+    if (m_model->canSuspend()) {
         m_Options.append({ tr("Suspend"), 1 });
     }
-    if (m_work->getCurCanHibernate()) {
+    if (m_model->canHibernate()) {
         m_Options.append({ tr("Hibernate"), 2 });
     }
     m_Options.append({ tr("Turn off the monitor"), 3 });

--- a/src/plugin-power/window/useelectricmodule.cpp
+++ b/src/plugin-power/window/useelectricmodule.cpp
@@ -243,10 +243,10 @@ void UseElectricModule::updateComboxActionList()
     if (m_model->getShutdown()) {
         m_comboxOptions.append({ tr("Shut down"), 0 });
     }
-    if (m_work->getCurCanSuspend()) {
+    if (m_model->canSuspend()) {
         m_comboxOptions.append({ tr("Suspend"), 1 });
     }
-    if (m_work->getCurCanHibernate()) {
+    if (m_model->canHibernate()) {
         m_comboxOptions.append({ tr("Hibernate"), 2 });
     }
     m_comboxOptions.append({ tr("Turn off the monitor"), 3 });


### PR DESCRIPTION
initialize ui by getting data from model

Issue: https://github.com/linuxdeepin/developer-center/issues/7171