### PR TITLE
Update CMakeLists.txt to include 'ICU::uc' component for dcc-datetime-plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -729,7 +729,7 @@ if (BUILD_PLUGIN)
         "src/plugin-datetime/operation/qrc/datetime.qrc"
     )
 
-    find_package(ICU COMPONENTS i18n)
+    find_package(ICU COMPONENTS i18n uc)
 
     add_library(${Datetime_Name} MODULE
         ${Datetime_SRCS}
@@ -749,6 +749,7 @@ if (BUILD_PLUGIN)
         Dtk::Widget
         ${Dcc_Widgets_Name}
         ICU::i18n
+        ICU::uc
     )
 
     target_include_directories(${Datetime_Name} PRIVATE


### PR DESCRIPTION
This commit updates the ICU components in the CMakeLists.txt file. Previously,
only the 'i18n' component was being found using find_package for ICU. This
update includes the 'uc' component as well to ensure that all necessary ICU
components are found and linked correctly during the build process.

By adding 'ICU::uc' to the list of components, we ensure that the DateTime
plugin can make use of the required ICU functionalities without any issues.
