### PR TITLE
fix: cannot search parenthese

### DIFF
--- a/src/plugin-datetime/window/widgets/regionformatdialog.cpp
+++ b/src/plugin-datetime/window/widgets/regionformatdialog.cpp
@@ -52,6 +52,7 @@ RegionFormatDialog::RegionFormatDialog(DatetimeModel *datetimeModel, QWidget *pa
     DSearchEdit *searchEdit = new DSearchEdit;
     m_model = new QStandardItemModel(this);
     m_proxyModel = new QSortFilterProxyModel(this);
+    m_proxyModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
     m_regionListView = new DListView;
     m_regionListView->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     m_regionListView->setEditTriggers(QAbstractItemView::NoEditTriggers);
@@ -125,7 +126,7 @@ RegionFormatDialog::RegionFormatDialog(DatetimeModel *datetimeModel, QWidget *pa
 
     setLayout(mainVLayout);
 
-    connect(searchEdit, &DLineEdit::textChanged, this, &RegionFormatDialog::onSearch);
+    connect(searchEdit, &DLineEdit::textChanged, m_proxyModel, &QSortFilterProxyModel::setFilterWildcard);
     connect(cancelBtn, &QPushButton::clicked, this, &RegionFormatDialog::close);
     connect(m_saveBtn, &QPushButton::clicked, this, &RegionFormatDialog::onSaved);
     connect(m_regionListView, &QListView::clicked, this, &RegionFormatDialog::onRegionSelected);
@@ -155,15 +156,6 @@ void RegionFormatDialog::setCurrentRegion(const QString &region)
     } else {
         qWarning() << "There is not anything matched in region proxyModel";
     }
-}
-
-void RegionFormatDialog::onSearch(const QString &text)
-{
-    if (text.contains("\\")) {
-        return;
-    }
-    auto re = QRegularExpression(text, QRegularExpression::CaseInsensitiveOption);
-    m_proxyModel->setFilterRegularExpression(re);
 }
 
 void RegionFormatDialog::onRegionSelected(const QModelIndex &index)

--- a/src/plugin-datetime/window/widgets/regionformatdialog.h
+++ b/src/plugin-datetime/window/widgets/regionformatdialog.h
@@ -37,7 +37,6 @@ Q_SIGNALS:
     void regionFormatSaved(const QString &langRegion, const QLocale &regionFormat);
 
 private Q_SLOTS:
-    void onSearch(const QString &text);
     void onRegionSelected(const QModelIndex &index);
     void onSaved();
 


### PR DESCRIPTION
Parentheses are considered as control characters in regular expression.
Use wildcard filter in this case.

Log: fix cannot search parenthese
Issue: https://github.com/linuxdeepin/developer-center/issues/6002
