### PR TITLE
fix: wrong long date format

### DIFF
--- a/src/plugin-datetime/operation/datetimeworker.cpp
+++ b/src/plugin-datetime/operation/datetimeworker.cpp
@@ -242,42 +242,50 @@ void DatetimeWorker::initRegionFormatData()
         m_model->setLocaleName(m_config->value(localeName_key).toString());
     }
     if (m_config->isDefaultValue(firstDayOfWeek_key)) {
-        m_model->setFirstDayOfWeek(m_regionInter->regionFormat(QLocale::system()).firstDayOfWeekFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setFirstDayOfWeek(m_regionInter->regionFormat(locale).firstDayOfWeekFormat);
     } else {
         m_model->setFirstDayOfWeek(m_config->value(firstDayOfWeek_key).toInt());
     }
     if (m_config->isDefaultValue(shortDateFormat_key)) {
-        m_model->setShortDateFormat(m_regionInter->regionFormat(QLocale::system()).shortDateFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setShortDateFormat(m_regionInter->regionFormat(locale).shortDateFormat);
     } else {
         m_model->setShortDateFormat(m_config->value(shortDateFormat_key).toString());
     }
     if (m_config->isDefaultValue(longDateFormat_key)) {
-        m_model->setLongDateFormat(m_regionInter->regionFormat(QLocale::system()).longDateFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setLongDateFormat(m_regionInter->regionFormat(locale).longDateFormat);
     } else {
         m_model->setLongDateFormat(m_config->value(longDateFormat_key).toString());
     }
     if (m_config->isDefaultValue(shortTimeFormat_key)) {
-        m_model->setShortTimeFormat(m_regionInter->regionFormat(QLocale::system()).shortTimeFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setShortTimeFormat(m_regionInter->regionFormat(locale).shortTimeFormat);
     } else {
         m_model->setShortTimeFormat(m_config->value(shortTimeFormat_key).toString());
     }
     if (m_config->isDefaultValue(longTimeFormat_key)) {
-        m_model->setLongTimeFormat(m_regionInter->regionFormat(QLocale::system()).longTimeFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setLongTimeFormat(m_regionInter->regionFormat(locale).longTimeFormat);
     } else {
         m_model->setLongTimeFormat(m_config->value(longTimeFormat_key).toString());
     }
     if (m_config->isDefaultValue(currencyFormat_key)) {
-        m_model->setCurrencyFormat(m_regionInter->regionFormat(QLocale::system()).currencyFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setCurrencyFormat(m_regionInter->regionFormat(locale).currencyFormat);
     } else {
         m_model->setCurrencyFormat(m_config->value(currencyFormat_key).toString());
     }
     if (m_config->isDefaultValue(numberFormat_key)) {
-        m_model->setNumberFormat(m_regionInter->regionFormat(QLocale::system()).numberFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setNumberFormat(m_regionInter->regionFormat(locale).numberFormat);
     } else {
         m_model->setNumberFormat(m_config->value(numberFormat_key).toString());
     }
     if (m_config->isDefaultValue(paperFormat_key)) {
-        m_model->setPaperFormat(m_regionInter->regionFormat(QLocale::system()).paperFormat);
+        QLocale locale(QLocale::system().name());
+        m_model->setPaperFormat(m_regionInter->regionFormat(locale).paperFormat);
     } else {
         m_model->setPaperFormat(m_config->value(paperFormat_key).toString());
     }

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -18,6 +18,10 @@
 #include <QDBusPendingCallWatcher>
 #include <QTranslator>
 
+#include <dconfig.h>
+
+const QString localeName_key = "localeName";
+
 using namespace DCC_NAMESPACE;
 bool caseInsensitiveLessThan(const MetaData &s1, const MetaData &s2);
 
@@ -34,6 +38,7 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
     , m_model(model)
     , m_keyboardDBusProxy(new KeyboardDBusProxy(this))
     , m_translatorLanguage(nullptr)
+    , m_config(DTK_CORE_NAMESPACE::DConfig::createGeneric("org.deepin.region-format", QString(), this))
 {
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Added, this, &KeyboardWorker::onAdded);
@@ -754,6 +759,9 @@ void KeyboardWorker::setLang(const QString &value)
 {
     Q_EMIT requestSetAutoHide(false);
 
+    if (m_config->isDefaultValue(localeName_key)) {
+        m_config->setValue(localeName_key, value);
+    }
     QDBusPendingCall call = m_keyboardDBusProxy->SetLocale(value);
     qDebug() << "setLang is " << value;
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -17,6 +17,10 @@
 class QDBusPendingCallWatcher;
 class QTranslator;
 
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
+
 namespace DCC_NAMESPACE {
 class KeyboardWorker : public QObject
 {
@@ -119,6 +123,7 @@ private:
     KeyboardDBusProxy *m_keyboardDBusProxy;
     ShortcutModel *m_shortcutModel = nullptr;
     QTranslator *m_translatorLanguage;
+    DTK_CORE_NAMESPACE::DConfig *m_config;
 };
 }
 #endif // KEYBOARDWORK_H


### PR DESCRIPTION
env LC_TIME is always zh_CN.UTF-8, though LANG=en_US.UTF-8. 
long date format of QLocale::system() is acquired by the value of LC_TIME. 
use the QLocale::system().name() to construct the locale

Issue:https://github.com/linuxdeepin/developer-center/issues/7648