### PR TITLE
fix: 调整控制中心一些模块增加按钮的位置

### DIFF
--- a/src/frame/window/modules/keyboard/kblayoutsettingwidget.cpp
+++ b/src/frame/window/modules/keyboard/kblayoutsettingwidget.cpp
@@ -86,7 +86,7 @@ KBLayoutSettingWidget::KBLayoutSettingWidget(QWidget *parent)
     btnLayout->addWidget(addLayout);
     vLayout->addLayout(btnLayout);
     vLayout->setSpacing(0);
-    vLayout->setContentsMargins(0, 10, 0, 5);
+    vLayout->setContentsMargins(0, 10, 0, 0);
     setLayout(vLayout);
 
     connect(addLayout, &DFloatingButton::clicked, this, &KBLayoutSettingWidget::onLayoutAdded);

--- a/src/frame/window/modules/keyboard/shortcutsettingwidget.cpp
+++ b/src/frame/window/modules/keyboard/shortcutsettingwidget.cpp
@@ -153,7 +153,7 @@ ShortCutSettingWidget::ShortCutSettingWidget(ShortcutModel *model, QWidget *pare
     btnLayout->setAlignment(Qt::AlignBottom | Qt::AlignHCenter);
     btnLayout->addWidget(m_addCustomShortcut);
     vlayout->addLayout(btnLayout);
-    vlayout->setContentsMargins(10, 10, 10, 5);
+    vlayout->setContentsMargins(10, 10, 10, 0);
     setLayout(vlayout);
     setFocusPolicy(Qt::FocusPolicy::ClickFocus);
 

--- a/src/frame/window/modules/keyboard/systemlanguagewidget.cpp
+++ b/src/frame/window/modules/keyboard/systemlanguagewidget.cpp
@@ -87,7 +87,7 @@ SystemLanguageWidget::SystemLanguageWidget(KeyboardModel *model, QWidget *parent
     btnLayout->setAlignment(Qt::AlignBottom | Qt::AlignHCenter);
     btnLayout->addWidget(m_addSystemLanguage);
     vLayout->addLayout(btnLayout);
-    vLayout->setContentsMargins(10, 10, 10, 5);
+    vLayout->setContentsMargins(10, 10, 10, 0);
     setLayout(vLayout);
 
     connect(m_langListview, &DListView::clicked, this, &SystemLanguageWidget::setCurLangChecked);


### PR DESCRIPTION
Log: 调整控制中心键盘和语言模块下的键盘布局,系统语言,快捷键下方的增加按钮的位置,与控制中心默认程序模块和时间日期模块的增加按钮一致