### PR TITLE
fix: data of datetime is unintialized

### DIFF
--- a/src/plugin-datetime/window/widgets/regionformatdialog.cpp
+++ b/src/plugin-datetime/window/widgets/regionformatdialog.cpp
@@ -148,6 +148,8 @@ void RegionFormatDialog::setCurrentRegion(const QString &region)
     if (results.size() > 0) {
         m_regionListView->setCurrentIndex(results.first());
         auto realIndex = m_proxyModel->mapToSource(results.first());
+        m_locale = realIndex.data(RegionFormatRole::LocaleRole).toLocale();
+        updateRegionFormat(m_locale);
         QStandardItem *selectedItem = m_model->itemFromIndex(realIndex);
         if (selectedItem) {
             selectedItem->setCheckState(Qt::Checked);


### PR DESCRIPTION
initialize the data before dialog is shown

Issue: https://github.com/linuxdeepin/developer-center/issues/8248