### PR TITLE
feat: Add translations for dde-control-center in plymouth notifications

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -101,7 +101,7 @@ static void notifyInfo(const QString &summary)
 {
     DUtil::DNotifySender(summary)
             .appIcon("dde-control-center")
-            .appName("dde-control-center")
+            .appName(QObject::tr("dde-control-center"))
             .timeOut(5000)
             .call();
 }
@@ -110,7 +110,7 @@ static void notifyInfoWithBody(const QString &summary, const QString &body)
 {
     DUtil::DNotifySender(summary)
             .appIcon("dde-control-center")
-            .appName("dde-control-center")
+            .appName(QObject::tr("dde-control-center"))
             .appBody(body)
             .timeOut(5000)
             .call();
@@ -349,7 +349,7 @@ void CommonInfoWork::deepinIdErrorSlot(int code, const QString &msg)
     Q_UNUSED(code);
 
     //初始化Notify 七个参数
-    QString in0("dde-control-center");
+    QString in0(QObject::tr("dde-control-center"));
     uint in1 = 101;
     QString in2("preferences-system");
     QString in3("");

--- a/src/plugin-commoninfo/window/developermodewidget.cpp
+++ b/src/plugin-commoninfo/window/developermodewidget.cpp
@@ -75,7 +75,7 @@ DeveloperModeWidget::DeveloperModeWidget(QWidget *parent)
                                          QDBusConnection::sessionBus());
 
             //初始化Notify 七个参数
-            QString in0("dde-control-center");
+            QString in0(QObject::tr("dde-control-center"));
             uint in1 = 101;
             QString in2("preferences-system");
             QString in3("");

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -2959,6 +2959,10 @@ UnionTech Software is committed to research and improve the security, accuracy a
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
+    <message>
+        <source>dde-control-center</source>
+        <translation>控制中心</translation>
+    </message>
 </context>
 <context>
     <name>RegionModule</name>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -2988,6 +2988,10 @@ UnionTech Software is committed to research and improve the security, accuracy a
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
+    <message>
+        <source>dde-control-center</source>
+        <translation>控制中心</translation>
+    </message>
 </context>
 <context>
     <name>RegionModule</name>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -2988,6 +2988,10 @@ UnionTech Software is committed to research and improve the security, accuracy a
         <source>Cancel</source>
         <translation>取消</translation>
     </message>
+    <message>
+        <source>dde-control-center</source>
+        <translation>控制中心</translation>
+    </message>
 </context>
 <context>
     <name>RegionModule</name>


### PR DESCRIPTION
Issue: https://github.com/linuxdeepin/developer-center/issues/8998
Log: Add translations for dde-control-center in plymouth notifications