### PR TITLE
fix: crash when selecting custom avatar

### DIFF
--- a/src/plugin-accounts/window/avatarlistframe.cpp
+++ b/src/plugin-accounts/window/avatarlistframe.cpp
@@ -564,6 +564,11 @@ void CustomAvatarView::endAvatarModify()
     }
 }
 
+void CustomAvatarView::stopAutoExitTimer()
+{
+    m_autoExitTimer->stop();
+}
+
 void CustomAvatarView::onZoomInImage(void)
 {
     m_zoomValue += 0.2;
@@ -656,4 +661,9 @@ void CustomAvatarWidget::enableAvatarScaledItem(bool enabled)
 {
     m_avatarScaledItem->setEnabled(enabled);
     m_avatarScaledItem->setValue(SLIDER_MINIMUM_SIZE);
+}
+
+void CustomAvatarWidget::stopAvatarModify()
+{
+    m_avatarView->stopAutoExitTimer();
 }

--- a/src/plugin-accounts/window/avatarlistframe.h
+++ b/src/plugin-accounts/window/avatarlistframe.h
@@ -130,6 +130,7 @@ Q_SIGNALS:
 public Q_SLOTS:
     void startAvatarModify();
     void endAvatarModify();
+    void stopAutoExitTimer();
     void setZoomValue(const int value);
     QString getCroppedImage();
 
@@ -160,6 +161,7 @@ public:
     ~CustomAvatarWidget() override = default;
 
     void enableAvatarScaledItem(bool enabled);
+    void stopAvatarModify();
 
     inline CustomAvatarView *getCustomAvatarView() { return m_avatarView; }
 

--- a/src/plugin-accounts/window/avatarlistwidget.cpp
+++ b/src/plugin-accounts/window/avatarlistwidget.cpp
@@ -168,6 +168,10 @@ AvatarListDialog::AvatarListDialog(User *usr, AccountsWorker *worker, QWidget *p
                     m_avatarFrames[Custom]->getCurrentListView()->getAvatarPath());
         }
 
+        if (auto customFrame = qobject_cast<CustomAvatarWidget*>(m_avatarFrames[Custom])) {
+            customFrame->stopAvatarModify();
+        }
+
         avatarSelectWidget->setCurrentIndex(index.row());
         QScrollArea *area = static_cast<QScrollArea *>(avatarSelectWidget->currentWidget());
         m_currentSelectAvatarWidget = static_cast<AvatarListFrame *>(area->widget());
@@ -191,12 +195,8 @@ AvatarListDialog::AvatarListDialog(User *usr, AccountsWorker *worker, QWidget *p
 
     connect(getCustomAvatarWidget()->getCustomAvatarView(),
             &CustomAvatarView::requestSaveCustomAvatar,
-            this,
-            [this](const QString &path) {
-                if (!path.isEmpty()) {
-                    m_currentSelectAvatarWidget->getCurrentListView()->saveAvatar(path);
-                }
-            });
+            m_avatarFrames[Custom]->getCurrentListView(),
+            &AvatarListView::saveAvatar);
 
     connect(static_cast<CustomAddAvatarWidget *>(m_avatarFrames[AvatarAdd]),
             &CustomAddAvatarWidget::requestUpdateCustomWidget,


### PR DESCRIPTION
requestSaveCustomAvatar signal receiver is only custom page object

Issue: https://github.com/linuxdeepin/developer-center/issues/9513