### PR TITLE
fix: Fix crash when switching Light/Dark theme

### DIFF
--- a/src/plugin-personalization-dock/window/dockplugin.cpp
+++ b/src/plugin-personalization-dock/window/dockplugin.cpp
@@ -423,7 +423,7 @@ void DockModuleObject::initPluginView(DListView *view)
                         updateItemCheckStatus(dockItem.itemKey, visible);
                         item->setData(visible, Dtk::UserRole + 1); });
             // 主题发生变化触发的信号
-            connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged, leftAction, [leftAction, this, dockItem, view]()
+            connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged, view, [leftAction, this, dockItem, view]()
                     { leftAction->setIcon(getIcon(dockItem.dcc_icon, !view->isActiveWindow())); });
         }
     };


### PR DESCRIPTION
connect to view instead of leftaction which has nothing to do with view's life span.

Issue: https://github.com/linuxdeepin/developer-center/issues/9883
Log: Fix crash when switching Light/Dark theme or Compisite status