### PR TITLE
fix: Datetime labels cannot adapt to theme type changes

### DIFF
--- a/src/plugin-datetime/window/widgets/datewidget.cpp
+++ b/src/plugin-datetime/window/widgets/datewidget.cpp
@@ -29,8 +29,10 @@ DateWidget::DateWidget(Type type, int minimum, int maximum, QWidget *parent)
 
     m_lineEdit->setContextMenuPolicy(Qt::NoContextMenu);
     m_lineEdit->setObjectName("DCC-Datetime-QLineEdit");
-    //m_lineEdit->setFrame(false) , 这样设置只能去掉边框,无法去除背景,目前只能使用qss进行设置
-    m_lineEdit->setStyleSheet("background:transparent; border-width:0; border-style:outset");
+    QPalette palette = m_lineEdit->palette();
+    palette.setColor(QPalette::Button, Qt::transparent);
+    m_lineEdit->setPalette(palette);
+    DStyle::setFocusRectVisible(m_lineEdit, false);
     m_addBtn->setObjectName("DCC-Datetime-Datewidget-Add");
     m_reducedBtn->setObjectName("DCC-Datetime-Datewidget-Reduce");
 


### PR DESCRIPTION
Stylesheet was set, so that, it is unable to respond to the theme change events.

Issue: https://github.com/linuxdeepin/developer-center/issues/10058
Log: Datetime labels cannot adapt to theme type changes