### PR TITLE
fix: dock panel min size error

### DIFF
--- a/src/plugin-personalization-dock/window/dockplugin.cpp
+++ b/src/plugin-personalization-dock/window/dockplugin.cpp
@@ -261,7 +261,8 @@ void DockModuleObject::initSizeSlider(TitledSliderItem *slider)
 
     slider->setAccessibleName("Slider");
     slider->addBackground();
-    slider->slider()->setRange(40, 100);
+    // dde-shell dock panel min size:37
+    slider->slider()->setRange(37, 100);
     QStringList ranges;
     ranges << tr("Small") << "" << tr("Large");
     slider->setAnnotations(ranges);


### PR DESCRIPTION
min size:37.

Log: as title
Issue: https://github.com/linuxdeepin/developer-center/issues/10069
Influence: can adjust dock's min size