### PR TITLE
fix: need click twice to set hidden dock plugin visible

### DIFF
--- a/src/plugin-personalization-dock/window/dockplugin.cpp
+++ b/src/plugin-personalization-dock/window/dockplugin.cpp
@@ -412,6 +412,7 @@ void DockModuleObject::initPluginView(DListView *view)
             auto icon = qobject_cast<DStyle *>(qApp->style())->standardIcon(checkstatus);
             action->setIcon(icon);
             view->update(item->index());
+            item->setData(visible, Dtk::UserRole + 1);
             break;
         }
     };


### PR DESCRIPTION
dock item status not updated

Bug: https://pms.uniontech.com/bug-view-271593.html
Log: need click twice to set hidden dock plugin visible