### PR TITLE
fix: powersave mode is shown on unsupported platform

### DIFF
--- a/src/plugin-power/operation/powerdbusproxy.cpp
+++ b/src/plugin-power/operation/powerdbusproxy.cpp
@@ -188,6 +188,11 @@ bool PowerDBusProxy::isBalancePerformanceSupported()
     return qvariant_cast<bool>(m_sysPowerInter->property("IsBalancePerformanceSupported"));
 }
 
+bool PowerDBusProxy::isPowerSaveSupported()
+{
+    return qvariant_cast<bool>(m_sysPowerInter->property("IsPowerSaveSupported"));
+}
+
 int PowerDBusProxy::linePowerScreenBlackDelay()
 {
     return qvariant_cast<int>(m_powerInter->property("LinePowerScreenBlackDelay"));

--- a/src/plugin-power/operation/powerdbusproxy.h
+++ b/src/plugin-power/operation/powerdbusproxy.h
@@ -53,6 +53,8 @@ public:
     bool isHighPerformanceSupported();
     Q_PROPERTY(bool IsBalancePerformanceSupported READ isBalancePerformanceSupported NOTIFY IsBalancePerformanceSupportedChanged)
     bool isBalancePerformanceSupported();
+    Q_PROPERTY(bool IsPowerSaveSupported READ isPowerSaveSupported NOTIFY IsPowerSaveSupportedChanged)
+    bool isPowerSaveSupported();
     Q_PROPERTY(int LinePowerScreenBlackDelay READ linePowerScreenBlackDelay WRITE setLinePowerScreenBlackDelay NOTIFY LinePowerScreenBlackDelayChanged)
     int linePowerScreenBlackDelay();
     void setLinePowerScreenBlackDelay(int value);
@@ -119,6 +121,7 @@ signals:
     void LinePowerLockDelayChanged(int value) const;
     void IsHighPerformanceSupportedChanged(bool value) const;
     void IsBalancePerformanceSupportedChanged(bool value) const;
+    void IsPowerSaveSupportedChanged(bool value) const;
     void LinePowerPressPowerBtnActionChanged(int value) const;
     void LinePowerLidClosedActionChanged(int value) const;
     void BatteryPressPowerBtnActionChanged(int value) const;

--- a/src/plugin-power/operation/powermodel.cpp
+++ b/src/plugin-power/operation/powermodel.cpp
@@ -41,6 +41,7 @@ PowerModel::PowerModel(QObject *parent)
     , m_powerPlan("")
     , m_isHighPerformanceSupported(false)
     , m_isBalancePerformanceSupported(false)
+    , m_isPowerSaveSupported(true)
 {
 }
 
@@ -328,6 +329,14 @@ void PowerModel::setBalancePerformanceSupported(bool isBalancePerformanceSupport
         return;
     m_isBalancePerformanceSupported = isBalancePerformanceSupported;
     Q_EMIT highPerformaceSupportChanged(isBalancePerformanceSupported);
+}
+
+void PowerModel::setPowerSaveSupported(bool isPowerSaveSupported)
+{
+    if (m_isPowerSaveSupported == isPowerSaveSupported)
+        return;
+    m_isPowerSaveSupported = isPowerSaveSupported;
+    Q_EMIT powerSaveSupportChanged(isPowerSaveSupported);
 }
 
 void PowerModel::setSuspend(bool suspend)

--- a/src/plugin-power/operation/powermodel.h
+++ b/src/plugin-power/operation/powermodel.h
@@ -125,6 +125,9 @@ public:
 
     inline bool isBalancePerformanceSupported() const { return m_isBalancePerformanceSupported; }
     void setBalancePerformanceSupported(bool isBalancePerformanceSupported);
+
+    inline bool isPowerSaveSupported() const { return m_isPowerSaveSupported; }
+    void setPowerSaveSupported(bool isPowerSaveSupported);
     // ----
     inline bool isNoPasswdLogin() const { return m_noPasswdLogin; }
 
@@ -171,6 +174,7 @@ Q_SIGNALS:
     void suspendChanged(bool suspendState);
     void powerPlanChanged(const QString &value);
     void highPerformaceSupportChanged(bool value);
+    void powerSaveSupportChanged(bool value);
 
     void noPasswdLoginChanged(bool value);
 
@@ -214,6 +218,7 @@ private:
     QString m_powerPlan;
     bool m_isHighPerformanceSupported;
     bool m_isBalancePerformanceSupported;
+    bool m_isPowerSaveSupported;
 
     // Account
     bool m_noPasswdLogin;

--- a/src/plugin-power/operation/powerworker.cpp
+++ b/src/plugin-power/operation/powerworker.cpp
@@ -34,6 +34,7 @@ PowerWorker::PowerWorker(PowerModel *model, QObject *parent)
     connect(m_powerDBusProxy, &PowerDBusProxy::BatteryLockDelayChanged, this, &PowerWorker::setResponseBatteryLockScreenDelay);
     connect(m_powerDBusProxy, &PowerDBusProxy::LinePowerLockDelayChanged, this, &PowerWorker::setResponsePowerLockScreenDelay);
     connect(m_powerDBusProxy, &PowerDBusProxy::IsHighPerformanceSupportedChanged, this, &PowerWorker::setHighPerformanceSupported);
+    connect(m_powerDBusProxy, &PowerDBusProxy::IsPowerSaveSupportedChanged, this, &PowerWorker::setPowerSaveSupported);
 
     connect(m_powerDBusProxy, &PowerDBusProxy::PowerSavingModeAutoChanged, m_powerModel, &PowerModel::setAutoPowerSaveMode);
     connect(m_powerDBusProxy, &PowerDBusProxy::PowerSavingModeEnabledChanged, m_powerModel, &PowerModel::setPowerSaveMode);
@@ -86,6 +87,7 @@ void PowerWorker::active()
 
     setHighPerformanceSupported(m_powerDBusProxy->isHighPerformanceSupported());
     setBalancePerformanceSupported(m_powerDBusProxy->isBalancePerformanceSupported());
+    setPowerSaveSupported(m_powerDBusProxy->isPowerSaveSupported());
 
     setScreenBlackDelayToModelOnPower(m_powerDBusProxy->linePowerScreenBlackDelay());
     setSleepDelayToModelOnPower(m_powerDBusProxy->linePowerSleepDelay());
@@ -208,6 +210,11 @@ void PowerWorker::setHighPerformanceSupported(bool state)
 void PowerWorker::setBalancePerformanceSupported(bool state)
 {
     m_powerModel->setBalancePerformanceSupported(state);
+}
+
+void PowerWorker::setPowerSaveSupported(bool state)
+{
+    m_powerModel->setPowerSaveSupported(state);
 }
 
 void PowerWorker::setPowerSavingModeAutoWhenQuantifyLow(bool bLowBatteryAutoIntoSaveEnergyMode)

--- a/src/plugin-power/operation/powerworker.h
+++ b/src/plugin-power/operation/powerworker.h
@@ -36,6 +36,7 @@ public Q_SLOTS:
     void setResponsePowerLockScreenDelay(const int delay);
     void setHighPerformanceSupported(bool state);
     void setBalancePerformanceSupported(bool state);
+    void setPowerSaveSupported(bool state);
     //------------sp2 add-----------------------
     void setPowerSavingModeAutoWhenQuantifyLow(bool bLowBatteryAutoIntoSaveEnergyMode);
     void setPowerSavingModeAuto(bool bAutoIntoSaveEnergyMode);


### PR DESCRIPTION
Hide powersave mode option if it is unsupported

Bug: https://pms.uniontech.com/bug-view-272203.html
Log: powersave mode is shown on unsupported platform