### PR TITLE
feat:  add dccrepeater

### DIFF
--- a/include/dccrepeater.h
+++ b/include/dccrepeater.h
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DCCREPEATER_H
+#define DCCREPEATER_H
+
+#include <QObject>
+#include <QQmlComponent>
+
+class QQmlChangeSet;
+
+namespace dccV25 {
+class DccRepeaterPrivate;
+class DccRepeater : public QObject
+{
+    Q_OBJECT
+public:
+    Q_PROPERTY(QVariant model READ model WRITE setModel NOTIFY modelChanged FINAL)
+    Q_PROPERTY(QQmlComponent *delegate READ delegate WRITE setDelegate NOTIFY delegateChanged FINAL)
+    Q_PROPERTY(int count READ count NOTIFY countChanged FINAL)
+
+    explicit DccRepeater(QObject *parent = nullptr);
+    ~DccRepeater() override;
+
+    QVariant model() const;
+    void setModel(const QVariant &newModel);
+
+    QQmlComponent *delegate() const;
+    void setDelegate(QQmlComponent *newDelegate);
+
+    int count() const;
+
+Q_SIGNALS:
+    void modelChanged();
+    void delegateChanged();
+    void countChanged();
+
+    void objAdded(int index, QObject *obj);
+    void objRemoved(int index, QObject *obj);
+
+private Q_SLOTS:
+    void createdItem(int index, QObject *item);
+    void initItem(int index, QObject *item);
+    void modelUpdated(const QQmlChangeSet &changeSet, bool reset);
+
+protected:
+    void regenerate();
+    void clear();
+
+private:
+    QScopedPointer<DccRepeaterPrivate> d_ptr;
+    Q_DECLARE_PRIVATE_D(qGetPtrHelper(d_ptr), DccRepeater)
+};
+} // namespace dccV25
+#endif // DCCREPEATER_H

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -12,10 +12,12 @@ add_library(${DCCFrame_Name} SHARED
     ${DCCFrame_SRCS}
 )
 
+find_package(${QT_NS} COMPONENTS QmlModels REQUIRED)
 set(DCCFrame_Libraries
     ${DTK_NS}::Gui
-    Qt::Gui
-    Qt::Quick
+    ${QT_NS}::Gui
+    ${QT_NS}::Quick
+    ${QT_NS}::QmlModelsPrivate
 )
 
 target_link_libraries(${DCCFrame_Name} PRIVATE

--- a/src/dde-control-center/frame/dccrepeater.cpp
+++ b/src/dde-control-center/frame/dccrepeater.cpp
@@ -1,0 +1,288 @@
+// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dccrepeater.h"
+#include "dccobject.h"
+#include "dccapp.h"
+
+#include <QtQml>
+#include <private/qqmldelegatemodel_p.h>
+#include <private/qqmlobjectmodel_p.h>
+
+namespace dccV25 {
+
+class DccRepeaterPrivate
+{
+public:
+    DccRepeaterPrivate(DccRepeater *qq) : q_ptr(qq) {
+
+    }
+
+    void requestItems()
+    {
+        if (!model)
+            return;
+
+        for (int i = 0; i < itemCount; i++) {
+            QObject *object = model->object(i, QQmlIncubator::AsynchronousIfNested);
+            if (object)
+                model->release(object);
+        }
+    }
+
+    QPointer<QQmlInstanceModel> model;
+    QVariant dataSource;
+    QPointer<QObject> dataSourceAsObject;
+    bool ownModel : 1;
+    bool dataSourceIsObject : 1;
+    bool delegateValidated : 1;
+    int itemCount = 0;
+
+    QVector<QPointer<DccObject> > deletables;
+
+    DccRepeater *q_ptr = nullptr;
+    Q_DECLARE_PUBLIC(DccRepeater)
+};
+
+DccRepeater::DccRepeater(QObject *parent)
+    : QObject(parent)
+    , d_ptr(new DccRepeaterPrivate(this))
+{
+
+}
+
+DccRepeater::~DccRepeater()
+{
+
+}
+
+QVariant DccRepeater::model() const
+{
+    Q_D(const DccRepeater);
+    if (d->dataSourceIsObject) {
+        QObject *o = d->dataSourceAsObject;
+        return QVariant::fromValue(o);
+    }
+
+    return d->dataSource;
+}
+
+void DccRepeater::setModel(const QVariant &m)
+{
+    Q_D(DccRepeater);
+    QVariant model = m;
+    if (model.userType() == qMetaTypeId<QJSValue>())
+        model = model.value<QJSValue>().toVariant();
+
+    if (d->dataSource == model)
+        return;
+
+    clear();
+    if (d->model) {
+        qmlobject_disconnect(d->model, QQmlInstanceModel, SIGNAL(modelUpdated(QQmlChangeSet,bool)),
+                             this, DccRepeater, SLOT(modelUpdated(QQmlChangeSet,bool)));
+        qmlobject_disconnect(d->model, QQmlInstanceModel, SIGNAL(createdItem(int,QObject*)),
+                             this, DccRepeater, SLOT(createdItem(int,QObject*)));
+        qmlobject_disconnect(d->model, QQmlInstanceModel, SIGNAL(initItem(int,QObject*)),
+                             this, DccRepeater, SLOT(initItem(int,QObject*)));
+    }
+    d->dataSource = model;
+    QObject *object = qvariant_cast<QObject*>(model);
+    d->dataSourceAsObject = object;
+    d->dataSourceIsObject = object != nullptr;
+    QQmlInstanceModel *vim = nullptr;
+    if (object && (vim = qobject_cast<QQmlInstanceModel *>(object))) {
+        if (d->ownModel) {
+            delete d->model;
+            d->ownModel = false;
+        }
+        d->model = vim;
+    } else {
+        if (!d->ownModel) {
+            d->model = new QQmlDelegateModel(qmlContext(this));
+            d->ownModel = true;
+            // if (isComponentComplete())
+            static_cast<QQmlDelegateModel *>(d->model.data())->componentComplete();
+        }
+        if (QQmlDelegateModel *dataModel = qobject_cast<QQmlDelegateModel*>(d->model)) {
+            if (dataModel->count() <= 0)
+                static_cast<QQmlDelegateModel *>(d->model.data())->componentComplete();
+            dataModel->setModel(model);
+        }
+    }
+    if (d->model) {
+        qmlobject_connect(d->model, QQmlInstanceModel, SIGNAL(modelUpdated(QQmlChangeSet,bool)),
+                          this, DccRepeater, SLOT(modelUpdated(QQmlChangeSet,bool)));
+        qmlobject_connect(d->model, QQmlInstanceModel, SIGNAL(createdItem(int,QObject*)),
+                          this, DccRepeater, SLOT(createdItem(int,QObject*)));
+        qmlobject_connect(d->model, QQmlInstanceModel, SIGNAL(initItem(int,QObject*)),
+                          this, DccRepeater, SLOT(initItem(int,QObject*)));
+        regenerate();
+    }
+    emit modelChanged();
+    emit countChanged();
+}
+
+QQmlComponent *DccRepeater::delegate() const
+{
+    Q_D(const DccRepeater);
+    if (d->model) {
+        if (QQmlDelegateModel *dataModel = qobject_cast<QQmlDelegateModel*>(d->model))
+            return dataModel->delegate();
+    }
+
+    return nullptr;
+}
+
+void DccRepeater::setDelegate(QQmlComponent *delegate)
+{
+    Q_D(DccRepeater);
+    if (QQmlDelegateModel *dataModel = qobject_cast<QQmlDelegateModel*>(d->model))
+        if (delegate == dataModel->delegate())
+            return;
+
+    if (!d->ownModel) {
+        d->model = new QQmlDelegateModel(qmlContext(this));
+        d->ownModel = true;
+    }
+
+    if (QQmlDelegateModel *dataModel = qobject_cast<QQmlDelegateModel*>(d->model)) {
+        dataModel->setDelegate(delegate);
+        regenerate();
+        emit delegateChanged();
+        d->delegateValidated = false;
+    }
+}
+
+int DccRepeater::count() const
+{
+    Q_D(const DccRepeater);
+    if (d->model)
+        return d->model->count();
+    return 0;
+}
+
+void DccRepeater::createdItem(int index, QObject *obj)
+{
+    Q_D(DccRepeater);
+    QObject *object = d->model->object(index, QQmlIncubator::AsynchronousIfNested);
+
+    DccObject *dccObj = qmlobject_cast<DccObject*>(object);
+    DccApp::instance()->addObject(dccObj);
+
+    emit objAdded(index, object);
+}
+
+void DccRepeater::initItem(int index, QObject *object)
+{
+    Q_D(DccRepeater);
+    if (index >= d->deletables.size())
+        d->deletables.resize(d->model->count() + 1);
+
+    DccObject *dccObj = qmlobject_cast<DccObject*>(object);
+
+    if (!d->deletables.at(index)) {
+        if (!dccObj) {
+            if (object) {
+                d->model->release(object);
+                if (!d->delegateValidated) {
+                    d->delegateValidated = true;
+                    QObject* delegate = this->delegate();
+                    qmlWarning(delegate ? delegate : this) << tr("Delegate must be of `DccObject` type");
+                }
+            }
+            return;
+        }
+        d->deletables[index] = dccObj;
+    }
+}
+
+void DccRepeater::modelUpdated(const QQmlChangeSet &changeSet, bool reset)
+{
+    Q_D(DccRepeater);
+
+    if (reset) {
+        regenerate();
+        if (changeSet.difference() != 0)
+            emit countChanged();
+        return;
+    }
+
+    int difference = 0;
+    QHash<int, QVector<QPointer<DccObject> > > moved;
+    for (const QQmlChangeSet::Change &remove : changeSet.removes()) {
+        int index = qMin(remove.index, d->deletables.size());
+        int count = qMin(remove.index + remove.count, d->deletables.size()) - index;
+        if (remove.isMove()) {
+            moved.insert(remove.moveId, d->deletables.mid(index, count));
+            d->deletables.erase(
+                    d->deletables.begin() + index,
+                    d->deletables.begin() + index + count);
+        } else while (count--) {
+                DccObject *item = d->deletables.at(index);
+                d->deletables.remove(index);
+                emit objRemoved(index, item);
+                if (item) {
+                    d->model->release(item);
+                    // item->setParentItem(nullptr);
+                }
+                --d->itemCount;
+            }
+
+        difference -= remove.count;
+    }
+
+    for (const QQmlChangeSet::Change &insert : changeSet.inserts()) {
+        int index = qMin(insert.index, d->deletables.size());
+        if (insert.isMove()) {
+            QVector<QPointer<DccObject> > items = moved.value(insert.moveId);
+            d->deletables = d->deletables.mid(0, index) + items + d->deletables.mid(index);
+
+        } else for (int i = 0; i < insert.count; ++i) {
+                int modelIndex = index + i;
+                ++d->itemCount;
+                d->deletables.insert(modelIndex, nullptr);
+                QObject *object = d->model->object(modelIndex, QQmlIncubator::AsynchronousIfNested);
+                if (object)
+                    d->model->release(object);
+            }
+        difference += insert.count;
+    }
+
+    if (difference != 0)
+        emit countChanged();
+}
+
+void DccRepeater::regenerate()
+{
+    Q_D(DccRepeater);
+    clear();
+
+    if (!d->model || !d->model->count() || !d->model->isValid() || !parent()/* || !isComponentComplete()*/)
+        return;
+
+    d->itemCount = count();
+    d->deletables.resize(d->itemCount);
+    d->requestItems();
+}
+
+void DccRepeater::clear()
+{
+    Q_D(DccRepeater);
+    if (d->model) {
+        for (int i = d->deletables.size() - 1; i >= 0; --i) {
+            if (DccObject *obj = d->deletables.at(i)) {
+                // reomve from dccApp
+                DccApp::instance()->removeObject(obj);
+                emit objRemoved(i, obj);
+                d->model->release(obj);
+            }
+        }
+
+    }
+    d->deletables.clear();
+    d->itemCount = 0;
+}
+
+}

--- a/src/dde-control-center/frame/plugin/src/dccqmlplugin.cpp
+++ b/src/dde-control-center/frame/plugin/src/dccqmlplugin.cpp
@@ -6,6 +6,7 @@
 #include "dccapp.h"
 #include "dccmodel.h"
 #include "dccobject.h"
+#include "dccrepeater.h"
 #include "dccquickdbusinterface.h"
 
 #include <qqml.h>
@@ -17,6 +18,7 @@ void DccQmlPlugin::registerTypes(const char *uri)
     // @uri org.deepin.dcc
     qmlRegisterModule(uri, 1, 0);
     qmlRegisterType<dccV25::DccObject>(uri, 1, 0, "DccObject");
+    qmlRegisterType<dccV25::DccRepeater>(uri, 1, 0, "DccRepeater");
     qmlRegisterType<dccV25::DccModel>(uri, 1, 0, "DccModel");
     qmlRegisterType<dccV25::DccQuickDBusInterface>(uri, 1, 0, "DccDBusInterface");
 


### PR DESCRIPTION
```qml
DccObject {
    name: "Repeater"
    parentName: "KeyboardLayout"
    weight: 20
    pageType: DccObject.Item
    page: DccGroupView {
    }
    DccRepeater {
        model: 3
        delegate: DccObject {
            name: "KeyboardLayoutItem" + index
            parentName: "Repeater"
            weight: 20 + index * 10
            pageType: DccObject.Item
            hasBackground: true
            page: Label {
                font.pointSize: 12
                text: "keyboard layout" + index
            }
        }
     }
}
```