### PR TITLE
chore: Add 'qt6-declarative-private-dev' dependency in control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends:
  qt6-base-dev,
  qt6-declarative-dev,
  qt6-tools-dev,
+ qt6-declarative-private-dev,
  libdtkcommon-dev,
  libdtk6gui-dev,
  libdtk6core-dev,


### PR DESCRIPTION
Resolve compilation issues

Log: As title.