### PR TITLE
fix: Modify the style of the image source list widget

### DIFF
--- a/dcc-old/src/plugin-datetime/window/timesettingmodule.cpp
+++ b/dcc-old/src/plugin-datetime/window/timesettingmodule.cpp
@@ -326,7 +326,9 @@ void TimeSettingModule::initDigitalClock(QWidget *w)
     layout->setSpacing(10);
     layout->setContentsMargins(0, 0, 0, 0);
     w->setLayout(layout);
-    w->setVisible(m_model->nTP());
+    QTimer::singleShot(10, w, [this, w]() {
+        w->setVisible(m_model->nTP());
+    });
     connect(m_model, &DatetimeModel::NTPChanged, w, &QWidget::setVisible);
     QTimer *timer = new QTimer(w);
     auto updateTime = [minLabel, hourLabel, yearLabel, monthLabel, dayLabel]() {

--- a/dcc-old/src/plugin-update/window/mirrorswidget.h
+++ b/dcc-old/src/plugin-update/window/mirrorswidget.h
@@ -42,6 +42,7 @@ public:
 
 protected:
     void closeEvent(QCloseEvent *event) override;
+    void showEvent(QShowEvent *event) override;
 
 Q_SIGNALS:
     void requestSetDefaultMirror(const MirrorInfo &mirror);
@@ -70,6 +71,7 @@ private:
     QPushButton *m_testButton;
     Dtk::Widget::DListView *m_view;
     QStandardItemModel *m_model;
+    UpdateModel *m_updateModel;
     int m_mirrorSourceNo;
     QWidget *m_listWidget;
 };

--- a/dcc-old/src/plugin-update/window/updatesettingsmodule.cpp
+++ b/dcc-old/src/plugin-update/window/updatesettingsmodule.cpp
@@ -352,16 +352,17 @@ void UpdateSettingsModule::initModuleList()
         });
         updateMirrors->setVisible(!m_model->smartMirrorSwitch());
         connect(updateMirrors, &ItemModule::clicked, this, [this]() {
-            auto mirrorsWidget = new MirrorsWidget(m_model);
-            mirrorsWidget->setAttribute(Qt::WA_DeleteOnClose);
-            mirrorsWidget->setWindowModality(Qt::ApplicationModal);
-            mirrorsWidget->setVisible(false);
-            m_work->checkNetselect();
-            mirrorsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
+            if (m_mirrorsWidget.isNull()) {
+                m_mirrorsWidget.reset(new MirrorsWidget(m_model));
+                m_mirrorsWidget->setWindowModality(Qt::ApplicationModal);
+                m_mirrorsWidget->setVisible(false);
+                m_mirrorsWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 
-            connect(mirrorsWidget, &MirrorsWidget::requestSetDefaultMirror, m_work, &UpdateWorker::setMirrorSource);
-            connect(mirrorsWidget, &MirrorsWidget::requestTestMirrorSpeed, m_work, &UpdateWorker::testMirrorSpeed);
-            mirrorsWidget->show();
+                connect(m_mirrorsWidget.get(), &MirrorsWidget::requestSetDefaultMirror, m_work, &UpdateWorker::setMirrorSource);
+                connect(m_mirrorsWidget.get(), &MirrorsWidget::requestTestMirrorSpeed, m_work, &UpdateWorker::testMirrorSpeed);
+            }
+            m_work->checkNetselect();
+            m_mirrorsWidget->show();
         });
 
         appendChild(new UpdateTitleModule("InternalUpdateSetting",

--- a/dcc-old/src/plugin-update/window/updatesettingsmodule.h
+++ b/dcc-old/src/plugin-update/window/updatesettingsmodule.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "interface/pagemodule.h"
+#include "mirrorswidget.h"
 
 #include <DTipLabel>
 
@@ -101,4 +102,5 @@ private:
     DCC_NAMESPACE::ModuleObject *m_backupUpdatesModule;
     DCC_NAMESPACE::ModuleObject *m_backupUpdatesTipModule;
     DCC_NAMESPACE::ModuleObject *m_updateNotifyModule;
+    QScopedPointer<DCC_NAMESPACE::update::MirrorsWidget> m_mirrorsWidget;
 };


### PR DESCRIPTION
1. Modify the style of the image source list widget
2. The mirror source list widget remains persistent

Log:
Bug: https://pms.uniontech.com/bug-view-277543.html 
Bug: https://pms.uniontech.com/bug-view-276725.html 
Bug: https://pms.uniontech.com/bug-view-276719.html