### PR TITLE
fix: Missing corresponding icon for bluetooth headset devices

### DIFF
--- a/dcc-old/src/plugin-bluetooth/window/bluetoothdevicemodel.cpp
+++ b/dcc-old/src/plugin-bluetooth/window/bluetoothdevicemodel.cpp
@@ -107,6 +107,7 @@ const QMap<QString, QString> BluetoothDeviceModel::deviceType2Icon = {
     {"input-gaming", "other"},
     {"input-tablet", "touchpad"},
     {"audio-card", "pheadset"},
+    {"audio-headset", "pheadset"},
     {"network-wireless", "lan"},
     {"camera-video", "vidicon"},
     {"printer", "print"},


### PR DESCRIPTION
Bug: https://pms.uniontech.com/bug-view-279283.html
Log: Missing corresponding icon for bluetooth headset devices