### PR TITLE
Fix: Fix the issue of excessively long Bluetooth names

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothadapter.cpp
+++ b/src/plugin-bluetooth/operation/bluetoothadapter.cpp
@@ -47,7 +47,7 @@ void BluetoothAdapter::addDevice(const BluetoothDevice *device)
                 m_myDevices->insertItem(0, const_cast<BluetoothDevice*>(device));
             }
 
-            setMyDeviceVisible(m_powered);
+            setMyDeviceVisible(true);
 
         } else {
             qCDebug(DdcBluetoothAdapter) << "BluetoothAdapter add other device " << device->name();
@@ -69,7 +69,7 @@ void BluetoothAdapter::removeDevice(const QString &deviceId)
 
         m_myDevices->removeDevice(deviceId);
         m_otherDevices->removeDevice(deviceId);
-        setMyDeviceVisible(m_myDevices->rowCount() && m_powered);
+        setMyDeviceVisible(m_myDevices->rowCount());
         Q_EMIT deviceRemoved(deviceId);
     }
 }

--- a/src/plugin-bluetooth/operation/bluetoothadaptersmodel.cpp
+++ b/src/plugin-bluetooth/operation/bluetoothadaptersmodel.cpp
@@ -55,7 +55,7 @@ QVariant BlueToothAdaptersModel::data(const QModelIndex &index, int role) const
     case Discoverabled:
         return bluetoothAdapterData->discoverabled();
     case NameDetail:
-        return bluetoothAdapterData->powered() ? tr("Bluetooth is turned on, and the namcde is displayed as %1").arg(bluetoothAdapterData->name()) + "<a href=\"Edit\">" + tr("Edit")+ "</a>" : tr("Enable Bluetooth to find nearby devices (speakers, keyboard, mouse)");
+        return bluetoothAdapterData->powered() ? tr("Bluetooth is turned on, and the namcde is displayed as %1").arg(bluetoothAdapterData->name()) : tr("Enable Bluetooth to find nearby devices (speakers, keyboard, mouse)");
     case MyDevice:
         return QVariant::fromValue(bluetoothAdapterData->myDevices());
     case OtherDevice:

--- a/src/plugin-bluetooth/qml/Adapters.qml
+++ b/src/plugin-bluetooth/qml/Adapters.qml
@@ -24,7 +24,6 @@ DccObject{
         parentName: "blueToothAdapters" + model.name
         weight: 30
         pageType: DccObject.Item
-        visible: model.myDeviceVisiable
         page: DccGroupView {
             spacing: 0
             isGroup: false
@@ -37,7 +36,6 @@ DccObject{
         name: "otherDevice" + model.name
         parentName: "blueToothAdapters" + model.name
         weight: 40
-        visible: model.powered
         pageType: DccObject.Item
         page: DccGroupView {
             spacing: 0

--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -54,7 +54,6 @@ Rectangle {
                         spacing: 0
                         height: 50
                         Label {
-                            width: 100
                             id: myDeviceName
                             height: 25
                             text: model.name
@@ -62,6 +61,8 @@ Rectangle {
                             horizontalAlignment: Qt.AlignLeft
                             verticalAlignment: Qt.AlignBottom
                             leftPadding: 0
+                            elide: Text.ElideRight
+                            width: Math.min(implicitWidth, root.width - 200)
                         }
 
                         Row {

--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -42,25 +42,41 @@ DccObject{
                     verticalAlignment: Qt.AlignBottom
                     leftPadding: 0
                 }
-                Label {
-                    id: nameDetail
-                    height: 25
+
+                Row {
                     width: root.width - deviceSwitch.width - 36 - 52
-                    text: model.nameDetail
-                    horizontalAlignment: Qt.AlignLeft
-                    verticalAlignment: Qt.AlignTop
-                    font.pointSize: 8
-                    //opacity: 0.5
-                    color:"#5A000000"
-                    // 超链接点击事件
-                    onLinkActivated: function(url) {
-                        console.log("点击的链接是: " + url)
-                        nameEdit.visible = true
-                        nameDetail.visible = false
-                        myDeviceName.visible = false
-                        nameEditBackgrd.visible = true
-                        nameEdit.forceActiveFocus(true)
-                        nameEdit.selectAll()
+                    spacing: 5
+                    Label {
+                        id: nameDetail
+                        height: 25
+                        width: Math.min(implicitWidth, root.width - deviceSwitch.width - 36 - 52)
+                        text: model.nameDetail
+                        horizontalAlignment: Qt.AlignLeft
+                        verticalAlignment: Qt.AlignTop
+                        font.pointSize: 8
+                        color:"#5A000000"
+                        elide: Text.ElideRight
+                    }
+
+                    ToolButton {
+                        id: editBtn
+                        flat: false
+                        height: 25
+                        font.pointSize: 8
+                        text: qsTr("Edit")
+                        checked: true
+                        spacing: 0
+                        visible: model.powered
+                        topPadding: -5
+                        onClicked: {
+                            nameEdit.visible = true
+                            nameDetail.visible = false
+                            myDeviceName.visible = false
+                            nameEditBackgrd.visible = true
+                            nameEdit.forceActiveFocus(true)
+                            nameEdit.selectAll()
+                            editBtn.visible = false
+                        }
                     }
                 }
 
@@ -79,8 +95,6 @@ DccObject{
                         text: myDeviceName.text
                         topPadding: 5
                         bottomPadding: 5
-
-                        //maximumLength: 32
 
                         onTextChanged: {
                             if (text.length > 32) {
@@ -104,6 +118,7 @@ DccObject{
                             nameDetail.visible = true
                             myDeviceName.visible = true
                             nameEditBackgrd.visible = false
+                            editBtn.visible = true
 
                             dccData.work().setAdapterAlias(model.id, nameEdit.text)
                         }

--- a/src/plugin-bluetooth/qml/MyDevice.qml
+++ b/src/plugin-bluetooth/qml/MyDevice.qml
@@ -15,21 +15,22 @@ DccObject{
         weight: 10
         hasBackground: false
         pageType: DccObject.Item
-        page: ColumnLayout {
-            Label {
-                Layout.leftMargin: 10
-                font.bold: true
-                font.pixelSize: 16
-                text: dccObj.displayName
-            }                     
+        visible: model.myDeviceVisiable
+        page: Label {
+            leftPadding: 10
+            font.bold: true
+            font.pixelSize: 16
+            text: dccObj.displayName
         }
+
     }
 
     DccObject {
         name: "myDeviceList"
         parentName: "myDevice" + model.name
-        weight: 40
+        weight: 11
         hasBackground: true
+        visible: model.myDeviceVisiable
         pageType: DccObject.Item
         page: BlueToothDeviceListView {
             deviceModel: model.myDevice

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -14,6 +14,7 @@ DccObject{
         displayName: qsTr("Other Devices")
         weight: 10
         hasBackground: false
+        visible: model.powered
         pageType: DccObject.Item
         page: ColumnLayout {
             Label {
@@ -31,6 +32,7 @@ DccObject{
         pageType: DccObject.Item
         weight: 20
         hasBackground: false
+        visible: model.powered
 
         page: RowLayout {
             CheckBox {
@@ -76,7 +78,7 @@ DccObject{
         name: "otherDeviceList"
         parentName: "otherDevice" + model.name
         weight: 40
-        visible: true
+        visible: model.powered
         hasBackground: true
         pageType: DccObject.Item
         page: BlueToothDeviceListView {


### PR DESCRIPTION
Log: When the text is too long to exceed the window width, use omission display
Bug: https://pms.uniontech.com/bug-view-283979.html
Bug: https://pms.uniontech.com/bug-view-284071.html