### PR TITLE
Fix timedate bug

### DIFF
--- a/src/plugin-datetime/operation/datetimedbusproxy.cpp
+++ b/src/plugin-datetime/operation/datetimedbusproxy.cpp
@@ -37,7 +37,7 @@ DatetimeDBusProxy::DatetimeDBusProxy(QObject *parent)
     , m_localeInter(new QDBusInterface(LangSelectorService, LangSelectorPath, LangSelectorInterface, QDBusConnection::sessionBus(), this))
     , m_timedateInter(new QDBusInterface(TimedateService, TimedatePath, TimedateInterface, QDBusConnection::sessionBus(), this))
     , m_systemtimedatedInter(new QDBusInterface(SystemTimedatedService, SystemTimedatedPath, SystemTimedatedInterface, QDBusConnection::systemBus(), this))
-    ,m_formatInter(new QDBusInterface(FormatService, FormatPath, FormatInterface, QDBusConnection::sessionBus(), this))
+    , m_formatInter(new QDBusInterface(FormatService, FormatPath, FormatInterface, QDBusConnection::sessionBus(), this))
 {
     registerZoneInfoMetaType();
 

--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -18,6 +18,7 @@
 #include <QSettings>
 #include <QCoreApplication>
 #include <QStringListModel>
+#include <QTimer>
 
 static installer::ZoneInfoList g_totalZones;
 
@@ -249,6 +250,16 @@ DatetimeModel::DatetimeModel(QObject *parent)
     connect(this, &DatetimeModel::longTimeFormatChanged, this, [this]() {
         Q_EMIT currentFormatChanged(LongTime);
     });
+
+    QTimer *timer = new QTimer(this);
+    timer->setInterval(500);
+    connect(timer, &QTimer::timeout, this, [this](){
+        Q_EMIT currentTimeChanged();
+
+        // maybe too frequently
+        Q_EMIT currentDateChanged();
+    });
+    timer->start();
 }
 
 void DatetimeModel::setNTP(bool ntp)
@@ -815,6 +826,14 @@ QString DatetimeModel::currentDate()
         dateFormat.replace("dddd", "ddd");
 
     return locale.toString(QDate::currentDate(), dateFormat);
+}
+
+QString DatetimeModel::currentTime() const
+{
+    QLocale locale(m_localeName);
+    QString timeFormat = longTimeFormat();
+
+    return locale.toString(QTime::currentTime(), timeFormat);
 }
 
 int DatetimeModel::currentLanguageAndRegionIndex()

--- a/src/plugin-datetime/operation/datetimemodel.h
+++ b/src/plugin-datetime/operation/datetimemodel.h
@@ -47,6 +47,7 @@ class DatetimeModel : public QObject
 
     Q_PROPERTY(QString currentLanguageAndRegion READ currentLanguageAndRegion NOTIFY currentLanguageAndRegionChanged FINAL)
     Q_PROPERTY(QString currentDate READ currentDate NOTIFY currentDateChanged FINAL)
+    Q_PROPERTY(QString currentTime READ currentTime NOTIFY currentTimeChanged FINAL)
 
     Q_PROPERTY(QString digitGroupingSymbol READ digitGroupingSymbol WRITE setDigitGroupingSymbol NOTIFY digitGroupingSymbolChanged FINAL)
 
@@ -194,6 +195,7 @@ Q_SIGNALS:
     void regionChanged(const QString &region);
     void currentRegionIndexChanged(int index);
     void currentDateChanged();
+    void currentTimeChanged();
     void currentFormatChanged(int format);
 
 public Q_SLOTS:
@@ -233,6 +235,7 @@ public Q_SLOTS:
     int currentFormatIndex(int format);
     void setCurrentFormat(int format, int index);
     QString currentDate();
+    QString currentTime() const;
 protected:
     void initModes(const QStringList &names, int indexBegin, int indexEnd, QAbstractListModel *model);
 private:

--- a/src/plugin-datetime/operation/datetimemodel.h
+++ b/src/plugin-datetime/operation/datetimemodel.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include <QPoint>
+#include <QAbstractListModel>
 
 #include "zoneinfo.h"
 #include "regionproxy.h"
@@ -47,16 +48,18 @@ class DatetimeModel : public QObject
     Q_PROPERTY(QString currentLanguageAndRegion READ currentLanguageAndRegion NOTIFY currentLanguageAndRegionChanged FINAL)
     Q_PROPERTY(QString currentDate READ currentDate NOTIFY currentDateChanged FINAL)
 
+    Q_PROPERTY(QString digitGroupingSymbol READ digitGroupingSymbol WRITE setDigitGroupingSymbol NOTIFY digitGroupingSymbolChanged FINAL)
+
 public:
     using Regions = QMap<QString, QLocale>;
     enum Format {
         // date time formats
         DayAbbreviations,     // Monday/Mon ; 星期一 / 周一
         DayOfWeek,            // 一周首日
-        LongDate,             // 长日期
         ShortDate,            // 短日期
-        LongTime,             // 长时间
+        LongDate,             // 长日期
         ShortTime,            // 短时间
+        LongTime,             // 长时间
 
         // currency formats
         CurrencySymbol,       // 货币符号 ￥
@@ -129,6 +132,9 @@ public:
     inline QString currencyFormat() const { return m_currencyFormat; }
     void setCurrencyFormat(const QString &currencyFormat);
 
+    QString digitGroupingSymbol() const { return m_digitGroupingSymbol; }
+    void setDigitGroupingSymbol(const QString &digitGroupingSymbol);
+
     inline QString numberFormat() const { return m_numberFormat; }
     void setNumberFormat(const QString &numberFormat);
 
@@ -174,7 +180,8 @@ Q_SIGNALS:
     void longDateFormatChanged(const QString &longDate);
     void shortTimeFormatChanged(const QString &shortTimeFormat);
     void longTimeFormatChanged(const QString &longTimeFormat);
-    void currencyFormatChanged(const QString &currencyFormat);
+    void currencyFormatChanged(const QString &oldFormat, const QString &newFormat);
+    void digitGroupingSymbolChanged(const QString &oldFormat, const QString &newFormat);
     void numberFormatChanged(const QString &numberFormat);
     void paperFormatChanged(const QString &numberFormat);
     // Language List changed
@@ -187,6 +194,7 @@ Q_SIGNALS:
     void regionChanged(const QString &region);
     void currentRegionIndexChanged(int index);
     void currentDateChanged();
+    void currentFormatChanged(int format);
 
 public Q_SLOTS:
     void set24HourFormat(bool state);
@@ -199,6 +207,9 @@ public Q_SLOTS:
     QSortFilterProxyModel *langSearchModel();
     QSortFilterProxyModel *langRegionSearchModel();
     QSortFilterProxyModel *regionSearchModel();
+    QAbstractListModel *timeDateModel();
+    QAbstractListModel *currencyModel();
+    QAbstractListModel *decimalModel();
     QString region(); // country
     int currentRegionIndex();
     void setRegion(const QString &region); // setCountry
@@ -221,9 +232,9 @@ public Q_SLOTS:
     QStringList availableFormats(int format);
     int currentFormatIndex(int format);
     void setCurrentFormat(int format, int index);
-
     QString currentDate();
-
+protected:
+    void initModes(const QStringList &names, int indexBegin, int indexEnd, QAbstractListModel *model);
 private:
     bool m_ntp;
     bool m_bUse24HourType;
@@ -248,6 +259,7 @@ private:
     QString m_shortTimeFormat;
     QString m_longTimeFormat;
     QString m_currencyFormat;
+    QString m_digitGroupingSymbol;
     QString m_numberFormat;
     QString m_paperFormat;
     RegionFormat m_regionFormat;
@@ -257,6 +269,9 @@ private:
     QSortFilterProxyModel *m_langSearchModel = nullptr;
     QSortFilterProxyModel *m_regionSearchModel = nullptr;
     QSortFilterProxyModel *m_countrySearchModel = nullptr;
+    QAbstractListModel *m_timeDateModel = nullptr;
+    QAbstractListModel *m_currencyModel = nullptr;
+    QAbstractListModel *m_decimalModel = nullptr;
     dccV25::KeyboardModel *m_langModel = nullptr;
     QMap<QString, QString> m_langRegionsCache;
     QString m_regionName;

--- a/src/plugin-datetime/operation/datetimeworker.cpp
+++ b/src/plugin-datetime/operation/datetimeworker.cpp
@@ -43,13 +43,20 @@ DatetimeWorker::DatetimeWorker(DatetimeModel *model, QObject *parent)
     connect(m_timedateInter, &DatetimeDBusProxy::TimezoneChanged, m_model, &DatetimeModel::setTimeZoneInfo);
     connect(m_timedateInter, &DatetimeDBusProxy::WeekdayFormatChanged, m_model, &DatetimeModel::weekdayFormatChanged);
 
-    connect(m_timedateInter, &DatetimeDBusProxy::CurrencySymbolChanged, m_model, [this](const QString &symbol){
+    connect(m_timedateInter, &DatetimeDBusProxy::CurrencySymbolChanged, m_model, [this](const QString &symbol) {
+        Q_EMIT m_model->symbolChanged(DatetimeModel::CurrencySymbol, symbol);
+    });
+    connect(m_timedateInter, &DatetimeDBusProxy::NegativeCurrencyFormatChanged, m_model, [this](const QString &symbol) {
+        Q_EMIT m_model->symbolChanged(DatetimeModel::CurrencySymbol, symbol);
+    });
+    connect(m_timedateInter, &DatetimeDBusProxy::PositiveCurrencyFormatChanged, m_model, [this](const QString &symbol) {
         Q_EMIT m_model->symbolChanged(DatetimeModel::CurrencySymbol, symbol);
     });
     connect(m_timedateInter, &DatetimeDBusProxy::DecimalSymbolChanged, m_model, [this](const QString &symbol){
         Q_EMIT m_model->symbolChanged(DatetimeModel::DecimalSymbol, symbol);
     });
     connect(m_timedateInter, &DatetimeDBusProxy::DigitGroupingSymbolChanged, m_model, [this](const QString &symbol){
+        m_model->setDigitGroupingSymbol(symbol);
         Q_EMIT m_model->symbolChanged(DatetimeModel::DigitGroupingSymbol, symbol);
     });
 
@@ -61,6 +68,7 @@ DatetimeWorker::DatetimeWorker(DatetimeModel *model, QObject *parent)
     m_model->setNtpServerAddress(m_timedateInter->nTPServer());
     m_model->setTimeZoneInfo(m_timedateInter->timezone());
     m_model->setNTP(m_timedateInter->nTP());
+    m_model->setDigitGroupingSymbol(m_timedateInter->digitGroupingSymbol());
 
     initRegionFormatData();
 }

--- a/src/plugin-datetime/operation/langregionmodel.cpp
+++ b/src/plugin-datetime/operation/langregionmodel.cpp
@@ -88,4 +88,54 @@ QHash<int, QByteArray> LangRegionModel::roleNames() const
     names[PaperSize] = "paperSize";
     return names;
 }
+
+FormatsModel::FormatsModel(QObject *parent)
+    : QAbstractListModel(parent)
+{
+
+}
+
+void FormatsModel::setDatas(const QList<FormatsInfo> &datas) {
+    if (datas == m_datas)
+        return;
+
+    beginResetModel();
+    m_datas = datas;
+    endResetModel();
+}
+
+int FormatsModel::rowCount(const QModelIndex &) const
+{
+    return m_datas.count();
+}
+
+QVariant FormatsModel::data(const QModelIndex &index, int role) const
+{
+    const auto &info = m_datas.value(index.row());
+    switch (role) {
+    case NameRole:
+        return info.name;
+    case ValuesRole:
+        return info.values;
+    case CurrentRole:
+        return info.index;
+    case IndexBegin:
+        return info.indexBegin;
+    default:
+        break;
+    }
+
+    return QVariant();
+}
+
+QHash<int, QByteArray> FormatsModel::roleNames() const
+{
+    QHash<int, QByteArray> names = QAbstractListModel::roleNames();
+    names[NameRole] = "name";
+    names[ValuesRole] = "values";
+    names[CurrentRole] = "current";
+    names[IndexBegin] = "indexBegin";
+    return names;
+}
+
 }

--- a/src/plugin-datetime/operation/langregionmodel.h
+++ b/src/plugin-datetime/operation/langregionmodel.h
@@ -34,5 +34,38 @@ public:
     QVariant data(const QModelIndex &index, int role) const;
     QHash<int, QByteArray> roleNames() const;
 };
+
+struct FormatsInfo
+{
+    QString name;
+    QStringList values;
+    int index = -1;
+    int indexBegin = -1;
+    bool operator ==(const FormatsInfo &info) const {
+        return info.name == name && info.values == values &&
+                info.index == index && info.indexBegin == indexBegin;
+    }
+};
+
+class FormatsModel : public QAbstractListModel {
+public:
+    enum FormatsRole {
+        NameRole = Qt::UserRole + 1,
+        ValuesRole,
+        CurrentRole,
+        IndexBegin,
+    };
+
+    explicit FormatsModel(QObject *parent = nullptr);
+    void setDatas(const QList<FormatsInfo> &datas);
+public:
+    int rowCount(const QModelIndex &parent) const;
+    QVariant data(const QModelIndex &index, int role) const;
+    QHash<int, QByteArray> roleNames() const;
+
+private:
+    QList<FormatsInfo> m_datas;
+};
+
 }
 #endif // LANGREGIONMODEL_H

--- a/src/plugin-datetime/operation/regionproxy.cpp
+++ b/src/plugin-datetime/operation/regionproxy.cpp
@@ -113,7 +113,7 @@ public:
 
     virtual QStringList longTimeFormats() override
     {
-        return { "H:mm:ss", "HH:mm:ss", "ap H:mm:ss", "ap HH:mm:ss" };
+        return { "H:mm:ss", "HH:mm:ss", "ap hh:mm:ss", "ap hh:mm:ss" };
     }
 };
 
@@ -132,12 +132,12 @@ public:
 
     virtual QStringList shortTimeFormats() override
     {
-        return { "HH:mm", "H:mm", "HH:mm ap", "H:mm ap" };
+        return { "HH:mm", "H:mm", "hh:mm ap", "h:mm ap" };
     }
 
     virtual QStringList longTimeFormats() override
     {
-        return { "HH:mm:ss", "H:mm:ss", "HH:mm:ss ap", "apH:mm:ss ap" };
+        return { "HH:mm:ss", "H:mm:ss", "hh:mm:ss ap", "h:mm:ss ap" };
     }
 };
 

--- a/src/plugin-datetime/operation/regionproxy.cpp
+++ b/src/plugin-datetime/operation/regionproxy.cpp
@@ -281,6 +281,14 @@ QString RegionProxy::langCountry() const
     return langCountry;
 }
 
+static inline QString replaceSpace(const QString &space) {
+    QString sp;
+    for (const QChar &c : space) {
+        sp.append(c.isSpace() ? QChar(' ') : c);
+    }
+    return sp;
+}
+
 RegionFormat RegionProxy::regionFormat(const QLocale &locale)
 {
     RegionFormat regionFormat;
@@ -290,7 +298,12 @@ RegionFormat RegionProxy::regionFormat(const QLocale &locale)
     regionFormat.shortTimeFormat = locale.timeFormat(QLocale::ShortFormat);
     regionFormat.longTimeFormat = locale.timeFormat(QLocale::LongFormat);
     regionFormat.currencyFormat = locale.currencySymbol(QLocale::CurrencySymbol);
-    regionFormat.numberFormat = locale.toString(123456789);
+    // 如果是货币符号空就用 ¥
+    if (regionFormat.currencyFormat.isEmpty())
+        regionFormat.currencyFormat = QString::fromLocal8Bit("¥");
+
+    regionFormat.numberFormat = replaceSpace(locale.toString(123456789));
+    regionFormat.digitgroupFormat = locale.groupSeparator();
     regionFormat.paperFormat = "A4";
 
     return regionFormat;
@@ -374,7 +387,7 @@ QDebug operator<<(QDebug debug, const RegionFormat &regionFormat)
     debug << regionFormat.firstDayOfWeekFormat << regionFormat.shortDateFormat
           << regionFormat.longDateFormat << regionFormat.shortTimeFormat
           << regionFormat.longTimeFormat << regionFormat.currencyFormat << regionFormat.numberFormat
-          << regionFormat.paperFormat;
+          << regionFormat.digitgroupFormat << regionFormat.paperFormat;
 
     return debug;
 }

--- a/src/plugin-datetime/operation/regionproxy.h
+++ b/src/plugin-datetime/operation/regionproxy.h
@@ -18,6 +18,7 @@ const QString shortTimeFormat_key = "shortTimeFormat";
 const QString longTimeFormat_key = "longTimeFormat";
 const QString currencyFormat_key = "currencyFormat";
 const QString numberFormat_key = "numberFormat";
+const QString digitgroupFormat_key = "digitgroupFormat";
 const QString paperFormat_key = "paperFormat";
 
 struct RegionFormat {
@@ -28,6 +29,7 @@ struct RegionFormat {
     QString longTimeFormat;
     QString currencyFormat;
     QString numberFormat;
+    QString digitgroupFormat; //groupSeparator;
     QString paperFormat;
     bool operator!=(const RegionFormat &other)
     {
@@ -36,13 +38,14 @@ struct RegionFormat {
     bool operator==(const RegionFormat &other)
     {
         return (this->firstDayOfWeekFormat == other.firstDayOfWeekFormat) &&
-               (this->shortDateFormat == other.shortDateFormat) &&
-               (this->longDateFormat == other.longDateFormat) &&
-               (this->shortTimeFormat == other.shortTimeFormat) &&
-               (this->longTimeFormat == other.longTimeFormat) &&
-               (this->currencyFormat == other.currencyFormat) &&
-               (this->numberFormat == other.numberFormat) &&
-               (this->paperFormat == other.paperFormat);
+                (this->shortDateFormat == other.shortDateFormat) &&
+                (this->longDateFormat == other.longDateFormat) &&
+                (this->shortTimeFormat == other.shortTimeFormat) &&
+                (this->longTimeFormat == other.longTimeFormat) &&
+                (this->currencyFormat == other.currencyFormat) &&
+                (this->numberFormat == other.numberFormat) &&
+                (this->digitgroupFormat == other.digitgroupFormat) &&
+                (this->paperFormat == other.paperFormat);
     }
 };
 

--- a/src/plugin-datetime/qml/ComboLabel.qml
+++ b/src/plugin-datetime/qml/ComboLabel.qml
@@ -30,6 +30,10 @@ Item {
         id: label
         visible: item.comboModel.length === 1
         text: item.comboModel[0]
-        anchors.verticalCenter: parent.verticalCenter
+        anchors {
+            verticalCenter: parent.verticalCenter
+            right: parent.right
+            rightMargin: 10
+        }
     }
 }

--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -272,7 +272,6 @@ DccObject {
                     currentIndex: dccData.currentLanguageAndRegionIndex()
                     viewModel: dccData.langRegionSearchModel()
                     onSelectedRegion: function (locale, lang) {
-                        console.log("locale:", locale, "lang:", lang)
                         dccData.setCurrentLocaleAndLangRegion(locale, lang)
                     }
 

--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -272,6 +272,7 @@ DccObject {
                     currentIndex: dccData.currentLanguageAndRegionIndex()
                     viewModel: dccData.langRegionSearchModel()
                     onSelectedRegion: function (locale, lang) {
+                        console.log("locale:", locale, "lang:", lang)
                         dccData.setCurrentLocaleAndLangRegion(locale, lang)
                     }
 
@@ -293,18 +294,6 @@ DccObject {
         onParentItemChanged: item => { if (item) item.topPadding = 10 }
     }
 
-    Timer {
-        id: timer
-        interval: 100
-        property DccRepeater repeater
-        onTriggered: {
-            if (repeater) {
-                repeater.resetModel()
-                repeater = null
-            }
-        }
-    }
-
     // 时间日期格式
     DccObject {
         id: timeFormats
@@ -317,21 +306,20 @@ DccObject {
         onParentItemChanged: item => { if (item) item.topPadding = 10 }
 
         DccRepeater {
-            model: [ qsTr("Week"), qsTr("First day of week"), qsTr("Long date"),
-                qsTr("Short date"), qsTr("Long time"), qsTr("Short time") ]
+            id: timeFormatsRepeater
+            model: dccData.timeDateModel()
             delegate: DccObject {
-                name: modelData
+                name: model.name
                 parentName: "timeFormats"
-                displayName: modelData
+                displayName: model.name
                 weight: 10 * (index + 1)
                 hasBackground: true
                 pageType: DccObject.Editor
                 page: ComboLabel {
-                    comboModel: dccData.availableFormats(index)
-                    comboCurrentIndex: dccData.currentFormatIndex(index)
+                    comboModel: model.values
+                    comboCurrentIndex: model.current
                     onComboBoxActivated: function (idx) {
-                        let startIndex = 0 // Week
-                        dccData.setCurrentFormat(startIndex + index, idx)
+                        dccData.setCurrentFormat(model.indexBegin + index, idx)
                     }
                 }
             }
@@ -351,22 +339,19 @@ DccObject {
 
         DccRepeater {
             id: currencyRepeater
-            property int startIndex: 6 // Currency
-            model: [ qsTr("Currency symbol"), qsTr("Positive currency"), qsTr("Negative currency") ]
+            model: dccData.currencyModel()
             delegate: DccObject {
-                name: modelData
+                name: model.name
                 parentName: "currencyFormats"
-                displayName: modelData
+                displayName: model.name
                 weight: 10 * (index + 1)
                 hasBackground: true
                 pageType: DccObject.Editor
                 page: ComboLabel {
-                    comboModel: dccData.availableFormats(index + currencyRepeater.startIndex)
-                    comboCurrentIndex: dccData.currentFormatIndex(index + currencyRepeater.startIndex)
+                    comboModel: model.values
+                    comboCurrentIndex: model.current
                     onComboBoxActivated: function (idx) {
-                        dccData.setCurrentFormat(currencyRepeater.startIndex + index, idx)
-                        timer.repeater = currencyRepeater
-                        timer.start()
+                        dccData.setCurrentFormat(model.indexBegin + index, idx)
                     }
                 }
             }
@@ -386,23 +371,19 @@ DccObject {
 
         DccRepeater {
             id: numRepeater
-            property int startIndex: 9 // number
-            model: [ qsTr("Decimal symbol"), qsTr("Digit grouping symbol"),
-                qsTr("Digit grouping"), qsTr("Page size") ]
+            model: dccData.decimalModel()
             delegate: DccObject {
-                name: modelData
+                name: model.name
                 parentName: "numberFormats"
-                displayName: modelData
+                displayName: model.name
                 weight: 10 * (index + 1)
                 hasBackground: true
                 pageType: DccObject.Editor
                 page: ComboLabel {
-                    comboModel: dccData.availableFormats(index + numRepeater.startIndex)
-                    comboCurrentIndex: dccData.currentFormatIndex(index + numRepeater.startIndex)
+                    comboModel: model.values
+                    comboCurrentIndex: model.current
                     onComboBoxActivated: function (idx) {
-                        dccData.setCurrentFormat(numRepeater.startIndex + index, idx)
-                        timer.repeater = numRepeater
-                        timer.start()
+                        dccData.setCurrentFormat(model.indexBegin + index, idx)
                     }
                 }
             }

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -24,7 +24,7 @@ DccObject {
                 height: contentHeight
                 Layout.leftMargin: 10
                 font: DTK.fontManager.t1
-                text: Qt.formatTime(Date(), longTimeFormat)
+                text: dccData.currentTime
             }
             Label {
                 id: dateLabel
@@ -35,16 +35,16 @@ DccObject {
                 text: dccData.currentDate
             }
 
-            Timer {
-                interval: 500
-                running: true
-                repeat: true
-                onTriggered: {
-                    timeLabel.text = Qt.formatTime(Date(), timeLabel.longTimeFormat)
+            // Timer {
+            //     interval: 500
+            //     running: true
+            //     repeat: true
+            //     onTriggered: {
+            //         timeLabel.text = Qt.formatTime(Date(), timeLabel.longTimeFormat)
 
-                    dateLabel.text = dccData.currentDate
-                }
-            }
+            //         dateLabel.text = dccData.currentDate
+            //     }
+            // }
         }
     }
 

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -226,6 +226,7 @@ DccObject {
             }
         }
         DccObject {
+            visible: false // 暂时隐藏，会导致逻辑很复杂
             name: "12/24h"
             parentName: "dateTimeGroup"
             displayName: qsTr("Use 24-hour format")


### PR DESCRIPTION
- 选择语言和区域之后更新所有格式
- 选择货币格式后更新货币数字（正负）
- 选择数字分组格式后更新数字分组
- 修复 label 对齐问题
- 修改长日期短时间日期顺序，先短后长
- 修复 24/12 小时制不对
- 更新时间日期在属性中更新
- 修复am/pm没翻译的bug
- 
Bug: https://pms.uniontech.com/bug-view-282897.html, https://pms.uniontech.com/bug-view-282871.html
