### PR TITLE
chore: Add version dependencies for libdtk6gui-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Build-Depends:
  qt6-tools-dev,
  qt6-declarative-private-dev,
  libdtkcommon-dev,
- libdtk6gui-dev,
+ libdtk6gui-dev(>=6.0.21),
  libdtk6core-dev,
  doxygen,
  libgtest-dev,


### PR DESCRIPTION
use treeland interface

Log: