### PR TITLE
fix: Crashes when switching icon themes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.0.74) UNRELEASED; urgency=medium
+
+  * release 6.0.74
+
+ -- Zhangkun <zhangkun2@uniontech.com>  Fri, 08 Nov 2024 14:26:12 +0800
+
 dde-control-center (6.0.73) unstable; urgency=medium
 
   * release 6.0.73 

--- a/src/plugin-personalization/qml/IconThemeGridView.qml
+++ b/src/plugin-personalization/qml/IconThemeGridView.qml
@@ -63,10 +63,12 @@ GridLayout {
                         Layout.fillWidth: true
                         Layout.fillHeight: true
                         color: "transparent"
-                        D.DciIcon {
+                        Image {
                             anchors.fill: parent
+                            fillMode: Image.PreserveAspectFit
                             sourceSize: Qt.size(parent.width, parent.height)
-                            name: model.pic
+                            source: model.pic
+                            asynchronous: true
                         }
                     }
                 }

--- a/src/plugin-personalization/qml/ThemeSelectView.qml
+++ b/src/plugin-personalization/qml/ThemeSelectView.qml
@@ -78,10 +78,11 @@ ListView {
                             color: "transparent"
                             radius: 7
 
-                            D.DciIcon {
+                            Image {
                                 anchors.fill: parent
                                 sourceSize: Qt.size(parent.width, parent.height)
-                                name: model.pic
+                                source: model.pic
+                                asynchronous: true
                             }
                         }
                     }


### PR DESCRIPTION
Replace Dciicon with Image, Dciicon will update the icon when the theme icon changes, which may cause crashes. First, switch to Image, and then follow Dciicon's crash problem

Log: