### PR TITLE
chore: The new version of the dcc specifies the use of only Qt6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,8 +171,10 @@ set(Test_Libraries
     -lgcov
     Threads::Threads
     GTest::gtest
-    Qt::Test
+    ${QT_NS}::Test
 )
+
+set(DCC_FRAME_Library dde-control-center_frame)
 
 add_subdirectory(src/dde-control-center)
 #--------------------------plugins--------------------------

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -1,8 +1,7 @@
 cmake_minimum_required(VERSION 3.18)
 
 #--------------------------frame--------------------------
-set(DCC_Library dde-control-center_frame)
-set(DCCFrame_Name ${DCC_Library})
+set(DCCFrame_Name ${DCC_FRAME_Library})
 file(GLOB DCCFrame_SRCS
     "${DCC_PROJECT_ROOT_DIR}/include/*.h"
     "frame/*.cpp"
@@ -73,12 +72,12 @@ target_include_directories(${Control_Center_Name} PRIVATE
 )
 
 set(Control_Center_Libraries
-    ${DCC_Library}
+    ${DCC_FRAME_Library}
     ${DTK_NS}::Gui
-    Qt::Gui
-    Qt::DBus
-    Qt::Concurrent
-    Qt::Quick
+    ${QT_NS}::Gui
+    ${QT_NS}::DBus
+    ${QT_NS}::Concurrent
+    ${QT_NS}::Quick
 )
 
 target_link_libraries(${Control_Center_Name} PRIVATE

--- a/src/dde-control-center/frame/CMakeLists.txt
+++ b/src/dde-control-center/frame/CMakeLists.txt
@@ -15,8 +15,8 @@ target_include_directories(${DCCFrame_Name} PRIVATE
 
 set(DCCFrame_Libraries
     ${DTK_NS}::Gui
-    Qt::Gui
-    Qt::Quick
+    ${QT_NS}::Gui
+    ${QT_NS}::Quick
 )
 
 target_link_libraries(${DCCFrame_Name} PRIVATE

--- a/src/dde-control-center/frame/plugin/CMakeLists.txt
+++ b/src/dde-control-center/frame/plugin/CMakeLists.txt
@@ -40,9 +40,9 @@ target_include_directories(${DCCQmlPlugin_Name} PRIVATE
 )
 
 set(DCCQmlPlugin_Libraries
-    Qt::Gui
-    Qt::Quick
-    ${DCC_Library}
+    ${QT_NS}::Gui
+    ${QT_NS}::Quick
+    ${DCC_FRAME_Library}
 )
 
 target_link_libraries(${DCCQmlPlugin_Name} PRIVATE

--- a/src/plugin-bluetooth/CMakeLists.txt
+++ b/src/plugin-bluetooth/CMakeLists.txt
@@ -1,26 +1,26 @@
 cmake_minimum_required(VERSION 3.18)
 set(BlueTooth_Name blueTooth)
 file(GLOB_RECURSE blueTooth_SRCS
-        "operation/*.cpp"
-        "operation/*.h"
-        "operation/qrc/bluetooth.qrc"
+    "operation/*.cpp"
+    "operation/*.h"
+    "operation/qrc/bluetooth.qrc"
 )
 
 add_library(${BlueTooth_Name} MODULE
-        ${blueTooth_SRCS}
-        operation/bluetoothdevicemodel.h operation/bluetoothdevicemodel.cpp
-        operation/bluetoothadaptersmodel.h operation/bluetoothadaptersmodel.cpp
+    ${blueTooth_SRCS}
+    operation/bluetoothdevicemodel.h operation/bluetoothdevicemodel.cpp
+    operation/bluetoothadaptersmodel.h operation/bluetoothadaptersmodel.cpp
 
 )
 
 set(BlueTooth_Libraries
-        dde-control-center
-        ${QT_NS}::DBus
-        ${DTK_NS}::Gui
+    ${DCC_FRAME_Library}
+    ${QT_NS}::DBus
+    ${DTK_NS}::Gui
 )
 
 target_link_libraries(${BlueTooth_Name} PRIVATE
-        ${BlueTooth_Libraries}
+    ${BlueTooth_Libraries}
 )
 
 dcc_install_plugin(NAME ${BlueTooth_Name} TARGET ${BlueTooth_Name})

--- a/src/plugin-commoninfo/CMakeLists.txt
+++ b/src/plugin-commoninfo/CMakeLists.txt
@@ -17,8 +17,7 @@ add_library(${CommonInfo_Name} MODULE
 )
 
 set(CommonInfo_Libraries
-    dde-control-center
-    ${DEEPIN_PW_CHECK_INCLUDE_DIRS}
+    ${DCC_FRAME_Library}
     ${QT_NS}::DBus
     ${DTK_NS}::Gui
 )

--- a/src/plugin-commoninfo/operation/commoninfomodel.cpp
+++ b/src/plugin-commoninfo/operation/commoninfomodel.cpp
@@ -4,7 +4,7 @@
 #include "commoninfomodel.h"
 
 #include <QDebug>
-#include <dtk5/DCore/DSysInfo>
+#include <DSysInfo>
 
 CommonInfoModel::CommonInfoModel(QObject *parent)
     : QObject(parent)

--- a/src/plugin-datetime/CMakeLists.txt
+++ b/src/plugin-datetime/CMakeLists.txt
@@ -15,7 +15,7 @@ add_library(${pluginName} MODULE
 find_package(ICU COMPONENTS i18n uc)
 
 set(dateTime_Libraries
-    dde-control-center
+    ${DCC_FRAME_Library}
     ${QT_NS}::DBus
     ${QT_NS}::Concurrent
      ${DTK_NS}::Gui

--- a/src/plugin-defaultapp/CMakeLists.txt
+++ b/src/plugin-defaultapp/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(${DefaultApp_Name} MODULE
 )
 
 set(DefaultApp_Libraries
-    dde-control-center
+    ${DCC_FRAME_Library}
     ${QT_NS}::DBus
 )
 

--- a/src/plugin-keyboard/CMakeLists.txt
+++ b/src/plugin-keyboard/CMakeLists.txt
@@ -17,7 +17,7 @@ if (BUILD_PLUGIN)
         src/plugin-keyboard/operation
     )
     set(keyboard_Libraries
-        dde-control-center
+        ${DCC_FRAME_Library}
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
         ${QT_NS}::Gui

--- a/src/plugin-mouse/CMakeLists.txt
+++ b/src/plugin-mouse/CMakeLists.txt
@@ -16,7 +16,7 @@ if (BUILD_PLUGIN)
         src/plugin-mouse/operation
     )
     set(mouse_Libraries
-        dde-control-center
+        ${DCC_FRAME_Library}
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
         ${QT_NS}::Qml

--- a/src/plugin-personalization/CMakeLists.txt
+++ b/src/plugin-personalization/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 
 set(Personalization_Libraries
+    ${DCC_FRAME_Library}
     ${DTK_NS}::Gui
     ${QT_NS}::DBus
     ${QT_NS}::Qml

--- a/src/plugin-personalization/operation/model/wallpapermodel.h
+++ b/src/plugin-personalization/operation/model/wallpapermodel.h
@@ -4,9 +4,7 @@
 #ifndef WALLPAPERMODEL_H
 #define WALLPAPERMODEL_H
 
-#include <qabstractitemmodel.h>
-#include <qt5/QtCore/qnamespace.h>
-#include <QObject>
+#include <QAbstractItemModel>
 #include <QPixmap>
 
 struct ItemNode {

--- a/src/plugin-power/CMakeLists.txt
+++ b/src/plugin-power/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(${Power_Name} MODULE
 )
 
 set(Power_Libraries
-    dde-control-center
+    ${DCC_FRAME_Library}
     ${DTK_NS}::Gui
     ${QT_NS}::DBus
     ${QT_NS}::Concurrent

--- a/src/plugin-sound/CMakeLists.txt
+++ b/src/plugin-sound/CMakeLists.txt
@@ -22,7 +22,7 @@ if (DISABLE_SOUND_ADVANCED)
 endif()
 
 set(Sound_Libraries
-    dde-control-center
+    ${DCC_FRAME_Library}
     ${DTK_NS}::Gui
     ${QT_NS}::DBus
 )

--- a/src/plugin-systeminfo/CMakeLists.txt
+++ b/src/plugin-systeminfo/CMakeLists.txt
@@ -12,7 +12,7 @@ add_library(${SystemInfo_Name} MODULE
 )
 
 set(SystemInfo_Libraries
-    dde-control-center
+    ${DCC_FRAME_Library}
     ${QT_NS}::DBus
     ${DTK_NS}::Gui
 )

--- a/src/plugin-touchscreen/CMakeLists.txt
+++ b/src/plugin-touchscreen/CMakeLists.txt
@@ -16,7 +16,7 @@ if (BUILD_PLUGIN)
         src/plugin-touchscreen/operation
     )
     set(touchscreen_Libraries
-        dde-control-center
+        ${DCC_FRAME_Library}
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
         ${QT_NS}::Qml

--- a/src/plugin-wacom/CMakeLists.txt
+++ b/src/plugin-wacom/CMakeLists.txt
@@ -16,7 +16,7 @@ if (BUILD_PLUGIN)
         src/plugin-wacom/operation
     )
     set(wacom_Libraries
-        dde-control-center
+        ${DCC_FRAME_Library}
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
     )


### PR DESCRIPTION
- Specify Qt6
- Cancel explicit linking to dde control center

Log: