### PR TITLE
fix: shortDate/longtime format error

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -821,9 +821,8 @@ void DatetimeModel::setCurrentFormat(int format, int index)
 QString DatetimeModel::currentDate()
 {
     QLocale locale(m_localeName);
-    QString dateFormat = longDateFormat();
-    if (weekdayFormat() == 1)
-        dateFormat.replace("dddd", "ddd");
+    QString week = weekdayFormat() == 1 ? "ddd" : "dddd";
+    QString dateFormat = shortDateFormat() + " " + week;
 
     return locale.toString(QDate::currentDate(), dateFormat);
 }

--- a/src/plugin-datetime/operation/regionproxy.cpp
+++ b/src/plugin-datetime/operation/regionproxy.cpp
@@ -108,12 +108,12 @@ public:
 
     virtual QStringList shortTimeFormats() override
     {
-        return { "APhh:mm" ,"H:mm", "HH:mm", "ap h:mm", "ap hh:mm" };
+        return { "aphh:mm", "H:mm", "HH:mm", "ap h:mm", "ap hh:mm" };
     }
 
     virtual QStringList longTimeFormats() override
     {
-        return { "H:mm:ss", "HH:mm:ss", "ap hh:mm:ss", "ap hh:mm:ss" };
+        return { "H:mm:ss", "HH:mm:ss", "ap h:mm:ss", "ap hh:mm:ss" };
     }
 };
 

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -19,7 +19,6 @@ DccObject {
         page: ColumnLayout {
             Label {
                 id: timeLabel
-                property string longTimeFormat: dccData.longTimeFormat
 
                 height: contentHeight
                 Layout.leftMargin: 10
@@ -34,17 +33,6 @@ DccObject {
                 font: DTK.fontManager.t5
                 text: dccData.currentDate
             }
-
-            // Timer {
-            //     interval: 500
-            //     running: true
-            //     repeat: true
-            //     onTriggered: {
-            //         timeLabel.text = Qt.formatTime(Date(), timeLabel.longTimeFormat)
-
-            //         dateLabel.text = dccData.currentDate
-            //     }
-            // }
         }
     }
 
@@ -164,7 +152,7 @@ DccObject {
             name: "customNTPServer"
             parentName: "dateTimeGroup"
             displayName: qsTr("Server address")
-            visible: dateAndTimeSettings.showCustom
+            visible: dateAndTimeSettings && dateAndTimeSettings.showCustom
             weight: 13
             hasBackground: true
             pageType: DccObject.Editor


### PR DESCRIPTION
- dcc 显示的日期根据 『短日期』+『空格』+『周/星期』
- 去掉一个退出是警告
- 修复一个长时间选项减少的问题（重复过滤了，可能是 @FeiWang1119  手抖了：）

Bug: https://pms.uniontech.com/bug-view-282993.html