### PR TITLE
feat: add the StartupWMClass field to the desktop file

### DIFF
--- a/misc/org.deepin.dde.control-center.desktop
+++ b/misc/org.deepin.dde.control-center.desktop
@@ -6,6 +6,7 @@ GenericName=Control Center
 Icon=preferences-system
 Name=Deepin Control Center
 StartupNotify=false
+StartupWMClass=dde-control-center
 Terminal=false
 Type=Application
 X-Deepin-TurboType=dtkwidget


### PR DESCRIPTION
控制中心desktop名和wmclass不匹配，增加一个字段来正确标注控制中心的wmclass,让任务栏正确显示控制中心的打开状态

Bug: Task-368711