### PR TITLE
fix: font size error

### DIFF
--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -12,6 +12,7 @@
 #include <QLoggingCategory>
 #include <QDebug>
 #include <QDir>
+#include "utils.hpp"
 
 #include <private/qguiapplication_p.h>
 #include <private/qwaylandintegration_p.h>
@@ -159,7 +160,7 @@ void TreeLandWorker::setFontSize(const int value)
     }
     m_fontSize = value;
     PersonalizationWorker::setFontSize(value);
-    m_fontContext->set_font_size(value);
+    m_fontContext->set_font_size(pxToPt(value) * 10);
 }
 
 void TreeLandWorker::setTitleBarHeight(int value)

--- a/src/plugin-personalization/qml/FontSizePage.qml
+++ b/src/plugin-personalization/qml/FontSizePage.qml
@@ -34,7 +34,6 @@ DccObject {
                 Layout.fillWidth: true
                 tickDirection: D.TipsSlider.TickDirection.Back
                 slider.handleType: Slider.HandleType.ArrowBottom
-                slider.value: fontSizeModel.indexOf(dccData.model.fontSizeModel.size)
                 slider.from: 0
                 slider.to: fontSizeModel.length - 1
                 slider.live: true
@@ -52,6 +51,10 @@ DccObject {
                 ]
                 slider.onValueChanged: {
                     dccData.worker.setFontSize(fontSizeSlider.fontSizeModel[fontSizeSlider.slider.value])
+                }
+
+                Component.onCompleted: {
+                    slider.value = fontSizeModel.indexOf(dccData.model.fontSizeModel.size)
                 }
             }
         }


### PR DESCRIPTION
向Treeland设置的字体大小约定为10倍的原始大小，用于间接存储存储浮点数

pms: TASK-368711