### PR TITLE
fix: have no input device,there are input titles and prompt texts

### DIFF
--- a/src/plugin-sound/operation/soundmodel.cpp
+++ b/src/plugin-sound/operation/soundmodel.cpp
@@ -305,6 +305,7 @@ void SoundModel::addPort(Port *port)
 
         if (port->direction() == Port::Out) {
             m_outputPorts.append(port);
+            setOutPutCount(static_cast<int>(m_outputPorts.count()));
             if (port->isEnabled()) {
                 m_outPutPortCombo.append(port->name() + "(" + port->cardName() + ")");
             }
@@ -312,6 +313,7 @@ void SoundModel::addPort(Port *port)
             m_soundOutputDeviceModel->addData(port);
         } else {
             m_inputPorts.append(port);
+            setInPutPortCount(static_cast<int>(m_inputPorts.count()));
             if (port->isEnabled()) {
                 m_inPutPortCombo.append(port->name() + "(" + port->cardName() + ")");
             }
@@ -333,12 +335,14 @@ void SoundModel::removePort(const QString &portId, const uint &cardId)
 
         if (port->direction() == Port::Out) {
             m_outputPorts.removeOne(port);
+            setOutPutCount(static_cast<int>(m_outputPorts.count()));
             m_outPutPortCombo.removeOne(port->name() + "(" + port->cardName() + ")");
 
             m_soundOutputDeviceModel->removeData(port);
 
         } else {
             m_inputPorts.removeOne(port);
+            setInPutPortCount(static_cast<int>(m_inputPorts.count()));
             m_inPutPortCombo.removeOne(port->name() + "(" + port->cardName() + ")");
             m_soundInputDeviceModel->removeData(port);
             emit inPutPortComboChanged();

--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -384,9 +384,6 @@ void SoundWorker::cardsChanged(const QString &cards)
     }
 
     m_model->updatePortCombo();
-
-    m_model->setInPutPortCount(m_model->inPutPortCombo().count());
-    m_model->setOutPutCount(m_model->outPutPortCombo().count());
 }
 
 void SoundWorker::activeSinkPortChanged(const AudioPort &activeSinkPort)

--- a/src/plugin-sound/qml/SoundDevicemanagesPage.qml
+++ b/src/plugin-sound/qml/SoundDevicemanagesPage.qml
@@ -14,6 +14,7 @@ DccObject {
         parentName: "sound/deviceManger"
         displayName: qsTr("Output Devices")
         description: qsTr("Choose whether to enable the device")
+        visible: dccData.model().outPutCount !== 0
         weight: 10
         pageType: DccObject.Editor
     }
@@ -21,7 +22,7 @@ DccObject {
         name: "outputDeviceList"
         parentName: "sound/deviceManger"
         weight: 20
-        visible: dccData.model().enableSoundEffect
+        visible: dccData.model().outPutCount !== 0
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: DeviceListView {
@@ -36,6 +37,7 @@ DccObject {
         parentName: "sound/deviceManger"
         displayName: qsTr("Input Devices")
         description: qsTr("Choose whether to enable the device")
+        visible: dccData.model().inPutPortCount !== 0
         weight: 30
         pageType: DccObject.Editor
     }
@@ -43,7 +45,7 @@ DccObject {
         name: "inputDeviceList"
         parentName: "sound/deviceManger"
         weight: 40
-        visible: dccData.model().enableSoundEffect
+        visible: dccData.model().inPutPortCount !== 0
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: DeviceListView {


### PR DESCRIPTION
have no input device,there are input titles and prompt texts

Log: The testing machine does not have an input device, and there are input titles and prompt texts in the device management interface
pms: TASK-362117