### PR TITLE
fix: add/delete account model not reset

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -634,7 +634,7 @@ void DccManager::onObjectRemoved(DccObject *obj)
 
     for (auto &&o : m_currentObjects) {
         if (o == obj) {
-            showPage(QString());
+            doShowPage(m_root, QString());
             break;
         }
     }

--- a/src/plugin-accounts/operation/accountlistmodel.cpp
+++ b/src/plugin-accounts/operation/accountlistmodel.cpp
@@ -10,6 +10,12 @@ AccountListModel::AccountListModel(QObject *parent)
 {
 }
 
+void AccountListModel::reset()
+{
+    beginResetModel();
+    endResetModel();
+}
+
 int AccountListModel::rowCount(const QModelIndex &) const
 {
     AccountsController *controller = dynamic_cast<AccountsController *>(parent());

--- a/src/plugin-accounts/operation/accountlistmodel.h
+++ b/src/plugin-accounts/operation/accountlistmodel.h
@@ -18,6 +18,7 @@ public:
     };
 
 public:
+    void reset();
     virtual int rowCount(const QModelIndex &parent) const override;
     virtual QVariant data(const QModelIndex &index, int role) const override;
     virtual QHash<int, QByteArray> roleNames() const override;

--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -169,6 +169,9 @@ void AccountsController::checkPwdLimitLevel(int lvl)
 bool AccountsController::isDeleteAble(const QString &id) const
 {
     User *editUser = m_model->getUser(id);
+    if (!editUser)
+        return false;
+
     User *curLoginUser = m_model->currentUser();
     auto isOnlyAdmin = [this, editUser] {         // 是最后一个管理员
         return isSystemAdmin(editUser)            // 是管理员
@@ -476,6 +479,8 @@ QAbstractListModel *AccountsController::accountsModel()
         auto index = m_accountsModel->index(idIdx);
         m_accountsModel->dataChanged(index, index, {AccountListModel::OnlineRole});
     });
+
+    connect(this, &AccountsController::userIdListChanged, static_cast<AccountListModel *>(m_accountsModel), &AccountListModel::reset);
 
     return m_accountsModel;
 }


### PR DESCRIPTION
- reset account model when userIdListChanged
- use doShowPage when dccobject removed
- add nullptr check for isDeleteAble