### PR TITLE
fix: CustomAvatarEmpatyArea not hide/switchbutton loop bind

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -16,6 +16,11 @@ DccObject {
     property bool nopasswdLoginChecked: true
     property bool isDeleteUser: false
 
+    Component.onCompleted: {
+        settings.autoLoginChecked = dccData.autoLogin(settings.userId)
+        settings.nopasswdLoginChecked = dccData.nopasswdLogin(settings.userId)
+    }
+
     Component.onDestruction: {
         if (isDeleteUser) {
             DccApp.showPage("accounts")
@@ -348,13 +353,16 @@ DccObject {
             visible: dccData.isAutoLoginVisable()
             enabled: dccData.currentUserId() === settings.userId
             page: Switch {
-                checked: settings.autoLoginChecked && dccData.autoLogin(settings.userId)
+                checked: settings.autoLoginChecked
                 onCheckedChanged: {
-                    settings.autoLoginChecked = checked
+                    if (settings.autoLoginChecked != checked)
+                        settings.autoLoginChecked = checked
+
                     dccData.setAutoLogin(settings.userId, checked)
                 }
             }
         }
+
         DccObject {
             id: noPassword
             name: settings.papaName + "noPassword"
@@ -365,9 +373,11 @@ DccObject {
             visible: dccData.isNoPassWordLoginVisable()
             enabled: dccData.currentUserId() === settings.userId
             page: Switch {
-                checked: settings.nopasswdLoginChecked && dccData.nopasswdLogin(settings.userId)
+                checked: settings.nopasswdLoginChecked
                 onCheckedChanged: {
-                    settings.nopasswdLoginChecked = checked
+                    if (settings.nopasswdLoginChecked != checked)
+                        settings.nopasswdLoginChecked = checked
+
                     dccData.setNopasswdLogin(settings.userId, checked)
                 }
             }

--- a/src/plugin-accounts/qml/AvatarSettingsDialog.qml
+++ b/src/plugin-accounts/qml/AvatarSettingsDialog.qml
@@ -121,19 +121,22 @@ D.DialogWindow {
 
             CustomAvatarEmpatyArea {
                 id: customEmptyAvatar
-                visible: {
+                visible: needShow()
+                onIconDropped: function (url){
+                    dialog.currentAvatar = url
+                    // 23 dcc 选中自定义就会出发设置图标
+                    dialog.accepted();
+                }
+                onRequireFileDialog: {
+                    fileDlgLoader.active = true
+                }
+
+                function needShow() {
                     if (!scrollView.isCustom)
                         return false
 
                     let icons = dccData.avatars(dialog.userId, scrollView.filter, "")
                     return icons.length < 1
-                }
-
-                onIconDropped: function (url){
-                    dialog.currentAvatar = url
-                }
-                onRequireFileDialog: {
-                    fileDlgLoader.active = true
                 }
             }
 
@@ -188,6 +191,8 @@ D.DialogWindow {
                                         view.currentAvatar = avatar
                                         view.model = []
                                         view.model = dccData.avatars(dialog.userId, scrollView.filter, modelData)
+
+                                        customEmptyAvatar.visible = customEmptyAvatar.needShow()
                                     }
                                 }
                             }


### PR DESCRIPTION
- hide CustomAvatarEmpatyArea on AvatarChanged
- autoLogin / nopasswdLogin switch button loop bind property

pms: Bug-292619, Bug-292671, Bug-292673