### PR TITLE
fix: cursor theme setting does not take effect in treeland

### DIFF
--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -139,6 +139,7 @@ void TreeLandWorker::setCursorTheme(const QString &id)
     m_cursorTheme = id;
     PersonalizationWorker::setCursorTheme(id);
     m_cursorContext->set_theme(id);
+    m_cursorContext->commit();
 }
 
 void TreeLandWorker::setActiveColor(const QString &hexColor)


### PR DESCRIPTION
没有调用commit协议，Qt6程序默认显示合成器提供的光标，直接调用协议即可控制

遗留问题: Qt5 应用无法做到实时变化

pms: TASK-365811