### PR TITLE
chore: Optimize accounts and groups loading speed

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -10,7 +10,7 @@
 
 #include <QObject>
 #include <QSortFilterProxyModel>
-
+#include <QHash>
 namespace dccV25 {
 
 class AccountsController : public QObject
@@ -52,7 +52,9 @@ public slots:
     bool isOnline(const QString &id);
 
     QStringList allGroups() const;
-    QStringList groups(const QString &id) const;
+    QStringList groups(const QString &id);
+    void updateGroups(const QString &id);
+    void updateAllGroups();
     void setGroup(const QString &id, const QString &group, bool on);
     bool groupContains(const QString &id, const QString &name) const;
     bool groupEnabled(const QString &id, const QString &name) const;
@@ -82,6 +84,7 @@ public slots:
 signals:
     void currentUserNameChanged();
     void userIdListChanged();
+    void userRemoved(const QString &userId);
     void onlineUserListChanged();
     void avatarChanged(const QString &userId, const QString &avatar);
     void userTypeChanged(const QString &userId, const int userType);
@@ -104,6 +107,7 @@ private:
     QSortFilterProxyModel *m_avatarFilterModel = nullptr;
     QAbstractListModel    *m_avatarTypesModel = nullptr;
     QAbstractListModel    *m_accountsModel = nullptr;
+    QHash<QString, QStringList> m_groups;
 };
 
 }

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -14,17 +14,10 @@ DccObject {
     property string papaName
     property bool autoLoginChecked: true
     property bool nopasswdLoginChecked: true
-    property bool isDeleteUser: false
 
     Component.onCompleted: {
         settings.autoLoginChecked = dccData.autoLogin(settings.userId)
         settings.nopasswdLoginChecked = dccData.nopasswdLogin(settings.userId)
-    }
-
-    Component.onDestruction: {
-        if (isDeleteUser) {
-            DccApp.showPage("accounts")
-        }
     }
 
     // 账户头像
@@ -83,6 +76,11 @@ DccObject {
                         function onNopasswdLoginChanged(userId, enable) {
                             if (userId === settings.userId) {
                                 settings.nopasswdLoginChecked = enable
+                            }
+                        }
+                        function onUserRemoved(userId) {
+                            if (userId === settings.userId) {
+                                DccApp.showPage("accounts")
                             }
                         }
                     }
@@ -446,7 +444,6 @@ DccObject {
                             cfdLoader.active = false
                         }
                         onRequestDelete: function (deleteHome) {
-                            settings.isDeleteUser = true
                             dccData.removeUser(settings.userId, deleteHome)
                         }
                     }

--- a/src/plugin-accounts/qml/accountsMain.qml
+++ b/src/plugin-accounts/qml/accountsMain.qml
@@ -152,18 +152,26 @@ DccObject {
                         separatorVisible: true
                     }
                     onClicked: {
+                        otherSettings.displayName = model.display
+                        otherSettings.userId = model.userId
                         DccApp.showPage(otherSettings)
                     }
                 }
 
-                AccountSettings {
-                    id: otherSettings
-                    name: "otherAccountsItem_" + index + "_Content"
-                    parentName: "otherAccountsItem" + index
-                    papaName: name
-                    displayName: model.display
-                    userId: model.userId
-                }
+            }
+        }
+
+        DccObject {
+            name: "otherSettingsHolder"
+            parentName: "accounts"
+            pageType: DccObject.Item
+            page: Item { }
+
+            AccountSettings {
+                id: otherSettings
+                name: "otherAccountSettings"
+                parentName: "otherSettingsHolder"
+                papaName: name
             }
         }
     }


### PR DESCRIPTION
- 将其他账户的 `AccountSettings` 移动到外部，减少 `dccobject` 的数量
- 当前账户被删除时返回账户首页
- 增加 `groups` 缓存，优化加载速度，放置频繁排序，新增/修改/删除分组时更新