### PR TITLE
fix: Hide mouse under Treeland and show mono Audio

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -9,6 +9,8 @@
 #include "pluginmanager.h"
 #include "searchmodel.h"
 
+#include <DGuiApplicationHelper>
+
 #include <QCoreApplication>
 #include <QDBusConnection>
 #include <QDBusPendingCall>
@@ -133,6 +135,11 @@ DccApp::UosEdition DccManager::uosEdition() const
 {
     DSysInfo::UosEdition edition = DSysInfo::uosEditionType();
     return DccApp::UosEdition(edition);
+}
+
+bool DccManager::isTreeland() const
+{
+    return Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform);
 }
 
 DccObject *DccManager::object(const QString &name)

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -48,6 +48,8 @@ public:
 
     Q_INVOKABLE DccApp::UosEdition uosEdition() const;
 
+    Q_INVOKABLE bool isTreeland() const;
+
     inline const QSet<QString> &hideModule() const { return m_hideModule; }
 
 public Q_SLOTS:

--- a/src/plugin-mouse/qml/mouse.qml
+++ b/src/plugin-mouse/qml/mouse.qml
@@ -12,13 +12,5 @@ DccObject {
     icon:"dcc_nav_mouse"
     weight: 30
 
-    visible: false
-    DccDBusInterface {
-        property var wheelSpeed
-        service: "org.deepin.dde.InputDevices1"
-        path: "/org/deepin/dde/InputDevices1"
-        inter: "org.deepin.dde.InputDevices1"
-        connection: DccDBusInterface.SessionBus
-        onWheelSpeedChanged: mouse.visible = true
-    }
+    visible: !DccApp.isTreeland()
 }

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -169,7 +169,6 @@ DccObject {
             displayName: qsTr("Mono audio")
             description: qsTr("Merge left and right channels into a single channel")
             weight: 40
-            visible: dccData.model().audioServer === "pipewire"
             pageType: DccObject.Editor
             page: Switch {
                 checked: dccData.model().audioMono


### PR DESCRIPTION
Hide mouse under Treeland and show mono Audio

Log: Hide mouse under Treeland and show mono Audio
pms: BUG-291831