### PR TITLE
fix: the icon for sending system notifications is incorrect

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -104,8 +104,8 @@ static const QString getDevelopModeLicense(const QString &filePath, const QStrin
 static void notifyInfo(const QString &summary)
 {
     DUtil::DNotifySender(summary)
-            .appIcon("dde-control-center")
-            .appName(QObject::tr("dde-control-center"))
+            .appIcon("")
+            .appName("org.deepin.dde.control-center")
             .timeOut(5000)
             .call();
 }
@@ -113,8 +113,8 @@ static void notifyInfo(const QString &summary)
 static void notifyInfoWithBody(const QString &summary, const QString &body)
 {
     DUtil::DNotifySender(summary)
-            .appIcon("dde-control-center")
-            .appName(QObject::tr("dde-control-center"))
+            .appIcon("")
+            .appName("org.deepin.dde.control-center")
             .appBody(body)
             .timeOut(5000)
             .call();


### PR DESCRIPTION
Change the appName to org.deepin.dde.control-center and keep the appIcon empty

pms: Bug-297659