### PR TITLE
fix: biometric authentication sometimes not displaying

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -657,7 +657,9 @@ void DccManager::onVisible(bool visible)
             }
         }
         DccObject::Private::FromObject(m_hideObjects)->removeChild(obj);
-        addObjectToParent(obj);
+        if (!addObjectToParent(obj)) {
+            DccObject::Private::FromObject(m_noAddObjects)->addChild(obj, false);
+        }
     } else {
         removeObjectFromParent(obj);
         DccObject::Private::FromObject(m_hideObjects)->addChild(obj, false);

--- a/src/plugin-authentication/qml/authentication.qml
+++ b/src/plugin-authentication/qml/authentication.qml
@@ -7,20 +7,14 @@ import QtQuick.Controls 2.15
 
 DccObject {
     id: authentication
+    property bool hasFingerprint: false
+    property bool hasChara: false
     name: "authentication"
     parentName: "accountsloginMethod"
     displayName: qsTr("Biometric Authentication")
     weight: 30
-    visible: false
+    visible: (hasFingerprint || hasChara) && !DccApp.isTreeland()
 
-    Timer {
-        id: showTimer
-        interval: 100
-        repeat: false
-        onTriggered: {
-            authentication.visible = !DccApp.isTreeland()
-        }
-    }
 
     DccDBusInterface {
         property var driverInfo
@@ -30,12 +24,14 @@ DccObject {
         connection: DccDBusInterface.SystemBus
         onDriverInfoChanged: {
             let jsonData = JSON.parse(driverInfo)
+            let found = false
             for (var i = 0; i < jsonData.length; i++) {
                 if (jsonData[i].CharaType !== 0) {
-                    showTimer.start()
+                    authentication.hasChara = true
                     return
                 }
             }
+            authentication.hasChara = found
         }
     }
 
@@ -46,9 +42,7 @@ DccObject {
         inter: "org.deepin.dde.Authenticate1.Fingerprint"
         connection: DccDBusInterface.SystemBus
         onDefaultDeviceChanged: {
-            if (defaultDevice !== "") {
-                showTimer.start()
-            }
+            authentication.hasFingerprint = defaultDevice !== ""
         }
     }
 }


### PR DESCRIPTION
- If the parent object has not been fully loaded after the plugin is loaded, it cannot be added to the object tree
- Support displaying and hiding after hot plugging

pms: TASK-372265