### PR TITLE
fit: Modifying the unplugged network card caused a crash issue

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -584,6 +584,7 @@ void DccManager::doShowPage(DccObject *obj, const QString &cmd)
         m_activeObject = m_currentObjects.last();
         Q_EMIT activeObjectChanged(m_activeObject);
     }
+    m_activeObject->setCurrentObject(nullptr);
     m_navModel->setNavigationObject(m_currentObjects);
     qCInfo(dccLog) << "trigger object:" << triggeredObj->name() << " active object:" << m_activeObject->name() << (void *)(triggeredObj->parentItem());
     if (!(triggeredObj->pageType() & DccObject::Menu) && triggeredObj->parentItem()) {

--- a/src/dde-control-center/frame/dccobject.cpp
+++ b/src/dde-control-center/frame/dccobject.cpp
@@ -134,6 +134,9 @@ void DccObject::Private::removeChild(int index)
     Q_EMIT q_ptr->childAboutToBeRemoved(q_ptr, index);
     m_children.erase(m_children.cbegin() + index);
     DccObject::Private::FromObject(child)->SetParent(nullptr);
+    if (child == m_currentObject) {
+        q_ptr->setCurrentObject(nullptr);
+    }
     Q_EMIT q_ptr->childRemoved(child);
     Q_EMIT q_ptr->childrenChanged(m_children);
 }


### PR DESCRIPTION
The current object was not set to null ptr in a timely manner

pms: BUG-303491