### PR TITLE
fix: font combobox displays incomplete font names

### DIFF
--- a/src/plugin-personalization/qml/FontCombobox.qml
+++ b/src/plugin-personalization/qml/FontCombobox.qml
@@ -8,6 +8,7 @@ D.ComboBox {
     id: control
     flat: true
     property string visibleRole
+    implicitWidth: Math.max(DS.Style.control.implicitWidth(control), 300)
 
     displayText: {
         if (currentIndex < 0 || currentIndex >= model.count) {


### PR DESCRIPTION
Optimize the width of the dropdown menu to display as fully as possible, and add a logic to display tooltips for names that are not fully displayed in the subsequent dtk

pms: TASK-368711