### PR TITLE
fix: combobox for slideShow wallpaper  will not select 'never'

### DIFF
--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -291,9 +291,7 @@ void PersonalizationWorker::onWallpaperSlideShowChanged()
     QVariantMap wallpaperSlideShowMap;
     for (auto &screen : qApp->screens()) {
         QString slideShow = m_personalizationDBusProxy->wallpaperSlideShow(screen->name());
-        if (!slideShow.isEmpty()) {
-            wallpaperSlideShowMap.insert(screen->name(), slideShow);
-        }
+        wallpaperSlideShowMap.insert(screen->name(), slideShow);
     }
     if (!wallpaperSlideShowMap.isEmpty()) {
         m_model->setWallpaperSlideShowMap(wallpaperSlideShowMap);


### PR DESCRIPTION
empty values should not be filtered, as they represent never

pms: TASK-368711