### PR TITLE
fix: Continuous calls to the enroll interface may not initiate enroll

### DIFF
--- a/src/plugin-authentication/operation/charamangermodel.h
+++ b/src/plugin-authentication/operation/charamangermodel.h
@@ -76,7 +76,7 @@ public:
         Enroll_AuthFailed,
         Enroll_ClaimFailed,
         Enroll_Failed,
-        Enroll_Success,
+        Enroll_AuthSuccess,
         Count
     };
 

--- a/src/plugin-authentication/operation/charamangerworker.cpp
+++ b/src/plugin-authentication/operation/charamangerworker.cpp
@@ -346,7 +346,7 @@ void CharaMangerWorker::tryEnroll(const QString &name, const QString &thumb)
                 m_model->refreshEnrollResult(CharaMangerModel::EnrollResult::Enroll_Failed);
             } else {
                 Q_EMIT requestMainWindowEnabled(true);
-                m_model->refreshEnrollResult(CharaMangerModel::EnrollResult::Enroll_Success);
+                m_model->refreshEnrollResult(CharaMangerModel::EnrollResult::Enroll_AuthSuccess);
             }
             Q_EMIT requestMainWindowEnabled(true);
             watcher->deleteLater();

--- a/src/plugin-authentication/qml/AddFaceinfoDialog.qml
+++ b/src/plugin-authentication/qml/AddFaceinfoDialog.qml
@@ -21,6 +21,12 @@ D.DialogWindow {
     modality: Qt.WindowModal
     title: qsTr("Enroll Face")
 
+    onVisibleChanged: function() {
+        if (listview.currentIndex != 0 && !visible) {
+            dccData.stopFaceEnroll()
+        }
+    }
+
     D.ListView {
         id: listview
         implicitWidth: dialog.width - DS.Style.dialogWindow.contentHMargin * 2
@@ -116,6 +122,7 @@ D.DialogWindow {
                     enabled: agreeCheckbox.checked
                     onClicked: {
                         dccData.startFaceEnroll();
+                        dialog.hide()
                     }
                 }
             }
@@ -278,6 +285,7 @@ D.DialogWindow {
                     target: dccData.model
                     function onTryStartInputFace(res) {
                         listview.currentIndex = 1
+                        dialog.show()
                     }
                 }
             }

--- a/src/plugin-authentication/qml/AddFingerDialog.qml
+++ b/src/plugin-authentication/qml/AddFingerDialog.qml
@@ -21,6 +21,12 @@ D.DialogWindow {
     modality: Qt.WindowModal
     title: qsTr("Enroll Finger")
 
+    onVisibleChanged: function() {
+        if (listview.currentIndex != 0 && !visible) {
+            dccData.requestStopFingerEnroll()
+        }
+    }
+
     D.ListView {
         id: listview
         implicitWidth: dialog.width - DS.Style.dialogWindow.contentHMargin * 2
@@ -115,6 +121,7 @@ D.DialogWindow {
                     enabled: agreeCheckbox.checked
                     onClicked: {
                         dccData.requestStartFingerEnroll();
+                        dialog.hide()
                     }
                 }
             }
@@ -286,8 +293,9 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
             target: dccData.model
             function onEnrollResult(res) {
                 switch(res) {
-                    case CharaMangerModel.Enroll_Success:
+                    case CharaMangerModel.Enroll_AuthSuccess:
                         listview.currentIndex = 1
+                        dialog.show()
                 }
             }
         }


### PR DESCRIPTION
Hide the authentication dialog box to prevent multiple clicks on the next step

pms: BUG-304535