### PR TITLE
fix: Can delete logged-in users

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -554,6 +554,7 @@ QAbstractListModel *AccountsController::accountsModel()
             return;
         auto index = m_accountsModel->index(idIdx);
         m_accountsModel->dataChanged(index, index, {AccountListModel::OnlineRole});
+        emit onlineUserListChanged();
     });
 
     connect(this, &AccountsController::userIdListChanged, static_cast<AccountListModel *>(m_accountsModel), &AccountListModel::reset);

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -465,6 +465,7 @@ DccObject {
         pageType: DccObject.Item
         page: RowLayout {
             Button {
+                id: deleteBtn
                 Layout.alignment: groupSettingsBtn.visible ? Qt.AlignLeft : Qt.AlignRight
                 text: qsTr("Delete current account")
                 enabled: dccData.isDeleteAble(settings.userId)
@@ -487,6 +488,12 @@ DccObject {
                 }
                 onClicked: {
                     cfdLoader.active = true
+                }
+                Connections {
+                    target: dccData
+                    function onOnlineUserListChanged() {
+                        deleteBtn.enabled = dccData.isDeleteAble(settings.userId)
+                    }
                 }
             }
 


### PR DESCRIPTION
Failed to monitor online user status updates
This allows the deletion of logged-in users

pms: BUG-303551