### PR TITLE
fix: wallpaper interface loads slowly

### DIFF
--- a/src/plugin-personalization/operation/model/wallpapermodel.cpp
+++ b/src/plugin-personalization/operation/model/wallpapermodel.cpp
@@ -52,9 +52,6 @@ QVariant WallpaperModel::data(const QModelIndex &index, int role) const
         break;
     case Item_Thumbnail_Role:
         ret = node->thumbnail;
-        if (ret.toString().isEmpty()) {
-            ret = node->url;
-        }
         break;
     case Item_deleteAble_Role:
         ret = node->deleteAble;
@@ -79,12 +76,18 @@ bool WallpaperModel::setData(const QModelIndex &index, const QVariant &value, in
     if (index.row() >= items.size() || index.row() < 0) {
         return false;
     }
+
     if (role == Item_Selected_Role) {
         if (items[index.row()]->selected != value.toBool()) {
             items[index.row()]->selected = value.toBool();
             Q_EMIT dataChanged(index, index, {role});
+
         }
+    } else if (role == Item_Thumbnail_Role) {
+        items[index.row()]->thumbnail = value.toString();
+        Q_EMIT dataChanged(index, index, {role});
     }
+
     return QAbstractItemModel::setData(index, value, role);
 }
 
@@ -157,6 +160,15 @@ void WallpaperModel::updateSelected(const QStringList &selectedLists)
     }
 }
 
+void WallpaperModel::setThumbnail(WallpaperItemPtr item, const QString &thumbnail)
+{
+    for (int i = 0; i < items.size(); ++i) {
+        if (items[i].get() == item.get()) {
+            setData(index(i, 0), thumbnail, Item_Thumbnail_Role);
+            break;
+        }
+    }
+}
 
 QString WallpaperSortModel::getPicPathByUrl(const QString &url) const
 {

--- a/src/plugin-personalization/operation/model/wallpapermodel.h
+++ b/src/plugin-personalization/operation/model/wallpapermodel.h
@@ -111,6 +111,7 @@ public:
     QModelIndex itemIndex(const QString &item) const;
     void resetData(const QList<WallpaperItemPtr> &list);
     void updateSelected(const QStringList &selectedLists);
+    void setThumbnail(WallpaperItemPtr item, const QString &thumbnail);
 protected:
     QHash<int, QByteArray> roleNames() const override;
 private:

--- a/src/plugin-personalization/operation/wallpaperprovider.h
+++ b/src/plugin-personalization/operation/wallpaperprovider.h
@@ -36,12 +36,16 @@ public:
 
 signals:
     void pushBackground(const QList<WallpaperItemPtr> &items, WallpaperType type = WallpaperType::Wallpaper_Sys);
+    void thumbnailFinished(WallpaperItemPtr item, const WallpaperType type, const QString &thumbnail);
     void listFinished();
 public slots:
     void startListBackground(WallpaperType type = WallpaperType::Wallpaper_all);
 private:
+    WallpaperItemPtr createItem(const QString &path, bool del, WallpaperType type);
+private:
     PersonalizationDBusProxy *m_proxy = nullptr;
     std::atomic_bool m_running = false;
+    static QHash<QString, QString> g_thumbnailMap;
 };
 
 class WallpaperProvider : public QObject
@@ -52,7 +56,6 @@ public:
     ~WallpaperProvider();
     void fetchData(WallpaperType type = WallpaperType::Wallpaper_all);
     static bool isColor(const QString &path);
-    static WallpaperItemPtr createItem(const QString &path, bool del);
     static WallpaperType getWallpaperType(const QString &path);
 
 signals:
@@ -60,6 +63,7 @@ signals:
 
 private slots:
     void setWallpaper(const QList<WallpaperItemPtr> &items, WallpaperType type = WallpaperType::Wallpaper_Sys);
+    void setThumbnail(WallpaperItemPtr item, const WallpaperType type, const QString &thumbnail);
 
 private:
     QThread *m_workThread = nullptr;

--- a/src/plugin-personalization/qml/WallpaperSelectView.qml
+++ b/src/plugin-personalization/qml/WallpaperSelectView.qml
@@ -140,10 +140,21 @@ ColumnLayout {
             }
         }
 
+        Timer {
+            id: updateTimer
+            interval: 20
+            running: false
+            repeat: false
+            onTriggered: {
+                sortedModel.update()
+            }
+        }
+
         D.SortFilterModel {
             id: sortedModel
             model: root.model
             property int maxCount: layout.lineCount * 2 - (root.firstItemVisible ? 1 : 0)
+            property int lastMaxCount: 0
             lessThan: function(left, right) {
                 return left.index < right.index
             }
@@ -151,7 +162,12 @@ ColumnLayout {
                 return root.isExpand ? true : item.index < maxCount
             }
             onMaxCountChanged: {
-                sortedModel.update()
+                if ((Math.abs(maxCount - lastMaxCount)) > 5) {
+                    updateTimer.start()
+                } else {
+                    sortedModel.update()
+                }
+                lastMaxCount = maxCount
             }
 
             delegate: Control {


### PR DESCRIPTION
- Thumbnails placed in sub threads for delayed loading
- Delay refresh when there are too many item positions that need to be refreshed

pms: BUG-308827
pms: BUG-306519
pms: BUG-305731
pms: BUG-306007

## Summary by Sourcery

Bug Fixes:
- Fixes slow loading of the wallpaper interface by delaying thumbnail loading and refresh when there are too many item positions that need to be refreshed.