### PR TITLE
fix: No configuration written after modifying the region format

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -558,9 +558,17 @@ void DatetimeModel::setRegion(const QString &region)
     for (const auto &locale : m_regions) {
         if (locale.territoryToCode(locale.territory()) == reg) {
             QString country = locale.countryToString(locale.country());
+            QString language = QLocale::languageToString(locale.language());
+            QString langCountry = QString("%1:%2").arg(language).arg(country);
             m_work->setConfigValue(country_key, country);
+            m_work->setConfigValue(localeName_key, locale.name());
+            m_work->genLocale(locale.name());
+            m_work->setConfigValue(languageRegion_key, langCountry);
+            setLangRegion(langCountry);
+
             Q_EMIT regionChanged(region);
             Q_EMIT currentRegionIndexChanged(currentRegionIndex());
+            break;
         }
     }
 }
@@ -616,6 +624,7 @@ void DatetimeModel::setCurrentLocaleAndLangRegion(const QString &localeName, con
     m_work->setDigitGroupingSymbol(unEscapSpace(regionFormat.digitgroupFormat));
     // case PaperSize:
     m_work->setConfigValue(paperFormat_key, regionFormat.paperFormat.toUtf8());
+    m_work->genLocale(locale.name());
 }
 
 QStringList DatetimeModel::availableFormats(int format)


### PR DESCRIPTION
No configuration written after modifying the region format

pms: BUG-308899

## Summary by Sourcery

Fixes an issue where configuration changes related to region format modifications were not being written. The fix ensures that the locale is generated and the configuration is updated correctly when the region is changed. Also refactors the CMakeLists.txt files to use the DCC_FRAME_Library variable.

Bug Fixes:
- Fixes an issue where configuration changes related to region format modifications were not being written after modifying the region format.

Enhancements:
- Refactors the CMakeLists.txt files to use the DCC_FRAME_Library variable.