### PR TITLE
fix: No configuration written after modifying the region format

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -555,21 +555,31 @@ void DatetimeModel::setRegion(const QString &region)
 
     m_regionName = region;
     auto reg = m_langRegionsCache.value(region, region);
-    for (const auto &locale : m_regions) {
-        if (locale.territoryToCode(locale.territory()) == reg) {
-            QString country = locale.countryToString(locale.country());
-            QString language = QLocale::languageToString(locale.language());
-            QString langCountry = QString("%1:%2").arg(language).arg(country);
-            m_work->setConfigValue(country_key, country);
-            m_work->setConfigValue(localeName_key, locale.name());
-            m_work->genLocale(locale.name());
-            m_work->setConfigValue(languageRegion_key, langCountry);
-            setLangRegion(langCountry);
-
-            Q_EMIT regionChanged(region);
-            Q_EMIT currentRegionIndexChanged(currentRegionIndex());
-            break;
+    QLocale locale(QLocale::C);
+    for (const auto &tmplocale : m_regions) {
+        if (tmplocale.territoryToCode(tmplocale.territory()) == reg) {
+            if (m_work->genLocale(tmplocale.name())) {
+                locale = tmplocale;
+                qDebug() << "set locale success:" << locale.name();
+                break;
+            }
+            if (locale.language() == QLocale::C) {
+                locale = tmplocale;
+            }
         }
+    }
+    if (locale.language() != QLocale::C) {
+        qDebug() << "set locale:" << locale.name();
+        QString country = locale.countryToString(locale.country());
+        QString language = QLocale::languageToString(locale.language());
+        QString langCountry = QString("%1:%2").arg(language).arg(country);
+        m_work->setConfigValue(country_key, country);
+        m_work->setConfigValue(localeName_key, locale.name());
+        m_work->setConfigValue(languageRegion_key, langCountry);
+        setLangRegion(langCountry);
+
+        Q_EMIT regionChanged(region);
+        Q_EMIT currentRegionIndexChanged(currentRegionIndex());
     }
 }
 

--- a/src/plugin-datetime/operation/datetimeworker.cpp
+++ b/src/plugin-datetime/operation/datetimeworker.cpp
@@ -475,7 +475,7 @@ void DatetimeWorker::setConfigValue(const QString &key, const QVariant &value)
     m_config->setValue(key, value);
 }
 
-void DatetimeWorker::genLocale(const QString &localeName)
+bool DatetimeWorker::genLocale(const QString &localeName)
 {
     static QString localeConfPath = QStandardPaths::writableLocation(QStandardPaths::ConfigLocation) + QDir::separator() + "locale.conf";
 
@@ -483,7 +483,7 @@ void DatetimeWorker::genLocale(const QString &localeName)
 
     auto supportedLocaleListRes = getSupportedLocale();
     if (!supportedLocaleListRes.has_value()) {
-        return;
+        return false;
     }
 
     QStringList supportedLocaleList = supportedLocaleListRes.value();
@@ -494,9 +494,8 @@ void DatetimeWorker::genLocale(const QString &localeName)
     } else if (supportedLocaleList.contains(localeName)) {
         localeSet = localeName;
     } else {
-        return;
+        return false;
     }
-
     settings.setValue("LC_NUMERIC", localeSet);
     settings.setValue("LC_MONETARY", localeSet);
     settings.setValue("LC_TIME", localeSet);
@@ -505,4 +504,5 @@ void DatetimeWorker::genLocale(const QString &localeName)
     settings.setValue("LC_ADDRESS", localeSet);
     settings.setValue("LC_TELEPHONE", localeSet);
     settings.setValue("LC_MEASUREMENT", localeSet);
+    return true;
 }

--- a/src/plugin-datetime/operation/datetimeworker.h
+++ b/src/plugin-datetime/operation/datetimeworker.h
@@ -60,7 +60,7 @@ public Q_SLOTS:
     void setShortTimeFormat(int type);
     void setWeekStartDayFormat(int type);
 
-    void genLocale(const QString &localeName);
+    bool genLocale(const QString &localeName);
 
     ZoneInfo GetZoneInfo(const QString &zoneId);
 


### PR DESCRIPTION
Prioritize using compatible configurations

pms: BUG-308899

## Summary by Sourcery

Improve locale configuration generation to ensure configuration is written after modifying the region format

Bug Fixes:
- Fix an issue where configuration was not being written consistently when changing region settings

Enhancements:
- Modify locale generation logic to more robustly handle locale configuration
- Add return value to genLocale method to track locale generation success