### PR TITLE
fix: loading system plugin when using built dde-control-center

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -15,6 +15,7 @@
 #include <QCoreApplication>
 #include <QDBusConnection>
 #include <QDBusPendingCall>
+#include <QDir>
 #include <QElapsedTimer>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -101,6 +102,11 @@ void DccManager::init()
     m_engine = new QQmlApplicationEngine(this);
     auto paths = m_engine->importPathList();
     paths.prepend(DefaultModuleDirectory);
+    const QString rootDir = QCoreApplication::applicationDirPath();
+    QDir pluginDir(rootDir);
+    if (pluginDir.cd("../lib")) {
+        paths.prepend(pluginDir.absolutePath());
+    }
     m_engine->setImportPathList(paths);
     QStringList dciPaths = Dtk::Gui::DIconTheme::dciThemeSearchPaths();
     dciPaths << QStringLiteral(DefaultModuleDirectory);


### PR DESCRIPTION
Add the build directory plugin path, which has higher priority
than the system directory.

## Summary by Sourcery

Modify plugin loading mechanism to prioritize the build directory plugin path

Bug Fixes:
- Ensure that plugins from the build directory can be loaded with higher priority than system directory plugins

Enhancements:
- Improve plugin path resolution by dynamically adding the build directory's lib path to import paths