### PR TITLE
fix: Fixed it was not refreshed in time when switching theme displays

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfoproxy.cpp
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.cpp
@@ -99,6 +99,8 @@ void CommonInfoProxy::setEnableTheme(const bool value)
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [=] {
         if (call.isError()) {
             Q_EMIT resetEnableTheme();
+        } else {
+            Q_EMIT EnableThemeChanged(value);
         }
         watcher->deleteLater();
     });

--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -172,7 +172,11 @@ CommonInfoWork::CommonInfoWork(CommonInfoModel *model, QObject *parent)
     connect(m_commonInfoProxy, &CommonInfoProxy::IsLoginChanged, m_commomModel, &CommonInfoModel::setIsLogin);
     connect(m_commonInfoProxy, &CommonInfoProxy::DeviceUnlockedChanged, m_commomModel, &CommonInfoModel::setDeveloperModeState);
     connect(m_commonInfoProxy, &CommonInfoProxy::DefaultEntryChanged, m_commomModel, &CommonInfoModel::setDefaultEntry);
-    connect(m_commonInfoProxy, &CommonInfoProxy::EnableThemeChanged, m_commomModel, &CommonInfoModel::setThemeEnabled);
+    // connect(m_commonInfoProxy, &CommonInfoProxy::EnableThemeChanged, m_commomModel, &CommonInfoModel::setThemeEnabled);
+    connect(m_commonInfoProxy, &CommonInfoProxy::EnableThemeChanged, m_commomModel, [this](bool ThemeEnable) {
+        m_commomModel->setGrubThemePath(m_commonInfoProxy->Background());
+        m_commomModel->setThemeEnabled(ThemeEnable);
+    });
     connect(m_commonInfoProxy, &CommonInfoProxy::TimeoutChanged, m_commomModel, [this] (const uint timeout) {
         m_commomModel->setBootDelay(timeout > 1);
     });

--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -64,6 +64,13 @@ DccObject {
                 clip: true
             }
 
+            Rectangle {
+                visible: dccData.mode().grubThemePath === ""
+                anchors.fill: image
+                color: "black"
+                radius: 10
+            }
+
             Column {
                 spacing: 5
                 leftPadding: 20


### PR DESCRIPTION
Fixed the issue that it was not refreshed in time when switching theme displays

Log: Fixed it was not refreshed in time when switching theme displays
pms: BUG-281385

## Summary by Sourcery

Improve theme switching and display handling in the boot page by updating theme refresh mechanism and adding a fallback visual state

Bug Fixes:
- Fix theme refresh timing issue when switching theme displays
- Ensure proper theme path and enable state are set during theme changes

Enhancements:
- Add a black background rectangle when no grub theme path is available
- Modify theme change connection to update theme path and enable state simultaneously