### PR TITLE
fix: number separator issue in SpinBox with C locale

### DIFF
--- a/src/plugin-datetime/qml/DateTimeSettingDialog.qml
+++ b/src/plugin-datetime/qml/DateTimeSettingDialog.qml
@@ -44,6 +44,7 @@ D.DialogWindow {
             SpinboxEx {
                 id: spYear
                 unitText: qsTr("Year")
+                locale: Qt.locale("C")
                 from: 1990
                 to: 2090
                 value: currentDate.getFullYear()


### PR DESCRIPTION
Fixed the issue that SpinBox shows comma as number separator in some regions

Log: Fixed the issue that SpinBox shows comma as number separator in some regions
pms: BUG-278709

## Summary by Sourcery

Bug Fixes:
- Resolved an issue where SpinBox was displaying comma as a number separator in certain regional settings by explicitly setting the locale to C