### PR TITLE
fix: remove redundant locale config when setting region

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -574,9 +574,6 @@ void DatetimeModel::setRegion(const QString &region)
         QString language = QLocale::languageToString(locale.language());
         QString langCountry = QString("%1:%2").arg(language).arg(country);
         m_work->setConfigValue(country_key, country);
-        m_work->setConfigValue(localeName_key, locale.name());
-        m_work->setConfigValue(languageRegion_key, langCountry);
-        setLangRegion(langCountry);
 
         Q_EMIT regionChanged(region);
         Q_EMIT currentRegionIndexChanged(currentRegionIndex());


### PR DESCRIPTION
Remove unnecessary locale name and language region configuration settings when setting a new region, as these values are handled elsewhere.

Log: remove redundant locale config when setting region
pms: BUG-311235

## Summary by Sourcery

Bug Fixes:
- Remove unnecessary locale name and language region configuration settings that are handled elsewhere in the code