### PR TITLE
fix: disable microphone input level slider interaction

### DIFF
--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -126,13 +126,23 @@ DccObject {
                     implicitWidth: 24
                     Layout.rightMargin: 4
                 }
-                Slider {
+                Item {
                     Layout.fillWidth: false
-                   // handleType: Slider.HandleType.NoArrowHorizontal
-                    handleType: -2
-                    highlightedPassedGroove: true
-                    implicitHeight: 24
-                    value: dccData.model().microphoneFeedback
+                    implicitHeight: slider.implicitHeight
+                    implicitWidth: slider.implicitWidth
+
+                    Slider {
+                        id: slider
+                        anchors.fill: parent
+                        handleType: -2
+                        highlightedPassedGroove: true
+                        value: dccData.model().microphoneFeedback
+                    }
+
+                    MouseArea {
+                        anchors.fill: parent
+                        hoverEnabled: true
+                    }
                 }
                 D.DciIcon {
                     name: "big_volume"


### PR DESCRIPTION
Wrap the input level slider in a container with MouseArea to prevent user interaction, keeping it as a display-only component.

Log: disable microphone input level slider interaction
pms: BUG-292099

## Summary by Sourcery

Bug Fixes:
- Prevent user interaction with the microphone input level slider, making it display-only