### PR TITLE
fix: The issue that the group title is not refreshed in time is fixed

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -165,7 +165,10 @@ DccObject {
                     text: dccData.userName(settings.userId)
                     font.pointSize: 16
                     font.bold: true
-                    color: palette.text // not update ?
+                    color: palette.text
+                    elide: Text.ElideRight
+                    maximumLineCount: 1
+                    Layout.maximumWidth: item.width - 230
                 }
                 Text {
                     id: userTypeName

--- a/src/plugin-accounts/qml/EditActionLabel.qml
+++ b/src/plugin-accounts/qml/EditActionLabel.qml
@@ -9,14 +9,26 @@ import org.deepin.dtk.style 1.0 as DS
 D.LineEdit {
     id: edit
     property alias editBtn: editButton
+    property alias alertText: panel.alertText
+    property alias showAlert: panel.showAlert
     signal finished()
 
     readOnly: true
-    background.visible: showAlert
     horizontalAlignment: TextInput.AlignLeft
     clearButton.visible: !readOnly
     rightPadding: clearButton.width + clearButton.anchors.rightMargin
-    alertDuration: 3000
+    background: D.EditPanel {
+        id: panel
+        control: edit
+        showBorder: !readOnly
+        alertDuration: 3000
+        implicitWidth: DS.Style.edit.width
+        implicitHeight: DS.Style.edit.textFieldHeight
+        backgroundColor: D.Palette {
+            normal: Qt.rgba(1, 1, 1, 0)
+            normalDark: Qt.rgba(1, 1, 1, 0)
+        }
+    }
     onEditingFinished: {
         if (edit.readOnly)
             return
@@ -31,10 +43,28 @@ D.LineEdit {
     D.ActionButton {
         id: editButton
         focusPolicy: Qt.NoFocus
+        width: 30
+        height: 30
         icon.name: "dcc-edit"
         icon.width: DS.Style.edit.actionIconSize
         icon.height: DS.Style.edit.actionIconSize
-        background: null
+        background: Rectangle {
+            anchors.fill: parent
+            property D.Palette pressedColor: D.Palette {
+                normal: Qt.rgba(0, 0, 0, 0.2)
+                normalDark: Qt.rgba(1, 1, 1, 0.25)
+            }
+            property D.Palette hoveredColor: D.Palette {
+                normal: Qt.rgba(0, 0, 0, 0.1)
+                normalDark: Qt.rgba(1, 1, 1, 0.1)
+            }
+            radius: DS.Style.control.radius
+            color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+            border {
+                color: parent.palette.highlight
+                width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+            }
+        }
         anchors {
             right: edit.right
             verticalCenter: edit.verticalCenter

--- a/src/plugin-accounts/qml/accountsMain.qml
+++ b/src/plugin-accounts/qml/accountsMain.qml
@@ -17,6 +17,7 @@ DccObject {
 
     // 其他账户
     DccObject {
+        id: otherAcountsTitle
         name: "otherAcountsTitle"
         parentName: "accounts"
         displayName: qsTr("Other accounts")
@@ -163,6 +164,9 @@ DccObject {
                        otherSettings.userId = model.userId
                        DccApp.showPage(otherSettings)
                    }
+               }
+               onCountChanged: {
+                   otherAcountsTitle.visible = count > 0;
                }
            }
         }


### PR DESCRIPTION
[fix: The issue that the group title is not refreshed in time is fixed]

The issue that the group title is not refreshed in time is fixed

Log: The issue that the group title is not refreshed in time is fixed
pms: BUG-292441

[fix: The issue that the username is displayed too long is fixed]

The issue that the username is displayed too long is fixed

Log: The issue that the username is displayed too long is fixed
pms: BUG-292471

[fix: Fixed the issue of formula bar style]

Fixed the issue of formula bar style

Log: Fixed the issue of formula bar style
pms: 292505

## Summary by Sourcery

Fix UI issues in the accounts plugin related to group titles, username display, and edit action styling

Bug Fixes:
- Ensure the 'Other accounts' group title visibility is dynamically updated based on account count
- Limit username display to prevent overflow by adding text elision and maximum width
- Improve edit action button styling with hover and pressed states

Enhancements:
- Refactor EditActionLabel component to use more flexible background and panel styling
- Add more robust text display properties to username text element