### PR TITLE
fix: simplify NTP server validation and address assignment

### DIFF
--- a/src/plugin-datetime/operation/datetimeworker.cpp
+++ b/src/plugin-datetime/operation/datetimeworker.cpp
@@ -166,7 +166,7 @@ void DatetimeWorker::setNtpServer(QString server)
 {
     qInfo() << "Try set server : " << server;
 
-    if (server.isEmpty() || server == m_timedateInter->nTPServer())
+    if (server == m_timedateInter->nTPServer())
         return;
     m_timedateInter->SetNTPServer(server, tr("Authentication is required to change NTP server"), this, SLOT(SetNTPServerFinished()), SLOT(SetNTPServerError()));
 }

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -108,8 +108,7 @@ DccObject {
                     onActivated: function (index) {
                         dateAndTimeSettings.showCustom = (serverList[index] === qsTr("Customize"))
                         if (dateAndTimeSettings.showCustom) {
-                            if (dateAndTimeSettings.customAddr.length > 0)
-                                dccData.ntpServerAddress = dateAndTimeSettings.customAddr
+                            dccData.ntpServerAddress = dateAndTimeSettings.customAddr
                             return
                         }
 


### PR DESCRIPTION
Remove redundant empty server check and simplify NTP server address assignment logic in datetime settings.

Log: simplify NTP server validation and address assignment
pms: BUG-278803

## Summary by Sourcery

Simplify NTP server validation and address assignment logic in datetime settings

Bug Fixes:
- Remove redundant empty server check in NTP server address assignment
- Streamline NTP server validation to reduce unnecessary checks

Enhancements:
- Simplify conditional logic for setting NTP server addresses
- Reduce unnecessary validation steps in server address handling