### PR TITLE
fix: Add the computer name tooltip

### DIFF
--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -83,6 +83,17 @@ DccObject {
                     id: hostNameLabel
                     Layout.alignment: Qt.AlignRight | Qt.AlignTop
                     text: dccData.systemInfoMode().hostName
+                    ToolTip {
+                        text: hostNameLabel.text
+                        delay: 500
+                        visible: hostNameArea.containsMouse
+                    }
+
+                    MouseArea {
+                        id: hostNameArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                    }
                 }
 
                 IconButton {


### PR DESCRIPTION
Add the computer name tooltip

Log: Add the computer name tooltip
pms: BUG-282901

## Summary by Sourcery

Bug Fixes:
- Improve visibility of full computer name in the system information page by adding a tooltip