### PR TITLE
fix: copyright cannot display Chinese

### DIFF
--- a/src/plugin-systeminfo/operation/systeminfowork.cpp
+++ b/src/plugin-systeminfo/operation/systeminfowork.cpp
@@ -214,7 +214,7 @@ void SystemInfoWork::initUserLicenseData()
 void SystemInfoWork::initSystemCopyright()
 {
     const QSettings settings("/etc/deepin-installer.conf", QSettings::IniFormat);
-    QString oem_copyright = settings.value("system_info_vendor_name").toString().toLatin1();
+    QString oem_copyright = settings.value("system_info_vendor_name").toString().toUtf8();
     if (oem_copyright.isEmpty()) {
         if (DSysInfo::productType() != DSysInfo::ProductType::Uos)
             oem_copyright = QCoreApplication::translate("LogoModule", "Copyright© 2011-%1 Deepin Community")


### PR DESCRIPTION
use utf-8

pms: BUG-312007

## Summary by Sourcery

Bug Fixes:
- Modify copyright text encoding from Latin1 to UTF-8 to correctly display non-ASCII characters like Chinese