### PR TITLE
fix: ScorllBar still hide when hovered

### DIFF
--- a/qml/SecondPage.qml
+++ b/qml/SecondPage.qml
@@ -148,6 +148,7 @@ Item {
         StackView {
             id: rightView
             clip: true
+            hoverEnabled: true
             anchors {
                 fill: parent
                 topMargin: 50


### PR DESCRIPTION
Contorl will eat mouse presse event, and it causes window can't
be dragged, That's why the Control is disabled hoverEnabled in
DccWindow.
TitleBar maybe assigned to header of Application, but it causes
SideBar is not conforming to the design ui.
hoverEnabled has an inheritance relationship.
We will release the hoverEnabled at the root of the content.

pms: BUG-311835

## Summary by Sourcery

Enable hover functionality for the StackView in SecondPage to improve user interaction and resolve scrollbar visibility issues

Bug Fixes:
- Fix an issue where the scrollbar was not visible when hovered due to hover being disabled

Chores:
- Adjust hover behavior to ensure proper UI interaction in the application