### PR TITLE
fix: missing unchecked state for DccCheckIcon

### DIFF
--- a/src/dde-control-center/frame/plugin/DccCheckIcon.qml
+++ b/src/dde-control-center/frame/plugin/DccCheckIcon.qml
@@ -10,6 +10,6 @@ D.ActionButton {
     icon {
         width: size
         height: size
-        name: "item_checked"
+        name: checked ? "item_checked" : "item_unchecked"
     }
 }


### PR DESCRIPTION
as title.

pms: BUG-313001

## Summary by Sourcery

Bug Fixes:
- Fix the icon display to show 'item_unchecked' when the component is not checked, addressing a visual state inconsistency