### PR TITLE
fix: Fixed the Bluetooth checkbox clicking issue

### DIFF
--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -195,13 +195,16 @@ DccObject{
         weight: 20
         visible: !dccData.model().airplaneEnable && model.powered
 
-        page: CheckBox {
-            checked: model.discoverabled
-            leftPadding: 10
-            text: qsTr("Allow other Bluetooth devices to find this device")
-            
-            onCheckedChanged: {
-                dccData.work().setAdapterDiscoverable(model.id ,checked)
+        page: RowLayout {
+            CheckBox {
+                checked: model.discoverabled
+                Layout.alignment: Qt.AlignLeft
+                leftPadding: 10
+                text: qsTr("Allow other Bluetooth devices to find this device")
+                
+                onCheckedChanged: {
+                    dccData.work().setAdapterDiscoverable(model.id ,checked)
+                }
             }
         }
     }


### PR DESCRIPTION
Fixed the Bluetooth checkbox clicking issue

Log: Fixed the Bluetooth checkbox clicking issue
pms: BUG-284331

## Summary by Sourcery

Modify the Bluetooth settings UI to improve the layout of the discoverable checkbox

Bug Fixes:
- Fixed an issue with the Bluetooth checkbox layout that may have been causing interaction problems

Enhancements:
- Wrapped the Bluetooth discoverable checkbox in a RowLayout to improve alignment and potentially resolve clicking issues