### PR TITLE
fix: always include switch-monitors in system shortcuts filter

### DIFF
--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -38,7 +38,8 @@ QStringList systemFilter = {"terminal",
                             "wm-switcher",
                             "system-monitor",
                             "color-picker",
-                            "clipboard"
+                            "clipboard",
+                            "switch-monitors"
 };
 
 const QStringList &windowFilter = {"maximize",
@@ -98,9 +99,6 @@ ShortcutModel::ShortcutModel(QObject *parent)
     : QObject(parent)
     , m_windowSwitchState(false)
 {
-    if (qApp->screens().count() > 1) {
-        systemFilter.append("switch-monitors");
-    }
 }
 
 ShortcutModel::~ShortcutModel()


### PR DESCRIPTION
Remove conditional check for screen count and make switch-monitors a permanent part of system shortcuts filter.

Log: always include switch-monitors in system shortcuts filter
pms: BUG-281865