### PR TITLE
fix: The issue of user group editing is fixed

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -616,11 +616,13 @@ DccObject {
                         }
                         implicitHeight: 40
                         implicitWidth: 200
+                        Layout.fillWidth: !readOnly
                         placeholderText: qsTr("Group name")
                         horizontalAlignment: TextInput.AlignLeft | Qt.AlignVCenter
                         editBtn.visible: readOnly && editAble
                                          && !groupSettings.isEditing
                         readOnly: model.display.length > 0
+                        background: null
 
                         onFinished: function () {
                             if (text.length < 1) {
@@ -658,7 +660,7 @@ DccObject {
                         focusPolicy: Qt.NoFocus
                         icon.width: 18
                         icon.height: 18
-                        visible: groupSettings.isEditing ? editLabel.editAble : true
+                        visible: groupSettings.isEditing ? editLabel.editAble : editLabel.readOnly
                         icon.name: {
                             if (groupSettings.isEditing) {
                                 return "list_delete"


### PR DESCRIPTION
The issue of user group editing is fixed

Log: The issue of user group editing is fixed
pms: BUG-298621

## Summary by Sourcery

Fix user group editing functionality in the account settings QML component

Bug Fixes:
- Resolve issues with group name editing and visibility of edit controls in the account settings interface

Enhancements:
- Improve layout and interaction of group editing controls
- Adjust visibility and readOnly states of group name input