### PR TITLE
fix: Modify the translation loading location

### DIFF
--- a/src/plugin-datetime/operation/keyboard/keyboardwork.cpp
+++ b/src/plugin-datetime/operation/keyboard/keyboardwork.cpp
@@ -82,8 +82,12 @@ void KeyboardWorker::active()
 {
     if (!m_translatorLanguage) {
         m_translatorLanguage = new QTranslator(this);
-        m_translatorLanguage->load("/usr/share/dde-control-center/translations/keyboard_language_" + QLocale::system().name());
-        qApp->installTranslator(m_translatorLanguage);
+        if (m_translatorLanguage->load(QLocale(), "keyboard_language", "_", TRANSLATE_READ_DIR)) {
+            qApp->installTranslator(m_translatorLanguage);
+        } else {
+            delete m_translatorLanguage;
+            m_translatorLanguage = nullptr;
+        }
     }
 
     m_keyboardDBusProxy->blockSignals(false);

--- a/src/plugin-datetime/operation/regionproxy.cpp
+++ b/src/plugin-datetime/operation/regionproxy.cpp
@@ -202,13 +202,13 @@ void RegionProxy::active()
     }
     m_isActive = true;
     m_translatorLanguage = new QTranslator(this);
-    m_translatorLanguage->load("/usr/share/dde-control-center/translations/datetime_language_"
-                               + QLocale::system().name());
-    qApp->installTranslator(m_translatorLanguage);
+    if (m_translatorLanguage->load(QLocale(), "datetime_language","_", TRANSLATE_READ_DIR)) {
+        qApp->installTranslator(m_translatorLanguage);
+    }
     m_translatorCountry = new QTranslator(this);
-    m_translatorCountry->load("/usr/share/dde-control-center/translations/datetime_country_"
-                              + QLocale::system().name());
-    qApp->installTranslator(m_translatorCountry);
+    if (m_translatorCountry->load(QLocale(), "datetime_country","_", TRANSLATE_READ_DIR)) {
+        qApp->installTranslator(m_translatorCountry);
+    }
 
     QList<QLocale> locales =
             QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);

--- a/src/plugin-defaultapp/qml/DetailItem.qml
+++ b/src/plugin-defaultapp/qml/DetailItem.qml
@@ -73,7 +73,6 @@ DccObject {
                     DccCheckIcon {
                         Layout.alignment: Qt.AlignCenter
                         visible: model.isDefault
-                        mouseEnabled: false
                     }
                     D.ActionButton {
                         Layout.alignment: Qt.AlignCenter

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -117,8 +117,12 @@ void KeyboardWorker::active()
 {
     if (!m_translatorLanguage) {
         m_translatorLanguage = new QTranslator(this);
-        m_translatorLanguage->load("/usr/share/dde-control-center/translations/keyboard_language_" + QLocale::system().name());
-        qApp->installTranslator(m_translatorLanguage);
+        if (m_translatorLanguage->load(QLocale(), "keyboard_language", TRANSLATE_READ_DIR)) {
+            qApp->installTranslator(m_translatorLanguage);
+        } else {
+            delete m_translatorLanguage;
+            m_translatorLanguage = nullptr;
+        }
     }
 
     m_keyboardDBusProxy->blockSignals(false);


### PR DESCRIPTION
Modify the translation loading location

pms: BUG-311277

## Summary by Sourcery

Modify the translation loading mechanism to use a more flexible and robust method for loading language translations across multiple plugins

Bug Fixes:
- Update translation loading to use QLocale's load method with a more generic approach, improving translation file detection and handling

Enhancements:
- Implement a more flexible translation loading mechanism that uses QLocale and a predefined translation directory

Chores:
- Remove hardcoded translation file paths in multiple plugins