### PR TITLE
fix: Added error sounds

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothworker.cpp
+++ b/src/plugin-bluetooth/operation/bluetoothworker.cpp
@@ -12,7 +12,9 @@
 #include <QJsonObject>
 #include <QLoggingCategory>
 #include <QTimer>
+#include <DDesktopServices>
 
+DGUI_USE_NAMESPACE
 Q_LOGGING_CATEGORY(DdcBluetoothWorkder, "dcc-bluetooth-worker")
 
 BluetoothWorker::BluetoothWorker(BluetoothModel *model, QObject *parent)
@@ -231,6 +233,10 @@ void BluetoothWorker::setAdapterDiscovering(const QString &path, bool enable)
     m_bluetoothDBusProxy->SetAdapterDiscovering(QDBusObjectPath(path), enable);
 }
 
+void BluetoothWorker::playErrorSound()
+{
+    DDesktopServices::playSystemSoundEffect(DDesktopServices::SSE_Error);
+}
 
 bool BluetoothWorker::displaySwitch()
 {

--- a/src/plugin-bluetooth/operation/bluetoothworker.h
+++ b/src/plugin-bluetooth/operation/bluetoothworker.h
@@ -35,6 +35,7 @@ public:
     Q_INVOKABLE void disconnectDevice(const QString & deviceId);
     Q_INVOKABLE void ignoreDevice(const QString & deviceId, const QString adapterId);
     Q_INVOKABLE void setAdapterDiscovering(const QString &path, bool enable);
+    Q_INVOKABLE void playErrorSound();
 
 public Q_SLOTS:
 

--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -107,6 +107,7 @@ DccObject{
                         text = text.substr(0, 64);  // 截断到31个字符
                         nameEdit.alertText = qsTr("Length greater than or equal to 64")
                         nameEdit.showAlert = true
+                        dccData.work().playErrorSound()
                         alertTimer.start()
                     } else {
                         nameEdit.showAlert = false


### PR DESCRIPTION
Added error sounds

Log: Added error sounds
pms: BUG-298925

## Summary by Sourcery

Add error sound functionality to Bluetooth plugin when encountering validation errors

Bug Fixes:
- Implement system error sound when Bluetooth device name exceeds maximum length

Enhancements:
- Integrate DDesktopServices to play system error sound effect