### PR TITLE
fix: use system locale for date formatting

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -879,7 +879,7 @@ void DatetimeModel::setCurrentFormat(int format, int index)
 
 QString DatetimeModel::currentDate()
 {
-    QLocale locale(m_localeName);
+    QLocale locale(QLocale::system().name());
     QString week = weekdayFormat() == 1 ? "ddd" : "dddd";
     QString dateFormat = shortDateFormat() + " " + week;
 


### PR DESCRIPTION
- Replace hardcoded locale name with system locale
- Ensure date format consistency across system
- Fix potential locale mismatch issues

Log: use system locale for date formatting
pms: BUG-299879

## Summary by Sourcery

Bug Fixes:
- Resolve potential locale mismatch issues by dynamically using the system's locale for date formatting