### PR TITLE
fix: Compatible with previous command parameters

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -498,11 +498,11 @@ void DccManager::waitShowPage(const QString &url, const QDBusMessage message)
             return;
         }
     }
+    if (obj && cmd.isEmpty()) {
+        show();
+    }
     if (message.type() != QDBusMessage::InvalidMessage) {
         if (obj) {
-            if (cmd.isEmpty()) {
-                show();
-            }
             QDBusConnection::sessionBus().send(message.createReply());
         } else {
             QDBusConnection::sessionBus().send(message.createErrorReply(QDBusError::InvalidArgs, QString("not found url:") + url));
@@ -535,10 +535,10 @@ void DccManager::tryShow()
     DccObject *obj = findObject(path, true);
     if (obj) {
         showPage(obj, cmd);
+        if (cmd.isEmpty()) {
+            show();
+        }
         if (m_showMessage.type() != QDBusMessage::InvalidMessage) {
-            if (cmd.isEmpty()) {
-                show();
-            }
             QDBusConnection::sessionBus().send(m_showMessage.createReply());
         }
         clearShowParam();

--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -32,14 +32,13 @@ DccObject {
         backgroundType: DccObject.Normal
         visible: dccData.model().inPutPortCombo.length === 0
         page: Column {
-            width: parent.width
             Label {
                 height: 100
                 width: parent.width
                 Layout.leftMargin: 10
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter
-                font: DTK.fontManager.t8
+                font: D.DTK.fontManager.t8
                 text: qsTr("No input device for sound found")
             }
         }


### PR DESCRIPTION
Compatible with previous command parameters

pms: BUG-309801

## Summary by Sourcery

Enhance command-line parameters and logging for the DDE Control Center application, improving compatibility and debugging capabilities.

New Features:
- Add support for specifying a module with the '-m' option
- Introduce a new '-z/--time' option to show control center execution time
- Add a '-l/--logging-module' option to filter logging output for specific modules

Bug Fixes:
- Fix compatibility with previous command parameters by maintaining existing functionality while adding new options

Enhancements:
- Improve command-line parameter handling to support more flexible module and page navigation
- Implement dynamic logging rule generation based on specified module and log level