### PR TITLE
feat: Disable QML caching mechanism

### DIFF
--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -135,6 +135,10 @@ int main(int argc, char *argv[])
 
     // QAccessible::installFactory(accessibleFactory);
 
+    // disable qml cache
+    if (qEnvironmentVariableIsEmpty("QML_DISABLE_DISK_CACHE"))
+        qputenv("QML_DISABLE_DISK_CACHE", "1");
+
     dccV25::DccManager *dccManager = new dccV25::DccManager(app);
     dccManager->init();
     QQmlApplicationEngine *engine = dccManager->engine();


### PR DESCRIPTION
QML cache may not refresh in a timely manner, leading to unpredictable errors in the control center

pms: TASK-368711

## Summary by Sourcery

Disable QML disk caching to prevent potential unpredictable errors in the control center

New Features:
- Added environment variable configuration to disable QML disk caching

Bug Fixes:
- Prevent potential caching-related errors by disabling QML disk cache by default