### PR TITLE
fix: add stopSoundEffectPlayback method in SoundWorker

### DIFF
--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -290,6 +290,17 @@ void SoundWorker::playSoundEffect(int index)
     m_sound->play();
 }
 
+void SoundWorker::stopSoundEffectPlayback()
+{
+    if (m_sound) {
+        if (m_sound->isPlaying()) {
+            m_model->updatePlayAniIconPath(m_upateSoundEffectsIndex, "");
+        }
+        delete m_sound;
+        m_sound = nullptr;
+    }
+}
+
 void SoundWorker::setBluetoothMode(const QString &mode)
 {
     m_soundDBusInter->SetBluetoothAudioMode(mode);

--- a/src/plugin-sound/operation/soundworker.h
+++ b/src/plugin-sound/operation/soundworker.h
@@ -40,6 +40,7 @@ public:
     Q_INVOKABLE void enableAllSoundEffect(bool enable);
     Q_INVOKABLE void setPortEnableIndex(int index, bool checked, int portType);
     Q_INVOKABLE void playSoundEffect(int index);
+    Q_INVOKABLE void stopSoundEffectPlayback();
     Q_INVOKABLE void setAudioServerIndex(int index);
     Q_INVOKABLE void setAudioMono(bool enable);
 

--- a/src/plugin-sound/qml/SoundEffectsPage.qml
+++ b/src/plugin-sound/qml/SoundEffectsPage.qml
@@ -41,6 +41,12 @@ DccObject {
 
                 dccData.worker().playSoundEffect(index)
             }
+
+            onVisibleChanged: {
+                if (!visible) {
+                    dccData.worker().stopSoundEffectPlayback();
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
- Implemented stopSoundEffectPlayback in SoundWorker to handle sound effect stopping and resource cleanup.
- Updated SoundEffectsPage to call stopSoundEffectPlayback when the visibility changes.

Log: add stopSoundEffectPlayback method and integrate into SoundEffectsPage
pms: BUG-292417

## Summary by Sourcery

Add method to stop sound effect playback and clean up resources

New Features:
- Added stopSoundEffectPlayback method to SoundWorker to handle stopping sound effects

Bug Fixes:
- Implement a method to stop sound effect playback and properly clean up audio resources when the sound effects page is no longer visible

Enhancements:
- Integrated sound effect stopping mechanism into SoundEffectsPage to manage audio resource lifecycle