### PR TITLE
fix: The issue of setting the background of grub startup is fixed

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfomodel.cpp
+++ b/src/plugin-commoninfo/operation/commoninfomodel.cpp
@@ -184,8 +184,6 @@ QString CommonInfoModel::grubThemePath() const
 
 void CommonInfoModel::setGrubThemePath(const QString &newGrubThemePath)
 {
-    if (m_grubThemePath == newGrubThemePath)
-        return;
     m_grubThemePath = newGrubThemePath;
     emit grubThemePathChanged();
 }

--- a/src/plugin-commoninfo/operation/commoninfoproxy.cpp
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.cpp
@@ -57,6 +57,15 @@ CommonInfoProxy::CommonInfoProxy(QObject *parent)
 {
     // in this function, it will wait for 50 seconds finall return
     m_grubScaleInter->setTimeout(50000);
+
+    QDBusConnection::systemBus().connect(
+        GrubService,
+        GrubThemePath,
+        GrubThemeInterface,
+        "BackgroundChanged",
+        this,
+        SIGNAL(BackgroundChanged())
+    );
 }
 
 bool CommonInfoProxy::IsLogin()

--- a/src/plugin-commoninfo/operation/commoninfowork.h
+++ b/src/plugin-commoninfo/operation/commoninfowork.h
@@ -44,6 +44,7 @@ public:
     Q_INVOKABLE void setLogDebug(int index);
     Q_INVOKABLE void importCertificate(QString filePath);
     Q_INVOKABLE void exportMessage(QString filePath);
+    Q_INVOKABLE void setBackground(const QString &path);
 
 public Q_SLOTS:
     void setBootDelay(bool value);
@@ -51,7 +52,6 @@ public Q_SLOTS:
     void setDefaultEntry(const QString &entry);
     void disableGrubEditAuth();
     void onSetGrubEditPasswd(const QString &password, const bool &isReset);
-    void setBackground(const QString &path);
     void setUeProgram(bool enabled);
     void closeUeProgram();
     void setEnableDeveloperMode(bool enabled);

--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -43,6 +43,26 @@ DccObject {
             color: "transparent"
             Layout.fillWidth: true
 
+            DropArea {
+                anchors.fill: parent
+                keys: ["text/uri-list"]
+
+                onDropped: (drop) => {
+                    if (drop.hasUrls) {
+                        let filePath = drop.urls[0].toString()
+                        if (filePath.endsWith(".png") || filePath.endsWith(".jpg") || filePath.endsWith(".jpeg") || filePath.endsWith(".bmp")) {
+                            console.log("Image dropped:", filePath)
+                            if (filePath.startsWith("file://")) {
+                                filePath = filePath.substring(7)
+                            }
+                            dccData.work().setBackground(filePath)
+                        } else {
+                            console.log("Dropped file is not a supported image:", filePath)
+                        }
+                    }
+                }
+            }
+
             ItemViewport {
                 id: viewport
                 anchors.fill: image
@@ -55,7 +75,7 @@ DccObject {
 
             Image {
                 id: image
-                source: "file://" + dccData.mode().grubThemePath
+                source: "file://" + dccData.mode().grubThemePath + "?timestamp=" + Date.now()
                 asynchronous: true
                 anchors.fill: parent
                 width: parent.width


### PR DESCRIPTION
The issue of setting the background of grub startup is fixed

Log: The issue of setting the background of grub startup is fixed 
pms: BUG-295107
          BUG-281399

## Summary by Sourcery

Fix the GRUB startup background setting issue by resolving symlinks and enhance the BootPage with a drag-and-drop feature for setting background images.

Bug Fixes:
- Fix the issue with setting the background of the GRUB startup by resolving symlinks to their real paths.

Enhancements:
- Add a drop area in the BootPage QML for users to drag and drop image files to set as the GRUB background.