### PR TITLE
fix: Modify search term configuration

### DIFF
--- a/misc/org.deepin.dde-grand-search.dde-control-center-setting.conf
+++ b/misc/org.deepin.dde-grand-search.dde-control-center-setting.conf
@@ -1,5 +1,5 @@
 [Grand Search]
-Name=org.deepin.dde-grand-search.dde-control-center-setting
+Name=com.deepin.dde-grand-search.dde-control-center-setting
 Mode=Trigger
 DBusService=org.deepin.dde.ControlCenter1
 DBusAddress=/org/deepin/dde/ControlCenter1


### PR DESCRIPTION
Modify search term configuration

pms: BUG-301227

## Summary by Sourcery

Bug Fixes:
- Corrected the configuration name from 'org.deepin.dde-grand-search.dde-control-center-setting' to 'com.deepin.dde-grand-search.dde-control-center-setting'