### PR TITLE
fix: Fixed the issue that Bluetooth was renamed to empty

### DIFF
--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -139,16 +139,23 @@ DccObject{
                     }
                 }
 
-                onEditingFinished: {
+                function updateAlias() {
+                    if (nameEdit.text.trim() === "") {
+                        nameEdit.text = myDeviceName.text
+                    } else {
+                        dccData.work().setAdapterAlias(model.id, nameEdit.text)
+                    }
                     nameEdit.visible = false
                     devName.visible = true
-                    dccData.work().setAdapterAlias(model.id, nameEdit.text)
                 }
+
+                onEditingFinished: {
+                    updateAlias()
+                }
+
                 onFocusChanged: {
                     if (!focus) {
-                        nameEdit.visible = false
-                        devName.visible = true
-                        dccData.work().setAdapterAlias(model.id, nameEdit.text)
+                        updateAlias()
                     }
                 }
 


### PR DESCRIPTION
Fixed the issue that Bluetooth was renamed to empty

Log: Fixed the issue that Bluetooth was renamed to empty
pms: BUG-311311

## Summary by Sourcery

Bug Fixes:
- Ensure that Bluetooth device name cannot be set to an empty value, automatically restoring the original name if an empty name is attempted