### PR TITLE
feat: DccCheckIcon defaults to checked status

### DIFF
--- a/src/dde-control-center/frame/plugin/DccCheckIcon.qml
+++ b/src/dde-control-center/frame/plugin/DccCheckIcon.qml
@@ -7,6 +7,7 @@ import org.deepin.dtk 1.0 as D
 D.ActionButton {
     id: root
     property real size: 16
+    checked: true
     icon {
         width: size
         height: size


### PR DESCRIPTION
as title

pms: BUG-313769

## Summary by Sourcery

Set the default checked state of DccCheckIcon to true

New Features:
- Add a default checked state to the DccCheckIcon component

Bug Fixes:
- Resolve an issue with the default state of the check icon