### PR TITLE
fix: Fixed that the password was empty and could still be determined

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -354,6 +354,7 @@ DccObject {
                             onTextChanged: {
                                 console.log(" newPasswordEdit text changed ", newPasswordEdit.text)
                                 if (newPasswordEdit.text.length === 0) {
+                                    submitbtn.enabled = false
                                     if (repeatPasswordEdit.text.length !== 0) {
                                         newPasswordEdit.alertText = qsTr("Password cannot be empty")
                                         newPasswordEdit.showAlert = true
@@ -404,6 +405,7 @@ DccObject {
                                 console.log(" repeatPasswordEdit text changed ",
                                     repeatPasswordEdit.text)
                                 if (repeatPasswordEdit.text.length === 0) {
+                                    submitbtn.enabled = false
                                     if (newPasswordEdit.text.length !== 0) {
                                         repeatPasswordEdit.alertText = qsTr("Password cannot be empty")
                                         repeatPasswordEdit.showAlert = true


### PR DESCRIPTION
Fixed that the password was empty and could still be determined

Log: Fixed that the password was empty and could still be determined
pms: BUG-307803

## Summary by Sourcery

Bug Fixes:
- Prevent form submission when password fields are empty, adding an additional layer of validation