### PR TITLE
fix: Modify the width of the strong reminder box

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -555,6 +555,7 @@ void DccManager::doShowPage(DccObject *obj, const QString &cmd)
     if (m_plugins->isDeleting() || !obj) {
         return;
     }
+    qCInfo(dccLog) << "ShowPage:" << obj << " have cmd:" << !cmd.isEmpty();
     // 禁用首页
     if (obj == m_root) {
         if (m_root->getChildren().isEmpty()) {

--- a/src/dde-control-center/frame/plugin/DccRightView.qml
+++ b/src/dde-control-center/frame/plugin/DccRightView.qml
@@ -37,12 +37,6 @@ Flickable {
         visible: false
         border.color: this.palette.highlight
         border.width: 2
-        anchors {
-            left: parent.left
-            right: parent.right
-            leftMargin: root.margin
-            rightMargin: root.margin
-        }
     }
     Timer {
         interval: 100
@@ -64,8 +58,10 @@ Flickable {
                     root.contentY = -itemY
                 }
 
+                panel.x = panel.item.mapToItem(root, 0, 0).x
                 panel.y = panel.item.mapToItem(root, 0, 0).y + root.contentY
                 panel.height = panel.item.height
+                panel.width = panel.item.width
                 panel.visible = panel.cnt & 1
                 panel.cnt++
             }

--- a/src/dde-control-center/frame/plugin/DccSettingsView.qml
+++ b/src/dde-control-center/frame/plugin/DccSettingsView.qml
@@ -69,12 +69,6 @@ Flickable {
         visible: false
         border.color: this.palette.highlight
         border.width: 2
-        anchors {
-            left: parent.left
-            right: parent.right
-            leftMargin: root.margin
-            rightMargin: root.margin
-        }
     }
     Timer {
         interval: 100
@@ -95,8 +89,10 @@ Flickable {
                     root.contentY = panel.item.mapToItem(groupView, 0, 0).y
                 }
 
+                panel.x = panel.item.mapToItem(root, 0, 0).x
                 panel.y = panel.item.mapToItem(root, 0, 0).y + root.contentY
                 panel.height = panel.item.height
+                panel.width = panel.item.width
                 panel.visible = panel.cnt & 1
                 panel.cnt++
             }


### PR DESCRIPTION
The width of the reminder box is the same as the corresponding item

pms: BUG-312817

## Summary by Sourcery

Modify the reminder box positioning and sizing in the control center UI to match the corresponding item's dimensions

Bug Fixes:
- Fix the reminder box width and positioning to accurately align with the selected item

Enhancements:
- Update panel positioning logic to dynamically set x, width, and y coordinates based on the selected item

Chores:
- Add a debug log message when showing a page in the control center