### PR TITLE
fix: Update Chinese translation

### DIFF
--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -3094,7 +3094,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"></translation>
+        <translation>该名称已存在</translation>
     </message>
 </context>
 <context>
@@ -3900,7 +3900,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"></translation>
+        <translation>界面和效果、窗口圆角</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
as title

Log:
pms: BUG-314451
pms: BUG-314453

## Summary by Sourcery

Update Chinese translations for specific messages in the control center

Bug Fixes:
- Resolve untranslated strings in the Chinese localization file

Documentation:
- Update translation for two specific messages: 'This name already exists' and 'Interface and effects, rounded corners'