### PR TITLE
fix: add setFirstDayOfWeek call in setCurrentFormat

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -820,6 +820,7 @@ void DatetimeModel::setCurrentFormat(int format, int index)
         m_work->setConfigValue(firstDayOfWeek_key, index + 1);
         // dbus
         m_work->setWeekStartDayFormat(index + 1);
+        setFirstDayOfWeek(index + 1);
         break;
     }
     case LongDate: {


### PR DESCRIPTION
- Added a call to setFirstDayOfWeek to ensure the correct week start day configuration.

Log: add setFirstDayOfWeek call in setCurrentFormat
pms: BUG-286155

## Summary by Sourcery

Bug Fixes:
- Add missing call to `setFirstDayOfWeek` in `setCurrentFormat` when handling the `FirstDayOfWeek` format.