### PR TITLE
fix: update system time zone check in addUserTimeZone method

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -965,7 +965,7 @@ void DatetimeModel::addUserTimeZone(const ZoneInfo &zone)
 {
     const QString zoneName = zone.getZoneName();
 
-    if (!m_userZoneIds.contains(zoneName) && zoneName != QTimeZone::systemTimeZoneId()) {
+    if (!m_userZoneIds.contains(zoneName) && zoneName != m_currentSystemTimeZone.getZoneName()) {
         m_userZoneIds.append(zoneName);
         m_userTimeZones.append(zone);
         Q_EMIT userTimeZoneAdded(zone);


### PR DESCRIPTION
- Changed the condition to use m_currentSystemTimeZone instead of QTimeZone::systemTimeZoneId for better accuracy in user time zone management.

Log: update system time zone check in addUserTimeZone method
pms: BUG-313147

## Summary by Sourcery

Bug Fixes:
- Update the condition in `addUserTimeZone` to compare against the cached system time zone (`m_currentSystemTimeZone`) instead of `QTimeZone::systemTimeZoneId()`.