### PR TITLE
fix: update locale in currentTime()

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -905,7 +905,7 @@ QString DatetimeModel::currentDate()
 
 QString DatetimeModel::currentTime() const
 {
-    QLocale locale(m_localeName);
+    QLocale locale(QLocale::system().name());
     QString timeFormat = longTimeFormat();
     // remove timezone format
     timeFormat.remove("t");


### PR DESCRIPTION
- Use QLocale::system().name() for consistency.

Log: update locale in currentTime()
pms: BUG-286911

## Summary by Sourcery

Bug Fixes:
- Ensure `currentTime` consistently uses the system locale (`QLocale::system().name()`) instead of a potentially different member locale.