### PR TITLE
fix: adjust icon size in LangAndFormat component

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -104,8 +104,8 @@ DccObject {
                             visible: (itemDelegate.isCurrentLang && dccObj.enabled) ||
                                      languageListTiltle.isEditing
                             icon.name: itemDelegate.isCurrentLang ? "item_checked" : "list_delete"
-                            icon.width: 24
-                            icon.height: 24
+                            icon.width: 16
+                            icon.height: 16
                             implicitWidth: 36
                             implicitHeight: 36
                             anchors {


### PR DESCRIPTION
- Changed icon dimensions from 24 to 16 for improved UI consistency.

Log: adjust icon size in LangAndFormat component
pms: BUG-302293

## Summary by Sourcery

Bug Fixes:
- Reduce icon dimensions from 24x24 to 16x16 in the `LangAndFormat` component.