### PR TITLE
fix: failed to retrieve search results for grand searching

### DIFF
--- a/src/dde-control-center/controlcenterdbusadaptor.cpp
+++ b/src/dde-control-center/controlcenterdbusadaptor.cpp
@@ -170,7 +170,7 @@ QString DBusControlCenterGrandSearchService::Search(const QString &json)
         return QString();
     }
     m_jsonCache = json;
-    QString val = parent()->search(json);
+    const QString &val = parent()->searchProxy(json);
     m_autoExitTimer->start();
     return val;
 }

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -69,7 +69,8 @@ public Q_SLOTS:
     void show();
     void showHelp();
     // DBus Search
-    QString search(const QString &json);
+    QString search(const QString &json) const;
+    QString searchProxy(const QString &json) const;
     bool stop(const QString &json);
     bool action(const QString &json);
     QString GetAllModule();


### PR DESCRIPTION
Delay to search if plugin is unloaded.

pms: BUG-299137

## Summary by Sourcery

Bug Fixes:
- Fix potential failures in retrieving search results by ensuring plugins are loaded before executing the search.