### PR TITLE
fix: clear filter wildcard in LangsChooserDialog when deactivated

### DIFF
--- a/src/plugin-datetime/qml/LangsChooserDialog.qml
+++ b/src/plugin-datetime/qml/LangsChooserDialog.qml
@@ -102,6 +102,11 @@ Loader {
     onLoaded: {
         item.show()
     }
+    onActiveChanged: {
+        if (!active) {
+            viewModel.setFilterWildcard("");
+        }
+    }
 }
 
 


### PR DESCRIPTION
- Added logic to reset the filter wildcard when the dialog is no longer active.

Log: clear filter wildcard in LangsChooserDialog when deactivated
pms: BUG-301787

## Summary by Sourcery

Bug Fixes:
- Clear the filter wildcard in the `LangsChooserDialog` when the dialog becomes inactive.