### PR TITLE
fix: Fixed the issue that the rename was empty

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -149,6 +149,11 @@ Rectangle {
                                 dccData.work().setDeviceAlias(model.id, nameEdit.text)
 
                             }
+                            onVisibleChanged: {
+                                if (visible) {
+                                    text = model.name
+                                }
+                            }
                             Keys.onPressed: {
                                 if (event.key === Qt.Key_Return) {
                                     hostNameEdit.forceActiveFocus(false); // 结束编辑


### PR DESCRIPTION
Fixed the issue that the rename was empty

Log: Fixed the issue that the rename was empty
pms: BUG-311341

## Summary by Sourcery

Bug Fixes:
- Initialize the device rename input field with the current device name upon becoming visible.