### PR TITLE
fix: update font in ShortcutSettingDialog

### DIFF
--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -32,6 +32,7 @@ Control {
     contentItem: RowLayout {
         Label {
             Layout.leftMargin: DS.Style.keySequenceEdit.margin
+            font: D.DTK.fontManager.t6
             text: control.text
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -30,13 +30,18 @@ D.DialogWindow {
         width: parent.width
         Label {
             Layout.alignment: Qt.AlignHCenter
-            font.bold: true
+            font {
+                family: D.DTK.fontManager.t5.family
+                pixelSize: D.DTK.fontManager.t5.pixelSize
+                weight: Font.Bold
+            }
             text: qsTr("Add custom shortcut")
         }
 
         Label {
             Layout.alignment: Qt.AlignLeft
             Layout.leftMargin: 4
+            font: D.DTK.fontManager.t6
             text: qsTr("Name:")
         }
 
@@ -44,12 +49,14 @@ D.DialogWindow {
             id: nameEdit
             Layout.rightMargin: 20
             Layout.preferredWidth: parent.width
+            font: D.DTK.fontManager.t6
             placeholderText: qsTr("Required")
         }
 
         Label {
             Layout.alignment: Qt.AlignLeft
             Layout.leftMargin: 4
+            font: D.DTK.fontManager.t6
             text: qsTr("Command:")
         }
 
@@ -57,6 +64,7 @@ D.DialogWindow {
             id: commandEdit
             Layout.rightMargin: 20
             Layout.preferredWidth: parent.width
+            font: D.DTK.fontManager.t6
             clearButton.visible: false
             placeholderText: qsTr("Required")
             D.ActionButton {
@@ -111,6 +119,7 @@ D.DialogWindow {
                 id: conflictText
                 elide: Text.ElideRight
                 clip: true
+                font: D.DTK.fontManager.t6
                 visible: text.length > 0
             }
         }
@@ -122,6 +131,7 @@ D.DialogWindow {
             Button {
                 Layout.bottomMargin: 14
                 Layout.fillWidth: true
+                font: D.DTK.fontManager.t6
                 Layout.leftMargin: 4
                 text: qsTr("Cancel")
                 onClicked: {
@@ -132,6 +142,7 @@ D.DialogWindow {
                 Layout.bottomMargin: 14
                 Layout.fillWidth: true
                 Layout.rightMargin: 24
+                font: D.DTK.fontManager.t6
                 text: qsTr("Add")
                 enabled: commandEdit.text.length > 0 && nameEdit.text.length >0
                 onClicked: {


### PR DESCRIPTION
- Use D.DTK.fontManager for Labels and Buttons.

Log: update font in ShortcutSettingDialog
pms: BUG-298633

## Summary by Sourcery

Update font styling in ShortcutSettingDialog using DTK font manager

Bug Fixes:
- Standardize font usage across labels, buttons, and text inputs in the shortcut setting dialog

Enhancements:
- Apply consistent font styling using D.DTK.fontManager across multiple UI components