### PR TITLE
fix: Fix layout errors

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -231,7 +231,7 @@ DccObject {
                     font: DTK.fontManager.t6
                     horizontalAlignment: Qt.AlignLeft
                     verticalAlignment: Qt.AlignVCenter
-                    leftPadding: 0
+                    leftPadding: 15
                 }
 
                 Row {
@@ -242,7 +242,7 @@ DccObject {
                         font: DTK.fontManager.t8
                         horizontalAlignment: Qt.AlignLeft
                         verticalAlignment: Qt.AlignVCenter
-                        leftPadding: 0
+                        leftPadding: 15
                         opacity: 0.5
                     }
 
@@ -268,6 +268,7 @@ DccObject {
                 Switch {
                     id: verificationSwitch
 
+                    rightPadding: 7
                     checked: dccData.mode().grubEditAuthEnabled
                     onCheckedChanged: {
                         if (checked && !dccData.mode().grubEditAuthEnabled) {


### PR DESCRIPTION
Fix layout errors

Log: Fix layout errors
pms: BUG-313315

## Summary by Sourcery

Adjust layout padding and alignment in the BootPage QML component to improve visual presentation

Bug Fixes:
- Fixed layout spacing by adding left padding to text elements
- Added right padding to Switch component