### PR TITLE
feat:  adapt to WallpaperChanged signal

### DIFF
--- a/src/plugin-personalization/operation/model/wallpapermodel.cpp
+++ b/src/plugin-personalization/operation/model/wallpapermodel.cpp
@@ -111,6 +111,13 @@ void WallpaperModel::insertItem(int pos, WallpaperItemPtr it)
     endInsertRows();
 }
 
+void WallpaperModel::appendItem(WallpaperItemPtr it)
+{
+    if (it.isNull())
+        return;
+    insertItem(rowCount(), it);
+}
+
 void WallpaperModel::removeItem(const QString &item)
 {
     auto idx = itemIndex(item);
@@ -119,6 +126,13 @@ void WallpaperModel::removeItem(const QString &item)
 
     beginRemoveRows(QModelIndex(), idx.row(), idx.row());
     items.removeAt(idx.row());
+    endRemoveRows();
+}
+
+void WallpaperModel::removeItem(WallpaperItemPtr item)
+{
+    beginRemoveRows(QModelIndex(), itemIndex(item).row(), itemIndex(item).row());
+    items.removeOne(item);
     endRemoveRows();
 }
 
@@ -141,6 +155,11 @@ QModelIndex WallpaperModel::itemIndex(const QString &item) const
         return QModelIndex();
     auto row = items.indexOf(*it);
     return index(row, 0);
+}
+
+QModelIndex WallpaperModel::itemIndex(WallpaperItemPtr item) const
+{
+    return index(items.indexOf(item), 0);
 }
 
 void WallpaperModel::resetData(const QList<WallpaperItemPtr> &list)

--- a/src/plugin-personalization/operation/model/wallpapermodel.h
+++ b/src/plugin-personalization/operation/model/wallpapermodel.h
@@ -65,7 +65,7 @@ public:
     }
 
     Q_INVOKABLE bool hasWallpaper(const QString &url) const {
-        for (size_t i = 0; i < sourceModel()->rowCount(); i++) {
+        for (int i = 0; i < sourceModel()->rowCount(); i++) {
             if (url == sourceModel()->data(sourceModel()->index(i, 0), Item_Url_Role).toString()) {
                 return true;
             }
@@ -106,9 +106,12 @@ public:
     bool setData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) override;
     Qt::ItemFlags flags(const QModelIndex &index) const override;
     void insertItem(int pos, WallpaperItemPtr it);
+    void appendItem(WallpaperItemPtr it);
     void removeItem(const QString &item);
+    void removeItem(WallpaperItemPtr item);
     WallpaperItemPtr itemNode(const QModelIndex &idx) const;
     QModelIndex itemIndex(const QString &item) const;
+    QModelIndex itemIndex(WallpaperItemPtr item) const;
     void resetData(const QList<WallpaperItemPtr> &list);
     void updateSelected(const QStringList &selectedLists);
     void setThumbnail(WallpaperItemPtr item, const QString &thumbnail);

--- a/src/plugin-personalization/operation/personalizationdbusproxy.cpp
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.cpp
@@ -58,6 +58,7 @@ PersonalizationDBusProxy::PersonalizationDBusProxy(QObject *parent)
 
     connect(m_AppearanceInter, SIGNAL(Changed(const QString &, const QString &)), this, SIGNAL(Changed(const QString &, const QString &)));
     connect(m_AppearanceInter, SIGNAL(Refreshed(const QString &)), this, SIGNAL(Refreshed(const QString &)));
+    connect(m_DaemonInter, SIGNAL(WallpaperChanged(const QString &, uint, const QStringList &)), this, SIGNAL(WallpaperChanged(const QString &, uint, const QStringList &)));
 }
 
 // Appearance

--- a/src/plugin-personalization/operation/personalizationdbusproxy.h
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.h
@@ -153,6 +153,8 @@ signals:
     void lockScreenAtAwakeChanged(bool value);
     void linePowerScreenSaverTimeoutChanged(int value);
     void batteryScreenSaverTimeoutChanged(int value);
+    // daemon
+    void WallpaperChanged(const QString &value, uint mode, const QStringList &urls);
 
 public slots:
     // Appearance

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -487,7 +487,6 @@ void PersonalizationWorker::addCustomWallpaper(const QString &url)
     } else {
         lastHashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), url);
     }
-    m_wallpaperWorker->fetchData(Wallpaper_Custom);
     setWallpaperForMonitor(m_model->getCurrentSelectScreen(), lastHashPath, false, PersonalizationExport::Option_All);
 }
 
@@ -510,7 +509,6 @@ void PersonalizationWorker::addSolidWallpaper(const QColor &color)
 
     //set to dde, and prefix solid:: to tell dde this is a solid color wallpaper.
     const QString &hashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), SOLID_PREFIX + file.fileName());
-    m_wallpaperWorker->fetchData(Wallpaper_Solid);
     setWallpaperForMonitor(m_model->getCurrentSelectScreen(), hashPath, false, PersonalizationExport::Option_All);
 }
 
@@ -522,7 +520,6 @@ void PersonalizationWorker::deleteWallpaper(const QString &str)
     } else {
         m_personalizationDBusProxy->deleteCustomWallpaper(currentUserName(), str);
     }
-    m_wallpaperWorker->fetchData();
 }
 
 void PersonalizationWorker::setScreenSaver(const QString &value)

--- a/src/plugin-personalization/operation/screensaverprovider.cpp
+++ b/src/plugin-personalization/operation/screensaverprovider.cpp
@@ -81,8 +81,8 @@ void ScreensaverProvider::setScreensaver(const QList<WallpaperItemPtr> &items)
 
 ScreensaverProvider::ScreensaverProvider(PersonalizationDBusProxy *proxy, PersonalizationModel *model, QObject *parent)
     : QObject(parent)
-    , m_proxy(proxy)
     , m_model(model)
+    , m_proxy(proxy)
 {
     workThread = new QThread(this);
     worker = new ScreensaverWorker(proxy);

--- a/src/plugin-personalization/operation/wallpaperprovider.h
+++ b/src/plugin-personalization/operation/wallpaperprovider.h
@@ -8,7 +8,7 @@
 #include <QObject>
 #include <QPixmap>
 #include <QMutex>
-#include <QMap>
+#include <QHash>
 #include <atomic>
 
 #include "operation/personalizationdbusproxy.h"
@@ -20,6 +20,7 @@ enum WallpaperType{
     Wallpaper_Sys,
     Wallpaper_Custom,
     Wallpaper_Solid,
+    Wallpaper_Unknown
 };
 
 class InterfaceWorker : public QObject
@@ -36,10 +37,12 @@ public:
 
 signals:
     void pushBackground(const QList<WallpaperItemPtr> &items, WallpaperType type = WallpaperType::Wallpaper_Sys);
+    void pushOneBackground(const WallpaperItemPtr items, WallpaperType type = WallpaperType::Wallpaper_Sys);
     void thumbnailFinished(WallpaperItemPtr item, const WallpaperType type, const QString &thumbnail);
     void listFinished();
 public slots:
     void startListBackground(WallpaperType type = WallpaperType::Wallpaper_all);
+    void startListOne(const QString &path, WallpaperType type = WallpaperType::Wallpaper_all);
 private:
     WallpaperItemPtr createItem(const QString &path, bool del, WallpaperType type);
 private:
@@ -56,7 +59,9 @@ public:
     ~WallpaperProvider();
     void fetchData(WallpaperType type = WallpaperType::Wallpaper_all);
     static bool isColor(const QString &path);
-    static WallpaperType getWallpaperType(const QString &path);
+    WallpaperType getWallpaperType(const QString &path);
+    void removeWallpaper(const QString &url);
+    void addWallpaper(const QString &url);
 
 signals:
     void fetchFinish();
@@ -64,6 +69,8 @@ signals:
 private slots:
     void setWallpaper(const QList<WallpaperItemPtr> &items, WallpaperType type = WallpaperType::Wallpaper_Sys);
     void setThumbnail(WallpaperItemPtr item, const WallpaperType type, const QString &thumbnail);
+    void pushWallpaper(WallpaperItemPtr item, WallpaperType type = WallpaperType::Wallpaper_Sys);
+    void onWallpaperChangedFromDaemon(const QString &user, uint mode, const QStringList &paths);
 
 private:
     QThread *m_workThread = nullptr;
@@ -71,8 +78,7 @@ private:
     PersonalizationModel *m_model = nullptr;
     PersonalizationDBusProxy *m_personalizationProxy = nullptr;
 
-    QList<WallpaperItemPtr> m_wallpaperList;
-    QList<WallpaperItemPtr> m_solidWallpaperList;
+    QHash<WallpaperType, QList<WallpaperItemPtr>> m_wallpaperList;
 };
 
 #endif // WALLPAPERPROVIDER_H


### PR DESCRIPTION
之前添加和删除壁纸的时候会无脑的重新获取壁纸, 性能较差, 且索引会有问题. 当壁纸变化的时候, dde-session-daemon 会发送WallpaperChanged信号, 指示当前哪些壁纸有更新, 监听这个信号去刷新壁纸列表效率更高

pms: BUG-314271

## Summary by Sourcery

Improve wallpaper management by adapting to the WallpaperChanged signal from dde-session-daemon, enabling more efficient and accurate wallpaper list updates

New Features:
- Add support for listening to WallpaperChanged signal to dynamically update wallpaper lists

Bug Fixes:
- Resolve performance issues with wallpaper list refreshing
- Fix indexing problems when adding or removing wallpapers

Enhancements:
- Implement more efficient wallpaper list management
- Add methods to add and remove wallpapers dynamically
- Replace linear list with a hash-based wallpaper list storage