### PR TITLE
fix: update mouse double-click speed slider labels

### DIFF
--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -129,7 +129,7 @@ DccObject {
                     }
                     D.TipsSlider {
                         id: doubleClickSlider
-                        readonly property var tips: [qsTr("Short"), (""), (""), (""), (""), (""), qsTr("Long")]
+                        readonly property var tips: [qsTr("Slow"), (""), (""), (""), (""), (""), qsTr("Fast")]
                         Layout.alignment: Qt.AlignCenter
                         Layout.margins: 10
                         Layout.fillWidth: true


### PR DESCRIPTION
- Changed slider tip labels from "Short/Long" to "Slow/Fast" for better clarity
- Improves user understanding of the double-click speed setting

Log: update mouse double-click speed slider labels
pms: BUG-313327

## Summary by Sourcery

Bug Fixes:
- Replaced 'Short/Long' labels with 'Slow/Fast' to provide clearer description of double-click speed setting