### PR TITLE
fix: improve country name translation in datetime module

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -221,6 +221,8 @@ static QString translate(const QString &localeName, const QString &langRegion)
         QString country = langRegions.at(1).toUtf8().data();
         if (country == "Taiwan") {
             country = GetChinaTaiWanName();
+        } else {
+            country = QCoreApplication::translate("dcc::datetime::Country", langRegions.at(1).toUtf8().data());
         }
 
         QString langCountry = QString("%1(%2)").arg(lang).arg(country);


### PR DESCRIPTION
- Add QCoreApplication::translate for country names to support proper localization
- Handle country name translation through dcc::datetime::Country context

Log: improve country name translation in datetime module

## Summary by Sourcery

Improve localization of country names in the datetime module by using Qt's translation mechanism

Bug Fixes:
- Implement translation for country names using dcc::datetime::Country context

Enhancements:
- Add QCoreApplication translation for country names to support proper localization