### PR TITLE
fix: optimize slider behavior in sound control center

### DIFF
--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -88,8 +88,8 @@ DccObject {
                     stepSize: 0.00001
                     to: 1
                     value: dccData.model().microphoneVolume
-                    onValueChanged: {
-                        if (voiceTipsSlider1.value != dccData.model().microphoneVolume) {
+                    onPressedChanged: {
+                        if (!pressed && voiceTipsSlider1.value != dccData.model().microphoneVolume) {
                             dccData.worker().setSourceVolume(voiceTipsSlider1.value)
                         }
                     }

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -82,8 +82,8 @@ DccObject {
                     highlightedPassedGroove: true
                     value: dccData.model().speakerVolume
                     to: dccData.model().increaseVolume ? 1.5 : 1.0
-                    onValueChanged: {
-                        if (voiceTipsSlider.value != dccData.model().speakerVolume) {
+                    onPressedChanged: {
+                        if (!pressed && voiceTipsSlider.value != dccData.model().speakerVolume) {
                             dccData.worker().setSinkVolume(voiceTipsSlider.value)
                         }
                     }
@@ -143,8 +143,8 @@ DccObject {
                     to: 1
                     value: dccData.model().speakerBalance
 
-                    onValueChanged: {
-                        if (balanceSlider.value != dccData.model().speakerBalance) {
+                    onPressedChanged: {
+                        if (!pressed && balanceSlider.value != dccData.model().speakerBalance) {
                             dccData.worker().setSinkBalance(balanceSlider.value)
                         }
                     }


### PR DESCRIPTION
- Changed volume and balance sliders to only apply changes when released
- Modified slider handlers from onValueChanged to onPressedChanged
- Added condition to check if slider is not pressed before applying changes
- Affects microphone volume, speaker volume and speaker balance controls

Log: optimize slider behavior in sound control center
pms: BUG-313969