### PR TITLE
fix: preserve original language data in LanguageListModel

### DIFF
--- a/src/plugin-datetime/operation/languagelistmodel.cpp
+++ b/src/plugin-datetime/operation/languagelistmodel.cpp
@@ -66,6 +66,7 @@ void LanguageListModel::setMetaData(const QList<dccV25::MetaData> &data)
 {
     if (m_datas != data) {
         beginResetModel();
+        m_originalDatas = data;
         m_datas = data;
         removeLocalLangs();
         endResetModel();
@@ -77,6 +78,7 @@ void LanguageListModel::setLocalLang(const QStringList &langs)
     if (m_localLangs != langs) {
         beginResetModel();
         m_localLangs = langs;
+        m_datas = m_originalDatas;
         removeLocalLangs();
         endResetModel();
     }

--- a/src/plugin-datetime/operation/languagelistmodel.h
+++ b/src/plugin-datetime/operation/languagelistmodel.h
@@ -33,6 +33,7 @@ protected:
 
 private:
     QList<dccV25::MetaData> m_datas;
+    QList<dccV25::MetaData> m_originalDatas;
     QStringList m_localLangs;
 };
 }


### PR DESCRIPTION
- Added m_originalDatas to store initial language metadata
- Restore original data when updating local languages
- Prevent data loss during language list updates

Log: fix language list data preservation issues
pms: BUG-282933

## Summary by Sourcery

Bug Fixes:
- Preserve original language metadata to prevent data loss during language list updates.