### PR TITLE
fix: improve datetime format handling for non-Chinese locales

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -493,10 +493,22 @@ QAbstractListModel *DatetimeModel::timeDateModel()
     QStringList names = { tr("Week"), tr("First day of week"), tr("Short date"),
                           tr("Long date"), tr("Short time"), tr("Long time") };
 
-    initModes(names, DayAbbreviations, LongTime, model);
-    connect(this, &DatetimeModel::currentFormatChanged, model, [model, names, this](int format){
-        if (format >= DayAbbreviations && format <= LongTime || format < 0)
-            initModes(names, DayAbbreviations, LongTime, model);
+    auto initFormattedModes = [this, model](const QStringList &names) {
+        QStringList nameList = names;
+        int indexBegin = DayAbbreviations;
+        QStringList langRegions = langRegion().split(":");
+        if (langRegions.size() >= 2 && !langRegions.first().contains("Chinese", Qt::CaseInsensitive)) {
+            indexBegin += 1;
+            nameList.removeFirst();
+        }
+        initModes(nameList, indexBegin, LongTime, model);
+    };
+
+    initFormattedModes(names);
+    connect(this, &DatetimeModel::currentFormatChanged, model, [model, names, this, initFormattedModes](int format){
+        if (format >= DayAbbreviations && format <= LongTime || format < 0) {
+            initFormattedModes(names);
+        }
     });
 
     m_timeDateModel = model;


### PR DESCRIPTION
- Refactored datetime format initialization logic
- Added locale-specific handling for week display
- Improved model update logic on format changes

Log: improve datetime format handling
pms: BUG-286259

## Summary by Sourcery

Improve datetime format handling and model updates to better support non-Chinese locales and enhance locale-specific display logic.

Bug Fixes:
- Fix datetime format initialization and week display for non-Chinese locales.

Enhancements:
- Refactor datetime model update logic for improved locale-specific handling.