### PR TITLE
fix: hide play button background

### DIFF
--- a/src/plugin-sound/qml/DeviceListView.qml
+++ b/src/plugin-sound/qml/DeviceListView.qml
@@ -62,6 +62,7 @@ Rectangle {
                             implicitWidth: 20
                             icon.width: 16
                             icon.height: 16
+                            background: null
                             onClicked: {
                                 console.log("play_back has clicked ")
                                 root.playbtnClicked(index)


### PR DESCRIPTION
- Removed background styling from play button for cleaner UI.

Log: hide play button background
pms: BUG-304407

## Summary by Sourcery

Bug Fixes:
- Removed background from play button to improve UI appearance.