### PR TITLE
fix: Fix text style

### DIFF
--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -103,10 +103,24 @@ DccObject{
                         anchors.top: nameDetail.top
                         font.pointSize: 8
                         text: qsTr("Edit")
+                        background: null
 
-                        hoverEnabled: false
+                        hoverEnabled: true
                         implicitHeight: 20
-                        textColor: DS.Style.highlightedButton.text
+                        textColor: Palette {
+                            normal {
+                                common: DTK.makeColor(Color.Highlight)
+                            }
+                            normalDark: normal
+                            hovered {
+                                common: DTK.makeColor(Color.Highlight).lightness(+10)
+                            }
+                            hoveredDark: hovered
+                            pressed {
+                                common: DTK.makeColor(Color.Highlight).lightness(-10)
+                            }
+                            pressedDark: pressed
+                        }
 
                         onClicked: {
                             nameEdit.visible = true
@@ -264,7 +278,7 @@ DccObject{
             }
             Label {
                 id: airplaneModeLinkLabel
-                text: "<a href=\"airplaneMode\">" + qsTr("Airplane Mode") +"</a>"
+                text: "<a href=\"airplaneMode\" style=\"text-decoration:none;\">" + qsTr("Airplane Mode") +"</a>"
                 anchors.left: airplaneModeTextLabel.right
                 anchors.top: parent.top
                 font.pointSize: 8

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -383,7 +383,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>To use the Bluetooth function, please turn off</source>
-        <translation>如需使用蓝牙功能，请关闭</translation>
+        <translation>若要使用蓝牙功能，请先关闭</translation>
     </message>
     <message>
         <source>Airplane Mode</source>


### PR DESCRIPTION
Fix text style

Log: Fix text style
pms: BUG-299395
BUG-305081

## Summary by Sourcery

Fix text style issues in the Bluetooth control UI, enhance button color handling, and update related Chinese translation.

Bug Fixes:
- Correct text styling for the 'Edit' button and 'Airplane Mode' link in the Bluetooth control UI.

Enhancements:
- Improve color palette and hover/pressed state handling for button text.

Documentation:
- Update Chinese translation for Bluetooth usage instructions.