### PR TITLE
fix: correct week start day format index

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -832,8 +832,8 @@ void DatetimeModel::setCurrentFormat(int format, int index)
     case DayOfWeek: {
         // dconfig
         m_work->setConfigValue(firstDayOfWeek_key, index + 1);
-        // dbus
-        m_work->setWeekStartDayFormat(index + 1);
+        // dbus (from 0 to 6)
+        m_work->setWeekStartDayFormat(index);
         setFirstDayOfWeek(index + 1);
         break;
     }


### PR DESCRIPTION
1. Changed the week start day format index from (index + 1) to (index) when calling setWeekStartDayFormat
2. The DBus interface expects values from 0 to 6 (Monday=0 to Sunday=6)
3. The previous implementation was incorrectly offset by 1, which could cause wrong weekday calculations
4. Maintained the dconfig value as (index + 1) since it uses 1-based indexing

fix: 修正周起始日格式索引

1. 将调用setWeekStartDayFormat时的周起始日格式索引从(index + 1)改 为(index)
2. DBus接口期望值为0到6(周一=0到周日=6)
3. 之前的实现错误地偏移了1，可能导致错误的星期计算
4. 保持dconfig值为(index + 1)，因为它使用基于1的索引

pms: BUG-288483

## Summary by Sourcery

Bug Fixes:
- Correct the week start day format index passed to the DBus interface to use 0-based indexing (Monday=0) as expected.