### PR TITLE
fix: Modifying settings for copying mode issues

### DIFF
--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -543,6 +543,11 @@ void DisplayModule::applySettings(QList<QObject *> listItems, qreal scale)
 
 void DisplayModule::applyChanged()
 {
+    Q_D(DisplayModule);
+    if (!d->m_model->monitorModeChanging()) {
+        return;
+    }
+    d->m_model->setmodeChanging(false);
     DccScreen *tmpPw = qobject_cast<DccScreen *>(sender());
     if (!tmpPw || d_ptrDisplayModule->m_model->displayMode() != EXTEND_MODE) {
         return;
@@ -563,7 +568,6 @@ void DisplayModule::applyChanged()
     }
     ConcatScreen *concatScreen = new ConcatScreen(tmpListItems, pwItem);
     concatScreen->executemultiScreenAlgo(false);
-    Q_D(DisplayModule);
     d->setScreenPosition(tmpListItems);
     delete concatScreen;
     qDeleteAll(tmpListItems);

--- a/src/plugin-display/operation/private/displaymodel.cpp
+++ b/src/plugin-display/operation/private/displaymodel.cpp
@@ -25,6 +25,7 @@ DisplayModel::DisplayModel(QObject *parent)
     , m_allowEnableMultiScaleRatio(false)
     , m_resolutionRefreshEnable(true)
     , m_brightnessEnable(true)
+    , m_monitorModeChanging(true)
 {
 }
 
@@ -256,4 +257,9 @@ void DisplayModel::checkAllSupportFillModes()
         }
     }
     m_allSupportFillModes = true;
+}
+
+void DisplayModel::setmodeChanging(bool changing)
+{
+    m_monitorModeChanging = changing;
 }

--- a/src/plugin-display/operation/private/displaymodel.h
+++ b/src/plugin-display/operation/private/displaymodel.h
@@ -91,6 +91,8 @@ public:
     inline bool allSupportFillModes() const { return m_allSupportFillModes; }
     void checkAllSupportFillModes();
 
+    inline bool monitorModeChanging() const { return m_monitorModeChanging; }
+    void setmodeChanging(bool changing);
 
 Q_SIGNALS:
     void screenHeightChanged(const int h) const;
@@ -156,6 +158,7 @@ private:
     TouchscreenMap m_touchMap;
     uint m_maxBacklightBrightness {0};
     bool m_allSupportFillModes;
+    bool m_monitorModeChanging; // 配置修改中,仅控制中心修改时才处理自动拼接
 };
 }
 

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -69,7 +69,7 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
 
         //display redSfit/autoLight
         connect(m_displayInter, &DisplayDBusProxy::HasAmbientLightSensorChanged, m_model, &DisplayModel::autoLightAdjustVaildChanged);
-        connect(m_timer, &QTimer::timeout, this, [=] {
+        connect(m_timer, &QTimer::timeout, this, [this] {
             m_displayInter->ApplyChanges().waitForFinished();
             m_displayInter->Save().waitForFinished();
         });
@@ -318,6 +318,7 @@ constexpr static int dccRotate2wl(int dccRotate) {
 
 void DisplayWorker::setMonitorRotate(Monitor *mon, const quint16 rotate)
 {
+    m_model->setmodeChanging(true);
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();
         for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
@@ -469,6 +470,7 @@ void DisplayWorker::resetBackup()
 
 void DisplayWorker::setMonitorResolution(Monitor *mon, const int mode)
 {
+    m_model->setmodeChanging(true);
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();
         auto res = mon->getResolutionById(mode);
@@ -910,6 +912,7 @@ void DisplayWorker::setTouchScreenAssociation(const QString &monitor, const QStr
 
 void DisplayWorker::setMonitorResolutionBySize(Monitor *mon, const int width, const int height)
 {
+    m_model->setmodeChanging(true);
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();
         for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {


### PR DESCRIPTION
Only handle automatic splicing when modifying modes from the control center

pms: BUG-313071

## Summary by Sourcery

Restrict automatic display splicing to only occur when mode changes are initiated from the control center by tracking a new flag in the display model.

Bug Fixes:
- Introduce a m_monitorModeChanging flag in DisplayModel to guard against unintended automatic splicing.
- Update DisplayModule::applyChanged to early-return unless monitorModeChanging is true and reset the flag after handling.
- Set monitorModeChanging to true in DisplayWorker before each rotate or resolution change to signal a control-center-initiated mode change.

Enhancements:
- Switch the QTimer lambda capture in DisplayWorker to [this] to avoid capturing unintended variables.