### PR TITLE
fix: ensure plain text format in KeySequenceDisplay

### DIFF
--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -33,6 +33,7 @@ Control {
         Label {
             Layout.leftMargin: DS.Style.keySequenceEdit.margin
             font: D.DTK.fontManager.t6
+            textFormat: Text.PlainText
             text: control.text
             horizontalAlignment: Qt.AlignLeft
             verticalAlignment: Qt.AlignVCenter


### PR DESCRIPTION
add textFormat property to prevent rich text rendering

Log: ensure plain text format in KeySequenceDisplay
pms: BUG-282647

## Summary by Sourcery

Bug Fixes:
- Add textFormat: Text.PlainText to the Label in KeySequenceDisplay to prevent rich text rendering.