### PR TITLE
fix: disable power management features in virtual environments

### DIFF
--- a/src/plugin-power/operation/powerinterface.h
+++ b/src/plugin-power/operation/powerinterface.h
@@ -27,6 +27,9 @@ public:
     Q_INVOKABLE int indexByValueOnMap(const QVariantList& dataMap, int targetValue);
     Q_INVOKABLE QString platformName();
 
+private:
+    void setPowerActionsVisible(QList<PowerOperatorModel*> actionModels, QList<PowerOperatorType> type,  bool visible);
+
 signals:
     void powerModelChanged(PowerModel *model);
     void powerWorkerChanged(PowerWorker *worker);

--- a/src/plugin-power/operation/powermodel.cpp
+++ b/src/plugin-power/operation/powermodel.cpp
@@ -493,3 +493,12 @@ void PowerModel::setEnableScheduledShutdown(const QString &value)
         Q_EMIT enableScheduledShutdownChanged(value);
     }
 }
+
+void PowerModel::setIsVirtualEnvironment(bool isVirtualEnvironment)
+{
+    if (m_isVirtualEnvironment != isVirtualEnvironment) {
+        m_isVirtualEnvironment = isVirtualEnvironment;
+
+        Q_EMIT isVirtualEnvironmentChanged(isVirtualEnvironment);
+    }
+}

--- a/src/plugin-power/operation/powermodel.h
+++ b/src/plugin-power/operation/powermodel.h
@@ -53,6 +53,7 @@ class PowerModel : public QObject
     Q_PROPERTY(int weekBegins READ weekBegins WRITE setWeekBegins NOTIFY weekBeginsChanged)
     Q_PROPERTY(int lowPowerAction READ lowPowerAction WRITE setLowPowerAction NOTIFY lowPowerActionChanged)
     Q_PROPERTY(QVariantList customShutdownWeekDays READ customShutdownWeekDays WRITE setCustomShutdownWeekDays NOTIFY customShutdownWeekDaysChanged)
+    Q_PROPERTY(bool isVirtualEnvironment READ isVirtualEnvironment WRITE setIsVirtualEnvironment NOTIFY isVirtualEnvironmentChanged)
 
     Q_PROPERTY(QVariantList batteryLockDelayModel READ batteryLockDelayModel WRITE setBatteryLockDelayModel NOTIFY batteryLockDelayModelChanged)
     Q_PROPERTY(QVariantList batteryScreenBlackDelayModel READ batteryScreenBlackDelayModel WRITE setBatteryScreenBlackDelayModel NOTIFY batteryScreenBlackDelayModelChanged)
@@ -222,6 +223,9 @@ public:
     inline QString enableScheduledShutdown() const { return m_enableScheduledShutdown; };
     void setEnableScheduledShutdown(const QString &value);
 
+    inline bool isVirtualEnvironment() const { return m_isVirtualEnvironment; }
+    void setIsVirtualEnvironment(bool isVirtualEnvironment);
+
 Q_SIGNALS:
     void sleepLockChanged(const bool sleepLock);
     void canSleepChanged(const bool canSleep);
@@ -272,6 +276,7 @@ Q_SIGNALS:
     void shutdownRepetitionChanged(int repetition);
     void weekBeginsChanged(int value);
     void customShutdownWeekDaysChanged(const QVariantList &value);
+    void isVirtualEnvironmentChanged(bool isVirtualEnvironment);
 
     void batteryLockDelayModelChanged(const QVariantList &value);
     void batteryScreenBlackDelayModelChanged(const QVariantList &value);
@@ -321,6 +326,7 @@ private:
     QString m_powerPlan;
     bool m_isHighPerformanceSupported;
     bool m_isBalancePerformanceSupported;
+    bool m_isVirtualEnvironment;
 
     // Account
     bool m_noPasswdLogin;

--- a/src/plugin-power/operation/powerworker.cpp
+++ b/src/plugin-power/operation/powerworker.cpp
@@ -214,6 +214,7 @@ void PowerWorker::active()
 
     m_powerModel->setAutoPowerSaveMode(m_powerDBusProxy->powerSavingModeAuto());
     m_powerModel->setPowerSaveMode(m_powerDBusProxy->powerSavingModeEnabled());
+    m_powerModel->setIsVirtualEnvironment(isVirtualEnvironment());
 
     QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
     const bool confVal = valueByQSettings<bool>(DCC_CONFIG_FILES, "Power", "sleep", true);

--- a/src/plugin-power/operation/utils.h
+++ b/src/plugin-power/operation/utils.h
@@ -9,6 +9,7 @@
 
 #include <QVariant>
 #include <QSettings>
+#include <QProcess>
 
 DCORE_USE_NAMESPACE
 
@@ -38,5 +39,21 @@ inline const static Dtk::Core::DSysInfo::UosType UosType = Dtk::Core::DSysInfo::
 inline const static bool IsServerSystem =
         (Dtk::Core::DSysInfo::UosServer == UosType); // 是否是服务器版
 
+inline static bool isVirtualEnvironment()
+{
+    static bool cached = false;
+    static bool result = false;
+    
+    if (!cached) {
+        QProcess proc;
+        proc.start("systemd-detect-virt");
+        proc.waitForFinished(1000);
+        QString output = proc.readAllStandardOutput();
+        result = !output.contains("none");
+        cached = true;
+    }
+    
+    return result;
+}
 
 #endif // UTILS_H

--- a/src/plugin-power/qml/BatteryPage.qml
+++ b/src/plugin-power/qml/BatteryPage.qml
@@ -122,7 +122,7 @@ DccObject {
         parentName: "power/onBattery"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
+        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment
         page: DccGroupView {}
 
         DccObject {

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -158,7 +158,7 @@ DccObject {
             parentName: "power/general/wakeupSettingsGroup"
             displayName: qsTr("Password is required to wake up the computer")
             weight: 1
-            visible: dccData.model.canSuspend && dccData.model.isSuspend
+            visible: dccData.model.canSuspend && dccData.model.isSuspend && !dccData.model.isVirtualEnvironment
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.model.sleepLock && !dccData.model.isNoPasswdLogin

--- a/src/plugin-power/qml/PowerPage.qml
+++ b/src/plugin-power/qml/PowerPage.qml
@@ -123,7 +123,7 @@ DccObject {
         parentName: "power/onPower"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
+        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment
         page: DccGroupView {}
 
         DccObject {


### PR DESCRIPTION
1. Added virtual environment detection using systemd-detect-virt
2. Disabled suspend and hibernate options when running in virtual machines
3. Added logging category for power interface operations
4. Modified UI visibility conditions to account for virtual environments
5. Added new isVirtualEnvironment() method to power interface

The changes prevent showing power management options that wouldn't work properly in virtualized environments, while maintaining full functionality on physical hardware. This improves user experience by not displaying non-functional options.

fix: 在虚拟环境中禁用电源管理功能

1. 使用 systemd-detect-virt 添加了虚拟环境检测功能
2. 在虚拟机中运行时禁用休眠和挂起选项
3. 为电源接口操作添加了日志分类
4. 修改了UI可见性条件以考虑虚拟环境
5. 在电源接口中添加了新的 isVirtualEnvironment() 方法

这些更改可以防止显示在虚拟化环境中无法正常工作的电源管理选项，同时在物理
硬件上保持完整功能。通过不显示非功能性选项来改善用户体验。

pms: BUG-301275
pms: BUG-301277
pms: BUG-301279

## Summary by Sourcery

Detect virtual environments and disable non-functional power management options in virtual machines.

New Features:
- Add isVirtualEnvironment() method with systemd-detect-virt detection and result caching.

Bug Fixes:
- Prevent display of non-functional suspend and hibernate options in virtual environments.

Enhancements:
- Disable suspend and hibernate actions at runtime and during initialization when running in virtual machines.
- Update QML pages to hide power management UI on virtual environments based on isVirtualEnvironment().
- Introduce a dedicated QLoggingCategory for power interface operations.