### PR TITLE
fix: improve sound device combo box dynamic sizing

### DIFF
--- a/src/plugin-sound/operation/soundDeviceModel.h
+++ b/src/plugin-sound/operation/soundDeviceModel.h
@@ -17,11 +17,12 @@ class SoundDeviceModel: public QAbstractListModel {
 
     Q_OBJECT
 public:
-    enum soundEffectsRoles{
+    enum SoundEffectsRoles{
         NameRole = Qt::UserRole + 1,
         IsEnabled,
         IsActive,
     };
+    Q_ENUM(SoundEffectsRoles)
 
     explicit SoundDeviceModel(QObject *parent = nullptr);
 

--- a/src/plugin-sound/operation/soundmodel.cpp
+++ b/src/plugin-sound/operation/soundmodel.cpp
@@ -99,6 +99,7 @@ SoundModel::SoundModel(QObject *parent)
         m_soundEffectMapBattery.removeOne({ tr("Wake up"), DDesktopServices::SSE_WakeUp });
         m_soundEffectMapPower.removeOne({ tr("Wake up"), DDesktopServices::SSE_WakeUp });
     }
+    qmlRegisterType<SoundDeviceModel>("SoundDeviceModel", 1, 0, "SoundDeviceModel");
 }
 
 SoundModel::~SoundModel()

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -9,6 +9,8 @@ import org.deepin.dtk.style 1.0 as DS
 
 import org.deepin.dcc 1.0
 
+import SoundDeviceModel 1.0
+
 DccObject {
     id: root
     function toPercent(value: string) {
@@ -19,6 +21,9 @@ DccObject {
         parentName: "sound/outPut"
         displayName: qsTr("Output")
         weight: 10
+    }
+    FontMetrics {
+        id: fm
     }
 
     DccObject {
@@ -197,10 +202,32 @@ DccObject {
                 Layout.rightMargin: 10
                 flat: true
                 textRole: "name"
-
                 currentIndex: dccData.model().outPutPortComboIndex
                 model: dccData.model().soundOutputDeviceModel()
                 enabled: dccData.model().outPutPortComboEnable
+                property real maxTextWidth: DS.Style.control.implicitWidth(control)
+                implicitWidth: maxTextWidth
+
+                function calculateMaxWidth() {
+                    var minWidth = DS.Style.control.implicitWidth(control);
+                    var calculatedWidth = 0;
+                    for (var i = 0; i < model.rowCount(); i++) {
+                        var nameData = model.data(model.index(i, 0), SoundDeviceModel.NameRole);
+                        var textWidth = fm.advanceWidth(nameData);
+                        calculatedWidth = Math.max(calculatedWidth, textWidth);
+                    }
+                    maxTextWidth = Math.max(minWidth,
+                        calculatedWidth + DS.Style.comboBox.iconSize + DS.Style.comboBox.spacing *3 + Layout.rightMargin * 2);
+                }
+
+                Component.onCompleted: {
+                    calculateMaxWidth();
+                }
+
+                Connections {
+                    target: model
+                    onDataChanged: calculateMaxWidth()
+                }
 
                 property bool isInitialized: false
 


### PR DESCRIPTION
- Register SoundDeviceModel for QML usage
- Add enum metadata support
- Implement dynamic width calculation for device selection

Log: improve sound device combo box dynamic sizing
pms: BUG-295857

## Summary by Sourcery

Enable dynamic sizing of the sound device combo box in QML and expose the SoundDeviceModel with enum role metadata for QML usage

Enhancements:
- Register SoundDeviceModel type for QML
- Add Q_ENUM metadata for sound device model roles
- Compute and apply combo box width dynamically based on text metrics and style parameters