### PR TITLE
fix: adjust device page plugin order

### DIFF
--- a/src/plugin-bluetooth/qml/blueTooth.qml
+++ b/src/plugin-bluetooth/qml/blueTooth.qml
@@ -13,7 +13,7 @@ DccObject {
     description: qsTr("Bluetooth settings, devices")
     visible: false
     icon: "bluetoothNomal"
-    weight: 70
+    weight: 10
 
     DccDBusInterface {
         id: bluetoothDbus

--- a/src/plugin-touchscreen/qml/touchscreen.qml
+++ b/src/plugin-touchscreen/qml/touchscreen.qml
@@ -10,7 +10,7 @@ DccObject {
     description: qsTr("Configuring Touchscreen")
     icon: "device_touchscreen"
     visible: false
-    weight: 60
+    weight: 50
     DccDBusInterface {
         property var touchscreensV2
         service: "org.deepin.dde.Display1"

--- a/src/plugin-wacom/qml/wacom.qml
+++ b/src/plugin-wacom/qml/wacom.qml
@@ -11,7 +11,7 @@ DccObject {
     description: qsTr("Configuring wacom")
     icon: "dcc_nav_wacom"
     visible: false
-    weight: 50
+    weight: 60
     DccDBusInterface {
         property var exist
         service: "org.deepin.dde.InputDevices1"


### PR DESCRIPTION
- Reordered plugins: bluetooth(10), touchscreen(50), wacom(60)
- Lower weight means higher position in device page

Log: optimize device page plugin display sequence
pms: BUG-275261

## Summary by Sourcery

Adjust plugin weights to change the display order of device page plugins

Bug Fixes:
- Set Bluetooth plugin weight to 10
- Set Touchscreen plugin weight to 50
- Set Wacom plugin weight to 60