### PR TITLE
fix: The application name contains the deepin character

### DIFF
--- a/src/plugin-notification/operation/notificationsetting.cpp
+++ b/src/plugin-notification/operation/notificationsetting.cpp
@@ -242,7 +242,7 @@ QList<NotificationSetting::AppItem> NotificationSetting::appItemsImpl() const
     for (int i = 0; i < apps.count(); i++) {
         const auto desktopId = apps[i]->appId;
         const auto icon = apps[i]->iconName;
-        const auto name = apps[i]->name;
+        const auto name = apps[i]->displayName;
 
         NotificationSetting::AppItem item;
         item.id = desktopId;


### PR DESCRIPTION
Update app item name to use displayName in NotificationSetting

log: as title
pms: BUG-315873

## Summary by Sourcery

Bug Fixes:
- Use displayName instead of name for app items in NotificationSetting to preserve deepin characters in application names