### PR TITLE
fix: improve language label display in LangsChooserDialog

### DIFF
--- a/src/plugin-datetime/qml/LangsChooserDialog.qml
+++ b/src/plugin-datetime/qml/LangsChooserDialog.qml
@@ -67,6 +67,68 @@ Loader {
                     text: model.display
                     hoverEnabled: true
                     ButtonGroup.group: langGroup
+                    contentItem: RowLayout {
+                        Loader {
+                            id: labelLoader
+                            property string text: checkDelegate.text
+                            property bool shouldSplit: text.split("-").length === 2
+                            Layout.fillWidth: !checkDelegate.content
+                            sourceComponent: shouldSplit ? splitComponent : singleComponent
+
+                            Component {
+                                id: singleComponent
+                                IconLabel {
+                                    spacing: checkDelegate.spacing
+                                    mirrored: checkDelegate.mirrored
+                                    display: checkDelegate.display
+                                    alignment: Qt.AlignLeft | Qt.AlignVCenter
+                                    text: labelLoader.text
+                                    font: checkDelegate.font
+                                    color: checkDelegate.palette.windowText
+                                    icon: DTK.makeIcon(checkDelegate.icon, checkDelegate.D.DciIcon)
+                                    Layout.fillWidth: !checkDelegate.content
+                                }
+                            }
+
+                            Component {
+                                id: splitComponent
+                                RowLayout {
+                                    spacing: 0
+                                    IconLabel {
+                                        mirrored: checkDelegate.mirrored
+                                        display: checkDelegate.display
+                                        alignment: Qt.AlignLeft | Qt.AlignVCenter
+                                        text: labelLoader.text.split("-")[0] || ""
+                                        font: checkDelegate.font
+                                        color: checkDelegate.palette.windowText
+                                    }
+                                    IconLabel {
+                                        mirrored: checkDelegate.mirrored
+                                        display: checkDelegate.display
+                                        alignment: Qt.AlignLeft | Qt.AlignVCenter
+                                        text: "-"
+                                        font: checkDelegate.font
+                                        color: checkDelegate.palette.windowText
+                                    }
+                                    IconLabel {
+                                        mirrored: checkDelegate.mirrored
+                                        display: checkDelegate.display
+                                        alignment: Qt.AlignLeft | Qt.AlignVCenter
+                                        text: labelLoader.text.split("-")[1] || ""
+                                        font: checkDelegate.font
+                                        color: checkDelegate.palette.windowText
+                                        icon: DTK.makeIcon(checkDelegate.icon, checkDelegate.D.DciIcon)
+                                        Layout.fillWidth: !checkDelegate.content
+                                    }
+                                }
+                            }
+                        }
+                        Loader {
+                            active: checkDelegate.content
+                            sourceComponent: checkDelegate.content
+                            Layout.fillWidth: true
+                        }
+                    }
                     onCheckedChanged: {
                         if (checked)
                             itemsView.checkedLang = model.key


### PR DESCRIPTION
- Added split component for hyphenated language labels
- Implemented Layout.fillWidth for better text visibility
- Enhanced IconLabel components for consistent styling

Log: improve language label display in LangsChooserDialog
pms: BUG-285911

## Summary by Sourcery

Improve the rendering of language labels in LangsChooserDialog by splitting hyphenated names, ensuring full-width display, and unifying IconLabel styling.

Bug Fixes:
- Fix incorrect rendering and truncation of hyphenated language labels in the chooser dialog.

Enhancements:
- Introduce a splitComponent to render hyphen-separated label segments individually.
- Use Layout.fillWidth in RowLayout and IconLabel components to occupy available width for better text visibility.
- Standardize IconLabel instantiation (spacing, alignment, color) for consistent styling across labels.