### PR TITLE
fix: Fix the issue of names that are too long not being truncated.

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -275,10 +275,14 @@ DccObject {
                     placeholderText: qsTr("Set fullname")
                     horizontalAlignment: TextInput.AlignRight
                     editBtn.visible: readOnly
+                    ToolTip {
+                        visible: parent.hovered && parent.readOnly && parent.completeText != "" && (parent.metrics.advanceWidth(parent.completeText) > (parent.width - parent.rightPadding - 10))
+                        text: parent.completeText
+                    }
                     onReadOnlyChanged: {
                         // Store the original text when editing starts
                         if (!readOnly) {
-                            originalFullName = text
+                            originalFullName = completeText
                         }
                     }
                     onTextEdited: {
@@ -299,6 +303,9 @@ DccObject {
                     onFinished: function () {
                         // If text hasn't changed, do nothing
                         if (text === originalFullName) {
+                            var elidedText = fullNameEdit.metrics.elidedText(fullNameEdit.completeText, Text.ElideRight, 
+                            fullNameEdit.width - fullNameEdit.rightPadding - 10)
+                            fullNameEdit.text = elidedText
                             return;
                         }
 
@@ -324,7 +331,10 @@ DccObject {
                         target: dccData
                         function onFullnameChanged(userId, fullname) {
                             if (userId === settings.userId) {
-                                fullNameEdit.text = dccData.fullName(settings.userId)
+                                fullNameEdit.completeText = dccData.fullName(settings.userId)
+                                var elidedText = fullNameEdit.metrics.elidedText(fullNameEdit.completeText, Text.ElideRight, 
+                                fullNameEdit.width - fullNameEdit.rightPadding - 10)
+                                fullNameEdit.text = elidedText
                             }
                         }
                     }

--- a/src/plugin-accounts/qml/EditActionLabel.qml
+++ b/src/plugin-accounts/qml/EditActionLabel.qml
@@ -11,6 +11,8 @@ D.LineEdit {
     property alias editBtn: editButton
     property alias alertText: panel.alertText
     property alias showAlert: panel.showAlert
+    property alias metrics: fontMetrics
+    property var completeText: ""
     signal finished()
 
     readOnly: true
@@ -38,6 +40,23 @@ D.LineEdit {
         edit.readOnly = true
 
         finished()
+    }
+
+    FontMetrics {
+        id: fontMetrics
+        font: edit.font
+    }
+
+    onReadOnlyChanged: {
+        if (!readOnly) {
+            text = completeText
+        }
+    }
+
+    Component.onCompleted: {
+        completeText = text
+        var elidedText = fontMetrics.elidedText(completeText, Text.ElideRight, width - rightPadding - 10)
+        text = elidedText
     }
 
     D.ActionButton {


### PR DESCRIPTION
Fix the issue of names that are too long not being truncated.

Log: Fix the issue of names that are too long not being truncated.
pms: BUG-292553

## Summary by Sourcery

Elide long account names in EditActionLabel and AccountSettings fields to fit the UI and show the full name in a tooltip on hover

Bug Fixes:
- Properly truncate names that exceed field width using FontMetrics.elidedText

Enhancements:
- Store the full text separately and reapply truncation after editing
- Display a tooltip with the complete name when truncated text is hovered