### PR TITLE
fix: Fix the display issue of the new creation failure interface.

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -70,6 +70,9 @@ AccountsController::AccountsController(QObject *parent)
         this->groupsUpdate();
     });
     connect(m_worker, &AccountsWorker::updateGroupFailed, this, &AccountsController::groupsUpdateFailed);
+    connect(m_worker, &AccountsWorker::createGroupFailed, this, [this]() {
+        requestClearEmptyGroup(currentUserId());
+    });
     connect(m_worker, &AccountsWorker::updateGroupFinished, this, [this]() {
         updateAllGroups();
         this->groupsUpdate();

--- a/src/plugin-accounts/operation/accountsworker.cpp
+++ b/src/plugin-accounts/operation/accountsworker.cpp
@@ -249,7 +249,7 @@ void AccountsWorker::createGroup(const QString &group, uint32_t gid, bool isSyst
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, group, gid] (QDBusPendingCallWatcher* call) {
         if (call->isError()) {
             qWarning() << "Create group, gid: " << gid << ", created group `" << group << "` failed, error:" << call->error().message();
-            Q_EMIT updateGroupFailed(group);
+            Q_EMIT createGroupFailed(group);
             return;
         }
 

--- a/src/plugin-accounts/operation/accountsworker.h
+++ b/src/plugin-accounts/operation/accountsworker.h
@@ -53,6 +53,7 @@ Q_SIGNALS:
     void showSafetyPage(const QString &errorTips);
     void updateGroupFinished(OperateType operation, bool successfully, const QString& groupName = QString());
     void updateGroupFailed(const QString& groupName = QString());
+    void createGroupFailed(const QString& groupName = QString());
 public Q_SLOTS:
     void randomUserIcon(User *user);
     void createAccount(const User *user);


### PR DESCRIPTION
Fix the display issue of the new creation failure interface.

Log: Fix the display issue of the new creation failure interface.
pms: BUG-298579

## Summary by Sourcery

Fix the display issue of the new group creation failure interface by introducing a dedicated failure signal and clearing empty groups when creation fails.

Bug Fixes:
- Emit createGroupFailed instead of updateGroupFailed on group creation errors in AccountsWorker
- Connect AccountsWorker::createGroupFailed to AccountsController to clear empty groups on creation failure