### PR TITLE
fix: disable focus on shortcut operation buttons

### DIFF
--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -78,6 +78,7 @@ Control {
 
                 D.IconButton {
                     id: editButton
+                    focusPolicy: Qt.NoFocus
                     visible: control.showEditButtons
                     icon.name: "edit"
                     icon.width: 16
@@ -91,6 +92,7 @@ Control {
                 }
                 D.IconButton {
                     id: removeButton
+                    focusPolicy: Qt.NoFocus
                     visible: control.showEditButtons
                     icon.name: "user-trash-symbolic"
                     icon.width: 24

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -87,6 +87,7 @@ DccObject {
 
                     D.Button {
                         id: button
+                        focusPolicy: Qt.NoFocus
                         visible: parent.section === qsTr("Custom")
                         checkable: true
                         checked: shortcutSettingsBody.isEditing


### PR DESCRIPTION
- Set focusPolicy: Qt.NoFocus for edit/remove buttons in KeySequenceDisplay
- Set focusPolicy: Qt.NoFocus for custom shortcut button in Shortcuts.qml
- Improved button interaction behavior

Log: disable focus on shortcut operation buttons
pms: BUG-311061

## Summary by Sourcery

Disable keyboard focus on shortcut operation buttons to improve interaction behavior.

Bug Fixes:
- Disable focus on edit and remove buttons in KeySequenceDisplay
- Disable focus on custom shortcut button in Shortcuts.qml

Enhancements:
- Improve button interaction by removing focusable behavior from shortcut operation buttons