### PR TITLE
chore: bump version to 6.1.26

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,20 @@
+dde-control-center (6.1.26) unstable; urgency=medium
+
+  * fix: ensure plain text format in KeySequenceDisplay
+  * fix: Correct spelling errors
+  * fix: improve sound device combo box dynamic sizing
+  * fix: disable power management features in virtual environments
+  * fix: adjust device page plugin order
+  * fix: The application name contains the deepin character
+  * fix: Fix the issue of names that are too long not being truncated.
+  * fix: improve language label display in LangsChooserDialog
+  * fix: Fix the display issue of the new creation failure interface.
+  * fix: disable focus on shortcut operation buttons
+  * fix: Modify custom time rules
+  * fix(auth): adjust unreasonable UI
+
+ -- xionglinlin <xionglinlin@uniontech.com>  Thu, 15 May 2025 22:05:47 +0800
+
 dde-control-center (6.1.25) unstable; urgency=medium
 
   * fix: Modifying settings for copying mode issues


### PR DESCRIPTION
update changelog to 6.1.26

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.1.26