### PR TITLE
fix: improve text visibility in Label components

### DIFF
--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -188,9 +188,16 @@ DccObject {
                                     onClosing: {
                                         shortcutSettingsBody.isEditing = false
                                         dialogloader.active = false
+
+                                        conflictText.visible = false
+                                        shortcutSettingsBody.conflictAccels = ""
+                                        shortcutView.editItem = null
+                                        shortcutView.conflictText = null
                                     }
                                 }
                                 onLoaded: {
+                                    edit.restore()
+
                                     item.keyId = model.id
                                     item.keyName = model.display
                                     item.cmdName = model.command


### PR DESCRIPTION
- Set fillWidth property for Label to ensure text displays properly

Log: improve text visibility in Label components
pms: BUG-282693

## Summary by Sourcery

Clear residual conflict indicators and restore editing state in the shortcuts dialog to ensure label text displays properly.

Bug Fixes:
- Reset conflict text visibility and clear stored conflict accelerators when closing the shortcut settings dialog
- Nullify the editItem and conflictText references on the shortcut view upon dialog closure
- Call edit.restore() when the dialog loads to reinstate the previous editing state