### PR TITLE
fix: Fix the issue of user group name not displaying completely

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -279,9 +279,17 @@ DccObject {
                         visible: parent.hovered && parent.readOnly && parent.completeText != "" && (parent.metrics.advanceWidth(parent.completeText) > (parent.width - parent.rightPadding - 10))
                         text: parent.completeText
                     }
+
+                    Component.onCompleted: {
+                        completeText = text
+                        var elidedText = metrics.elidedText(completeText, Text.ElideRight, width - rightPadding - 10)
+                        text = elidedText
+                    }
+
                     onReadOnlyChanged: {
                         // Store the original text when editing starts
                         if (!readOnly) {
+                            text = completeText
                             originalFullName = completeText
                         }
                     }
@@ -634,12 +642,15 @@ DccObject {
                         id: editLabel
                         property bool editAble: model.groupEditAble
                         text: model.display
+                        completeText: model.display
+                        rightPadding: editButton.width + 10
                         validator: RegularExpressionValidator {
                             // 仅使用字母、数字、下划线或短横线，并且以字母开头
                             regularExpression: /[a-zA-Z][a-zA-Z0-9-_]{0,31}$/
                         }
                         implicitHeight: 40
-                        implicitWidth: 200
+                        implicitWidth: Math.min(metrics.advanceWidth(completeText) + editButton.width + 20,
+                                        groupview.width - editButton.width - 30)
                         Layout.fillWidth: !readOnly
                         placeholderText: qsTr("Group name")
                         horizontalAlignment: TextInput.AlignLeft | Qt.AlignVCenter
@@ -647,7 +658,6 @@ DccObject {
                                          && !groupSettings.isEditing
                         readOnly: model.display.length > 0
                         background: null
-
                         onFinished: function () {
                             if (text.length < 1) {
                                 text = model.display

--- a/src/plugin-accounts/qml/EditActionLabel.qml
+++ b/src/plugin-accounts/qml/EditActionLabel.qml
@@ -47,18 +47,6 @@ D.LineEdit {
         font: edit.font
     }
 
-    onReadOnlyChanged: {
-        if (!readOnly) {
-            text = completeText
-        }
-    }
-
-    Component.onCompleted: {
-        completeText = text
-        var elidedText = fontMetrics.elidedText(completeText, Text.ElideRight, width - rightPadding - 10)
-        text = elidedText
-    }
-
     D.ActionButton {
         id: editButton
         focusPolicy: Qt.NoFocus
@@ -67,6 +55,7 @@ D.LineEdit {
         icon.name: "dcc-edit"
         icon.width: DS.Style.edit.actionIconSize
         icon.height: DS.Style.edit.actionIconSize
+        hoverEnabled: true
         background: Rectangle {
             anchors.fill: parent
             property D.Palette pressedColor: D.Palette {


### PR DESCRIPTION
Fix the issue of user group name not displaying completely

Log: Fix the issue of user group name not displaying completely
pms: BUG-292807

## Summary by Sourcery

Fix the incomplete display of user group names by eliding text to fit, preserving the full name for editing, and dynamically sizing the input field.

Bug Fixes:
- Prevent truncation of group names by properly eliding and preserving full text in labels.

Enhancements:
- Store the full group name in a separate property and restore it when entering edit mode.
- Compute the input’s implicit width dynamically based on text and edit button widths, constrained by the view width.

Chores:
- Remove redundant eliding logic from the EditActionLabel component.