### PR TITLE
fix: The following is fixed for the user group sorting error

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -305,7 +305,7 @@ void AccountsController::updateGroups(const QString &id)
         bool isRightContains = groupContains(id, right);
 
         if (!(isLeftContains ^ isRightContains)) { // both true or both false
-            return left < right;
+            return left.compare(right, Qt::CaseInsensitive) < 0;
         } else {
             return isLeftContains ? true : false;
         }


### PR DESCRIPTION
The following is fixed for the user group sorting error

Log: The following is fixed for the user group sorting error
pms: BUG-292771

## Summary by Sourcery

Bug Fixes:
- Use Qt::CaseInsensitive compare instead of default operator< for sorting group names to avoid case sensitivity issues