### PR TITLE
fix: Tab key cannot traverse application notifications

### DIFF
--- a/src/plugin-notification/qml/ImageCheckBox.qml
+++ b/src/plugin-notification/qml/ImageCheckBox.qml
@@ -6,6 +6,7 @@ import QtQuick.Layouts 1.15
 import QtQuick.Templates as T
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc 1.0
 
 T.Control {
     id: control
@@ -14,31 +15,74 @@ T.Control {
     property string imageName: ""
     implicitWidth: contentItem.implicitWidth
     implicitHeight: contentItem.implicitHeight
+    Keys.onPressed: function(event) {
+        if (event.key === Qt.Key_Space || event.key === Qt.Key_Return) {
+            checked = !checked
+        }
+    }
     MouseArea {
         anchors.fill: parent
         onClicked: {
             checked = !checked
         }
     }
-
     ColumnLayout {
         id: contentItem
-        Image {
+        anchors.fill: parent
+        
+        Item {
             Layout.alignment: Qt.AlignCenter
-            sourceSize: Qt.size(96, 65)
-            mipmap: true
-            source: D.DTK.themeType === D.ApplicationHelper.LightType ?
-                "qrc:/icons/deepin/builtin/light/icons/" + imageName +"_84px.png" : "qrc:/icons/deepin/builtin/dark/icons/" + imageName +"_84px.png"
+            implicitWidth: 96
+            implicitHeight: 65
+            focus: true
+            activeFocusOnTab: true
+
+            Rectangle {
+                anchors.fill: parent
+                visible: parent.activeFocus
+                color: "transparent"
+                border.width: 2
+                border.color: control.palette.highlight
+                radius: DS.Style.control.radius
+                z: 1
+            }
+
+            Image {
+                anchors.centerIn: parent
+                sourceSize: Qt.size(96, 65)
+                mipmap: true
+                source: D.DTK.themeType === D.ApplicationHelper.LightType ?
+                    "qrc:/icons/deepin/builtin/light/icons/" + imageName +"_84px.png" : "qrc:/icons/deepin/builtin/dark/icons/" + imageName +"_84px.png"
+            }
         }
+        
         RowLayout {
             Layout.alignment: Qt.AlignCenter
-            D.DciIcon {
+            Item {
                 Layout.alignment: Qt.AlignCenter
-                palette: control.D.DTK.makeIconPalette(control.palette)
-                mode: control.D.ColorSelector.controlState
-                theme: control.D.ColorSelector.controlTheme
-                name: control.checked ? "item_checked" :  "item_unchecked"
-                fallbackToQIcon: false
+                implicitWidth: 24
+                implicitHeight: 24
+                focus: true
+                activeFocusOnTab: true
+
+                Rectangle {
+                    anchors.fill: parent
+                    visible: parent.activeFocus
+                    color: "transparent"
+                    border.width: 2
+                    border.color: control.palette.highlight
+                    radius: DS.Style.control.radius
+                    z: 1
+                }
+
+                DccCheckIcon {
+                    anchors.centerIn: parent
+                    checked: control.checked
+                    activeFocusOnTab: false
+                    onClicked: {
+                        control.checked = !control.checked
+                    }
+                }
             }
             Text {
                 Layout.alignment: Qt.AlignCenter

--- a/src/plugin-notification/qml/notificationMain.qml
+++ b/src/plugin-notification/qml/notificationMain.qml
@@ -23,8 +23,6 @@ DccObject {
     DccObject {
         name: "enableDoNotDisturb"
         parentName: "notification"
-        // displayName: qsTr("Enable Do Not Disturb")
-        // icon: "notification"
         weight: 20
         pageType: DccObject.Item
         page: DccGroupView {}
@@ -33,7 +31,6 @@ DccObject {
             parentName: "enableDoNotDisturb"
             description: qsTr("App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.")
             displayName: qsTr("Enable Do Not Disturb")
-            // icon: "notification"
             weight: 10
             pageType: DccObject.Editor
             page: D.Switch {
@@ -73,7 +70,6 @@ DccObject {
                         if (dccData.sysItemModel.lockScreen !== checked) {
                             dccData.sysItemModel.lockScreen = checked
                         }
-                        // dccData.sysItemModel.lockScreen = checked
                     }
                 }
                 D.Label {
@@ -134,7 +130,6 @@ DccObject {
                 weight: 10 + index
                 icon: model.AppIcon
                 displayName: model.AppName
-                // pageType: DccObject.Item
                 backgroundType: DccObject.Normal
                 page: D.Switch {
                     checked: model.EnableNotification
@@ -147,7 +142,6 @@ DccObject {
                 DccObject{
                     name: "notificationItemDetails" + index
                     parentName: "applicationList/" + "notificationItem" + index
-                    // pageType: DccObject.Menu
                     DccObject{
                         backgroundType: DccObject.Normal
                         name: "allowNotifications" + index


### PR DESCRIPTION
Enhance ImageCheckBox with keyboard navigation and focus visuals

pms: BUG-315981

## Summary by Sourcery

Add keyboard navigation and focus visuals to the ImageCheckBox component and clean up unused commented code in notificationMain.qml.

Enhancements:
- Enable toggling the ImageCheckBox via Space/Return keys and support tab focus
- Display focus outlines around the checkbox image and icon for clear keyboard navigation
- Replace legacy DciIcon with DccCheckIcon and restructure the QML layout in ImageCheckBox to facilitate focus handling

Chores:
- Remove stale commented-out displayName, icon, and pageType lines in notificationMain.qml