### PR TITLE
fix: The default program of the terminal cannot be set

### DIFF
--- a/src/plugin-defaultapp/operation/defappworker.h
+++ b/src/plugin-defaultapp/operation/defappworker.h
@@ -62,6 +62,7 @@ private:
     const QStringList getTypeListByCategory(const DefAppWorker::DefaultAppsCategory &category);
     Category* getCategory(const QString &mime) const;
     // QGSettings *m_defaultTerminal;
+    bool executeGsettingsCommand(const QStringList &args, const QString &errorMessage);
 };
 
 #endif // DEFAPPWORKER_H


### PR DESCRIPTION
Implement gsettings command execution for default terminal configuration

pms: BUG-300489

## Summary by Sourcery

Use QProcess to execute gsettings for setting and retrieving the default terminal instead of the unused QGSettings approach, adding a helper for command execution, error handling, and result logging.

Bug Fixes:
- Fix typo in default terminal category variable name.
- Ensure QDBusPendingCallWatcher is cleaned up with deleteLater() after result handling.

Enhancements:
- Introduce executeGsettingsCommand helper to run gsettings commands and log errors.
- Update onSetDefaultTerminal to invoke gsettings set for "app-id" and "exec" and record success in the model.
- Enhance onGetListApps to query gsettings get for the current terminal app-id, parse its output, and apply the default in the model.
- Remove the commented-out QGSettings dependency and related placeholders.