### PR TITLE
fix: Fixed the issue that other account status was abnormal

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -16,6 +16,14 @@ DccObject {
     property bool nopasswdLoginChecked: true
 
     Component.onCompleted: {
+        updateLoginSettings()
+    }
+    
+    onUserIdChanged: {
+        updateLoginSettings()
+    }
+    
+    function updateLoginSettings() {
         settings.autoLoginChecked = dccData.autoLogin(settings.userId)
         settings.nopasswdLoginChecked = dccData.nopasswdLogin(settings.userId)
     }


### PR DESCRIPTION
Fixed the issue that other account status was abnormal

Log: Fixed the issue that other account status was abnormal
pms: BUG-298649

## Summary by Sourcery

Ensure login settings reflect the current account by refreshing them when the component loads or the userId changes

Bug Fixes:
- Fix abnormal account status by updating auto-login and passwordless-login flags when switching accounts

Enhancements:
- Extract settings update logic into an updateLoginSettings() function and invoke it on component completion and userId changes