### PR TITLE
chore: Update obs workflows.yml

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -10,6 +10,8 @@ test_build:
         repositories:
           - name: deepin_develop
             paths:
+              - target_project: deepin:Develop:dde
+                target_repository: deepin_develop
               - target_project: deepin:CI
                 target_repository: deepin_develop
               - target_project: deepin:CI:dodconfig
@@ -17,20 +19,6 @@ test_build:
             architectures:
               - x86_64
               - aarch64
-
-          - name: debian
-            paths:
-              - target_project: deepin:CI
-                target_repository: debian_sid
-            architectures:
-              - x86_64
-
-          - name: archlinux
-            paths:
-              - target_project: deepin:CI
-                target_repository: archlinux
-            architectures:
-              - x86_64
 
   filters:
     event: pull_request


### PR DESCRIPTION
取消掉archlinux和debian的ci构建检查，改为只关注obs上dde的构建状态，同时添加构建依赖仓库。

## Summary by Sourcery

Update OBS workflows to focus on DDE builds by removing Debian and Archlinux checks and adding the DDE build dependency repository.

CI:
- Remove Debian and Archlinux build checks from OBS workflows
- Add deepin:Develop:dde as a build dependency in OBS workflows