### PR TITLE
fix: adjust component heights and vertical alignment for localization

### DIFF
--- a/src/plugin-datetime/qml/ComboLabel.qml
+++ b/src/plugin-datetime/qml/ComboLabel.qml
@@ -9,7 +9,7 @@ Item {
     property var comboModel: [""]
     property int comboCurrentIndex: -1
     // property string textRole
-    implicitHeight: 36
+    implicitHeight: 30
     implicitWidth: item.comboModel.length > 1 ? 280 : 80
     signal comboBoxActivated(int index)
 
@@ -23,6 +23,9 @@ Item {
         hoverEnabled: true
         onActivated: function (index) {
             item.comboBoxActivated(index)
+        }
+        anchors {
+            verticalCenter: parent.verticalCenter
         }
     }
 

--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -83,7 +83,7 @@ DccObject {
                         property bool isCurrentLang: dccData.currentLang === dccObj.displayName
                         visible: dccObj
                         hoverEnabled: true
-                        implicitHeight: 50
+                        implicitHeight: 40
                         icon.name: dccObj.icon
                         checkable: false
 
@@ -190,6 +190,7 @@ DccObject {
                     languageListTiltle.isEditing = false
                 }
             }
+            onParentItemChanged: item => { if (item) item.implicitHeight = 40 }
         }
     }
 
@@ -346,6 +347,7 @@ DccObject {
                         dccData.setCurrentFormat(model.indexBegin + index, idx)
                     }
                 }
+                onParentItemChanged: item => { if (item) item.implicitHeight = 40 }
             }
         }
     }
@@ -378,6 +380,7 @@ DccObject {
                         dccData.setCurrentFormat(model.indexBegin + index, idx)
                     }
                 }
+                onParentItemChanged: item => { if (item) item.implicitHeight = 40 }
             }
         }
     }
@@ -410,6 +413,7 @@ DccObject {
                         dccData.setCurrentFormat(model.indexBegin + index, idx)
                     }
                 }
+                onParentItemChanged: item => { if (item) item.implicitHeight = 40 }
             }
         }
     }


### PR DESCRIPTION
- Reduced implicitHeight to accommodate longer translations
- Added verticalCenter anchors for multilingual text alignment
- Unified item heights to 40 for consistent layout across languages
- Enhanced parentItemChanged handling for dynamic language switching

Log: improve UI layout for better localization support in datetime plugin
pms: BUG-316149

## Summary by Sourcery

Adjust item heights and vertical alignment to support longer translations and dynamic language switching in the datetime plugin UI.

Enhancements:
- Set implicitHeight of language and format list items to 40 for a unified layout across languages
- Add onParentItemChanged handlers to reapply the unified height when items are recreated
- Reduce ComboLabel implicitHeight to 30 and add verticalCenter anchoring for proper text alignment