### PR TITLE
fix: Add Bluetooth connection animation

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -165,6 +165,15 @@ Rectangle {
                             id: rowCtl
                             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                             spacing: 10
+                            D.BusyIndicator {
+                                id: connectBusyIndicator
+                                implicitHeight: 20
+                                implicitWidth: 20
+                                Layout.rightMargin: showMoreBtn ? 0 : 10
+                                Layout.alignment: Qt.AlignVCenter
+                                running: model.connectStatus === 1
+                                visible: model.connectStatus === 1
+                            }
                             D.ToolButton {
                                 id: connectBtn
                                 implicitHeight: 30
@@ -172,7 +181,7 @@ Rectangle {
                                 text: model.connectStatus === 2 ? qsTr("Disconnect") : qsTr("Connect")
                                 enabled: model.connectStatus === 2 || model.connectStatus === 0
                                 font: D.DTK.fontManager.t6
-                                visible: itemCtl.hovered
+                                visible: itemCtl.hovered && model.connectStatus !== 1
 
                                 Layout.alignment: Qt.AlignVCenter
                                 onClicked: {


### PR DESCRIPTION
Add Bluetooth connection animation

Log: Add Bluetooth connection animation
pms: BUG-284419

## Summary by Sourcery

Add Bluetooth connection animation to the device list view by showing a spinner during connection and hiding the connect button while connecting

Enhancements:
- Show a BusyIndicator spinner next to each device when connection is in progress
- Hide the connect button while a Bluetooth connection is being established