### PR TITLE
fix: update time format strings in RegionProxy

### DIFF
--- a/src/plugin-datetime/operation/regionproxy.cpp
+++ b/src/plugin-datetime/operation/regionproxy.cpp
@@ -157,7 +157,7 @@ public:
 
     virtual QStringList shortTimeFormats() override
     {
-        return { "H:mm AP", "HH:mm AP", "H:mm", "HH:mm" };
+        return { "h:mm Ap", "hh:mm Ap", "H:mm", "HH:mm" };
     }
 
     virtual QStringList longTimeFormats() override


### PR DESCRIPTION
- Changed time format patterns from "H:mm AP" to "h:mm Ap" for better AM/PM display

Log: resolve time format display issues in RegionProxy
pms: BUG-295959

## Summary by Sourcery

Bug Fixes:
- Update short time format patterns from "H:mm AP" to "h:mm Ap" for proper AM/PM rendering