### PR TITLE
fix: update numberKeepList with Arabic thousands separator

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -149,7 +149,7 @@ static inline QString escapSpace(const QString &space)
 static inline QString normalizeSpace(const QString &value)
 {
     QString ret = " ";
-    QStringList numberKeepList{ QString("."), QString(","), QString("'")};
+    QStringList numberKeepList{ QString("."), QString(","), QString("'"), QString("٬")};
     if (numberKeepList.contains(value)) {
         ret = value;
     } else {


### PR DESCRIPTION
- Added Arabic thousands separator (٬) to numberKeepList in normalizeSpace function

Log: resolve locale formatting issue in datetime normalization
pms: BUG-315799

## Summary by Sourcery

Bug Fixes:
- Add Arabic thousands separator (٬) to numberKeepList in normalizeSpace to preserve it during datetime normalization