### PR TITLE
fix: Same page return and item animation

### DIFF
--- a/include/dccapp.h
+++ b/include/dccapp.h
@@ -35,17 +35,28 @@ public:
     };
     Q_ENUM(UosEdition)
 
+    enum AnimationMode {
+        AnimationPush,
+        AnimationPop
+    };
+    Q_ENUM(AnimationMode)
+
     static DccApp *instance();
 
     Q_PROPERTY(int width READ width)
     Q_PROPERTY(int height READ height)
     Q_PROPERTY(DccObject * root READ root NOTIFY rootChanged)
     Q_PROPERTY(DccObject * activeObject READ activeObject NOTIFY activeObjectChanged)
+    Q_PROPERTY(AnimationMode animationMode READ animationMode WRITE setAnimationMode NOTIFY animationModeChanged)
 
     virtual int width() const;
     virtual int height() const;
     virtual DccObject *root() const;
     virtual DccObject *activeObject() const;
+    virtual AnimationMode animationMode() const {
+        return m_animationMode;
+    }
+    virtual void setAnimationMode(AnimationMode mode);
 
 public Q_SLOTS:
     virtual DccObject *object(const QString &name);
@@ -62,10 +73,13 @@ Q_SIGNALS:
     void rootChanged(DccObject *root);
     void activeObjectChanged(DccObject *activeObject);
     void activeItemChanged(QQuickItem *item);
+    void animationModeChanged(AnimationMode mode);
 
 protected:
     explicit DccApp(QObject *parent = nullptr);
     ~DccApp() override;
+private:
+    AnimationMode m_animationMode;
 };
 } // namespace dccV25
 

--- a/qml/SecondPage.qml
+++ b/qml/SecondPage.qml
@@ -225,7 +225,9 @@ Item {
         if (activeObj.page === null) {
             activeObj.page = rightLayout
         }
-        rightView.replace(activeObj.getSectionItem(rightView))
+        rightView.replace(activeObj.getSectionItem(rightView), DccApp.animationMode === DccApp.AnimationPush
+                          ? StackView.PushTransition
+                          : StackView.PopTransition)
     }
     Connections {
         target: DccApp

--- a/src/dde-control-center/frame/dccapp.cpp
+++ b/src/dde-control-center/frame/dccapp.cpp
@@ -13,12 +13,21 @@ DccApp *DccApp::instance()
 
 DccApp::DccApp(QObject *parent)
     : QObject(parent)
+    , m_animationMode(AnimationPop)
 {
     Q_ASSERT(!dccApp);
     dccApp = this;
 }
 
 DccApp::~DccApp() { }
+
+void DccApp::setAnimationMode(AnimationMode mode)
+{
+    if (m_animationMode != mode) {
+        m_animationMode = mode;
+        Q_EMIT animationModeChanged(mode);
+    }
+}
 
 int DccApp::width() const
 {


### PR DESCRIPTION
Add animation mode support for page transitions

pms: BUG-310319

## Summary by Sourcery

Introduce push/pop animation mode support for page transitions and wire it through C++ and QML to apply the correct StackView transition when navigating between pages.

Enhancements:
- Add AnimationMode enum, property, getter, setter, and change signal to DccApp
- Default animation mode to Pop and toggle between Push and Pop in DccManager during navigation
- Update QML SecondPage to choose StackView.PushTransition or StackView.PopTransition based on the current animation mode