### PR TITLE
style: improve window blur color handling

### DIFF
--- a/qml/DccWindow.qml
+++ b/qml/DccWindow.qml
@@ -27,7 +27,15 @@ D.ApplicationWindow {
     D.StyledBehindWindowBlur {
         anchors.fill: parent
         control: root
-        blendColor: DS.Style.control.selectColor(control ? control.palette.window : undefined, Qt.rgba(1, 1, 1, 0.8), Qt.rgba(0.06, 0.06, 0.06, 0.8))
+        blendColor: {
+            if (valid) {
+                return DS.Style.control.selectColor(control ? control.palette.window : undefined, Qt.rgba(1, 1, 1, 0.8), Qt.rgba(0.06, 0.06, 0.06, 0.8))
+            }
+                return DS.Style.control.selectColor(undefined,
+                                                    DS.Style.behindWindowBlur.lightNoBlurColor,
+                                                    DS.Style.behindWindowBlur.darkNoBlurColor)
+        }
+
     }
     Shortcut {
         context: Qt.ApplicationShortcut


### PR DESCRIPTION
1. Modified blendColor logic to check for 'valid' state before applying colors
2. Added fallback colors from DS.Style.behindWindowBlur when not valid
3. Improved code readability by breaking down the conditional logic
4. Ensures proper color display even when window state is invalid

style: 改进窗口模糊颜色处理

1. 修改 blendColor 逻辑，在应用颜色前检查 'valid' 状态
2. 当状态无效时添加来自 DS.Style.behindWindowBlur 的回退颜色
3. 通过分解条件逻辑提高代码可读性
4. 确保在窗口状态无效时也能正确显示颜色

pms: BUG-314863

## Summary by Sourcery

Improve window blur color handling by checking the blur validity and applying fallback colors when necessary

Bug Fixes:
- Use DS.Style.behindWindowBlur fallback colors when the window blur state is invalid

Enhancements:
- Refactor blendColor logic into an explicit conditional block for improved readability