### PR TITLE
fix: prevent duplicate format in TimeAndDate component

### DIFF
--- a/src/plugin-datetime/operation/regionproxy.cpp
+++ b/src/plugin-datetime/operation/regionproxy.cpp
@@ -315,6 +315,7 @@ RegionAvailableData RegionProxy::allTextData(const QLocale &locale)
     allTextData += RegionProxy::defaultTextData(locale);
     allTextData += RegionProxy::customTextData(locale);
 
+    m_allFormat.clear();
     m_allFormat += m_defaultFormat;
     m_allFormat += m_customFormat;
 

--- a/src/plugin-datetime/operation/regionproxy.h
+++ b/src/plugin-datetime/operation/regionproxy.h
@@ -85,6 +85,13 @@ struct RegionAvailableData {
         }
         return *this;
     }
+    void clear() {
+        daysAvailable.clear();
+        shortDatesAvailable.clear();
+        longDatesAvailable.clear();
+        shortTimesAvailable.clear();
+        longTimesAvailable.clear();
+    }
 };
 
 using Regions = QMap<QString, QLocale>;


### PR DESCRIPTION
- Fixed duplicate format declarations in region switching
- Standardized Label width handling with fillWidth property
- Ensured consistent display across all locales

Log: fix duplicate format in TimeAndDate component
pms: BUG-296013

## Summary by Sourcery

Prevent duplicate date and time formats by clearing accumulated formats before merging and add a clear method to reset region format data

Bug Fixes:
- Prevent duplicate date and time formats by clearing combined format list before merging default and custom formats

Enhancements:
- Add clear() method to RegionAvailableData to reset available date and time format data