### PR TITLE
style: add subtle borders to preview containers

### DIFF
--- a/src/plugin-personalization/qml/ScreenSaverPage.qml
+++ b/src/plugin-personalization/qml/ScreenSaverPage.qml
@@ -64,6 +64,14 @@ DccObject {
                     }
                 }
 
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 6
+                    color: "transparent"
+                    border.color: Qt.rgba(0, 0, 0, 0.1)
+                    border.width: 1
+                }
+
                 D.Button {
                     id: previewBtn
                     anchors.bottom: parent.bottom

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -95,6 +95,14 @@ DccObject {
                         radius: 6
                     }
                 }
+
+                Rectangle {
+                    anchors.fill: parent
+                    radius: 6
+                    color: "transparent"
+                    border.color: Qt.rgba(0, 0, 0, 0.1)
+                    border.width: 1
+                }
             }
         }
     }


### PR DESCRIPTION
1. Added transparent Rectangle elements with subtle borders to ScreenSaverPage and WallpaperPage
2. The borders have 6px radius to match existing rounded corners
3. Uses a very light black (10% opacity) for a subtle visual separation
4. Improves visual hierarchy and makes the preview areas more distinct

style: 为预览容器添加细微边框

1. 在 ScreenSaverPage 和 WallpaperPage 中添加了带细微边框的透明矩形元素
2. 边框使用6px圆角以匹配现有的圆角设计
3. 采用非常浅的黑色(10%透明度)实现细微的视觉分隔
4. 改善视觉层次结构，使预览区域更加清晰可辨

pms: BUG-316721

## Summary by Sourcery

Enhancements:
- Add transparent rectangles with 6px radius and 1px 10%-opacity black borders around preview containers in ScreenSaverPage and WallpaperPage for better visual separation