### PR TITLE
fix: Fixed the issue that the font size did not change with the change

### DIFF
--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -303,12 +303,14 @@ ColumnLayout {
 
         Label {
             id: leftItem
+            font: D.DTK.fontManager.t7
             Layout.preferredWidth: 120
             Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
         }
 
         D.PasswordEdit {
             id: rightItem
+            font: D.DTK.fontManager.t7
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
             echoMode: echoButtonVisible ? TextInput.Password :  TextInput.Normal

--- a/src/plugin-accounts/qml/PasswordModifyDialog.qml
+++ b/src/plugin-accounts/qml/PasswordModifyDialog.qml
@@ -31,6 +31,7 @@ D.DialogWindow {
         Label {
             text: dialog.title
             font.bold: true
+            font.pixelSize: cancelButton.font.pixelSize
             Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
         }
         Label {
@@ -40,6 +41,7 @@ D.DialogWindow {
                 else
                     return qsTr("Resetting the password will clear the data stored in the keyring.")
             }
+            font: D.DTK.fontManager.t8
             wrapMode: Text.WordWrap
             rightPadding: 10
             leftPadding: 10
@@ -68,8 +70,10 @@ D.DialogWindow {
             Layout.rightMargin: 20
 
             Button {
+                id: cancelButton
                 Layout.fillWidth: true
                 text: qsTr("Cancel")
+                font: D.DTK.fontManager.t7
                 onClicked: {
                     close()
                 }
@@ -77,6 +81,7 @@ D.DialogWindow {
             D.RecommandButton {
                 Layout.fillWidth: true
                 text: qsTr("Modify password")
+                font: D.DTK.fontManager.t7
                 onClicked: {
                     if (!pwdLayout.checkPassword())
                         return


### PR DESCRIPTION
Fixed the issue that the font size did not change with the change

Log: Fixed the issue that the font size did not change with the change
pms: BUG-305245

## Summary by Sourcery

Bug Fixes:
- Ensure password dialog titles, messages, buttons, and layout labels use the DTK fontManager sizes so font changes are applied correctly