### PR TITLE
feat: disables search in privacy plugin settings

### DIFF
--- a/src/plugin-privacy/qml/Camera.qml
+++ b/src/plugin-privacy/qml/Camera.qml
@@ -25,6 +25,7 @@ DccObject {
             weight: 1
             parentName: "privacy/camera/cameraAppViewGroup"
             pageType: DccObject.Editor
+            canSearch: false
             displayName: qsTr("Allow below apps to access your camera:")
         }
 
@@ -37,6 +38,7 @@ DccObject {
                 icon: model.iconName
                 displayName: model.name
                 pageType: DccObject.Editor
+                canSearch: false
                 page: D.Switch {
                     checked: model.cameraPermission
                     onCheckedChanged: {

--- a/src/plugin-privacy/qml/FileAndFolder.qml
+++ b/src/plugin-privacy/qml/FileAndFolder.qml
@@ -25,6 +25,7 @@ DccObject {
             weight: 1
             parentName: "privacy/filefolder/filefolderViewGroup"
             pageType: DccObject.Editor
+            canSearch: false
             displayName: qsTr("Allow below apps to access these files and folders:")
         }
 
@@ -40,6 +41,7 @@ DccObject {
                 weight: 10 + index * 10
                 pageType: DccObject.Item
                 visible: !model.noDisplay
+                canSearch: false
 
                 Connections {
                     target: parentItem


### PR DESCRIPTION
as title

pms: BUG-303397

## Summary by Sourcery

Disable search functionality in the privacy plugin settings for camera and file/folder permission pages by setting canSearch to false on relevant QML components

Enhancements:
- Disable search in camera privacy settings
- Disable search in file and folder privacy settings