### PR TITLE
fix: update focus handling in Common

### DIFF
--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -190,8 +190,8 @@ DccObject {
             background: null
             horizontalAlignment: Text.AlignHCenter
             font: D.DTK.fontManager.t5
-            onFocusChanged: {
-                if (!focus) {
+            onActiveFocusChanged: {
+                if (!activeFocus) {
                     text = ""
                 }
             }


### PR DESCRIPTION
replace onFocusChanged with activeFocusChanged for better text clearing behavior

Log: update focus handling in Common
pms: BUG-303227

## Summary by Sourcery

Bug Fixes:
- Clear text only when active focus is lost by switching to onActiveFocusChanged handler