### PR TITLE
fix: The scrollbar does not display

### DIFF
--- a/qml/SecondPage.qml
+++ b/qml/SecondPage.qml
@@ -79,6 +79,9 @@ Item {
             currentIndex: dccObj ? dccObj.children.indexOf(dccObj.currentObject) : -1
             activeFocusOnTab: true
             clip: true
+            ScrollBar.vertical: ScrollBar {
+                width: 10
+            }
             model: DccModel {
                 id: dccModel
                 root: dccObj


### PR DESCRIPTION
- Add `ScrollBar.vertical` to `ListView` in `SecondPage.qml` for improved scrolling experience

pms: BUG-310591

## Summary by Sourcery

Add a vertical scrollbar to the ListView on SecondPage.qml to fix its absence and enhance scrolling experience.

Bug Fixes:
- Show vertical scrollbar in ListView to address missing scrollbar issue.

Enhancements:
- Set scrollbar width to 10 for improved scrolling experience.