### PR TITLE
fix: optimize text filtering in keyboard shortcuts

### DIFF
--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -229,9 +229,12 @@ void ShortcutModel::onParseInfo(const QString &info)
         ShortcutInfo *info = new ShortcutInfo();
         info->type         = type;
         info->accels       = obj["Accels"].toArray().first().toString();
-        info->name    = obj["Name"].toString();
-        info->pinyin =  toPinyin(info->name);
         info->id      = obj["Id"].toString();
+        info->name    = obj["Name"].toString();
+        if (systemShortKeys.contains(info->id)) {
+            info->name    = info->name.trimmed();
+        }
+        info->pinyin  =  toPinyin(info->name);
         info->command = obj["Exec"].toString();
 
         m_infos << info;

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -34,7 +34,7 @@ DccObject {
                 id: timer
                 interval: 100
                 onTriggered: {
-                    shortcutView.model.setFilterWildcard(searchEdit.text);
+                    shortcutView.model.setFilterFixedString(searchEdit.text);
                 }
             }
 


### PR DESCRIPTION
- Add trim() for shortcut names in ShortcutModel
- Change wildcard to fixed string matching in Shortcuts.qml

Log: optimize text filtering in keyboard shortcuts
pms: BUG-282541

## Summary by Sourcery

Optimize text filtering in keyboard shortcuts by trimming shortcut names and switching from wildcard to fixed string matching

Bug Fixes:
- Trim whitespace from system shortcut names in ShortcutModel to ensure correct filtering

Enhancements:
- Replace wildcard-based search filtering with fixed string matching in the Shortcuts.qml view