### PR TITLE
chore: Update QML imports for compatibility with Qt >= 6.9

### DIFF
--- a/qml/Crumb.qml
+++ b/qml/Crumb.qml
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.3
-import Qt.labs.qmlmodels 1.2
+import QtQml.Models //Delegatechoice for Qt >= 6.9
+import Qt.labs.qmlmodels //DelegateChooser
 import QtQuick.Layouts 1.15
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS

--- a/src/dde-control-center/frame/plugin/DccGroupView.qml
+++ b/src/dde-control-center/frame/plugin/DccGroupView.qml
@@ -4,7 +4,8 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import Qt.labs.platform 1.1
-import Qt.labs.qmlmodels 1.2
+import QtQml.Models //Delegatechoice for Qt >= 6.9
+import Qt.labs.qmlmodels //DelegateChooser
 
 import org.deepin.dtk 1.0 as D
 


### PR DESCRIPTION
Replace `Qt.labs.qmlmodels 1.2` with `QtQml.Models` and retain `Qt.labs.qmlmodels` for `DelegateChooser` to ensure compatibility with Qt versions 6.9 and above. Changes applied to `Crumb.qml` and `DccGroupView.qml`.

log: as title

## Summary by Sourcery

Chores:
- Replace deprecated Qt.labs.qmlmodels 1.2 import with QtQml.Models and retain Qt.labs.qmlmodels in Crumb.qml and DccGroupView.qml for DelegateChooser compatibility