### PR TITLE
fix: optimize window switch handling in keyboard plugin

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -179,6 +179,7 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
     });
     connect(m_shortcutModel, &ShortcutModel::addCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::reset);
+    connect(m_shortcutModel, &ShortcutModel::windowSwitchChanged, sourceModel, &ShortcutListModel::reset);
 
     m_shortcutSearchModel->setSourceModel(sourceModel);
     m_shortcutSearchModel->setFilterRole(ShortcutListModel::SearchedTextRole);

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -48,6 +48,8 @@ void KeyboardDBusProxy::init()
     m_dBusKeyboardInter = new DDBusInterface(KeyboardService, KeyboardPath, KeyboardInterface, QDBusConnection::sessionBus(), this);
     m_dBusKeybingdingInter = new DDBusInterface(KeybingdingService, KeybingdingPath, KeybingdingInterface, QDBusConnection::sessionBus(), this);
     m_dBusWMInter = new DDBusInterface(WMService, WMPath, WMInterface, QDBusConnection::sessionBus(), this);
+
+    QDBusConnection::sessionBus().connect(WMService, WMPath, WMInterface, "wmCompositingEnabledChanged", this, SIGNAL(compositingEnabledChanged(bool)));
 }
 
 void KeyboardDBusProxy::langSelectorStartServiceProcess()

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -71,8 +71,7 @@ void KeyboardWorker::resetAll() {
 
 void KeyboardWorker::onGetWindowWM(bool value)
 {
-    if (m_shortcutModel)
-        m_shortcutModel->onWindowSwitchChanged(value);
+    windowSwitch();
 }
 
 void KeyboardWorker::setShortcutModel(ShortcutModel *model)

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -25,6 +25,7 @@ struct ShortcutInfo
     ShortcutItem *item = nullptr;
     QString sectionName;
     QString pinyin;
+    int index = 0;
 
     ShortcutInfo()
         : type(0)
@@ -113,6 +114,7 @@ private:
     QList<ShortcutInfo *> m_assistiveToolsInfos;
     QList<ShortcutInfo *> m_customInfos;
     QList<ShortcutInfo *> m_searchList;
+    QList<ShortcutInfo *> m_windowSwitchStateInfos;
     ShortcutInfo *m_currentInfo = nullptr;
     bool m_windowSwitchState;
     //dcc::display::DisplayModel m_dis;


### PR DESCRIPTION
- Added window switch signal connections
- Simplified window state change logic
- Improved shortcut model update efficiency

Log: optimize window switch handling in keyboard plugin
pms: BUG-301391

## Summary by Sourcery

Optimize window switch handling in the keyboard plugin by adding necessary D-Bus signal connections, streamlining state logic, and improving shortcut model update efficiency.

New Features:
- Listen to `wmCompositingEnabledChanged` D-Bus signal to propagate compositing status to the plugin.

Bug Fixes:
- Ensure consistent handling of window switch state and trigger UI updates on changes.

Enhancements:
- Simplify window switch state logic in `ShortcutModel` by removing redundant branches.
- Cache and manage `preview-workspace` shortcut info with index-based insertion/removal for better performance.
- Refactor `KeyboardWorker::onGetWindowWM` to delegate to `windowSwitch()`.
- Reset the shortcut search model on window switch changes in `KeyboardController`.