### PR TITLE
fix: Fixed the issue of slow creation of multiple accounts

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -85,6 +85,8 @@ public slots:
     QVariantMap checkPasswordResult(int code, const QString &msg, const QString &name, const QString &pwd);
     void showDefender();
 
+    void updateSingleUserGroups(const QString &id);
+
 signals:
     void currentUserNameChanged();
     void userIdListChanged();
@@ -115,6 +117,7 @@ private:
     QAbstractListModel    *m_accountsModel = nullptr;
     QHash<QString, QStringList> m_groups;
     QAbstractListModel    *m_groupsModel = nullptr;
+    bool m_isCreatingUser = false;
 };
 
 }

--- a/src/plugin-accounts/operation/accountsworker.cpp
+++ b/src/plugin-accounts/operation/accountsworker.cpp
@@ -398,9 +398,8 @@ void AccountsWorker::createAccount(const User *user)
     qDebug() << "create account";
 
     QFutureWatcher<CreationResult *> *watcher = new QFutureWatcher<CreationResult *>(this);
-    connect(watcher, &QFutureWatcher<CreationResult *>::finished, [this, watcher] {
+    connect(watcher, &QFutureWatcher<CreationResult *>::finished, [this, watcher, user] {
         CreationResult *result = watcher->result();
-        m_userModel->setAllGroups(m_accountsInter->GetGroups());
         Q_EMIT accountCreationFinished(result);
         Q_EMIT requestMainWindowEnabled(true);
         watcher->deleteLater();


### PR DESCRIPTION
Fixed the issue of slow creation of multiple accounts

Log: Fixed the issue of slow creation of multiple accounts
pms: BUG-317565

## Summary by Sourcery

Optimize user group update logic to speed up batch account creation by introducing an isCreatingUser flag, caching group membership checks, and performing single-user updates on creation completion.

New Features:
- Add updateSingleUserGroups method to perform per-user group updates after account creation finishes.

Bug Fixes:
- Skip full group list refresh during user creation to prevent slow account batch creation.

Enhancements:
- Cache groupContains results and split contained/non-contained groups for faster sorting in updateGroups and updateAllGroups.
- Defer single-user group refresh using QTimer to reduce immediate update overhead.