### PR TITLE
feat: Add URL fuzzy matching function

### DIFF
--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -82,8 +82,10 @@ Q_SIGNALS:
 private:
     void initConfig();
     bool contains(const QSet<QString> &urls, const DccObject *obj);
+    bool isMatch(const QString &url, const DccObject *obj);
     bool isEqual(const QString &url, const DccObject *obj);
     DccObject *findObject(const QString &url, bool onlyRoot = false);
+    QVector<DccObject *> findObjects(const QString &url, bool onlyRoot = false, bool one = false);
     DccObject *findParent(const DccObject *obj);
     bool eventFilter(QObject *watched, QEvent *event) override;
 


### PR DESCRIPTION
Support * to match any character

pms: TASK-361721

## Summary by Sourcery

Add URL fuzzy matching with wildcard support and multi-object retrieval to DccManager, replacing exact-match logic and improving module configuration filtering

New Features:
- Support '*' wildcard fuzzy URL matching via the new isMatch method
- Introduce findObjects to fetch one or many DccObjects matching a URL pattern

Enhancements:
- Replace exact path lookups and isEqual calls with fuzzy matching and multi-object retrieval in contains, waitShowPage, and configuration updates
- Preprocess module configuration entries to discard empty, whitespace-padded, or invalid paths before applying flags
- Qualify calls to mainWindow() and showPage with class scope for consistency