### PR TITLE
fix: Fixed the issue that the menu position was abnormal

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -292,7 +292,7 @@ Rectangle {
                                     console.log(" contextMenu 单击事件 ");
                                     // 在点击位置下方显示菜单
                                     // 获取按钮的全局位置，确保菜单在按钮的正下方显示
-                                    var buttonGlobalX = moreBtn.x + moreBtn.width / 2
+                                    var buttonGlobalX = moreBtn.x + moreBtn.width / 2 - contextMenu.width
                                     var buttonGlobalY = moreBtn.y + moreBtn.height + 5
                                     contextMenu.popup(buttonGlobalX, buttonGlobalY)
                                 }


### PR DESCRIPTION
Fixed the issue that the menu position was abnormal

Log: Fixed the issue that the menu position was abnormal
pms: BUG-306361

## Summary by Sourcery

Bug Fixes:
- Adjust context menu X coordinate by subtracting its width to align it under the ‘more’ button