### PR TITLE
fix: remove ai-assistant from assistive tools filter

### DIFF
--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -57,8 +57,7 @@ const QStringList &workspaceFilter = {"switch-to-workspace-left",
                                       "move-to-workspace-left",
                                       "move-to-workspace-right"};
 
-const QStringList &assistiveToolsFilter = {"ai-assistant",
-                                           "text-to-speech",
+const QStringList &assistiveToolsFilter = {"text-to-speech",
                                            "speech-to-text",
                                            "translation",
                                             "view-zoom-in",


### PR DESCRIPTION
- Removed deprecated ai-assistant entry from assistive tools list

Log: clean up assistive tools filter list
pms: BUG-312639

## Summary by Sourcery

Bug Fixes:
- Remove ai-assistant from assistive tools filter list