### PR TITLE
fix: resolve shortcut conflicts by adding type parameter

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -188,15 +188,15 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
     return m_shortcutSearchModel;
 }
 
-void KeyboardController::updateKey(const QString &id)
+void KeyboardController::updateKey(const QString &id, const int &type)
 {
     ShortcutInfo *shortcut = nullptr;
     if (!id.isEmpty()) { // new shortcuts
-        shortcut = m_shortcutModel->findInfoIf([id](ShortcutInfo *info){
-            return id == info->id;
+        shortcut = m_shortcutModel->findInfoIf([id, type](ShortcutInfo *info){
+            return id == info->id && type == info->type;
         });
         if (!shortcut) {
-            qWarning() << "shortcut not found..." << id;
+            qWarning() << "shortcut not found..." << id << type;
             return;
         }
     }
@@ -250,11 +250,11 @@ void KeyboardController::deleteCustomShortcut(const QString &id)
     m_worker->delShortcut(shortcut);
 }
 
-void KeyboardController::modifyShortcut(const QString &id, const QString &accels)
+void KeyboardController::modifyShortcut(const QString &id, const QString &accels, const int &type)
 {
-    ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id](ShortcutInfo *info){ return id == info->id; });
+    ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id, type](ShortcutInfo *info){ return id == info->id && type == info->type; });
     if (!shortcut) {
-        qWarning() << "shortcut not found..." << id;
+        qWarning() << "shortcut not found..." << id << type;
         return;
     }
 

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -57,12 +57,12 @@ public Q_SLOTS:
     QSortFilterProxyModel *layoutSearchModel();
     QSortFilterProxyModel *shortcutSearchModel();
 
-    void updateKey(const QString &id);
+    void updateKey(const QString &id, const int &type);
     QStringList formatKeys(const QString &shortcuts);
 
     void addCustomShortcut(const QString &name, const QString &cmd, const QString &accels);
     void modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels);
-    void modifyShortcut(const QString &id, const QString &accels);
+    void modifyShortcut(const QString &id, const QString &accels, const int &type);
     void deleteCustomShortcut(const QString &id);
 
     void resetAllShortcuts();

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -344,8 +344,9 @@ void ShortcutModel::onKeyBindingChanged(const QString &value)
 {
     const QJsonObject &obj       = QJsonDocument::fromJson(value.toStdString().c_str()).object();
     const QString     &update_id = obj["Id"].toString();
+    const int     &update_type = obj["Type"].toInt();
     auto res = std::find_if(m_infos.begin(), m_infos.end(), [ = ] (const ShortcutInfo *info)->bool{
-        return info->id == update_id;
+        return info->id == update_id && info->type == update_type;
     });
 
     if (res != m_infos.end()) {
@@ -569,6 +570,8 @@ QVariant ShortcutListModel::data(const QModelIndex &index, int role) const
         return info->name + info->pinyin + "_" + displayKeys.join("_");
     case IdRole:
         return info->id;
+    case TypeRole:
+        return info->type;
     case KeySequenceRole:
         return displayKeys;
     case CommandRole:
@@ -593,6 +596,7 @@ QHash<int, QByteArray> ShortcutListModel::roleNames() const
     QHash<int, QByteArray> names = QAbstractListModel::roleNames();
     names[SearchedTextRole] = "searchedText";
     names[IdRole] = "id";
+    names[TypeRole] = "type";
     names[KeySequenceRole] = "keySequence";
     names[CommandRole] = "command";
     names[SectionNameRole] = "section";

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -127,6 +127,7 @@ public:
     enum ShortcutRole {
         SearchedTextRole = Qt::UserRole + 1,
         IdRole,
+        TypeRole,
         CommandRole,
         KeySequenceRole,
         AccelsRole,

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -109,7 +109,7 @@ D.DialogWindow {
             }
             onRequestKeys: {
                 keys = []
-                dccData.updateKey("")
+                dccData.updateKey("", 1)
             }
         }
 

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -153,7 +153,7 @@ DccObject {
                                 }
 
                                 edit.keys = ""
-                                dccData.updateKey(model.id)
+                                dccData.updateKey(model.id, model.type)
                                 shortcutView.editItem = edit
                                 shortcutView.conflictText = conflictText
                                 shortcutSettingsBody.isEditing = false
@@ -167,9 +167,9 @@ DccObject {
                             }
 
                             function modifyShortcut(accels) {
-                                console.log("modifyShortcut", model.id, accels)
+                                console.log("modifyShortcut", model.id, accels, model.type)
                                 if (accels.length > 0)
-                                    dccData.modifyShortcut(model.id, accels)
+                                    dccData.modifyShortcut(model.id, accels, model.type)
                             }
 
                             function restore() {


### PR DESCRIPTION
- Add type parameter to updateKey and modifyShortcut methods
- Update ShortcutModel to handle type-based queries
- Add TypeRole in shortcut model for data binding
- Adjust QML components to pass type parameter

Log: fix shortcut identification conflicts in keyboard plugin
pms: BUG-303217