### PR TITLE
fix: Add password hint restrictions

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -795,6 +795,11 @@ void AccountsController::showDefender()
     m_worker->showDefender();
 }
 
+void AccountsController::playSystemSound(int soundType)
+{
+    m_worker->playSystemSound(soundType);
+}
+
 QString AccountsController::currentUserName() const
 {
     return m_model->getCurrentUserName();

--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -84,6 +84,7 @@ public slots:
     QString checkPassword(const QString &name, const QString &pwd);
     QVariantMap checkPasswordResult(int code, const QString &msg, const QString &name, const QString &pwd);
     void showDefender();
+    void playSystemSound(int soundType);
 
     void updateSingleUserGroups(const QString &id);
 

--- a/src/plugin-accounts/operation/accountsworker.cpp
+++ b/src/plugin-accounts/operation/accountsworker.cpp
@@ -9,6 +9,7 @@
 #include "securitydbusproxy.h"
 
 #include <ddbussender.h>
+#include <DDesktopServices>
 
 #include <QtConcurrent>
 #include <QFutureWatcher>
@@ -29,6 +30,7 @@ using namespace PolkitQt1;
 
 using namespace dccV25;
 DCORE_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 AccountsWorker::AccountsWorker(UserModel *userList, QObject *parent)
     : QObject(parent)
@@ -927,4 +929,9 @@ BindCheckResult AccountsWorker::checkLocalBind(const QString &uosid, const QStri
     else
         result.error = m_syncInter->lastError();
     return result;
+}
+
+void AccountsWorker::playSystemSound(int soundType)
+{
+    DDesktopServices::playSystemSoundEffect(static_cast<DDesktopServices::SystemSoundEffect>(soundType));
 }

--- a/src/plugin-accounts/operation/accountsworker.h
+++ b/src/plugin-accounts/operation/accountsworker.h
@@ -92,6 +92,7 @@ public Q_SLOTS:
     SecurityLever getSecUserLeverbyname(QString userName);
     void checkPwdLimitLevel(int level);
     void showDefender();
+    void playSystemSound(int soundType);
 
 private Q_SLOTS:
     void updateUserOnlineStatus(const QList<QDBusObjectPath> &paths);

--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -41,6 +41,10 @@ ColumnLayout {
         return pwdContainter.checkPassword()
     }
 
+    function playErrorSound() {
+        dccData.playSystemSound(14)
+    }
+
     PasswordItem {
         id: currentPwd
         visible: pwdLayout.currentPwdVisible
@@ -319,6 +323,12 @@ ColumnLayout {
                 if (showAlert)
                     showAlert = false
 
+                if (!echoButtonVisible && text.length > 14) {
+                    rightItem.text = text.substring(0, 14)
+                    playErrorSound()
+                    return
+                }
+                
                 pwdItem.textChanged(text)
             }
 


### PR DESCRIPTION
Add password hint restrictions

Log: Add password hint restrictions
pms: BUG-312281

## Summary by Sourcery

Implement password hint restrictions by truncating input over 14 characters when echo is off and triggering a system error sound via new playSystemSound methods in the C++ backend and QML layer

New Features:
- Restrict password hint length to 14 characters when echo is disabled

Enhancements:
- Add error sound feedback for invalid password hint input