### PR TITLE
fix: Edit compilation warning

### DIFF
--- a/src/dde-control-center/frame/dccmodel.cpp
+++ b/src/dde-control-center/frame/dccmodel.cpp
@@ -10,7 +10,7 @@
 #include <QLoggingCategory>
 
 namespace dccV25 {
-static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.model");
+// static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.model");
 
 enum DccModelRole {
     DccItemRole = Qt::UserRole + 300,

--- a/src/dde-control-center/frame/dccobject.cpp
+++ b/src/dde-control-center/frame/dccobject.cpp
@@ -450,7 +450,7 @@ void DccObject::setPageType(quint8 type)
     }
 }
 
-QQuickItem *DccObject::getSectionItem(QObject *parent)
+QQuickItem *DccObject::getSectionItem(QObject *)
 {
     p_ptr->deleteSectionItem();
     if (p_ptr->m_page) {

--- a/src/dde-control-center/frame/dccrepeater.cpp
+++ b/src/dde-control-center/frame/dccrepeater.cpp
@@ -37,6 +37,8 @@ public:
         }
     }
 
+public:
+    DccRepeater *q_ptr = nullptr;
     QPointer<QQmlInstanceModel> model;
     QVariant dataSource;
     QPointer<QObject> dataSourceAsObject;
@@ -47,7 +49,6 @@ public:
 
     QVector<QPointer<DccObject> > deletables;
 
-    DccRepeater *q_ptr = nullptr;
     Q_DECLARE_PUBLIC(DccRepeater)
 };
 
@@ -173,7 +174,7 @@ void DccRepeater::resetModel()
     modelUpdated(QQmlChangeSet(), true);
 }
 
-void DccRepeater::createdItem(int index, QObject *obj)
+void DccRepeater::createdItem(int index, QObject *)
 {
     Q_D(DccRepeater);
     QObject *object = d->model->object(index, QQmlIncubator::AsynchronousIfNested);

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -154,7 +154,7 @@ int main(int argc, char *argv[])
 
     dccV25::ControlCenterDBusAdaptor *adaptor = new dccV25::ControlCenterDBusAdaptor(dccManager);
     dccV25::DBusControlCenterGrandSearchService *grandSearchadAptor = new dccV25::DBusControlCenterGrandSearchService(dccManager);
-
+    Q_UNUSED(grandSearchadAptor)
     if (!conn.registerObject(DccDBusPath, dccManager)) {
         qDebug() << "dbus service already registered!" << "pid is:" << qApp->applicationPid();
         return -1;

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -506,6 +506,7 @@ void PluginManager::onVisibleToAppChanged(bool visibleToApp)
 
 void PluginManager::loadModules(DccObject *root, bool async, const QStringList &dirs)
 {
+    Q_UNUSED(async)
     if (!root)
         return;
     m_rootModule = root;

--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -506,7 +506,7 @@ QAbstractListModel *DatetimeModel::timeDateModel()
 
     initFormattedModes(names);
     connect(this, &DatetimeModel::currentFormatChanged, model, [model, names, this, initFormattedModes](int format){
-        if (format >= DayAbbreviations && format <= LongTime || format < 0) {
+        if ((format >= DayAbbreviations && format <= LongTime) || format < 0) {
             initFormattedModes(names);
         }
     });
@@ -525,7 +525,7 @@ QAbstractListModel *DatetimeModel::currencyModel()
 
     initModes(names, CurrencySymbol, NegativeCurrency, model);
     connect(this, &DatetimeModel::currentFormatChanged, model, [model, names, this](int format){
-        if (format >= CurrencySymbol && format <= NegativeCurrency || format < 0)
+        if ((format >= CurrencySymbol && format <= NegativeCurrency) || format < 0)
             initModes(names, CurrencySymbol, NegativeCurrency, model);
     });
     m_currencyModel = model;
@@ -543,7 +543,7 @@ QAbstractListModel *DatetimeModel::decimalModel()
 
     initModes(names, DecimalSymbol, PageSize, model);
     connect(this, &DatetimeModel::currentFormatChanged, model, [model, names, this](int format){
-        if (format >= DecimalSymbol && format <= PageSize || format < 0)
+        if ((format >= DecimalSymbol && format <= PageSize) || format < 0)
             initModes(names, DecimalSymbol, PageSize, model);
     });
     m_decimalModel = model;


### PR DESCRIPTION
Edit compilation warning

## Summary by Sourcery

Silence numerous compilation warnings by clarifying condition precedence, removing or marking unused symbols, and cleaning up duplicate declarations.

Chores:
- Add parentheses around combined range checks to resolve precedence warnings
- Reposition and remove duplicate q_ptr declaration in DccRepeaterPrivate
- Comment out unused Q_LOGGING_CATEGORY to silence logging warnings
- Mark unused parameters and variables with Q_UNUSED or remove their names to suppress warnings