### PR TITLE
fix: Modifying desktop display without options issue

### DIFF
--- a/qml/HomePage.qml
+++ b/qml/HomePage.qml
@@ -104,7 +104,7 @@ Control {
 
         highlight: Item {
             z: 2
-            FocusBoxBorder {
+            D.FocusBoxBorder {
                 anchors {
                     fill: parent
                     margins: 5

--- a/src/plugin-display/qml/ScreenItem.qml
+++ b/src/plugin-display/qml/ScreenItem.qml
@@ -50,7 +50,7 @@ Rectangle {
         color: "white"
     }
     D.DciIcon {
-        visible: screen && (screen.name === dccData.primaryScreen.name)
+        visible: screen && dccData.primaryScreen && (screen.name === dccData.primaryScreen.name)
         name: "home_screen"
         anchors.bottom: parent.bottom
         anchors.right: parent.right


### PR DESCRIPTION
The current item is not among the available options

pms: BUG-308025

## Summary by Sourcery

Restructure display mode and fill selection combo boxes to maintain only valid options, add safety guards in layout calculations and icon rendering, and add null checks for primaryScreen to prevent runtime errors.

Bug Fixes:
- Prevent runtime errors in monitor layout when a repeater item is undefined.
- Guard against invalid ComboBox index when retrieving icon names.
- Check primaryScreen existence before comparing for screen icon visibility.

Enhancements:
- Embed display mode and fill ListModels and functions within ComboBox components to simplify option management.
- Filter available fill modes to include only valid options plus the current mode.