### PR TITLE
fix: optimize volume control step size for better usability

### DIFF
--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -14,7 +14,7 @@ import org.deepin.dcc 1.0
 DccObject {
     id: root
 
-    function toPercent(value: string) {
+    function toPercent(value) {
         return Number(value * 100).toFixed(0) + "%"
     }
 
@@ -86,7 +86,7 @@ DccObject {
                     handleType: Slider.HandleType.NoArrowHorizontal
                     highlightedPassedGroove: true
                     from: 0
-                    stepSize: 0.00001
+                    stepSize: 0.01
                     to: 1
                     value: dccData.model().microphoneVolume
                     onPressedChanged: {

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -14,7 +14,7 @@ import SoundDeviceModel 1.0
 
 DccObject {
     id: root
-    function toPercent(value: string) {
+    function toPercent(value) {
         return Number(value * 100).toFixed(0) + "%"
     }
     DccTitleObject {
@@ -85,6 +85,7 @@ DccObject {
                     highlightedPassedGroove: true
                     value: dccData.model().speakerVolume
                     to: dccData.model().increaseVolume ? 1.5 : 1.0
+                    stepSize: 0.01
                     onPressedChanged: {
                         if (!pressed && voiceTipsSlider.value != dccData.model().speakerVolume) {
                             dccData.worker().setSinkVolume(voiceTipsSlider.value)
@@ -143,7 +144,7 @@ DccObject {
                     from: -1
                     handleType: Slider.HandleType.ArrowBottom
                     highlightedPassedGroove: true
-                    stepSize: 0.00001
+                    stepSize: 0.01
                     to: 1
                     value: dccData.model().speakerBalance
 


### PR DESCRIPTION
- Adjust step size from 0.00001 to 0.01 for microphone volume control
- Add step size of 0.01 for speaker volume control
- Set balance control step size to 0.01 for smoother adjustment
- Remove unnecessary type declaration in toPercent function

Log: optimize volume control step size
pms: BUG-309257

## Summary by Sourcery

Optimize slider step sizes for volume and balance controls to improve adjustment precision and simplify code.

Enhancements:
- Standardize stepSize to 0.01 for microphone volume slider
- Add stepSize of 0.01 to speaker volume slider
- Adjust speaker balance slider stepSize to 0.01 for smoother control
- Remove redundant type declaration in toPercent functions