### PR TITLE
fix: Fixed the issue of the background color of the list item hover

### DIFF
--- a/src/plugin-accounts/qml/accountsMain.qml
+++ b/src/plugin-accounts/qml/accountsMain.qml
@@ -3,6 +3,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import Qt5Compat.GraphicalEffects
 import org.deepin.dcc 1.0
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
@@ -69,6 +70,7 @@ DccObject {
                    bottomPadding: bottomInset
                    leftPadding: 10
                    rightPadding: 8
+                   hoverEnabled: true
                    icon {
                        name: model.avatar
                        width: menuItemDelegate.iconSize
@@ -78,6 +80,7 @@ DccObject {
                        Item {
                            implicitWidth: icon.width + 10
                            implicitHeight: icon.height + 10
+                           
                            D.IconLabel {
                                id: iconLabel
                                anchors.centerIn: parent
@@ -86,15 +89,24 @@ DccObject {
                                display: menuItemDelegate.display
                                alignment: Qt.AlignLeft | Qt.AlignVCenter
                                icon: D.DTK.makeIcon(menuItemDelegate.icon, menuItemDelegate.D.DciIcon)
+                               visible: false
                            }
 
-                           D.BoxShadow {
-                               hollow: true
-                               anchors.fill: iconLabel
-                               shadowBlur: 10
-                               spread: 10
-                               shadowColor: palette.base
-                               cornerRadius: menuItemDelegate.iconRadius
+                           Rectangle {
+                               id: mask
+                               width: menuItemDelegate.iconSize
+                               height: menuItemDelegate.iconSize
+                               radius: menuItemDelegate.iconRadius
+                               visible: false
+                               anchors.centerIn: parent
+                           }
+
+                           OpacityMask {
+                               anchors.centerIn: parent
+                               width: menuItemDelegate.iconSize
+                               height: menuItemDelegate.iconSize
+                               source: iconLabel
+                               maskSource: mask
                            }
 
                            Rectangle {
@@ -158,6 +170,7 @@ DccObject {
                    background: DccItemBackground {
                        id: background
                        separatorVisible: true
+                       backgroundType: DccObject.Hover
                    }
                    onClicked: {
                        otherSettings.displayName = model.display


### PR DESCRIPTION
Fixed the issue of the background color of the list item hover

Log: Fixed the issue of the background color of the list item hover
pms: BUG-292911

## Summary by Sourcery

Enable hover effects on account list items and replace the shadow-based icon effect with an opacity mask to restore the correct hover background color.

Bug Fixes:
- Restore the proper background color when hovering over list items.

Enhancements:
- Replace BoxShadow with an OpacityMask for icon visuals.
- Enable hover handling and set background type for list items.
- Import Qt5Compat.GraphicalEffects to support the new mask effect.