### PR TITLE
fix: remove redundant displayName properties in sound component

### DIFF
--- a/src/plugin-sound/qml/soundMain.qml
+++ b/src/plugin-sound/qml/soundMain.qml
@@ -11,7 +11,6 @@ DccObject {
     DccObject {
         name: "outPut"
         parentName: "sound"
-        displayName: qsTr("Output")
         icon: "system"
         weight: 10
         pageType: DccObject.Item
@@ -28,7 +27,6 @@ DccObject {
     DccObject {
         name: "inPut"
         parentName: "sound"
-        displayName: qsTr("Input")
         icon: "system"
         weight: 20
         pageType: DccObject.Item


### PR DESCRIPTION
- Removed displayName properties from output and input sections in soundMain.qml

Log: remove redundant displayName properties in sound component
pms: BUG-315967

## Summary by Sourcery

Remove redundant displayName properties from the sound component’s input and output sections in soundMain.qml

Chores:
- Delete displayName entries from the outPut DccObject definition
- Delete displayName entries from the inPut DccObject definition