### PR TITLE
feat: Implement keyboard on/off function

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -23,6 +23,7 @@ KeyboardController::KeyboardController(QObject *parent)
     connect(m_model, &KeyboardModel::capsLockChanged, this, &KeyboardController::capsLockChanged);
     connect(m_model, &KeyboardModel::userLayoutChanged, this, &KeyboardController::layoutCountChanged);
     connect(m_model, &KeyboardModel::curLayoutChanged, this, &KeyboardController::currentLayoutChanged);
+    connect(m_model, &KeyboardModel::keyboardEnabledChanged, this, &KeyboardController::keyboardEnabledChanged);
 
     connect(m_shortcutModel, &ShortcutModel::keyEvent, this, [this](bool press, const QString &shortcut){
         ShortcutInfo *current = m_shortcutModel->currentInfo();
@@ -92,6 +93,19 @@ void KeyboardController::setRepeatDelay(uint newRepeatDelay)
         return;
 
     m_worker->setRepeatDelay(newRepeatDelay);
+}
+
+bool KeyboardController::keyboardEnabled() const
+{
+    return m_model->keyboardEnabled();
+}
+
+void KeyboardController::setKeyboardEnabled(bool enabled)
+{
+    if (keyboardEnabled() == enabled)
+        return;
+
+    m_worker->setKeyboardEnabled(enabled);
 }
 
 bool KeyboardController::numLock() const

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -18,6 +18,7 @@ class KeyboardController : public QObject
     Q_OBJECT
     Q_PROPERTY(uint repeatInterval READ repeatInterval WRITE setRepeatInterval NOTIFY repeatIntervalChanged FINAL)
     Q_PROPERTY(uint repeatDelay READ repeatDelay WRITE setRepeatDelay NOTIFY repeatDelayChanged FINAL)
+    Q_PROPERTY(bool keyboardEnabled READ keyboardEnabled WRITE setKeyboardEnabled NOTIFY keyboardEnabledChanged FINAL)
     Q_PROPERTY(bool numLock READ numLock WRITE setNumLock NOTIFY numLockChanged FINAL)
     Q_PROPERTY(bool capsLock READ capsLock WRITE setCapsLock NOTIFY capsLockChanged FINAL)
     Q_PROPERTY(int layoutCount READ layoutCount NOTIFY layoutCountChanged FINAL)
@@ -32,6 +33,9 @@ public:
 
     uint repeatDelay() const;
     void setRepeatDelay(uint newRepeatDelay);
+
+    bool keyboardEnabled() const;
+    void setKeyboardEnabled(bool enabled);
 
     bool numLock() const;
     void setNumLock(bool newNumLock);
@@ -82,6 +86,7 @@ signals:
     void keyEvent(const QString &accels);
 
     void conflictTextChanged();
+    void keyboardEnabledChanged();
 
 private:
     uint m_repeatInterval;

--- a/src/plugin-keyboard/operation/keyboardmodel.cpp
+++ b/src/plugin-keyboard/operation/keyboardmodel.cpp
@@ -9,6 +9,7 @@
 using namespace dccV25;
 KeyboardModel::KeyboardModel(QObject *parent)
     : QObject(parent)
+    , m_keyboardEnabled(true)
     , m_capsLock(true)
     , m_numLock(true)
     , m_repeatInterval(1)
@@ -151,6 +152,19 @@ void KeyboardModel::setRepeatInterval(const uint &repeatInterval)
     if (m_repeatInterval != repeatInterval) {
         m_repeatInterval = repeatInterval;
         Q_EMIT repeatIntervalChanged(repeatInterval);
+    }
+}
+
+bool KeyboardModel::keyboardEnabled() const
+{
+    return m_keyboardEnabled;
+}
+
+void KeyboardModel::setKeyboardEnabled(bool keyboardEnabled)
+{
+    if (m_keyboardEnabled != keyboardEnabled) {
+        m_keyboardEnabled = keyboardEnabled;
+        Q_EMIT keyboardEnabledChanged(m_keyboardEnabled);
     }
 }
 

--- a/src/plugin-keyboard/operation/keyboardmodel.h
+++ b/src/plugin-keyboard/operation/keyboardmodel.h
@@ -41,6 +41,8 @@ public:
     uint repeatInterval() const;
     void setRepeatInterval(const uint &repeatInterval);
 
+    bool keyboardEnabled() const;
+
     uint repeatDelay() const;
     void setRepeatDelay(const uint &repeatDelay);
 
@@ -57,6 +59,7 @@ Q_SIGNALS:
 #ifndef DCC_DISABLE_KBLAYOUT
     void curLayoutChanged(const QString &layout);
 #endif
+    void keyboardEnabledChanged(bool value);
     void curLangChanged(const QString &lang);
     void capsLockChanged(bool value);
     void numLockChanged(bool value);
@@ -78,9 +81,11 @@ public Q_SLOTS:
     void setLocaleList(const QList<MetaData> &langList);
     void setCapsLock(bool value);
     void setAllShortcut(const QMap<QStringList, int> &map);
+    void setKeyboardEnabled(bool keyboardEnabled);
 private:
     QStringList convertLang(const QStringList &langList);
 private:
+    bool m_keyboardEnabled;
     bool m_capsLock;
     bool m_numLock;
     uint m_repeatInterval;

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -10,6 +10,8 @@
 #include "keyboardmodel.h"
 #include "keyboarddbusproxy.h"
 
+#include <DConfig>
+
 #include <QObject>
 
 class QDBusPendingCallWatcher;
@@ -54,6 +56,7 @@ public:
 
     void setNumLock(bool value);
     void setCapsLock(bool value);
+    void setKeyboardEnabled(bool value);
     Q_INVOKABLE void active();
     void deactive();
     bool keyOccupy(const QStringList &list);
@@ -117,6 +120,7 @@ private:
     KeyboardDBusProxy *m_keyboardDBusProxy;
     ShortcutModel *m_shortcutModel = nullptr;
     QTranslator *m_translatorLanguage;
+    Dtk::Core::DConfig *m_inputDevCfg;
 };
 }
 #endif // KEYBOARDWORK_H

--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -27,11 +27,26 @@ DccObject {
         }
     }
     DccObject {
+        name: "enableKeyboard"
+        parentName: "KeyboardCommon"
+        displayName: qsTr("Enable Keyboard")
+        weight: 20
+        backgroundType: DccObject.Normal
+        pageType: DccObject.Editor
+        page: D.Switch {
+            checked: dccData.keyboardEnabled
+            onCheckedChanged: {
+                dccData.keyboardEnabled = checked
+            }
+        }
+    }
+    DccObject {
         name: "RepeatDelay"
         parentName: "KeyboardCommon"
         displayName: qsTr("Repeat delay")
         backgroundType: DccObject.Normal
-        weight: 20
+        weight: 30
+        visible: dccData.keyboardEnabled
         pageType: DccObject.Item
         page: ColumnLayout {
             Layout.fillHeight: true
@@ -96,7 +111,8 @@ DccObject {
     DccObject {
         name: "RepeatRateGroup"
         parentName: "KeyboardCommon"
-        weight: 30
+        weight: 40
+        visible: dccData.keyboardEnabled
         pageType: DccObject.Item
         page: DccGroupView {
             height: implicitHeight + 20
@@ -107,7 +123,8 @@ DccObject {
         name: "RepeatRate"
         parentName: "RepeatRateGroup"
         displayName: qsTr("Repeat rate")
-        weight: 30
+        weight: 50
+        visible: dccData.keyboardEnabled
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: Rectangle {
@@ -182,7 +199,8 @@ DccObject {
         name: "EditTesting"
         parentName: "RepeatRateGroup"
         displayName: qsTr("Numeric Keypad")
-        weight: 40
+        weight: 60
+        visible: dccData.keyboardEnabled
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: TextField {
@@ -202,7 +220,8 @@ DccObject {
         name: "KeypadSettings"
         parentName: "KeyboardCommon"
         displayName: qsTr("Numeric Keypad")
-        weight: 40
+        weight: 70
+        visible: dccData.keyboardEnabled
         pageType: DccObject.Item
         page: DccGroupView {
             height: implicitHeight + 20
@@ -212,7 +231,8 @@ DccObject {
         name: "EnableNumLock"
         parentName: "KeypadSettings"
         displayName: qsTr("Numeric Keypad")
-        weight: 40
+        weight: 80
+        visible: dccData.keyboardEnabled
         backgroundType: DccObject.Normal
         pageType: DccObject.Editor
         page: D.Switch {
@@ -226,7 +246,8 @@ DccObject {
         name: "CapsLockPrompt"
         parentName: "KeypadSettings"
         displayName: qsTr("Caps lock prompt")
-        weight: 50
+        weight: 90
+        visible: dccData.keyboardEnabled
         backgroundType: DccObject.Normal
         pageType: DccObject.Editor
         page: D.Switch {


### PR DESCRIPTION
Implement keyboard on/off function

pms: TASK-248483

## Summary by Sourcery

Implement keyboard on/off functionality by adding a toggle in QML, persisting its state via Dtk::Core::DConfig, and wiring the model, controller, and worker to respect and expose the enabled state

New Features:
- Add a keyboard enable/disable toggle in the settings UI
- Persist the keyboardEnabled state using DConfig and react to external changes
- Expose keyboardEnabled property in the model, controller, and worker to handle state changes

Enhancements:
- Hide dependent keyboard settings when the keyboard is disabled
- Adjust weight ordering of keyboard setting items to accommodate the new toggle