### PR TITLE
fix: optimize input field layout and validation in TimeAndDate

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -187,18 +187,18 @@ DccObject {
                     alertDuration: 3000
                     horizontalAlignment: TextInput.AlignRight
                     anchors{
-                        rightMargin: 10
+                        rightMargin: 0
                         right: editBtn.left
                         verticalCenter: parent.verticalCenter
                     }
-                    rightPadding: (!addr.readOnly && addr.text.length > 0 ? addr.clearButton.width : 0)
+                    rightPadding: (!addr.readOnly && addr.text.length > 0 ? addr.clearButton.width : 10)
                     onReadOnlyChanged: {
                         addr.background.visible = !addr.readOnly
                         addr.clearButton.visible = !addr.readOnly && text.length > 0
                         addr.focus = !addr.readOnly
                     }
                     onTextChanged: {
-                        if (addr.showAlert && addr.text.trim().length > 0) {
+                        if (addr.showAlert && addr.text.length > 0) {
                             addr.showAlert = false
                         }
                     }
@@ -209,7 +209,6 @@ DccObject {
                 }
                 D.IconButton {
                     id: editBtn
-                    enabled: addr.text.length > 0
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
                     hoverEnabled: true
@@ -236,7 +235,7 @@ DccObject {
                         height: 16
                     }
                     onClicked: {
-                        if (addr.text.trim().length === 0) {
+                        if (addr.text.length === 0) {
                             addr.showAlert = true
                             return
                         }


### PR DESCRIPTION
- Adjust rightMargin and padding values for better text alignment
- Remove trim() checks from text validation logic
- Remove edit button's enabled state dependency on text length

Log: optimize input field layout and validation in TimeAndDate
pms: BUG-278863

## Summary by Sourcery

Improve the TimeAndDate input field by refining its layout and streamlining validation logic

Bug Fixes:
- Prevent alerts from lingering when the field contains only whitespace

Enhancements:
- Refine input alignment by setting rightMargin to zero and establishing a default right padding of 10
- Remove whitespace trimming from validation, using raw text length to manage alert visibility
- Decouple the edit button’s enabled state from input length to allow unconditional access