### PR TITLE
fix: Modify menu translations

### DIFF
--- a/src/plugin-systeminfo/qml/systemInfoMain.qml
+++ b/src/plugin-systeminfo/qml/systemInfoMain.qml
@@ -20,7 +20,7 @@ DccObject {
     DccObject {
         name: "versionProtocol"
         parentName: "system"
-        displayName: qsTr("Open Source Software Description")
+        displayName: qsTr("Open Source Software Notice")
         description: qsTr("View the notice of open source software")
         icon: "software_declaration"
         weight: 1020

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -4018,10 +4018,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>نوع النظام، معلومات الأجهزة</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>وصف البرمجيات المصدر المفتوح</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>عرض إشعار البرمجيات المصدر المفتوح</translation>
     </message>
@@ -4048,6 +4044,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>عرض معلومات سياسة الخصوصية</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -4022,10 +4022,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>إصدار النظام، معلومات الجهاز</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>وصف البرمجيات المفتوحة المصدر</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>عرض ملاحظة البرمجيات المفتوحة المصدر</translation>
     </message>
@@ -4052,6 +4048,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>عرض المعلومات حول سياسة الخصوصية</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -4044,10 +4044,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>সিস্টেম ভার্সন, ডিভাইস তথ্য</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>অপেন সোর্স সোফটওয়্যার বর্ণনা</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>অপেন সোর্স সোফটওয়্যারের নীতি দেখুন</translation>
     </message>
@@ -4074,6 +4070,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>خصوصতি তথ্য দেখুন</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -4009,10 +4009,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Join the user experience program to help improve the product</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -4028,10 +4028,6 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
         <translation>Versió del sistema, informació del dispositiu</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Descripció de programari de codi obert</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Vegeu l&apos;avís del programari de codi obert</translation>
     </message>
@@ -4058,6 +4054,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>View information about privacy policy</source>
         <translation>Vegeu informació sobre la política de privadesa</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -4029,10 +4029,6 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
         <translation>Versión del sistema e información del hardware</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Descripción del software de código abierto</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Declaración del software de código abierto</translation>
     </message>
@@ -4059,6 +4055,10 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>View information about privacy policy</source>
         <translation>Muestra información sobre la política de seguridad</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -4021,10 +4021,6 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
         <translation>Süsteemversioon, pereteadused</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Avatud läningarülesande kirjeldus</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Vaata avatud läningarülesande pööre</translation>
     </message>
@@ -4051,6 +4047,10 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>View information about privacy policy</source>
         <translation>Vaata priivaatsipoliitika teaveid</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -4025,10 +4025,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Versio, järjestelmätiedot</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Avoimen lähdekoodin ohjelmistokuvaus</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Katso ilmoitus avoimen lähdekoodin ohjelmistoista</translation>
     </message>
@@ -4055,6 +4051,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Katso tietoja tietosuojakäytännöstä</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -4044,10 +4044,6 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
         <translation>Versión del sistema, información del dispositivo</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Descripción del software de código abierto</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Ver la notificación de software de código abierto</translation>
     </message>
@@ -4074,6 +4070,10 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>View information about privacy policy</source>
         <translation>Ver información sobre la política de privacidad</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -4043,10 +4043,6 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
         <translation>Versión do sistema, información do dispositivo</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Descripción do Software de Orixe Aberta</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Ver a noticia do software de orixe aberta</translation>
     </message>
@@ -4073,6 +4069,10 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>View information about privacy policy</source>
         <translation>Ver información sobre a política de privacidade</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>גרסה של מערכת, מידע על מכשיר</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>תיאור תוכנה פתוחה</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>הצגת הודעה של תוכנה פתוחה</translation>
     </message>
@@ -4043,6 +4039,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>הצג מידע על מדיניות הפרטיות</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -4040,10 +4040,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Rendszer verzió, eszköz információ</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Nyílt forráskódú programok leírása</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Nyílt forráskódú programok értesítésének megtekintése</translation>
     </message>
@@ -4070,6 +4066,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Adatvédelmi szabályzat információinek megtekintése</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -4009,10 +4009,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Join the user experience program to help improve the product</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -4027,10 +4027,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>システムバージョン、デバイス情報</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>オープンソースライセンス</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>オープンソースソフトウェアに関する通知を表示</translation>
     </message>
@@ -4057,6 +4053,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>プライバシーポリシーに関する情報を表示</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -4014,10 +4014,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Система мүнөтү, касиеттер</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Комплекттүү программалык өнүктүрмөлөрдүн түзүлүшү</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Комплекттүү программалык өнүктүрмөлөрдүн айтымчысын көрүү</translation>
     </message>
@@ -4044,6 +4040,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Тақырыптың мағынасын түзүү аbout privacy policy</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -4065,10 +4065,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>시스템 버전, 장치 정보</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>오픈 소스 소프트웨어 설명</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>오픈 소스 소프트웨어에 대한 공지를 확인하세요</translation>
     </message>
@@ -4095,6 +4091,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>개인 정보 보호 정책에 대한 정보 확인</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -4038,10 +4038,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Sistemos versija, įrenginio informacija</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Atviro kodo programinės įrangos aprašymas</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Peržiūrėkite atviro kodo programinės įrangos paskelbimą</translation>
     </message>
@@ -4068,6 +4064,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Peržiūrėti informaciją apie privatumo politiką</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -4009,10 +4009,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Join the user experience program to help improve the product</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -4018,10 +4018,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>सिस्टम संस्करण, डिवाइस जानकारी</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>क्रान्तिकारी सॉफ्टवेयरको वर्णन</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>क्रान्तिकारी सॉफ्टवेयरको नोटिस देख्नुहोस्</translation>
     </message>
@@ -4048,6 +4044,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>प्राइवेची नीतिमा तहर देख्नुहोस्</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -4026,10 +4026,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4055,6 +4051,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -4028,10 +4028,6 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
         <translation>Wersja systemu, informacje o urządzeniu</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Informacja oprogramowania open-source</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Wyświetl notatkę oprogramowania open-source</translation>
     </message>
@@ -4058,6 +4054,10 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
     <message>
         <source>View information about privacy policy</source>
         <translation>Wyświetl informacje o polityce prywatności</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Versão do sistema, informações do dispositivo</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Descrição do software de código aberto</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Ver aviso de software de código aberto</translation>
     </message>
@@ -4043,6 +4039,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Ver informações sobre a política de privacidade</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -4027,10 +4027,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Версия системы, информация о устройстве</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Описание программного обеспечения с открытым исходным кодом</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Посмотреть уведомление о программном обеспечении с открытым исходным кодом</translation>
     </message>
@@ -4057,6 +4053,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Посмотреть информацию о политике конфиденциальности</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -4017,10 +4017,6 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
         <translation>Vrstica sistema, informacije o napravi</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Opis programske opreme s otvorenim kodo</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Pogledaj opozorilo o programskem opremi s otvorenim kodo</translation>
     </message>
@@ -4047,6 +4043,10 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>View information about privacy policy</source>
         <translation>Pogled na informacije o zaščiti osebnih podatkov</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -4028,10 +4028,6 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
         <translation>Version sistemi, hollësi pajisjesh</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Përshkrim Software-i Me Burim të Hapët</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Shihni shënimin për “software” me burim të hapët</translation>
     </message>
@@ -4058,6 +4054,10 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>View information about privacy policy</source>
         <translation>Shihni informacion rreth rregullash privatësie</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -4030,10 +4030,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Systemversion, enhetsinformation</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Beskrivning av öppen källkod</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Visa meddelandet om öppen källkod</translation>
     </message>
@@ -4060,6 +4056,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Visa information om intimskyldighetspolicy</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -4016,10 +4016,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>เวอร์ชันระบบ, ข้อมูลอุปกรณ์</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>คำอธิบายโปรแกรมฟรีและเปิดแหล่ง</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>ดูคำประกาศของโปรแกรมฟรีและเปิดแหล่ง</translation>
     </message>
@@ -4046,6 +4042,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>ดูข้อมูลเกี่ยวกับนโยบายความเป็นส่วนตัว</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Sistem sürümü, cihaz bilgileri</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -4027,10 +4027,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Версія системи, відомості щодо пристроїв</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Опис програмного забезпечення з відкритим кодом</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Переглянути зауваження щодо вільного програмного забезпечення</translation>
     </message>
@@ -4057,6 +4053,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Переглянути відомості щодо правил конфіденційності</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -4013,10 +4013,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4042,6 +4038,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -4040,10 +4040,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Phiên bản hệ thống, thông tin thiết bị</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>Mô tả phần mềm nguồn mở</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>Xem thông báo về phần mềm nguồn mở</translation>
     </message>
@@ -4070,6 +4066,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>Xem thông tin về chính sách bảo mật</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -4028,10 +4028,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>系统版本、设备信息</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>开源软件声明</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>查看开源软件声明</translation>
     </message>
@@ -4058,6 +4054,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>查看隐私政策相关信息</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation>开源软件声明</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -4026,10 +4026,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>系統版本、設備信息</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>開源軟件聲明</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>查看開源軟件聲明</translation>
     </message>
@@ -4056,6 +4052,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>查看私隱政策相關信息</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -4026,10 +4026,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>系統版本、裝置資訊</translation>
     </message>
     <message>
-        <source>Open Source Software Description</source>
-        <translation>開源軟體宣告</translation>
-    </message>
-    <message>
         <source>View the notice of open source software</source>
         <translation>檢視開源軟體宣告</translation>
     </message>
@@ -4056,6 +4052,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>View information about privacy policy</source>
         <translation>檢視隱私政策相關資訊</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Modify menu translations

Log: Modify menu translations
pms: BUG-285935

## Summary by Sourcery

Update the open source software menu label to "Open Source Software Notice" and synchronize the change across all locale files

Bug Fixes:
- Correct the menu text from "Open Source Software Description" to "Open Source Software Notice"

Enhancements:
- Remove the old translation key and add the new one in all translation files
- Update systemInfoMain.qml to use the new display name