### PR TITLE
feat: Implement keyboard on/off authentication

### DIFF
--- a/src/plugin-keyboard/CMakeLists.txt
+++ b/src/plugin-keyboard/CMakeLists.txt
@@ -16,12 +16,14 @@ if (BUILD_PLUGIN)
     set(keyboard_Includes
         src/plugin-keyboard/operation
     )
+    find_package(PolkitQt6-1 REQUIRED)
     set(keyboard_Libraries
         ${DCC_FRAME_Library}
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
         ${QT_NS}::Gui
         ${QT_NS}::Qml
+        PolkitQt6-1::Agent
     )
     target_include_directories(${Plugin_Name} PUBLIC
         ${keyboard_Includes}


### PR DESCRIPTION
Implement keyboard on/off authentication

pms: TASK-377383

## Summary by Sourcery

Enforce Polkit-based authentication when toggling the keyboard enable state

New Features:
- Require Polkit authorization before enabling or disabling the keyboard

Build:
- Add PolkitQt6-1 dependency and link the Agent library in the keyboard plugin build