### PR TITLE
fix: Fix text length limit

### DIFF
--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -133,11 +133,21 @@ DccObject {
                         if (showAlert)
                             showAlert = false
                             
-                        if (!/^[A-Za-z0-9-]{0,64}$/.test(text)) {
+                        if (text.length > 63) {
+                            var cursorPos = cursorPosition
+                            text = text.slice(0, 63)
+                            cursorPosition = Math.min(cursorPos, text.length)
+                            showAlert = true
+                            alertText = qsTr("1~63 characters please")
+                            dccData.systemInfoWork().playSystemSound(14)
+                            return
+                        }
+                        
+                        if (!/^[A-Za-z0-9-]{0,63}$/.test(text)) {
                             var cursorPos = cursorPosition
                             var filteredText = text.replace(/[^A-Za-z0-9-]/g, "")
                             
-                            filteredText = filteredText.slice(0, 64)
+                            filteredText = filteredText.slice(0, 63)
                             
                             if (filteredText !== text) {
                                 text = filteredText

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -1822,6 +1822,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>ذاكرة</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -1822,6 +1822,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>ذاكرة</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -1823,6 +1823,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>মেমরি</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Kernel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -1832,6 +1832,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
         <source>Memory</source>
         <translation>Memòria</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished">Operační paměť</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished">Hukommelse</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished">Speicher</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -1833,6 +1833,10 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -1825,6 +1825,10 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
         <source>Memory</source>
         <translation>Muist</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -1829,6 +1829,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Muisti</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -1847,6 +1847,10 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
         <source>Memory</source>
         <translation>Mémoire</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -1822,6 +1822,10 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
         <source>Memory</source>
         <translation>Memoria</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>זיכרון</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -1819,6 +1819,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Kernel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -1831,6 +1831,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>メモリ</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -1818,6 +1818,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Негізгі памық</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -1844,6 +1844,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>메모리</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Atmintis</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Kernel</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -1822,6 +1822,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>प्रयोग यादान्वान</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -1830,6 +1830,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -1832,6 +1832,10 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
         <source>Memory</source>
         <translation>Pamięć</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished">Memória</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Memória</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -1831,6 +1831,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Оперативная память</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -1821,6 +1821,10 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
         <source>Memory</source>
         <translation>Pomnilnik</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -1832,6 +1832,10 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
         <source>Memory</source>
         <translation>Kujtesë</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -1834,6 +1834,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Minnesutrymme</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -1820,6 +1820,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>ความจำ</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Bellek</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"> ئىچكى ساقلىغۇچ</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -1831,6 +1831,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Пам&apos;ять</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -1817,6 +1817,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -1844,6 +1844,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>Bộ nhớ</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -1832,6 +1832,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>内存</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation>计算机名长度必须介于1到63个字符之间</translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -1830,6 +1830,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>內存</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -1830,6 +1830,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Memory</source>
         <translation>記憶體</translation>
     </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>OtherDevice</name>


### PR DESCRIPTION
Fix text length limit

Log: Fix text length limit
pms: BUG-282895

## Summary by Sourcery

Enforce a strict 1–63 character alphanumeric/ hyphen limit on text input by trimming excess characters, filtering invalid ones, and providing user feedback via an alert and system sound.

Bug Fixes:
- Correct the maximum input length from 64 to 63 characters and adjust regex validation accordingly.

Enhancements:
- Show an alert message and play a system sound when the text exceeds the allowed length.