### PR TITLE
feat: add Lock the height of dock.

### DIFF
--- a/src/plugin-dock/operation/dockdbusproxy.cpp
+++ b/src/plugin-dock/operation/dockdbusproxy.cpp
@@ -59,7 +59,8 @@ DockDBusProxy::DockDBusProxy(QObject *parent)
     QDBusConnection::sessionBus().connect(DaemonDockService, DaemonDockPath, DaemonDockInterface, "WindowSizeEfficientChanged", this, SIGNAL(WindowSizeEfficientChanged(uint)));
     QDBusConnection::sessionBus().connect(DaemonDockService, DaemonDockPath, DaemonDockInterface, "WindowSizeFashionChanged", this, SIGNAL(WindowSizeFashionChanged(uint)));
     QDBusConnection::sessionBus().connect(DaemonDockService, DaemonDockPath, DaemonDockInterface, "showRecentChanged", this, SIGNAL(showRecentChanged(bool)));
-
+    QDBusConnection::sessionBus().connect(DaemonDockService, DaemonDockPath, DaemonDockInterface, "LockedChanged", this, SIGNAL(LockedChanged(bool)));
+    
     QDBusConnection::sessionBus().connect(DockService, DockPath, DockInterface, "showInPrimaryChanged", this, SLOT(ShowInPrimaryChanged(bool)));
     QDBusConnection::sessionBus().connect(DockService, DockPath, DockInterface, "pluginVisibleChanged", this, SLOT(pluginVisibleChanged(const QString &, bool)));
 
@@ -124,6 +125,16 @@ bool DockDBusProxy::showInPrimary()
 void DockDBusProxy::setShowInPrimary(bool value)
 {
     m_dockInter->setProperty("showInPrimary", QVariant::fromValue(value));
+}
+
+bool DockDBusProxy::locked()
+{
+    return qvariant_cast<bool>(m_daemonDockInter->property("Locked"));
+}
+
+void DockDBusProxy::setLocked(bool value)
+{
+    m_daemonDockInter->setProperty("Locked", QVariant::fromValue(value));
 }
 
 bool DockDBusProxy::showRecent()

--- a/src/plugin-dock/operation/dockdbusproxy.h
+++ b/src/plugin-dock/operation/dockdbusproxy.h
@@ -49,6 +49,10 @@ public:
     bool showInPrimary();
     Q_INVOKABLE void setShowInPrimary(bool value);
 
+    Q_PROPERTY(bool locked READ locked WRITE setLocked NOTIFY LockedChanged)
+    bool locked();
+    Q_INVOKABLE void setLocked(bool value);
+
     Q_PROPERTY(bool ShowRecent READ showRecent NOTIFY showRecentChanged)
     bool showRecent();
 
@@ -70,6 +74,7 @@ Q_SIGNALS:
     void WindowSizeEfficientChanged(uint windowSizeEfficient) const;
     void WindowSizeFashionChanged(uint windowSizeFashion) const;
     void ShowInPrimaryChanged(bool showInPrimary) const;
+    void LockedChanged(bool locked) const;
 
     // real singals
     void pluginVisibleChanged(const QString &pluginName, bool visible) const;

--- a/src/plugin-dock/qml/main.qml
+++ b/src/plugin-dock/qml/main.qml
@@ -154,7 +154,20 @@ DccObject {
                 }
             }
         }
-
+        DccObject {
+            name: "lockedDock"
+            parentName: "personalization/dock/dockSettingsGroup"
+            displayName: qsTr("Lock the Dock")
+            weight: 20
+            pageType: DccObject.Editor
+            page: Switch {
+                checked: dccData.dockInter.locked 
+                onCheckedChanged: {
+                    if (dccData.dockInter.locked != checked)
+                        dccData.dockInter.setLocked(checked)
+                }
+            }
+        }
         DccObject {
             name: "positionInScreen"
             parentName: "personalization/dock/dockSettingsGroup"


### PR DESCRIPTION
add dbus interface for dde-shell.
add a button with Lock Dock.

Log

## Summary by Sourcery

Provide a DBus-backed dock height lock feature with a new property and UI toggle

New Features:
- Expose dock lock status via a new "locked" DBus property and LockedChanged signal in DockDBusProxy
- Add a "Lock the Dock" toggle in the dock settings QML to control the dock lock state