### PR TITLE
feat: add battery power state awareness to screensaver

### DIFF
--- a/src/plugin-personalization/operation/personalizationdbusproxy.cpp
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.cpp
@@ -33,6 +33,10 @@ const QString WallpaperSlideshowService = QStringLiteral("org.deepin.dde.Wallpap
 const QString WallpaperSlideshowPath = QStringLiteral("/org/deepin/dde/WallpaperSlideshow");
 const QString WallpaperSlideshowInterface = QStringLiteral("org.deepin.dde.WallpaperSlideshow");
 
+const QString PowerService = QStringLiteral("org.deepin.dde.Power1");
+const QString PowerPath = QStringLiteral("/org/deepin/dde/Power1");
+const QString PowerInterface = QStringLiteral("org.deepin.dde.Power1");
+
 const QString PropertiesInterface = QStringLiteral("org.freedesktop.DBus.Properties");
 const QString PropertiesChanged = QStringLiteral("PropertiesChanged");
 
@@ -45,16 +49,17 @@ PersonalizationDBusProxy::PersonalizationDBusProxy(QObject *parent)
     m_DaemonInter = new QDBusInterface(DaemonService, DaemonPath, DaemonInterface, QDBusConnection::systemBus(), this);
     m_screenSaverInter = new QDBusInterface(ScreenSaverServive, ScreenSaverPath, ScreenSaverInterface, QDBusConnection::sessionBus(), this);
     m_wallpaperSlideshowInter = new QDBusInterface(WallpaperSlideshowService, WallpaperSlideshowPath, WallpaperSlideshowInterface, QDBusConnection::sessionBus(), this);
+    m_powerInter = new QDBusInterface(PowerService, PowerPath, PowerInterface, QDBusConnection::sessionBus(), this);
     if (!DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
         m_WMInter = new QDBusInterface(WMService, WMPath, WMInterface, QDBusConnection::sessionBus(), this);
         m_EffectsInter = new QDBusInterface(EffectsService, EffectsPath, EffectsInterface, QDBusConnection::sessionBus(), this);
 
         QDBusConnection::sessionBus().connect(WMService, WMPath, PropertiesInterface, PropertiesChanged, this, SLOT(onPropertiesChanged(QDBusMessage)));
     }
-    
     QDBusConnection::sessionBus().connect(AppearanceService, AppearancePath, PropertiesInterface, PropertiesChanged, this, SLOT(onPropertiesChanged(QDBusMessage)));
     QDBusConnection::sessionBus().connect(ScreenSaverServive, ScreenSaverPath, PropertiesInterface, PropertiesChanged, this, SLOT(onPropertiesChanged(QDBusMessage)));
     QDBusConnection::sessionBus().connect(WallpaperSlideshowService, WallpaperSlideshowPath, PropertiesInterface, PropertiesChanged, this, SLOT(onPropertiesChanged(QDBusMessage)));
+    QDBusConnection::sessionBus().connect(PowerService, PowerPath, PropertiesInterface, PropertiesChanged, this, SLOT(onPropertiesChanged(QDBusMessage)));
 
     connect(m_AppearanceInter, SIGNAL(Changed(const QString &, const QString &)), this, SIGNAL(Changed(const QString &, const QString &)));
     connect(m_AppearanceInter, SIGNAL(Refreshed(const QString &)), this, SIGNAL(Refreshed(const QString &)));
@@ -462,6 +467,12 @@ QString PersonalizationDBusProxy::activeColors()
 void PersonalizationDBusProxy::setActiveColors(const QString &activeColors)
 {
     m_AppearanceInter->asyncCall(QStringLiteral("SetActiveColors"), QVariant::fromValue(activeColors));
+}
+
+// power
+bool PersonalizationDBusProxy::OnBattery()
+{
+    return qvariant_cast<bool>(m_powerInter->property("OnBattery"));
 }
 
 void PersonalizationDBusProxy::onPropertiesChanged(const QDBusMessage &message)

--- a/src/plugin-personalization/operation/personalizationdbusproxy.h
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.h
@@ -117,6 +117,9 @@ public:
 
     QString GetScreenSaverCover(const QString &name);
 
+    // power
+    bool OnBattery();
+
 signals:
     // Appearance
     void Changed(const QString &in0, const QString &in1);
@@ -156,6 +159,9 @@ signals:
     // daemon
     void WallpaperChanged(const QString &value, uint mode, const QStringList &urls);
 
+    // power
+    void OnBatteryChanged(bool value);
+
 public slots:
     // Appearance
     QString List(const QString &ty);
@@ -183,6 +189,7 @@ private:
     QDBusInterface *m_DaemonInter = nullptr;
     QDBusInterface *m_screenSaverInter = nullptr;
     QDBusInterface *m_wallpaperSlideshowInter = nullptr;
+    QDBusInterface *m_powerInter = nullptr;
 };
 
 #endif // PERSONALIZATIONDBUSPROXY_H

--- a/src/plugin-personalization/operation/personalizationmodel.cpp
+++ b/src/plugin-personalization/operation/personalizationmodel.cpp
@@ -193,12 +193,22 @@ void PersonalizationModel::setLockScreenAtAwake(bool value)
     Q_EMIT lockScreenAtAwakeChanged(value);
 }
 
-void PersonalizationModel::setScreenSaverIdleTime(int value)
+void PersonalizationModel::setLinePowerScreenSaverIdleTime(int value)
 {
-    if (m_screenSaverIdleTime == value)
+    if (m_linePowerScreenSaverIdleTime == value)
         return;
-    m_screenSaverIdleTime = value;
-    Q_EMIT screenSaverIdleTimeChanged(value);
+
+    m_linePowerScreenSaverIdleTime = value;
+    qWarning() << "model: setLinePowerScreenSaverIdleTime" << value << m_linePowerScreenSaverIdleTime;
+    Q_EMIT linePowerScreenSaverIdleTimeChanged(value);
+}
+
+void PersonalizationModel::setBatteryScreenSaverIdleTime(int value)
+{
+    if (m_batteryScreenSaverIdleTime == value)
+        return;
+    m_batteryScreenSaverIdleTime = value;
+    Q_EMIT batteryScreenSaverIdleTimeChanged(value);
 }
 
 void PersonalizationModel::setCurrentScreenSaverPicMode(const QString &value)
@@ -207,4 +217,13 @@ void PersonalizationModel::setCurrentScreenSaverPicMode(const QString &value)
         return;
     m_currentScreenSaverPicMode = value;
     Q_EMIT currentScreenSaverPicModeChanged(value);
+}
+
+void PersonalizationModel::setOnBattery(bool value)
+{
+    if (m_onBattery == value)
+        return;
+
+    m_onBattery = value;
+    Q_EMIT onBatteryChanged(value);
 }

--- a/src/plugin-personalization/operation/personalizationmodel.h
+++ b/src/plugin-personalization/operation/personalizationmodel.h
@@ -33,9 +33,11 @@ class PersonalizationModel : public QObject
     Q_PROPERTY(QString currentSelectScreen READ getCurrentSelectScreen WRITE setCurrentSelectScreen NOTIFY currentSelectScreenChanged)
     Q_PROPERTY(QStringList screens READ getScreens WRITE setScreens NOTIFY screensChanged)
     Q_PROPERTY(bool lockScreenAtAwake WRITE setLockScreenAtAwake READ getLockScreenAtAwake NOTIFY lockScreenAtAwakeChanged)
-    Q_PROPERTY(int screenSaverIdleTime WRITE setScreenSaverIdleTime READ getScreenSaverIdleTime NOTIFY screenSaverIdleTimeChanged)
+    Q_PROPERTY(int linePowerScreenSaverIdleTime WRITE setLinePowerScreenSaverIdleTime READ getLinePowerScreenSaverIdleTime NOTIFY linePowerScreenSaverIdleTimeChanged)
+    Q_PROPERTY(int batteryScreenSaverIdleTime WRITE setBatteryScreenSaverIdleTime READ getBatteryScreenSaverIdleTime NOTIFY batteryScreenSaverIdleTimeChanged)
     Q_PROPERTY(QString currentScreenSaverPicMode WRITE setCurrentScreenSaverPicMode READ getCurrentScreenSaverPicMode NOTIFY currentScreenSaverPicModeChanged)
     Q_PROPERTY(QVariantMap wallpaperSlideShowMap WRITE setWallpaperSlideShowMap READ getWallpaperSlideShowMap NOTIFY wallpaperSlideShowMapChanged)
+    Q_PROPERTY(bool onBattery READ getOnBattery WRITE setOnBattery NOTIFY onBatteryChanged)
 
     Q_PROPERTY(FontSizeModel *fontSizeModel MEMBER m_fontSizeModel CONSTANT)
     Q_PROPERTY(FontModel *standardFontModel MEMBER m_standFontModel CONSTANT)
@@ -119,11 +121,17 @@ public:
     inline bool getLockScreenAtAwake() const { return m_lockScreenAtAwake; }
     void setLockScreenAtAwake(bool value);
 
-    inline int getScreenSaverIdleTime() const { return m_screenSaverIdleTime; };
-    void setScreenSaverIdleTime(int value);
+    inline int getLinePowerScreenSaverIdleTime() const { return m_linePowerScreenSaverIdleTime; };
+    void setLinePowerScreenSaverIdleTime(int value);
+
+    inline int getBatteryScreenSaverIdleTime() const { return m_batteryScreenSaverIdleTime; };
+    void setBatteryScreenSaverIdleTime(int value);
 
     inline QString getCurrentScreenSaverPicMode() const { return m_currentScreenSaverPicMode; }
     void setCurrentScreenSaverPicMode(const QString &mode);
+
+    inline bool getOnBattery() const { return m_onBattery; }
+    void setOnBattery(bool value);
 
 Q_SIGNALS:
     void wmChanged(const bool is3d);
@@ -145,10 +153,11 @@ Q_SIGNALS:
     void currentScreenSaverChanged(const QString &current);
     void screensChanged(const QStringList &screens);
     void lockScreenAtAwakeChanged(bool value);
-    void screenSaverIdleTimeChanged(int value);
+    void linePowerScreenSaverIdleTimeChanged(int value);
+    void batteryScreenSaverIdleTimeChanged(int value);
     void currentScreenSaverPicModeChanged(const QString &value);
     void wallpaperSlideShowMapChanged(const QVariantMap &value);
-
+    void onBatteryChanged(bool value);
 private:
     ThemeModel *m_windowModel;
     ThemeModel *m_iconModel;
@@ -189,7 +198,9 @@ private:
     QString m_currentScreenSaver;
     QStringList m_screens;
     bool m_lockScreenAtAwake;
-    int m_screenSaverIdleTime;
+    int m_linePowerScreenSaverIdleTime;
+    int m_batteryScreenSaverIdleTime;
     QString m_currentScreenSaverPicMode;
+    bool m_onBattery;
 };
 #endif // PERSONALIZATIONMODEL_H

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -77,7 +77,9 @@ PersonalizationWorker::PersonalizationWorker(PersonalizationModel *model, QObjec
     connect(m_personalizationDBusProxy, &PersonalizationDBusProxy::currentScreenSaverChanged, this, &PersonalizationWorker::onCurrentScreenSaverChanged);
     connect(m_personalizationDBusProxy, &PersonalizationDBusProxy::lockScreenAtAwakeChanged, this, &PersonalizationWorker::onLockScreenAtAwakeChanged);
     connect(m_personalizationDBusProxy, &PersonalizationDBusProxy::linePowerScreenSaverTimeoutChanged, this, &PersonalizationWorker::onLinePowerScreenSaverTimeoutChanged);
+    connect(m_personalizationDBusProxy, &PersonalizationDBusProxy::batteryScreenSaverTimeoutChanged, this, &PersonalizationWorker::onBatteryScreenSaverTimeoutChanged);
     connect(m_personalizationDBusProxy, &PersonalizationDBusProxy::WallpaperSlideShowChanged, this, &PersonalizationWorker::onWallpaperSlideShowChanged);
+    connect(m_personalizationDBusProxy, &PersonalizationDBusProxy::OnBatteryChanged, m_model, &PersonalizationModel::setOnBattery);
 
     connect(m_wallpaperWorker, &WallpaperProvider::fetchFinish, this, &PersonalizationWorker::updateWallpaperSelected);
 
@@ -136,7 +138,9 @@ void PersonalizationWorker::active()
     }
 
     m_model->setLockScreenAtAwake(m_personalizationDBusProxy->getLockScreenAtAwake());
-    m_model->setScreenSaverIdleTime(m_personalizationDBusProxy->getLinePowerScreenSaverTimeout());
+    m_model->setOnBattery(m_personalizationDBusProxy->OnBattery());
+    m_model->setBatteryScreenSaverIdleTime(m_personalizationDBusProxy->getBatteryScreenSaverTimeout());
+    m_model->setLinePowerScreenSaverIdleTime(m_personalizationDBusProxy->getLinePowerScreenSaverTimeout());
 
     QString scrollbarConfig = m_personalizationConfig->value(SCROLLBAR_POLICY_CONFIG_KEY).toString();
     m_model->setScrollBarPolicyConfig(scrollbarConfig);
@@ -290,7 +294,12 @@ void PersonalizationWorker::onLockScreenAtAwakeChanged(bool value)
 
 void PersonalizationWorker::onLinePowerScreenSaverTimeoutChanged(int value)
 {
-    m_model->setScreenSaverIdleTime(value);
+    m_model->setLinePowerScreenSaverIdleTime(value);
+}
+
+void PersonalizationWorker::onBatteryScreenSaverTimeoutChanged(int value)
+{
+    m_model->setBatteryScreenSaverIdleTime(value);
 }
 
 void PersonalizationWorker::onWallpaperSlideShowChanged()
@@ -556,13 +565,11 @@ void PersonalizationWorker::stopScreenSaverPreview()
 
 void PersonalizationWorker::setLockScreenAtAwake(bool value)
 {
-    m_model->setLockScreenAtAwake(value);
     m_personalizationDBusProxy->setLockScreenAtAwake(value);
 }
 
 void PersonalizationWorker::setScreenSaverIdleTime(int value)
 {
-    m_model->setScreenSaverIdleTime(value);
     m_personalizationDBusProxy->setLinePowerScreenSaverTimeout(value);
     m_personalizationDBusProxy->setBatteryScreenSaverTimeout(value);
 }

--- a/src/plugin-personalization/operation/personalizationworker.h
+++ b/src/plugin-personalization/operation/personalizationworker.h
@@ -89,6 +89,7 @@ private Q_SLOTS:
     void onCurrentScreenSaverChanged(const QString &value);
     void onLockScreenAtAwakeChanged(bool value);
     void onLinePowerScreenSaverTimeoutChanged(int value);
+    void onBatteryScreenSaverTimeoutChanged(int value);
     void onWallpaperSlideShowChanged();
     void updateWallpaperSelected();
 

--- a/src/plugin-personalization/qml/ScreenSaverPage.qml
+++ b/src/plugin-personalization/qml/ScreenSaverPage.qml
@@ -138,7 +138,7 @@ DccObject {
                     flat: true
                     textRole: "text"
                     currentIndex: {
-                        let value = dccData.model.screenSaverIdleTime
+                        let value = dccData.model.onBattery ? dccData.model.batteryScreenSaverIdleTime : dccData.model.linePowerScreenSaverIdleTime
                         return indexByValue(value)
                     }
                     model: ListModel {
@@ -151,7 +151,10 @@ DccObject {
                         ListElement { text: qsTr("never"); value: 0 }
                     }
                     onCurrentIndexChanged: {
-                        dccData.worker.setScreenSaverIdleTime(model.get(currentIndex).value)
+                        let value = dccData.model.onBattery ? dccData.model.batteryScreenSaverIdleTime : dccData.model.linePowerScreenSaverIdleTime
+                        if (value !== model.get(currentIndex).value) {
+                            dccData.worker.setScreenSaverIdleTime(model.get(currentIndex).value)
+                        }
                     }
                 }
             }


### PR DESCRIPTION
1. Added power management interface to detect battery state
2. Separated screensaver idle time settings for battery and line power modes
3. Implemented dynamic switching between power modes
4. Updated UI to reflect current power state settings
5. Added signal handling for power state changes

feat: 为屏幕保护程序添加电池电源状态感知

1. 添加电源管理接口以检测电池状态
2. 为电池和电源模式分别设置屏幕保护空闲时间
3. 实现电源模式之间的动态切换
4. 更新UI以反映当前电源状态设置
5. 添加电源状态变化的信号处理

pms: BUG-316795

## Summary by Sourcery

Add battery power state awareness to the screensaver by integrating a Power1 D-Bus interface, splitting idle time settings for battery/line power, and dynamically switching behavior and UI based on the current power source

New Features:
- Introduce a D-Bus Power1 interface to detect and signal battery state
- Expose separate screensaver idle time settings for battery and line power modes
- Implement dynamic switching of screensaver idle time based on current power state

Enhancements:
- Update QML screensaver settings UI to reflect and select idle time according to power source
- Subscribe to OnBatteryChanged signals in the worker and update the model accordingly