### PR TITLE
fix: Add a full name error message

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -318,6 +318,12 @@ DccObject {
                             var filteredText = text
                             filteredText = filteredText.replace(":", "")
 
+                            if (filteredText.length > 32) {
+                                showAlert = true
+                                alertText = qsTr("The full name is too long")
+                                dccData.playSystemSound(14)
+                            }
+
                             // 长度 32
                             filteredText = filteredText.slice(0, 32)
                             text = filteredText

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>نوع الحساب</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">اسم المستخدم طويل جدًا</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>نوع الحساب</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">اسم المستخدم الكاملtoo long</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Пълното име е прекалено дълго</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>অ্যাকাউন্ট টাইপ</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">মোট নাম খুব দীর্ঘ</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Tipus de compte</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">El nom complet és massa llarg.</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Celé jméno je příliš dlouhé</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Det fulde navn er for langt</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Der vollständige Name ist zu lang</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Kontotyp</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Το πλήρες όνομα είναι πολύ μεγάλο</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">The full name is too long</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">The full name is too long</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Tipo de cuenta</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">El nombre completo es muy largo</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Kontotüüp</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Täielik nimi on liiga pikk</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Tilin tyyppi</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Nimesi on liian pitkä</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Type de compte</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">El nombre completo es demasiado largo</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Tipo de conta</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">O nome completo é moi lonxe</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>סוג חשבון</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">שם מלא הוא מדי ארוך</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Puno ime je predugo</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Fióktípus</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">A teljes nev túl hosszú</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Nama lengkap terlalu panjang</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>アカウントの種類</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">フルネームが長すぎます</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">სრული სახელი ძალიან გრძელია</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Сметанын түрі</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Толық аты-жөні толған</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>계정 유형</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">전체 이름이 너무 길�습니다</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Vartotojo tipas</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Vardas yra per ilgas</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Бүтэн нэр хэтэрхий урт байна</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Nama penuh terlalu panjang</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>खाताको प्रकार</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Soort account</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">ਪੂਰਾ ਨਾਂ ਬਹੁਤ ਲੰਮਾ ਹੈ</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Typ konta</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Imię i nazwisko jest za długie</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">O nome completo é muito comprido</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Tipo de conta</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">O nome completo é muito longo</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Numele complet este prea lung</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>نوع الحساب</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Имя слишком длинное</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">සම්පූර්ණ නම දිග වැඩිය</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Celé meno je príliš dlhé</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Vrsta računa</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Ime je preprosto dolgo</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Lloj llogarie</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Emri i plotë është shumë i gjatë</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Пуно име је предугачко</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Kontotyp</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Komplettera namnet är för långt</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>ประเภทบัญชี</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">ชื่อจริงยาวเกินไป</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Hesap Türü</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Tam isim çok uzun</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">تولۇق ئىسمى بەك ئۇزۇن</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Тип облікового запису</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Ім&apos;я повністю є надто довгим</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -79,6 +79,10 @@
         <source>Add group</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>Loại tài khoản</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">Tên đầy đủ quá dài</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>账户类型</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation>名称过长</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>賬户類型</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">全名太長了</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -79,6 +79,10 @@
         <source>Account type</source>
         <translation>帳戶型別</translation>
     </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation type="unfinished">全名太長了</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>


### PR DESCRIPTION
Add a full name error message

Log: Add a full name error message
pms: BUG-292551

## Summary by Sourcery

Add a validation alert for overly long full names in the account settings and update localization files to include the new error message

Bug Fixes:
- Show an alert with "The full name is too long" and play a system sound when the full name exceeds 32 characters

Documentation:
- Include the new full name error message in translation templates across all supported locales