### PR TITLE
fix: prevent key sequence recording when edit button is clicked

### DIFF
--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -114,7 +114,10 @@ Control {
 
             MouseArea {
                 anchors.fill: parent
-                onClicked: {
+                onClicked: (mouse) => {
+                    if (control.showEditButtons && mouse.x >= editButton.x) {
+                        return
+                    }
                     control.requestKeys()
                 }
             }


### PR DESCRIPTION
- Added click event coordinates check to avoid triggering requestKeys when clicking on edit button area.

Log: prevent key sequence recording when edit button is clicked
pms: BUG-288739

## Summary by Sourcery

Bug Fixes:
- Add coordinate check in MouseArea onClicked handler to skip recording if the click occurs over the edit button