### PR TITLE
fix: add disambiguation context for "Medium" copywriting

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,36 +1,32 @@
 [main]
 host = https://www.transifex.com
-minimum_perc = 80
-mode = developer
 
-[o:linuxdeepin:p:deepin-desktop-environment:r:dde-control-center]
+[o:linuxdeepin:p:deepin-desktop-environment:r:332dacad18d2b1a048dba06b5c1f0293]
 file_filter = translations/dde-control-center_<lang>.ts
-minimum_perc = 0
 source_file = translations/dde-control-center_en.ts
-source_lang = en
+source_lang = en_US
 type = QT
 
-[o:linuxdeepin:p:deepin-desktop-environment:r:dde-control-center-desktop]
+[o:linuxdeepin:p:deepin-desktop-environment:r:4ea171636f1b3b620948addfb330f0d9]
 file_filter = translations/desktop/desktop_<lang>.ts
 source_file = translations/desktop/desktop.ts
-source_lang = en
+source_lang = en_US
 type = QT
 
-[o:linuxdeepin:p:deepin-desktop-environment:r:dde-control-center-keyboard_language]
+[o:linuxdeepin:p:deepin-desktop-environment:r:09fb6462e5f74e720875a8bc02c8e3ab]
 file_filter = translations/keyboard_language_<lang>.ts
 source_file = translations/keyboard_language_en.ts
-source_lang = en
+source_lang = en_US
 type = QT
 
-[o:linuxdeepin:p:deepin-desktop-environment:r:datetime_language]
+[o:linuxdeepin:p:deepin-desktop-environment:r:f36a590ee78fdf786aa8e4324a9fe090]
 file_filter = translations/datetime_language_<lang>.ts
 source_file = translations/datetime_language_en.ts
-source_lang = en
+source_lang = en_US
 type = QT
 
-
-[o:linuxdeepin:p:deepin-desktop-environment:r:datetime_country]
+[o:linuxdeepin:p:deepin-desktop-environment:r:221f00280dc088592ed4096a7fb595ae]
 file_filter = translations/datetime_country_<lang>.ts
 source_file = translations/datetime_country_en.ts
-source_lang = en
+source_lang = en_US
 type = QT

--- a/src/plugin-personalization/qml/WindowEffectPage.qml
+++ b/src/plugin-personalization/qml/WindowEffectPage.qml
@@ -62,7 +62,7 @@ DccObject {
                     Layout.fillWidth: true
                     Layout.bottomMargin: 10
                     Layout.leftMargin: 10
-                    property var tips: [qsTr("None"), qsTr("Small"), qsTr("Medium"), qsTr("Large")]
+                    property var tips: [qsTr("None"), qsTr("Small"), qsTr("Medium", "describe size of window rounded corners"), qsTr("Large")]
                     property var icons: ["corner_none", "corner_small", "corner_middle", "corner_big"]
                     spacing: 8
                     Repeater {
@@ -278,7 +278,7 @@ DccObject {
                     value: 32
                 },
                 {
-                    text: qsTr("Medium"),
+                    text: qsTr("Medium", "describe height of window title bar"),
                     value: 40
                 },
                 {

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">ትንሽ</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">መካከለኛ</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">ትልቅ</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">መካከለኛ</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">መካከለኛ</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ar">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ar">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">اسم المستخدم طويل جدًا</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">لقد قرأت وقبلت REGARDING TO</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"> tuyên殃</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">التالي</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1346,15 +1348,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"> tuyên殃</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1536,15 +1538,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1826,7 +1828,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2063,7 +2065,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2261,15 +2263,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">حفظ</translation>
     </message>
 </context>
 <context>
@@ -2343,7 +2345,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2784,7 +2786,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2943,10 +2945,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>صغير</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>متوسط</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>كبير</translation>
     </message>
@@ -3009,6 +3007,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>مصغر جداً</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">متوسط</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">متوسط</translation>
     </message>
 </context>
 <context>
@@ -3084,7 +3092,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3623,7 +3631,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3992,7 +4000,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4053,7 +4061,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="az">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="az">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">اسم المستخدم الكاملtoo long</translation>
     </message>
 </context>
 <context>
@@ -110,7 +112,7 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
@@ -118,11 +120,11 @@
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,7 +138,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -151,61 +153,61 @@ In order to better use of face recognition, please pay attention to the followin
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">أقر وأوافق على</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">الشروط والأحكام</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">التالي</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
@@ -213,15 +215,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -229,7 +231,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Dimensional style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -872,109 +874,109 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/privacy-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"> соглашайтесь и присоединяйтесь к Программе опыта пользователя</translation>
     </message>
 </context>
 <context>
     <name>DateTimeSettingDialog</name>
     <message>
         <source>Date and time setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Year</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">الوقت</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">تأكيد</translation>
     </message>
 </context>
 <context>
     <name>DatetimeModel</name>
     <message>
         <source>Tomorrow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yesterday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours earlier than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours later than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Space</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First day of week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">أول يوم في الأسبوع</translation>
     </message>
     <message>
         <source>Short date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">التاريخ القصير</translation>
     </message>
     <message>
         <source>Long date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">التاريخ الطويل</translation>
     </message>
     <message>
         <source>Short time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">الوقت القصير</translation>
     </message>
     <message>
         <source>Long time</source>
@@ -1346,15 +1348,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">الشروط والأحكام</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1536,15 +1538,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1826,7 +1828,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2063,7 +2065,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2261,15 +2263,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">حفظ</translation>
     </message>
 </context>
 <context>
@@ -2343,7 +2345,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2784,7 +2786,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2943,10 +2945,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>صغير</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>متوسط</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>كبير</translation>
     </message>
@@ -3009,6 +3007,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>مُشِغر جدا</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">متوسط</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">متوسط</translation>
     </message>
 </context>
 <context>
@@ -3088,7 +3096,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3627,7 +3635,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3894,7 +3902,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3996,7 +4004,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4057,7 +4065,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Малък</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Среден</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Голям</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Среден</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Среден</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="bn">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="bn">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">মোট নাম খুব দীর্ঘ</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">আমি পড়েছি এবং আমি এটির সহমতি দিয়েছি</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">রিজার্মেন্ট</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">পরবর্তী</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -872,109 +874,110 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/privacy-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">সম্মত হলে ইউজার এক্সপারিয়েন্স প্রোগ্রামে যোগ দিন</translation>
     </message>
 </context>
 <context>
     <name>DateTimeSettingDialog</name>
     <message>
         <source>Date and time setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Year</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">যাচাই করুন</translation>
     </message>
 </context>
 <context>
     <name>DatetimeModel</name>
     <message>
         <source>Tomorrow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yesterday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours earlier than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours later than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Space</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First day of week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">সপ্তাহের প্রথম দিন
+</translation>
     </message>
     <message>
         <source>Short date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ছুটির তারিখ</translation>
     </message>
     <message>
         <source>Long date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">দীর্ঘ তারিখ</translation>
     </message>
     <message>
         <source>Short time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ছুটির সময়</translation>
     </message>
     <message>
         <source>Long time</source>
@@ -1346,15 +1349,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">রিজার্মেন্ট</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1536,15 +1539,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1826,7 +1829,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2063,7 +2066,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2286,15 +2289,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2368,7 +2371,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2805,171 +2808,167 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>UserExperienceProgramPage</name>
     <message>
         <source>Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VerifyDialog</name>
     <message>
         <source>Security Verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The action is sensitive, please enter the login password first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">8-64 ক্যারেক্টার</translation>
     </message>
     <message>
         <source>Forgot Password?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">যাচাই করুন</translation>
     </message>
 </context>
 <context>
     <name>WallpaperPage</name>
     <message>
         <source>wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>My pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solid color wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customizable wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>fill style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic wallpaper change</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">বসে থাকলেও</translation>
     </message>
     <message>
         <source>30 second</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 মিনিট</translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">5 মিনিট</translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">10 মিনিট</translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">15 মিনিট</translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">30 মিনিট</translation>
     </message>
     <message>
         <source>login</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>wake up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Live Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 ঘন্টা</translation>
     </message>
 </context>
 <context>
     <name>WallpaperSelectView</name>
     <message>
         <source>unfold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>show all</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>items</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WindowEffectPage</name>
     <message>
         <source>Interface and Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">কোনো একটি নেই</translation>
     </message>
     <message>
         <source>Small</source>
         <translation>ক্ষুদ্র</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>মধ্যম</translation>
     </message>
     <message>
         <source>Large</source>
@@ -3034,6 +3033,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>অত্যন্ত ক্ষুদ্র</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3109,7 +3118,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3648,7 +3657,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3915,7 +3924,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4017,7 +4026,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4078,7 +4087,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -186,7 +188,7 @@ Per tal d&apos;usar millor el reconeixement facial, presteu atenció als aspecte
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>L&apos;autenticació biomètrica ​​és una funció per a l&apos;autenticació de la identitat d&apos;usuari proporcionada per UnionTech Software Technology Co., Ltd. Mitjançant l&apos;autenticació biomètrica, les dades biomètriques recollides es compararan amb les emmagatzemades al dispositiu i la identitat de l&apos;usuari es verificarà en funció del resultat de la comparació.
@@ -2953,10 +2955,6 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
         <translation>Petita</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Mitjana</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Grossa</translation>
     </message>
@@ -3019,6 +3017,16 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>Extremely small</source>
         <translation>Extremadament petita</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Mitjana</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Mitjana</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Malý</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Střední</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Velký</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Střední</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Střední</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Lille</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Medium</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Stor</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Medium</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Medium</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Klein</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Mittel</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Groß</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Mittel</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Mittel</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="de_DE">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="de_DE">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -136,7 +138,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -176,10 +178,10 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -391,7 +393,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>grub start delay</source>
@@ -403,15 +405,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Boot menu verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After opening, entering the menu editing requires a password.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change Password</source>
@@ -419,11 +421,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Change boot menu verification password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the boot menu authentication password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Name :</source>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -741,7 +743,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -875,7 +877,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/experience-en</source>
@@ -883,11 +885,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
@@ -1041,7 +1043,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unlinked</source>
@@ -1073,604 +1075,604 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>After binding your local account, you can use the following functions:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>WeChat Scan Code Login System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password via %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDInterface</name>
     <message>
         <source>deepin</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDLogin</name>
     <message>
         <source>Cloud Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The feature is not available at present, please activate your system first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DetailItem</name>
     <message>
         <source>Please choose the default program to open &apos;%1&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Desktop file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apps (*.desktop)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>All files (*)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DevelopModePage</name>
     <message>
         <source>Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Online</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Login UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Import Certificate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Datei auswählen</translation>
     </message>
     <message>
         <source>Your UOS ID has been logged in, click to enter developer mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your UOS ID first and continue</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1.Export PC Info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>3.Import Certificate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Development and debugging options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System logging level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Debug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Haftungsausschluss</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FileAndFolder</name>
     <message>
         <source>Allow below apps to access these files and folders:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Documents</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Videos</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Downloads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>folder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FontSizePage</name>
     <message>
         <source>Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard Font</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monospaced Font</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GeneralPage</name>
     <message>
         <source>Power Plans</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saving Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto power saving on low battery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Low battery threshold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Wert für niedrigen Akkustand</translation>
     </message>
     <message>
         <source>Auto power saving on battery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wakeup Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password is required to wake up the computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password is required to wake up the monitor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Shutdown Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scheduled Shutdown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Zeit</translation>
     </message>
     <message>
         <source>Repeat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Every day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Working days</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Decrease screen brightness on power saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GestureModel</name>
     <message>
         <source>Three-finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Links</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Rechts</translation>
     </message>
     <message>
         <source>tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HomePage</name>
     <message>
         <source>,</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InterfaceEffectListview</name>
     <message>
         <source>Optimal Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KeyboardLayout</name>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">fertig</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ändern</translation>
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangAndFormat</name>
     <message>
         <source>Language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">fertig</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ändern</translation>
     </message>
     <message>
         <source>Other languages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region and format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangsChooserDialog</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LayoutsChooser</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LoginMethod</name>
     <message>
         <source>Login method</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password, wechat, biometric authentication, security key</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Modify password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Validity days</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Always</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1700,232 +1702,232 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No input device for sound found</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mouse</name>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Langsam</translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Schnell</translation>
     </message>
     <message>
         <source>Pointer Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kurz</translation>
     </message>
     <message>
         <source>Long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Lang</translation>
     </message>
     <message>
         <source>Mouse Acceleration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable touchpad when a mouse is connected</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Natural Scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MyDevice</name>
     <message>
         <source>My Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NativeInfoPage</name>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Computer name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>It cannot start or end with dashes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>OS Name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Edition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>bit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Authorization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System installation time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Kernel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Graphics Platform</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Processor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OtherDevice</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show Bluetooth devices without names</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PasswordLayout</name>
     <message>
         <source>Current password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Erforderlich</translation>
     </message>
     <message>
         <source>Weak</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Strong</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password hint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Freiwillig</translation>
     </message>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Passwort darf nicht leer bleiben</translation>
     </message>
     <message>
         <source>Passwords do not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Passwörter stimmen nicht überein</translation>
     </message>
     <message>
         <source>New password should differ from the current one</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PasswordModifyDialog</name>
     <message>
         <source>Modify password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resetting the password will clear the data stored in the keyring.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
 </context>
 <context>
     <name>PersonalizationInterface</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1950,61 +1952,61 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PowerOperatorModel</name>
     <message>
         <source>Shut down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Herunterfahren</translation>
     </message>
     <message>
         <source>Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hibernate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off the monitor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show the shutdown Interface</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do nothing</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerPage</name>
     <message>
         <source>Screen and Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bildschirm und Abschalten</translation>
     </message>
     <message>
         <source>Turn off the monitor after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Monitor abschalten nach</translation>
     </message>
     <message>
         <source>Lock screen after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bildschirm sperren nach</translation>
     </message>
     <message>
         <source>Computer suspends after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Computer schaltet ab nach</translation>
     </message>
     <message>
         <source>When the lid is closed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Wenn der Deckel geschlossen wird</translation>
     </message>
     <message>
         <source>When the power button is pressed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Wenn der Ausschaltknopf gedrückt wird</translation>
     </message>
 </context>
 <context>
     <name>PowerPlansListview</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
@@ -2012,7 +2014,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
@@ -2024,41 +2026,41 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerWorker</name>
     <message>
         <source>Minutes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PrivacyPolicyPage</name>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2148,7 +2150,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>dde-control-center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch Screen Settings</source>
@@ -2160,298 +2162,298 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This system wallpaper is locked. Please contact your admin.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RegionFormatDialog</name>
     <message>
         <source>Regions and formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First day of week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Erster Tag der Woche</translation>
     </message>
     <message>
         <source>Short date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kurzes Datum</translation>
     </message>
     <message>
         <source>Long date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Langform-Datum</translation>
     </message>
     <message>
         <source>Short time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kurzform-Zeit</translation>
     </message>
     <message>
         <source>Long time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Langform-Zeit</translation>
     </message>
     <message>
         <source>Currency symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Währungssymbol</translation>
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Speichern</translation>
     </message>
 </context>
 <context>
     <name>RegionsChooserWindow</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RegisterDialog</name>
     <message>
         <source>Set a Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat the password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bestätigen</translation>
     </message>
     <message>
         <source>Passwords don&apos;t match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Speichern</translation>
     </message>
 </context>
 <context>
     <name>ScreenSaverPage</name>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>preview</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>idle time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SearchableListViewPopup</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutSettingDialog</name>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Erforderlich</translation>
     </message>
     <message>
         <source>Command:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click Add to replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Shortcuts</name>
     <message>
         <source>Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System shortcut, custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Benutzerdefiniert</translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">fertig</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ändern</translation>
     </message>
     <message>
         <source>Please enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SoundDevicemanagesPage</name>
     <message>
         <source>Output Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select whether to enable the devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2548,123 +2550,123 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No output device for sound found</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left Right Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mono audio</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Merge left and right channels into a single channel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto pause</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SyncInfoListModel</name>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeSelectView</name>
     <message>
         <source>More Wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TimeAndDate</name>
     <message>
         <source>Auto sync time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ntp server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System date and time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Server address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Erforderlich</translation>
     </message>
     <message>
         <source>The ntp server address cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use 24-hour format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>system time zone</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Timezone list</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TimeRange</name>
     <message>
         <source>from</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2690,924 +2692,930 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>TimezoneDialog</name>
     <message>
         <source>Add time zone</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time zone:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nearest City:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Speichern</translation>
     </message>
 </context>
 <context>
     <name>TouchScreen</name>
     <message>
         <source>TouchScreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set up here when connecting the touch screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Touchpad</name>
     <message>
         <source>Basic Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Langsam</translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Schnell</translation>
     </message>
     <message>
         <source>Disable touchpad during input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Tap to Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Natural Scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Gesture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger gestures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger gestures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UserExperienceProgramPage</name>
     <message>
         <source>Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VerifyDialog</name>
     <message>
         <source>Security Verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The action is sensitive, please enter the login password first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Forgot Password?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Abbrechen</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bestätigen</translation>
     </message>
 </context>
 <context>
     <name>WallpaperPage</name>
     <message>
         <source>wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>My pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solid color wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customizable wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>fill style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic wallpaper change</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>30 second</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>login</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>wake up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Live Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WallpaperSelectView</name>
     <message>
         <source>unfold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>show all</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>items</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WindowEffectPage</name>
     <message>
         <source>Interface and Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Klein</translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Groß</translation>
     </message>
     <message>
         <source>Enable transparent effects when moving windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Minimize Effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scale</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Magic Lamp</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Opacity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Bars</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show on scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keep shown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Angezeigt lassen</translation>
     </message>
     <message>
         <source>Compact Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>If enabled, more content is displayed in the window.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Title Bar Height</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only suitable for application window title bars drawn by the window manager.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extremely small</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>accounts</name>
     <message>
         <source>Account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account manager</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>accountsMain</name>
     <message>
         <source>Other accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>authentication</name>
     <message>
         <source>Biometric Authentication</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>authenticationMain</name>
     <message>
         <source>Biometric Authentication</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Up to 5 facial data can be entered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identifying user identity through scanning fingerprints</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identity recognition through iris scanning</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add a new </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>blueTooth</name>
     <message>
         <source>bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Bluetooth settings, devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>commonInfoMain</name>
     <message>
         <source>Boot Menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your boot menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer root permission management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer Options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>datetime</name>
     <message>
         <source>Time and date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time and date, time zone settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System language, region format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsController</name>
     <message>
         <source>Username must be between 3 and 32 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The first character must be a letter or number</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your username should not only have numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The username has been used by other user accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The full name has been used by other user accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard User</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customized</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsWorker</name>
     <message>
         <source>Your host was removed from the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host joins the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to leave the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to join the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AD domain settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AvatarTypesModel</name>
     <message>
         <source>Dimensional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::BiometricAuthController</name>
     <message>
         <source>Use your face to unlock the device and make settings later</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Faceprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and place it on the sensor again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Finger entfernen und erneut auflegen</translation>
     </message>
     <message>
         <source>Scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the position to scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and do that again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint added</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scan Suspended</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the edges of your fingerprint on the sensor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::KeyboardController</name>
     <message>
         <source>This shortcut conflicts with [%1]</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::PwqualityManager</name>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Passwort darf nicht leer bleiben</translation>
     </message>
     <message>
         <source>Password must have at least %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Das Passwort muss mindestens %1 Zeichen haben</translation>
     </message>
     <message>
         <source>Password must be no more than %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Das Passwort darf nicht mehr als %1 Zeichen haben</translation>
     </message>
     <message>
         <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Das Passwort darf nur aus lateinischen Buchstaben (A-Z,a-z), Ziffern oder Spezialzeichen (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/) bestehen</translation>
     </message>
     <message>
         <source>No more than %1 palindrome characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nicht mehr als %1 gespiegelte Zeichen bitte</translation>
     </message>
     <message>
         <source>No more than %1 monotonic characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nicht mehr als %1 monotone Zeichen hintereinander bitte</translation>
     </message>
     <message>
         <source>No more than %1 repeating characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nicht mehr als %1 sich wiederholende Zeichen bitte</translation>
     </message>
     <message>
         <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Das Passwort muss aus Groß- und Kleinbuchstaben, Ziffern und Symbolen (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/) bestehen</translation>
     </message>
     <message>
         <source>Password must not contain more than 4 palindrome characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Das Passwort darf nicht mehr als 4 gespiegelte Buchstaben enthalten</translation>
     </message>
     <message>
         <source>Do not use common words and combinations as password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Verwenden Sie keine gebräuchlichen Worte oder Kombinationen daraus als Passwort</translation>
     </message>
     <message>
         <source>Create a strong password please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bitte erstellen Sie ein starkes Passwort</translation>
     </message>
     <message>
         <source>It does not meet password rules</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Das entspricht nicht den Passwort-Erfordernissen</translation>
     </message>
 </context>
 <context>
     <name>dccV25::ShortcutModel</name>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Benutzerdefiniert</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>deepinid</name>
     <message>
         <source>deepin ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cloud services</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>defaultapp</name>
     <message>
         <source>Default App</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the default application for opening various types of files</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>defaultappMain</name>
     <message>
         <source>Webpage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mail</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Terminal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>device</name>
     <message>
         <source>Device</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>display</name>
     <message>
         <source>Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Brightness,resolution,scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>displayMain</name>
     <message>
         <source>100%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>125%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>150%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>175%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>200%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>225%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>250%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>275%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>300%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Stretch</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only on %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source> (Recommended)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hz</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Multiple Displays Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Modus</translation>
     </message>
     <message>
         <source>Main Screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display And Layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Brightness</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Refresh Rate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Rotation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>90°</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>180°</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>270°</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display Scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The monitor only supports 100% display scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Eye Comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Zeit</translation>
     </message>
     <message>
         <source>All day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sunset to Sunrise</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>from</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color Temperature</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3618,33 +3626,33 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>keyboard</name>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>General Settings, keyboard layout, input method, shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>keyboardMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Gemeinsam</translation>
     </message>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set system default keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3659,11 +3667,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Classic Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Centered Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dock size</source>
@@ -3742,369 +3750,369 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>mouse</name>
     <message>
         <source>Mouse and Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Common、Mouse、Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mouseMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Gemeinsam</translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>notification</name>
     <message>
         <source>DND mode, app notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Benachrichtigung</translation>
     </message>
 </context>
 <context>
     <name>notificationMain</name>
     <message>
         <source>Do Not Disturb Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable Do Not Disturb</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>When the screen is locked</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Number of notifications shown on the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>App Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allow Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display notification on desktop or show unread messages in the notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show message preview</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Play a sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>personalization</name>
     <message>
         <source>Personalization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>personalizationMain</name>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Personalize your wallpaper and screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Colors and icons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust accent color and theme icons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Font and font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change system font and size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select light, dark or automatic theme appearance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>power</name>
     <message>
         <source>Power saving settings, screen and suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>powerMain</name>
     <message>
         <source>General</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Plugged In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen and suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On Battery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>screen and suspend, low battery, battery management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>privacy</name>
     <message>
         <source>Privacy and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Camera, folder permissions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>privacyMain</name>
     <message>
         <source>Camera</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Choose whether the application has access to the camera</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Files and Folders</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Choose whether the application has access to files and folders</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>sound</name>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output, input, sound effects, devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>soundMain</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Klangeffekte</translation>
     </message>
     <message>
         <source>Enable/disable sound effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable/disable audio devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>system</name>
     <message>
         <source>Common settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>systemInfo</name>
     <message>
         <source>Auxiliary Information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>systemInfoMain</name>
     <message>
         <source>About This PC</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System version, device information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View the notice of open source software</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Join the user experience program to help improve the product</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>End User License Agreement</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View the end  user license agreement</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View information about privacy policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>touchscreen</name>
     <message>
         <source>Touchscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuring Touchscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>touchscreenMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Gemeinsam</translation>
     </message>
 </context>
 <context>
     <name>wacom</name>
     <message>
         <source>wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuring wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>wacomMain</name>
     <message>
         <source>wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wacom Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pen Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pressure Sensitivity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Μικρό</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Μεγάλο</translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Medium</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Medium</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Medium</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Malgranda</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Mezgranda</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Granda</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Mezgranda</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Mezgranda</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="es">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="es">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">El nombre completo es muy largo</translation>
     </message>
 </context>
 <context>
@@ -187,7 +189,7 @@ Para un mejor uso del reconocimiento facial, tenga en cuenta lo siguiente al reg
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>La autenticación biométrica es una función de autenticación de identidad de usuario proporcionada por UnionTech Software Technology Co., Ltd. Mediante la autenticación biométrica, los datos biométricos recopilados se compararán con los almacenados en el dispositivo y la identidad del usuario se verificará con base en el resultado de la comparación.
@@ -756,7 +758,7 @@ UnionTech Software Technology Co., Ltd. se compromete a investigar y mejorar la 
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1837,7 +1839,7 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2954,10 +2956,6 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
         <translation>Pequeño</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Mediano</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
@@ -3020,6 +3018,16 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>Extremely small</source>
         <translation>Extremadamente pequeño</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4064,7 +4072,7 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Medio</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Medio</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Medio</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="et">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="et">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Täielik nimi on liiga pikk</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Olen lugenud ja nõustun</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Huvilause</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Järgmine</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1349,15 +1351,15 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Huvilause</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1539,15 +1541,15 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1829,7 +1831,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2066,7 +2068,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2264,15 +2266,15 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Salvesta</translation>
     </message>
 </context>
 <context>
@@ -2346,7 +2348,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2783,57 +2785,57 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <name>UserExperienceProgramPage</name>
     <message>
         <source>Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VerifyDialog</name>
     <message>
         <source>Security Verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The action is sensitive, please enter the login password first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">8-64 tähed</translation>
     </message>
     <message>
         <source>Forgot Password?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WallpaperPage</name>
     <message>
         <source>wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Aken rohkem külgi</translation>
     </message>
     <message>
         <source>My pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solid color wallpaper</source>
@@ -2946,10 +2948,6 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
         <translation>Väikne</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Keskmine</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Suur</translation>
     </message>
@@ -3012,6 +3010,16 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>Extremely small</source>
         <translation>Üllatavalt väikse</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3087,7 +3095,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3626,7 +3634,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3893,7 +3901,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3995,7 +4003,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4056,7 +4064,7 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">متوسط</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">متوسط</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">متوسط</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Nimesi on liian pitkä</translation>
     </message>
 </context>
 <context>
@@ -186,7 +188,7 @@ Kasvojentunnistuksen paremman toimivuuden varmistamiseksi huomioi seuraavat asia
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>&quot;Biometrinen todennus&quot; on UnionTech Software Technology Co., Ltd:n kehittämä toiminto käyttäjän identiteetin tunnistamiseen. &quot;Biometrisen todentamisen&quot; avulla kerättyjä biometrisiä tietoja verrataan tietokoneeseen tallennettuihin tietoihin ja varmistetaan näiden tietojen perusteella.
@@ -753,7 +755,7 @@ UnionTech Software Technology Co., Ltd on sitoutunut parantamaan biometrisen tod
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1833,7 +1835,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2950,10 +2952,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Pieni</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Hyvä</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Suuri</translation>
     </message>
@@ -3016,6 +3014,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Erittäin pieni</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Hyvä</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Hyvä</translation>
     </message>
 </context>
 <context>
@@ -4060,7 +4068,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fr">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">El nombre completo es demasiado largo</translation>
     </message>
 </context>
 <context>
@@ -196,7 +198,7 @@ Pour pouvoir utiliser l&apos;identification faciale de manière optimale, veuill
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>L&apos;authentification biométrique est une fonction d&apos;authentification d&apos;identité utilisateur fournie par UnionTech Software Technology Co., Ltd. À travers l&apos;authentification biométrique, les données biométriques collectées seront comparées à celles stockées sur l&apos;appareil, et l&apos;identité de l&apos;utilisateur sera vérifiée en fonction du résultat de la comparaison.
@@ -393,7 +395,7 @@ UnionTech Software Technology Co., Ltd. est engagée à rechercher et améliorer
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -645,7 +647,7 @@ UnionTech Software Technology Co., Ltd. est engagée à rechercher et améliorer
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -765,7 +767,7 @@ UnionTech Software Technology Co., Ltd. est engagée à rechercher et améliorer
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1371,22 +1373,22 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FileAndFolder</name>
     <message>
         <source>Allow below apps to access these files and folders:</source>
-        <translation>Autoriser les applications suivantes à accéder à ces fichiers et dossiers :</translation>
+        <translation>Autoriser les applications suivantes à accéder à ces fichiers et dossiers&#xa0;:</translation>
     </message>
     <message>
         <source>Documents</source>
@@ -1561,15 +1563,15 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1851,7 +1853,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2088,7 +2090,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2286,15 +2288,15 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuler</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Enregistrer</translation>
     </message>
 </context>
 <context>
@@ -2368,7 +2370,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2810,7 +2812,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2969,10 +2971,6 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
         <translation>Petit</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Moyen</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Grand</translation>
     </message>
@@ -3035,6 +3033,16 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>Extremely small</source>
         <translation>Muy pequeño</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Moyen</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Moyen</translation>
     </message>
 </context>
 <context>
@@ -3110,7 +3118,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3649,7 +3657,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4018,7 +4026,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4079,7 +4087,7 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="gl_ES">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="gl_ES">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">O nome completo é moi lonxe</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Leido e acordo coa</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Aviso</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Seguinte</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -757,118 +759,118 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Failed to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your Union ID first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cannot read your PC information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No network connection</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Certificate loading failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Signature verification failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Concordar e unirse ao Programa de Experiencia do Usuario</translation>
     </message>
     <message>
         <source>The Disclaimer of Developer Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Setting new boot animation finished</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The settings will be applied after rebooting the system</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ConfirmManager</name>
     <message>
         <source>Password must contain numbers and letters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must be between 8 and 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CreateAccountDialog</name>
     <message>
         <source>Create a new account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Tipo de conta</translation>
     </message>
     <message>
         <source>UserName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>FullName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Opcional</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Create account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomAvatarEmpatyArea</name>
     <message>
         <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoModel</name>
     <message>
         <source>available</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoWork</name>
     <message>
         <source>https://www.deepin.org/en/agreement/privacy/</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/privacy-en</source>
@@ -1346,15 +1348,15 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Aviso</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1506,118 +1508,118 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HomePage</name>
     <message>
         <source>,</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InterfaceEffectListview</name>
     <message>
         <source>Optimal Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KeyboardLayout</name>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Dispostivo de teclado</translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">feito</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">editar</translation>
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangAndFormat</name>
     <message>
         <source>Language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">feito</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">editar</translation>
     </message>
     <message>
         <source>Other languages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">añadir</translation>
     </message>
     <message>
         <source>Region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region and format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangsChooserDialog</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Engadir idioma</translation>
     </message>
     <message>
         <source>Search</source>
@@ -1826,7 +1828,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2063,7 +2065,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2286,15 +2288,15 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Gardar</translation>
     </message>
 </context>
 <context>
@@ -2368,7 +2370,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2809,7 +2811,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2968,10 +2970,6 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
         <translation>Pequeño</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Mediano</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
@@ -3034,6 +3032,16 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>Extremely small</source>
         <translation>Extremadamente pequeno</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3109,7 +3117,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3193,115 +3201,115 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Standard User</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customized</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsWorker</name>
     <message>
         <source>Your host was removed from the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host joins the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to leave the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to join the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AD domain settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AvatarTypesModel</name>
     <message>
         <source>Dimensional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::BiometricAuthController</name>
     <message>
         <source>Use your face to unlock the device and make settings later</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Faceprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and place it on the sensor again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Leve o dedo e posidxo de novo no sensor</translation>
     </message>
     <message>
         <source>Scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the position to scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and do that again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint added</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scan Suspended</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the edges of your fingerprint on the sensor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Irís</translation>
     </message>
 </context>
 <context>
     <name>dccV25::KeyboardController</name>
     <message>
         <source>This shortcut conflicts with [%1]</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3648,7 +3656,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3915,7 +3923,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4017,7 +4025,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4078,7 +4086,7 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="he">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="he">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">שם מלא הוא מדי ארוך</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">אילותי ומסכים ל</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">האזהרה</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הבא</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -334,42 +336,42 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Send Files</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Rename</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Remove Device</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">בחר קובץ</translation>
     </message>
 </context>
 <context>
     <name>BluetoothCtl</name>
     <message>
         <source>Edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allow other Bluetooth devices to find this device</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the Bluetooth function, please turn off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Airplane Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -380,66 +382,66 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Not connected</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>BootPage</name>
     <message>
         <source>Startup Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>grub start delay</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Boot menu verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After opening, entering the menu editing requires a password.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change boot menu verification password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the boot menu authentication password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Name :</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>root</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>New Password :</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password cannot be empty</source>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -640,119 +642,119 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Customize your theme icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cursor Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize your theme cursor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComfirmDeleteDialog</name>
     <message>
         <source>Are you sure you want to delete this account?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delete account directory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComfirmSafePage</name>
     <message>
         <source>Go to settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Common</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat delay</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ק krat</translation>
     </message>
     <message>
         <source>Long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">אורך</translation>
     </message>
     <message>
         <source>Repeat rate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">איטי</translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Numeric Keypad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>test here</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Caps lock prompt</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Double Click Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Double Click Test</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left Hand Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CommonInfoWork</name>
     <message>
         <source>Large size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Small size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to get root access</source>
@@ -1089,122 +1091,122 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDInterface</name>
     <message>
         <source>deepin</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">UOS</translation>
     </message>
 </context>
 <context>
     <name>DeepinIDLogin</name>
     <message>
         <source>Cloud Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
@@ -1341,15 +1343,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">האזהרה</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1501,118 +1503,118 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HomePage</name>
     <message>
         <source>,</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InterfaceEffectListview</name>
     <message>
         <source>Optimal Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KeyboardLayout</name>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">מסלול שטיח</translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">נגמר</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ערוך</translation>
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangAndFormat</name>
     <message>
         <source>Language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">נגמר</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ערוך</translation>
     </message>
     <message>
         <source>Other languages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הוסף</translation>
     </message>
     <message>
         <source>Region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region and format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangsChooserDialog</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הוסף שפה</translation>
     </message>
     <message>
         <source>Search</source>
@@ -1821,7 +1823,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1958,122 +1960,122 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Hibernate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off the monitor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show the shutdown Interface</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do nothing</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerPage</name>
     <message>
         <source>Screen and Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">מסך ופסק פעילות</translation>
     </message>
     <message>
         <source>Turn off the monitor after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">כבה את מסך המחשב לאחר</translation>
     </message>
     <message>
         <source>Lock screen after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">לOCK מסך המחשב לאחר</translation>
     </message>
     <message>
         <source>Computer suspends after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">מחשב הפסק פעילות לאחר</translation>
     </message>
     <message>
         <source>When the lid is closed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">כאשר סילוק הסלע נסגר</translation>
     </message>
     <message>
         <source>When the power button is pressed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">כאשר לחץ על כפתור האמצעי</translation>
     </message>
 </context>
 <context>
     <name>PowerPlansListview</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerWorker</name>
     <message>
         <source>Minutes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PrivacyPolicyPage</name>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">מדיניות פרטיות</translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PwqualityManager</name>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הסיסמה不能为空</translation>
     </message>
     <message>
         <source>Password must have at least %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הסיסמה חייבת להכיל לפחות %1 תווים</translation>
     </message>
     <message>
         <source>Password must be no more than %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הסיסמה חייבת להכיל לא יותר מ-%1 תווים</translation>
     </message>
     <message>
         <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
@@ -2256,15 +2258,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">שמור</translation>
     </message>
 </context>
 <context>
@@ -2338,7 +2340,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2779,7 +2781,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2935,115 +2937,121 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">קטן</translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">גדול</translation>
     </message>
     <message>
         <source>Enable transparent effects when moving windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Minimize Effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scale</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Magic Lamp</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Opacity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Bars</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show on scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keep shown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">הישאר מוצג</translation>
     </message>
     <message>
         <source>Compact Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>If enabled, more content is displayed in the window.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Title Bar Height</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only suitable for application window title bars drawn by the window manager.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extremely small</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">בינוני</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">בינוני</translation>
     </message>
 </context>
 <context>
     <name>accounts</name>
     <message>
         <source>Account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account manager</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>accountsMain</name>
     <message>
         <source>Other accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>authentication</name>
     <message>
         <source>Biometric Authentication</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>authenticationMain</name>
     <message>
         <source>Biometric Authentication</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Up to 5 facial data can be entered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint</source>
@@ -3079,7 +3087,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3618,7 +3626,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3885,7 +3893,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3987,7 +3995,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4048,7 +4056,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">छोटा</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">मध्यम</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">बड़ा</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">मध्यम</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">मध्यम</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Maleno</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Srednje</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Veliko</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Srednje</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Srednje</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="hu">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="hu">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">A teljes nev túl hosszú</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kész</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,7 +138,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -151,61 +153,61 @@ In order to better use of face recognition, please pay attention to the followin
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Olvastam és elfogadom a</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Monitortájékoztatás</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Következő</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
@@ -213,15 +215,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -229,7 +231,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Dimensional style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -741,7 +743,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1106,119 +1108,119 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">UOS</translation>
     </message>
 </context>
 <context>
     <name>DeepinIDLogin</name>
     <message>
         <source>Cloud Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The feature is not available at present, please activate your system first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1343,15 +1345,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Monitortájékoztatás</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1533,15 +1535,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1823,7 +1825,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2060,7 +2062,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2226,79 +2228,79 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Currency symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Pénznem jele</translation>
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Mentés</translation>
     </message>
 </context>
 <context>
     <name>RegionsChooserWindow</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RegisterDialog</name>
     <message>
         <source>Set a Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">8-64 karakter</translation>
     </message>
     <message>
         <source>Repeat the password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Megerősítés</translation>
     </message>
     <message>
         <source>Passwords don&apos;t match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Mentés</translation>
     </message>
 </context>
 <context>
     <name>ScreenSaverPage</name>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>preview</source>
@@ -2306,7 +2308,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
@@ -2314,47 +2316,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>idle time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 perc</translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">5 perc</translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">10 perc</translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">15 perc</translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">30 perc</translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 óra</translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">soha</translation>
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2365,7 +2367,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2806,7 +2808,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2965,10 +2967,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Kicsi</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Közepes</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Nagy</translation>
     </message>
@@ -3031,6 +3029,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Rendkívül kicsi</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Közepes</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Közepes</translation>
     </message>
 </context>
 <context>
@@ -3106,7 +3114,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3458,39 +3466,39 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>displayMain</name>
     <message>
         <source>100%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>125%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>150%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>175%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>200%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>225%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>250%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>275%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>300%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Duplicate</source>
@@ -3534,11 +3542,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Identify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
@@ -3594,7 +3602,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The monitor only supports 100% display scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Eye Comfort</source>
@@ -3602,7 +3610,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust screen display to warmer colors, reducing screen blue light</source>
@@ -3634,7 +3642,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Color Temperature</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3645,33 +3653,33 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>keyboard</name>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>General Settings, keyboard layout, input method, shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>keyboardMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Billentyűzetbeállítás</translation>
     </message>
     <message>
         <source>Set system default keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4014,7 +4022,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4075,7 +4083,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Kecil</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Sedang</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Besar</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Sedang</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Sedang</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ja">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ja">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">フルネームが長すぎます</translation>
     </message>
 </context>
 <context>
@@ -186,7 +188,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>「生体認証」とは、UnionTech Software Technology Co., Ltd.が提供するユーザー本人認証機能です。「生体認証」では、収集した生体データとデバイスに保存されている生体データを照合し、その照合結果に基づいてユーザーの本人確認を行います。
@@ -383,7 +385,7 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -473,7 +475,7 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Sure</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start animation</source>
@@ -575,19 +577,19 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Already scanned</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the finger position to scan your fingerprint fully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Finger moved too fast. Please do not lift until prompted</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and place it on the sensor again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">指をセンサーから離して、もう一度置いてください</translation>
     </message>
     <message>
         <source>Position your face inside the frame</source>
@@ -635,7 +637,7 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -755,7 +757,7 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -893,19 +895,19 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">同意してユーザーエクスペリエンスプログラムに参加</translation>
     </message>
 </context>
 <context>
@@ -959,11 +961,11 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>%1 hours earlier than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours later than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Space</source>
@@ -1051,11 +1053,11 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     <name>DeepinIDAccountSecurity</name>
     <message>
         <source>Bind WeChat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unlinked</source>
@@ -1063,7 +1065,7 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Unbinding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Link</source>
@@ -1071,43 +1073,43 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     </message>
     <message>
         <source>Are you sure you want to unbind WeChat?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Let me think it over</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Local Account Binding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After binding your local account, you can use the following functions:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>WeChat Scan Code Login System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password via %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1130,61 +1132,61 @@ UnionTech Software Technology Co., Ltd.は、生体認証のセキュリティ�
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
@@ -1199,11 +1201,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
@@ -1211,14 +1213,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
@@ -1226,7 +1228,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The feature is not available at present, please activate your system first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
@@ -1237,133 +1239,133 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DetailItem</name>
     <message>
         <source>Please choose the default program to open &apos;%1&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">追加</translation>
     </message>
     <message>
         <source>Open Desktop file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apps (*.desktop)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>All files (*)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DevelopModePage</name>
     <message>
         <source>Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Online</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Login UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Import Certificate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ファイルを選択</translation>
     </message>
     <message>
         <source>Your UOS ID has been logged in, click to enter developer mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your UOS ID first and continue</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1.Export PC Info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>3.Import Certificate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Development and debugging options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System logging level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Debug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">免責事項</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">キャンセル</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1572,7 +1574,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
@@ -1787,7 +1789,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>It cannot start or end with dashes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>OS Name</source>
@@ -1807,15 +1809,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>bit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Authorization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System installation time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Kernel</source>
@@ -1835,14 +1837,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OtherDevice</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show Bluetooth devices without names</source>
@@ -1916,11 +1918,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resetting the password will clear the data stored in the keyring.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2026,7 +2028,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
@@ -2095,35 +2097,35 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No more than %1 palindrome characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than %1 monotonic characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than %1 repeating characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must not contain more than 4 palindrome characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do not use common words and combinations as password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Create a strong password please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">もっと強いパスワードを作成してください</translation>
     </message>
     <message>
         <source>It does not meet password rules</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">パスワードのルールに適合していません</translation>
     </message>
 </context>
 <context>
@@ -2142,7 +2144,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>To be activated</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Activate</source>
@@ -2217,7 +2219,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
@@ -2293,7 +2295,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
@@ -2333,15 +2335,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2395,7 +2397,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Click Add to replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2461,7 +2463,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select whether to enable the devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
@@ -2674,11 +2676,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>TimeRange</name>
     <message>
         <source>from</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">開始時刻</translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">終了時刻</translation>
     </message>
 </context>
 <context>
@@ -2708,7 +2710,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time zone:</source>
@@ -2735,7 +2737,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Set up here when connecting the touch screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2922,11 +2924,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Set lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2950,10 +2952,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Small</source>
         <translation>小</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>中</translation>
     </message>
     <message>
         <source>Large</source>
@@ -3019,6 +3017,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Extremely small</source>
         <translation>極小</translation>
     </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">中</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">中</translation>
+    </message>
 </context>
 <context>
     <name>accounts</name>
@@ -3077,23 +3085,23 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add a new </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3157,7 +3165,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Your username should not only have numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The username has been used by other user accounts</source>
@@ -3185,30 +3193,30 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Customized</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsWorker</name>
     <message>
         <source>Your host was removed from the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host joins the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to leave the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to join the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AD domain settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password not match</source>
@@ -3219,18 +3227,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>dccV25::AvatarTypesModel</name>
     <message>
         <source>Dimensional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::BiometricAuthController</name>
     <message>
         <source>Use your face to unlock the device and make settings later</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Faceprint</source>
@@ -3300,35 +3308,35 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password must be no more than %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">パスワードは %1 文字以上にする必要があります</translation>
     </message>
     <message>
         <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">パスワードには英字 (大文字と小文字を区別します)、数字、特殊記号 (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/) のみを使用できます</translation>
     </message>
     <message>
         <source>No more than %1 palindrome characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than %1 monotonic characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than %1 repeating characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must not contain more than 4 palindrome characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do not use common words and combinations as password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Create a strong password please</source>
@@ -3525,7 +3533,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
@@ -3809,7 +3817,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Number of notifications shown on the desktop</source>
-        <translation>　デスクトップに表示する通知の数</translation>
+        <translation>&#x3000;デスクトップに表示する通知の数</translation>
     </message>
     <message>
         <source>App Notifications</source>
@@ -4062,7 +4070,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="kk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="kk">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Толық аты-жөні толған</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Мен бул қалыптанузды оқыймын жана атқаруым</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Туура келбейт</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Келесі</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -757,118 +759,118 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Failed to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your Union ID first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cannot read your PC information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No network connection</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Certificate loading failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Signature verification failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Клиенттердің досы программасына қатысуу үшін қатысқаныңызды қатыстыру</translation>
     </message>
     <message>
         <source>The Disclaimer of Developer Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Setting new boot animation finished</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The settings will be applied after rebooting the system</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ConfirmManager</name>
     <message>
         <source>Password must contain numbers and letters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must be between 8 and 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CreateAccountDialog</name>
     <message>
         <source>Create a new account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Сметанын түрі</translation>
     </message>
     <message>
         <source>UserName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>FullName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Кездесетін</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Create account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomAvatarEmpatyArea</name>
     <message>
         <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoModel</name>
     <message>
         <source>available</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoWork</name>
     <message>
         <source>https://www.deepin.org/en/agreement/privacy/</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/privacy-en</source>
@@ -1090,122 +1092,122 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDInterface</name>
     <message>
         <source>deepin</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">UOS</translation>
     </message>
 </context>
 <context>
     <name>DeepinIDLogin</name>
     <message>
         <source>Cloud Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
@@ -1342,15 +1344,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Туура келбейт</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1532,15 +1534,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1822,7 +1824,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2059,7 +2061,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2257,15 +2259,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2339,7 +2341,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2780,7 +2782,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2830,117 +2832,113 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Solid color wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customizable wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>fill style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic wallpaper change</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ақпарат бермей</translation>
     </message>
     <message>
         <source>30 second</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 минутта</translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">5 минутта</translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">10 минутта</translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">15 минутта</translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">30 минут</translation>
     </message>
     <message>
         <source>login</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>wake up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Live Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 сағат</translation>
     </message>
 </context>
 <context>
     <name>WallpaperSelectView</name>
     <message>
         <source>unfold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>show all</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>items</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WindowEffectPage</name>
     <message>
         <source>Interface and Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Окнонын жооптануу канттары</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Жоқ</translation>
     </message>
     <message>
         <source>Small</source>
         <translation>Кішкентай</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>Мысалык</translation>
     </message>
     <message>
         <source>Large</source>
@@ -3005,6 +3003,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Жөнөкөй</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3080,7 +3088,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3619,7 +3627,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3886,7 +3894,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3988,7 +3996,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4049,7 +4057,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ko">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ko">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">전체 이름이 너무 길�습니다</translation>
     </message>
 </context>
 <context>
@@ -196,7 +198,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>&quot;생체 인증&quot;는 유닉스테크 소프트웨어 기술 주식회사가 제공하는 사용자 인증 기능입니다. &quot;생체 인증&quot;을 통해 수집된 생체 정보는 장치에 저장된 정보와 비교되어 사용자 인증이 이루어집니다.
@@ -393,7 +395,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -645,7 +647,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -765,7 +767,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1131,119 +1133,119 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">우ОС</translation>
     </message>
 </context>
 <context>
     <name>DeepinIDLogin</name>
     <message>
         <source>Cloud Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The feature is not available at present, please activate your system first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1368,15 +1370,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">免责声明</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1558,15 +1560,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1848,7 +1850,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2085,7 +2087,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2251,79 +2253,79 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Currency symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">통화 기호</translation>
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">저장</translation>
     </message>
 </context>
 <context>
     <name>RegionsChooserWindow</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RegisterDialog</name>
     <message>
         <source>Set a Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">8-64자</translation>
     </message>
     <message>
         <source>Repeat the password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">확인</translation>
     </message>
     <message>
         <source>Passwords don&apos;t match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">취소</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">저장</translation>
     </message>
 </context>
 <context>
     <name>ScreenSaverPage</name>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>preview</source>
@@ -2331,7 +2333,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
@@ -2339,47 +2341,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>idle time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1분</translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">5분</translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">10분</translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">15분</translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">30분</translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 시간</translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">없음</translation>
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2390,7 +2392,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2831,7 +2833,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2990,10 +2992,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>작은 것</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>중간</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>큰 것</translation>
     </message>
@@ -3056,6 +3054,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>극히 작은 것</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">중간</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">중간</translation>
     </message>
 </context>
 <context>
@@ -3131,7 +3139,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3670,7 +3678,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4039,7 +4047,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4100,7 +4108,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -2965,10 +2965,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Mažas</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Vidutinis</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Didelis</translation>
     </message>
@@ -3031,6 +3027,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Praškusia</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Vidutinis</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Vidutinis</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">ചെറുത്</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">ഇടത്തരം</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">വലുത്</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">ഇടത്തരം</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">ഇടത്തരം</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Жижиг</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Дундаж</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Том</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Дундаж</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Дундаж</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Kecil</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Sederhana</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Besar</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Sederhana</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Sederhana</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Liten</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Medium</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Stor</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Medium</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Medium</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ne">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ne">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">म जानाउँछु र विचारहरूलाई सहमत छु</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">कथनको विचारहरू</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">अगाध</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -757,118 +759,118 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Failed to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your Union ID first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cannot read your PC information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No network connection</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Certificate loading failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Signature verification failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">योजनालाई सहमत र जुन्न गर्नुहोस्</translation>
     </message>
     <message>
         <source>The Disclaimer of Developer Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Setting new boot animation finished</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The settings will be applied after rebooting the system</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ConfirmManager</name>
     <message>
         <source>Password must contain numbers and letters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must be between 8 and 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CreateAccountDialog</name>
     <message>
         <source>Create a new account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">खाताको प्रकार</translation>
     </message>
     <message>
         <source>UserName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>FullName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">वैकल्पिक</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Create account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomAvatarEmpatyArea</name>
     <message>
         <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoModel</name>
     <message>
         <source>available</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoWork</name>
     <message>
         <source>https://www.deepin.org/en/agreement/privacy/</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/privacy-en</source>
@@ -1346,15 +1348,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">कथनको विचारहरू</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1536,15 +1538,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1826,7 +1828,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2063,7 +2065,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2261,15 +2263,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2343,7 +2345,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2780,57 +2782,57 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>UserExperienceProgramPage</name>
     <message>
         <source>Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VerifyDialog</name>
     <message>
         <source>Security Verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The action is sensitive, please enter the login password first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">8-64 वर्णहरू</translation>
     </message>
     <message>
         <source>Forgot Password?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WallpaperPage</name>
     <message>
         <source>wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">विंडोको बाँकी छोडको छेदको पार्दा</translation>
     </message>
     <message>
         <source>My pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solid color wallpaper</source>
@@ -2943,10 +2945,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>कम</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>मध्यम</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>बडा</translation>
     </message>
@@ -3010,6 +3008,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Extremely small</source>
         <translation>कामपन्न बहिरून कम</translation>
     </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">मध्यम</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">मध्यम</translation>
+    </message>
 </context>
 <context>
     <name>accounts</name>
@@ -3052,119 +3060,119 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identifying user identity through scanning fingerprints</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">इरिस</translation>
     </message>
     <message>
         <source>Identity recognition through iris scanning</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add a new </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>blueTooth</name>
     <message>
         <source>bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Bluetooth settings, devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>commonInfoMain</name>
     <message>
         <source>Boot Menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your boot menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer root permission management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer Options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>datetime</name>
     <message>
         <source>Time and date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time and date, time zone settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System language, region format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsController</name>
     <message>
         <source>Username must be between 3 and 32 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The first character must be a letter or number</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your username should not only have numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The username has been used by other user accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The full name has been used by other user accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard User</source>
@@ -3283,115 +3291,115 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>dccV25::PwqualityManager</name>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must have at least %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">लास्पासमा कम्पulsary राख्न सकिन्छ %1 वा त्यो भन्दा बढी अक्षरहरू</translation>
     </message>
     <message>
         <source>Password must be no more than %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">लास्पासमा कम्पulsary राख्न सकिन्छ %1 वा त्यो भन्दा कम अक्षरहरू</translation>
     </message>
     <message>
         <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">पासवर्ड मा अंग्रेजी वर्ण (विशेष रूप से विचारले), अंकहरू वा विशेष सिम्बोलहरू (~`!@#$%^&amp;*()-_+=|{}[]:&quot;&apos;&lt;&gt;,.?/) शामिल र सकिन्हो।</translation>
     </message>
     <message>
         <source>No more than %1 palindrome characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">%1 तयार वापरको पलिनड्रोम वर्णहरू अनुरोध</translation>
     </message>
     <message>
         <source>No more than %1 monotonic characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">%1 तयार वापरको एकाधिकारिक वर्णहरू अनुरोध</translation>
     </message>
     <message>
         <source>No more than %1 repeating characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">%1 तयार वापरको वापरित वर्णहरू अनुरोध</translation>
     </message>
     <message>
         <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">पासवर्डमा उचित अक्षरहरू, निषुल्क अक्षरहरू, अंकहरू र विशेष सिम्बोलहरू (~`!@#$%^&amp;*()-_+=|{}[]:&quot;&apos;&lt;&gt;,.?/) शामिल र सकिन्हो।</translation>
     </message>
     <message>
         <source>Password must not contain more than 4 palindrome characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">पासवर्डमा 4 तयार वापरको पलिनड्रोम वर्णहरू भन्दा अधिक वापर गर्न सकिन्हो।</translation>
     </message>
     <message>
         <source>Do not use common words and combinations as password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">सामान्य शब्दहरू वा योजनाहरू उपयोग गर्ने पासवर्ड राख्न सकिन्हो।</translation>
     </message>
     <message>
         <source>Create a strong password please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">कृपया शक्तिशाली पासवर्ड बनाउनुहोस्</translation>
     </message>
     <message>
         <source>It does not meet password rules</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">यो पासवर्ड नियमहरू सम्म न छ</translation>
     </message>
 </context>
 <context>
     <name>dccV25::ShortcutModel</name>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">सिस्टम</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>deepinid</name>
     <message>
         <source>deepin ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cloud services</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>defaultapp</name>
     <message>
         <source>Default App</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the default application for opening various types of files</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>defaultappMain</name>
     <message>
         <source>Webpage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mail</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text</source>
@@ -3623,7 +3631,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3890,7 +3898,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3992,7 +4000,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4053,7 +4061,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="nl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="nl">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -186,7 +188,7 @@ Neem het volgende in acht om de gezichtsherkenning zo goed als mogelijk in te st
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>‘Biometrische authenticatie’ is een functie die de gebruiker authenticeert. Deze functie wordt aangeboden door UnionTech Software Technology Co., Ltd. De biometrische gegevens worden vergeleken met de lokale gegevens op het apparaat, waarna er al dan niet verificatie plaatsvindt.
@@ -382,7 +384,7 @@ UnionTech Software doet onderzoek naar de verbetering en beveiliging van de func
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -416,78 +418,78 @@ UnionTech Software doet onderzoek naar de verbetering en beveiliging van de func
     </message>
     <message>
         <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Boot menu verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After opening, entering the menu editing requires a password.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change boot menu verification password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the boot menu authentication password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Name :</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>root</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>New Password :</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Voer een wachtwoord in</translation>
     </message>
     <message>
         <source>Passwords do not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat password:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Sure</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start animation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the size of the logo animation on the system startup interface</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Camera</name>
     <message>
         <source>Allow below apps to access your camera:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -634,391 +636,391 @@ UnionTech Software doet onderzoek naar de verbetering en beveiliging van de func
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ColorAndIcons</name>
     <message>
         <source>Accent Color</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Icon Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Icon Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize your theme icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cursor Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize your theme cursor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComfirmDeleteDialog</name>
     <message>
         <source>Are you sure you want to delete this account?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Delete account directory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ComfirmSafePage</name>
     <message>
         <source>Go to settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
 </context>
 <context>
     <name>Common</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat delay</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat rate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Numeric Keypad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>test here</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Caps lock prompt</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Double Click Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Double Click Test</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left Hand Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CommonInfoWork</name>
     <message>
         <source>Large size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Small size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your Union ID first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cannot read your PC information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No network connection</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Certificate loading failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Signature verification failed, unable to get root access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The Disclaimer of Developer Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Setting new boot animation finished</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The settings will be applied after rebooting the system</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ConfirmManager</name>
     <message>
         <source>Password must contain numbers and letters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password must be between 8 and 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CreateAccountDialog</name>
     <message>
         <source>Create a new account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Soort account</translation>
     </message>
     <message>
         <source>UserName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>FullName</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Create account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CustomAvatarEmpatyArea</name>
     <message>
         <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoModel</name>
     <message>
         <source>available</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DCC_NAMESPACE::SystemInfoWork</name>
     <message>
         <source>https://www.deepin.org/en/agreement/privacy/</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/privacy-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DateTimeSettingDialog</name>
     <message>
         <source>Date and time setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Year</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DatetimeModel</name>
     <message>
         <source>Tomorrow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yesterday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours earlier than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours later than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Space</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First day of week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Currency symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Positive currency</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Negative currency</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Decimal symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Digit grouping symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Digit grouping</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Page size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1032,658 +1034,658 @@ UnionTech Software doet onderzoek naar de verbetering en beveiliging van de func
     <name>DccColorDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Opslaan</translation>
     </message>
 </context>
 <context>
     <name>DccWindow</name>
     <message>
         <source>Control Center provides the options for system settings.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDAccountSecurity</name>
     <message>
         <source>Bind WeChat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unlinked</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unbinding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Link</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to unbind WeChat?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Let me think it over</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Local Account Binding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After binding your local account, you can use the following functions:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>WeChat Scan Code Login System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password via %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDInterface</name>
     <message>
         <source>deepin</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDLogin</name>
     <message>
         <source>Cloud Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinIDUserInfo</name>
     <message>
         <source>Synchronization Service</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign out</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operation Successful</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinidModel</name>
     <message>
         <source>Mainland China</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other regions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The feature is not available at present, please activate your system first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DetailItem</name>
     <message>
         <source>Please choose the default program to open &apos;%1&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Desktop file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apps (*.desktop)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>All files (*)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DevelopModePage</name>
     <message>
         <source>Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Request Root Access</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Online</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Login UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Offline</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Import Certificate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kies een bestand</translation>
     </message>
     <message>
         <source>Your UOS ID has been logged in, click to enter developer mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your UOS ID first and continue</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1.Export PC Info</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Export</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>3.Import Certificate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Development and debugging options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System logging level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Debug</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Verklaring</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FileAndFolder</name>
     <message>
         <source>Allow below apps to access these files and folders:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Documents</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Videos</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Downloads</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>folder</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FontSizePage</name>
     <message>
         <source>Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard Font</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monospaced Font</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GeneralPage</name>
     <message>
         <source>Power Plans</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saving Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto power saving on low battery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Low battery threshold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Laag accuniveau</translation>
     </message>
     <message>
         <source>Auto power saving on battery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wakeup Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password is required to wake up the computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password is required to wake up the monitor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Shutdown Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scheduled Shutdown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Once</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Every day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Working days</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Decrease screen brightness on power saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GestureModel</name>
     <message>
         <source>Three-finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Links</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Rechts</translation>
     </message>
     <message>
         <source>tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HomePage</name>
     <message>
         <source>,</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InterfaceEffectListview</name>
     <message>
         <source>Optimal Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KeyboardLayout</name>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Klaar</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bewerken</translation>
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangAndFormat</name>
     <message>
         <source>Language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Klaar</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bewerken</translation>
     </message>
     <message>
         <source>Other languages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region and format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangsChooserDialog</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LayoutsChooser</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LoginMethod</name>
     <message>
         <source>Login method</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password, wechat, biometric authentication, security key</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Modify password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Validity days</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Always</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1713,22 +1715,22 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No input device for sound found</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Mouse</name>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Speed</source>
@@ -1736,31 +1738,31 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse Acceleration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable touchpad when a mouse is connected</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Natural Scrolling</source>
@@ -1771,174 +1773,174 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>MyDevice</name>
     <message>
         <source>My Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>NativeInfoPage</name>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Computer name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>It cannot start or end with dashes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>OS Name</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Edition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>bit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Authorization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System installation time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Kernel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Graphics Platform</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Processor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Memory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>OtherDevice</name>
     <message>
         <source>Other Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show Bluetooth devices without names</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PasswordLayout</name>
     <message>
         <source>Current password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Weak</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Strong</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password hint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Voer een wachtwoord in</translation>
     </message>
     <message>
         <source>Passwords do not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>New password should differ from the current one</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PasswordModifyDialog</name>
     <message>
         <source>Modify password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resetting the password will clear the data stored in the keyring.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
 </context>
 <context>
     <name>PersonalizationInterface</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1963,115 +1965,115 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PowerOperatorModel</name>
     <message>
         <source>Shut down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Afsluiten</translation>
     </message>
     <message>
         <source>Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hibernate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off the monitor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show the shutdown Interface</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Do nothing</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerPage</name>
     <message>
         <source>Screen and Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Beeldscherm en pauzestand</translation>
     </message>
     <message>
         <source>Turn off the monitor after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Beeldscherm uitschakelen na</translation>
     </message>
     <message>
         <source>Lock screen after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Scherm vergrendelen na</translation>
     </message>
     <message>
         <source>Computer suspends after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Computer onderbreken na</translation>
     </message>
     <message>
         <source>When the lid is closed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Actie na sluiten van deksel</translation>
     </message>
     <message>
         <source>When the power button is pressed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Actie na indrukken van aan-/uitknop</translation>
     </message>
 </context>
 <context>
     <name>PowerPlansListview</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PowerWorker</name>
     <message>
         <source>Minutes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PrivacyPolicyPage</name>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2161,7 +2163,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>dde-control-center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch Screen Settings</source>
@@ -2173,298 +2175,298 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This system wallpaper is locked. Please contact your admin.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RegionFormatDialog</name>
     <message>
         <source>Regions and formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First day of week</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Short time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Currency symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Opslaan</translation>
     </message>
 </context>
 <context>
     <name>RegionsChooserWindow</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>RegisterDialog</name>
     <message>
         <source>Set a Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat the password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Passwords don&apos;t match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Opslaan</translation>
     </message>
 </context>
 <context>
     <name>ScreenSaverPage</name>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>preview</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>idle time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SearchableListViewPopup</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutSettingDialog</name>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Command:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click Add to replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Shortcuts</name>
     <message>
         <source>Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System shortcut, custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Aangepast</translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Klaar</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bewerken</translation>
     </message>
     <message>
         <source>Please enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SoundDevicemanagesPage</name>
     <message>
         <source>Output Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select whether to enable the devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2561,123 +2563,123 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No output device for sound found</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left Right Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mono audio</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Merge left and right channels into a single channel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto pause</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SyncInfoListModel</name>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ThemeSelectView</name>
     <message>
         <source>More Wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TimeAndDate</name>
     <message>
         <source>Auto sync time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ntp server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System date and time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Server address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The ntp server address cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use 24-hour format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>system time zone</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Timezone list</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>TimeRange</name>
     <message>
         <source>from</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2703,924 +2705,930 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>TimezoneDialog</name>
     <message>
         <source>Add time zone</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time zone:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nearest City:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Opslaan</translation>
     </message>
 </context>
 <context>
     <name>TouchScreen</name>
     <message>
         <source>TouchScreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set up here when connecting the touch screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Touchpad</name>
     <message>
         <source>Basic Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Aanwijzersnelheid</translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable touchpad during input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Tap to Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Natural Scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Natuurlijk scrollen</translation>
     </message>
     <message>
         <source>Gesture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger gestures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger gestures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UserExperienceProgramPage</name>
     <message>
         <source>Join User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VerifyDialog</name>
     <message>
         <source>Security Verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The action is sensitive, please enter the login password first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Forgot Password?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Annuleren</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WallpaperPage</name>
     <message>
         <source>wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>My pictures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Solid color wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customizable wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>fill style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic wallpaper change</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>30 second</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>login</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>wake up</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System Wallapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Live Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WallpaperSelectView</name>
     <message>
         <source>unfold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>show all</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>items</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set lock screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>WindowEffectPage</name>
     <message>
         <source>Interface and Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Klein</translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Groot</translation>
     </message>
     <message>
         <source>Enable transparent effects when moving windows</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window Minimize Effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scale</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Magic Lamp</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Opacity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Low</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>High</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Bars</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show on scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keep shown</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Altijd tonen</translation>
     </message>
     <message>
         <source>Compact Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>If enabled, more content is displayed in the window.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Title Bar Height</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only suitable for application window title bars drawn by the window manager.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extremely small</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>accounts</name>
     <message>
         <source>Account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account manager</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>accountsMain</name>
     <message>
         <source>Other accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>authentication</name>
     <message>
         <source>Biometric Authentication</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>authenticationMain</name>
     <message>
         <source>Biometric Authentication</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Up to 5 facial data can be entered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identifying user identity through scanning fingerprints</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identity recognition through iris scanning</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No more than 15 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add a new </source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>blueTooth</name>
     <message>
         <source>bluetooth</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Bluetooth settings, devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>commonInfoMain</name>
     <message>
         <source>Boot Menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your boot menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer root permission management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer Options</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>datetime</name>
     <message>
         <source>Time and date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time and date, time zone settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System language, region format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsController</name>
     <message>
         <source>Username must be between 3 and 32 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The first character must be a letter or number</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your username should not only have numbers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The username has been used by other user accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The full name has been used by other user accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard User</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customized</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AccountsWorker</name>
     <message>
         <source>Your host was removed from the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host joins the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to leave the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to join the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AD domain settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::AvatarTypesModel</name>
     <message>
         <source>Dimensional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::BiometricAuthController</name>
     <message>
         <source>Use your face to unlock the device and make settings later</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Faceprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and place it on the sensor again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Til je vinger op en plaats hem nogmaals op de lezer</translation>
     </message>
     <message>
         <source>Scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the position to scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and do that again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint added</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scan Suspended</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the edges of your fingerprint on the sensor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::KeyboardController</name>
     <message>
         <source>This shortcut conflicts with [%1]</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::PwqualityManager</name>
     <message>
         <source>Password cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Voer een wachtwoord in</translation>
     </message>
     <message>
         <source>Password must have at least %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord moet minimaal %1 tekens bevatten</translation>
     </message>
     <message>
         <source>Password must be no more than %1 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord mag niet langer zijn dan %1 tekens</translation>
     </message>
     <message>
         <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord mag alleen Nederlandstalige letters (hoofdlettergevoelig), cijfers of speciale tekens (~!@#$%^&amp;*()[]{}\|/?,.&lt;&gt;) bevatten</translation>
     </message>
     <message>
         <source>No more than %1 palindrome characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Maximaal %1 palindroomtekens</translation>
     </message>
     <message>
         <source>No more than %1 monotonic characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Maximaal %1 monotone tekens</translation>
     </message>
     <message>
         <source>No more than %1 repeating characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Maximaal %1 dezelfde tekens</translation>
     </message>
     <message>
         <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord moet hoofdletters, kleine letters, getallen en speciale tekens bevatten (~!@#$%^&amp;*()[]{}\|/?,.&lt;&gt;)</translation>
     </message>
     <message>
         <source>Password must not contain more than 4 palindrome characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord mag niet meer dan 4 palindroomtekens bevatten</translation>
     </message>
     <message>
         <source>Do not use common words and combinations as password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord mag geen algemene woorden of samenstellingen bevatten</translation>
     </message>
     <message>
         <source>Create a strong password please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Stel een sterk wachtwoord samen</translation>
     </message>
     <message>
         <source>It does not meet password rules</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Het wachtwoord voldoet niet aan de vereisten</translation>
     </message>
 </context>
 <context>
     <name>dccV25::ShortcutModel</name>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Aangepast</translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>deepinid</name>
     <message>
         <source>deepin ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cloud services</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>defaultapp</name>
     <message>
         <source>Default App</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the default application for opening various types of files</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>defaultappMain</name>
     <message>
         <source>Webpage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mail</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Terminal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>device</name>
     <message>
         <source>Device</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>display</name>
     <message>
         <source>Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Brightness,resolution,scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>displayMain</name>
     <message>
         <source>100%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>125%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>150%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>175%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>200%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>225%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>250%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>275%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>300%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Stretch</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Only on %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source> (Recommended)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hz</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Multiple Displays Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Modus</translation>
     </message>
     <message>
         <source>Main Screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display And Layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Brightness</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Refresh Rate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Rotation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>90°</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>180°</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>270°</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display Scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The monitor only supports 100% display scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Eye Comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable eye comfort</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>All day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sunset to Sunrise</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom Time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>from</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>to</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Color Temperature</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3631,33 +3639,33 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>keyboard</name>
     <message>
         <source>Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>General Settings, keyboard layout, input method, shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>keyboardMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set system default keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3755,369 +3763,369 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>mouse</name>
     <message>
         <source>Mouse and Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Common、Mouse、Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mouseMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>notification</name>
     <message>
         <source>DND mode, app notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Meldingen</translation>
     </message>
 </context>
 <context>
     <name>notificationMain</name>
     <message>
         <source>Do Not Disturb Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable Do Not Disturb</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>When the screen is locked</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Number of notifications shown on the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>App Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allow Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display notification on desktop or show unread messages in the notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock Screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Notification Center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Show message preview</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Play a sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>personalization</name>
     <message>
         <source>Personalization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>personalizationMain</name>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Appearance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window effect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Personalize your wallpaper and screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Colors and icons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust accent color and theme icons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Font and font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change system font and size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select light, dark or automatic theme appearance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>power</name>
     <message>
         <source>Power saving settings, screen and suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>powerMain</name>
     <message>
         <source>General</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Plugged In</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen and suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On Battery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>screen and suspend, low battery, battery management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>privacy</name>
     <message>
         <source>Privacy and Security</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Camera, folder permissions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>privacyMain</name>
     <message>
         <source>Camera</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Choose whether the application has access to the camera</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Files and Folders</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Choose whether the application has access to files and folders</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>sound</name>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output, input, sound effects, devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>soundMain</name>
     <message>
         <source>Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sound Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Geluidseffecten</translation>
     </message>
     <message>
         <source>Enable/disable sound effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable/disable audio devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>system</name>
     <message>
         <source>Common settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>systemInfo</name>
     <message>
         <source>Auxiliary Information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>systemInfoMain</name>
     <message>
         <source>About This PC</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System version, device information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View the notice of open source software</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Experience Program</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Join the user experience program to help improve the product</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>End User License Agreement</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View the end  user license agreement</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Privacy Policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>View information about privacy policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>touchscreen</name>
     <message>
         <source>Touchscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuring Touchscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>touchscreenMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>wacom</name>
     <message>
         <source>wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuring wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>wacomMain</name>
     <message>
         <source>wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wacom Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pen Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pressure Sensitivity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pl">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -186,7 +188,7 @@ Aby umiejętnie korzystać z rozpoznawania twarzy, podczas wprowadzania danych t
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>„Uwierzytelnienie biometryczne” to funkcja uwierzytelnienia tożsamości użytkownika stworzona przez UnionTech Software Technology Co., Ltd. Dzięki „uwierzytelnieniu biometrycznemu” zebrane dane biometryczne będą porównywane z danymi przechowywanymi na urządzeniu, a tożsamość użytkownika zostanie zweryfikowana na podstawie wyniku porównania.
@@ -2953,10 +2955,6 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
         <translation>Małe</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Średnie</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Duże</translation>
     </message>
@@ -3019,6 +3017,16 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
     <message>
         <source>Extremely small</source>
         <translation>Bardzo mała</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Średnie</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Średnie</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Pequeno</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Médio</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Grande</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Médio</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Médio</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">O nome completo é muito longo</translation>
     </message>
 </context>
 <context>
@@ -176,7 +178,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>&quot;A autenticação biométrica&quot; ​​é uma função para autenticação de identidade do usuário fornecida pela UnionTech Software Technology Co., Ltd. Por meio da &quot;autenticação biométrica&quot;, os dados biométricos coletados serão comparados com os armazenados no dispositivo, e a identidade do usuário será verificada com base no resultado da comparação.Observe que a UnionTech Software Technology Co., Ltd. não coletará ou acessará suas informações biométricas, que serão armazenadas em seu dispositivo local. Habilite apenas a autenticação biométrica em seu dispositivo pessoal e use suas próprias informações biométricas para operações relacionadas, e desabilite ou exclua imediatamente as informações biométricas de outras pessoas naquele dispositivo, caso contrário, você arcará com o risco decorrente disso.A UnionTech Software Technology Co., Ltd. está comprometida em pesquisar e melhorar a segurança, precisão e estabilidade da autenticação biométrica. No entanto, devido a fatores ambientais, de equipamento, técnicos e outros e controle de risco, não há garantia de que você passará pela autenticação biométrica temporariamente. Portanto, não tome a autenticação biométrica como a única maneira de fazer login no UOS.  Caso tenha alguma dúvida ou sugestão ao usar a autenticação biométrica, você pode nos dar um feedback através de &quot;Serviço e Suporte&quot; no UOS.</translation>
@@ -741,7 +743,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1531,15 +1533,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1821,7 +1823,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2256,15 +2258,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Cancelar</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Salvar</translation>
     </message>
 </context>
 <context>
@@ -2938,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Pequeno</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Média</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
@@ -3004,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Mínima</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Média</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Média</translation>
     </message>
 </context>
 <context>
@@ -3618,7 +3626,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4048,7 +4056,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Mic</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Mediu</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Mare</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Mediu</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Mediu</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ru">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Имя слишком длинное</translation>
     </message>
 </context>
 <context>
@@ -188,7 +190,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>&quot;Биометрическая аутентификация&quot; — это функция для аутентификации пользовательской идентификации, предоставленная компанией UnionTech Software Technology Co., Ltd. Через &quot;биометрическую аутентификацию&quot; собранные биометрические данные будут сравниваться с данными, сохраненными на устройстве, и пользовательская идентификация будет подтверждаться на основе результата сравнения.</translation>
@@ -381,7 +383,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -633,7 +635,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -753,7 +755,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1355,15 +1357,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1545,15 +1547,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1835,7 +1837,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2072,7 +2074,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2217,11 +2219,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2229,63 +2231,63 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Сохранить</translation>
     </message>
 </context>
 <context>
     <name>RegionsChooserWindow</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Поиск</translation>
     </message>
 </context>
 <context>
     <name>RegisterDialog</name>
     <message>
         <source>Set a Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">8-64 символа</translation>
     </message>
     <message>
         <source>Repeat the password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Passwords don&apos;t match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Отмена</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Сохранить</translation>
     </message>
 </context>
 <context>
     <name>ScreenSaverPage</name>
     <message>
         <source>Screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>preview</source>
@@ -2293,7 +2295,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
@@ -2301,47 +2303,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>idle time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 минута</translation>
     </message>
     <message>
         <source>5 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">5 минут</translation>
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">10 минут</translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">15 минут</translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">30 минут</translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 час</translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">никогда</translation>
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2352,7 +2354,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2793,7 +2795,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2952,10 +2954,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Маленький</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Средний</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Большой</translation>
     </message>
@@ -3018,6 +3016,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Очень маленький</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Средний</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Средний</translation>
     </message>
 </context>
 <context>
@@ -3093,7 +3101,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3632,7 +3640,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4001,7 +4009,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4062,7 +4070,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">මාධ්‍යය</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">මාධ්‍යය</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">මාධ්‍යය</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Malý</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Stredne</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Veľký</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Stredne</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Stredne</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sl">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sl">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ime je preprosto dolgo</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Prekliči</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Prekliči</translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Sem prebral/a in se strinjam z</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Oznanitvama</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Naprej</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -742,7 +744,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1345,15 +1347,15 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Oznanitvama</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Prekliči</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1535,15 +1537,15 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1825,7 +1827,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2062,7 +2064,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2260,15 +2262,15 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Prekliči</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Shrani</translation>
     </message>
 </context>
 <context>
@@ -2342,7 +2344,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2783,7 +2785,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2942,10 +2944,6 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
         <translation>Malo</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Srednje</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Veliko</translation>
     </message>
@@ -3008,6 +3006,16 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>Extremely small</source>
         <translation>Preprosto malo</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3083,7 +3091,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3622,7 +3630,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3889,7 +3897,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3991,7 +3999,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4052,7 +4060,7 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sq">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sq">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Emri i plotë është shumë i gjatë</translation>
     </message>
 </context>
 <context>
@@ -186,7 +188,7 @@ Me qëllim përdorimin më të mirë të njohjes së fytyrave, ju lutemi, bëni 
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>“Mirëfilltësimi biometrik” është një funksion mirëfilltësimi identiteti përdoruesi, që jepet nga UnionTech Software Technology Co., Ltd. Përmes “mirëfilltësimit biometrik”, të dhënat biometrike të grumbulluara do të krahasohen me ato të depozituara në pajisje dhe identiteti i përdoruesit do të verifikohet bazuar në përfundimin e krahasimit.
@@ -699,7 +701,7 @@ UnionTech Software Technology Co., Ltd. është e përkushtuar të studiojë dhe
     <name>Common</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat delay</source>
@@ -735,7 +737,7 @@ UnionTech Software Technology Co., Ltd. është e përkushtuar të studiojë dhe
     </message>
     <message>
         <source>Caps lock prompt</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Speed</source>
@@ -874,7 +876,7 @@ UnionTech Software Technology Co., Ltd. është e përkushtuar të studiojë dhe
     <name>DCC_NAMESPACE::SystemInfoModel</name>
     <message>
         <source>available</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1200,7 +1202,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
@@ -1273,11 +1275,11 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Allowed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enter</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Online</source>
@@ -1341,7 +1343,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Debug</source>
@@ -1715,7 +1717,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No input device for sound found</source>
@@ -2019,7 +2021,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <name>PowerPlansListview</name>
     <message>
         <source>High Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance Performance</source>
@@ -2736,7 +2738,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Set up here when connecting the touch screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2763,7 +2765,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Disable touchpad during input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Tap to Click</source>
@@ -2900,7 +2902,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Live Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
@@ -2911,7 +2913,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <name>WallpaperSelectView</name>
     <message>
         <source>unfold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>show all</source>
@@ -2950,15 +2952,11 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">E vogël</translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">E madhe</translation>
     </message>
     <message>
         <source>Enable transparent effects when moving windows</source>
@@ -3019,6 +3017,16 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>Extremely small</source>
         <translation>Tejet e vockël</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Çka</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Çka</translation>
     </message>
 </context>
 <context>
@@ -3209,7 +3217,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>AD domain settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password not match</source>
@@ -3235,7 +3243,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Faceprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger</source>
@@ -3651,7 +3659,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <name>keyboardMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Keyboard layout</source>
@@ -3761,14 +3769,14 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Common、Mouse、Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>mouseMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse</source>
@@ -3776,7 +3784,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Touchpad</translation>
     </message>
 </context>
 <context>
@@ -4081,14 +4089,14 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <name>touchscreenMain</name>
     <message>
         <source>Common</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>wacom</name>
     <message>
         <source>wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuring wacom</source>
@@ -4099,7 +4107,7 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <name>wacomMain</name>
     <message>
         <source>wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wacom Mode</source>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Мала</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Велика</translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="sv">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="sv">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Komplettera namnet är för långt</translation>
     </message>
 </context>
 <context>
@@ -102,7 +104,7 @@
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Face enrolled</source>
@@ -114,11 +116,11 @@
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
@@ -156,11 +158,11 @@ För att använda ansiktsidentifiering på ett bättre sätt, vänligen notera f
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
@@ -180,7 +182,7 @@ För att använda ansiktsidentifiering på ett bättre sätt, vänligen notera f
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Retry Enroll</source>
@@ -189,7 +191,7 @@ För att använda ansiktsidentifiering på ett bättre sätt, vänligen notera f
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>Biometrisk autentisering är en funktion för användaridentitetsautentisering som tillhandahålls av UnionTech Software Technology Co., Ltd. Genom biometrisk autentisering kommer de biometriska data som samlat in att jämföras med de som lagras på enheten, och användaridentiteten kommer att verifieras baserat på jämförelseresultatet.
@@ -214,7 +216,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
@@ -254,11 +256,11 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spara</translation>
     </message>
 </context>
 <context>
@@ -343,11 +345,11 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     <name>BlueToothDeviceListView</name>
     <message>
         <source>Disconnect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Connect</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Send Files</source>
@@ -370,7 +372,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     <name>BluetoothCtl</name>
     <message>
         <source>Edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Allow other Bluetooth devices to find this device</source>
@@ -386,7 +388,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -456,7 +458,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password cannot be empty</source>
@@ -472,7 +474,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Sure</source>
@@ -638,7 +640,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -653,7 +655,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Icon Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize your theme icon</source>
@@ -661,7 +663,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Cursor Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize your theme cursor</source>
@@ -676,15 +678,15 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Delete account directory</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Delete</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -695,7 +697,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
 </context>
 <context>
@@ -710,11 +712,11 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Short</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat rate</source>
@@ -722,11 +724,11 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Numeric Keypad</source>
@@ -758,7 +760,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -847,7 +849,7 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>FullName</source>
@@ -855,11 +857,11 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Create account</source>
@@ -923,15 +925,15 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Year</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Month</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Day</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
@@ -939,30 +941,30 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DatetimeModel</name>
     <message>
         <source>Tomorrow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Yesterday</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Today</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours earlier than local</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>%1 hours later than local</source>
@@ -1036,11 +1038,11 @@ UnionTech Software Technology Co., Ltd. är engagerat att forskar och förbättr
     <name>DccColorDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spara</translation>
     </message>
 </context>
 <context>
@@ -1144,7 +1146,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DeepinIDSyncService</name>
     <message>
         <source>Auto Sync</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
@@ -1172,7 +1174,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Clear</source>
@@ -1248,7 +1250,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Desktop file</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Apps (*.desktop)</source>
@@ -1358,15 +1360,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1393,7 +1395,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Downloads</source>
@@ -1408,11 +1410,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>FontSizePage</name>
     <message>
         <source>Size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard Font</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Monospaced Font</source>
@@ -1510,11 +1512,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Vänster</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Höger</translation>
     </message>
     <message>
         <source>tap</source>
@@ -1548,15 +1550,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1633,15 +1635,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1652,15 +1654,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1675,7 +1677,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Modify password</source>
@@ -1687,7 +1689,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Always</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1717,7 +1719,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No input device for sound found</source>
@@ -1732,7 +1734,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>Mouse</name>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Speed</source>
@@ -1740,11 +1742,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Size</source>
@@ -1752,15 +1754,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Short</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse Acceleration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable touchpad when a mouse is connected</source>
@@ -1798,7 +1800,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Version</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Edition</source>
@@ -1806,7 +1808,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>bit</source>
@@ -1838,7 +1840,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1860,15 +1862,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Weak</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Strong</source>
@@ -1876,11 +1878,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Repeat Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password hint</source>
@@ -1888,7 +1890,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Optional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password cannot be empty</source>
@@ -1900,7 +1902,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>New password should differ from the current one</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
@@ -1927,18 +1929,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
 </context>
 <context>
     <name>PersonalizationInterface</name>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dark</source>
@@ -1967,15 +1969,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PowerOperatorModel</name>
     <message>
         <source>Shut down</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Stäng av</translation>
     </message>
     <message>
         <source>Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hibernate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off the monitor</source>
@@ -2033,7 +2035,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Balanced</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power Saver</source>
@@ -2064,7 +2066,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2075,7 +2077,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2188,7 +2190,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default formats</source>
@@ -2228,18 +2230,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spara</translation>
     </message>
 </context>
 <context>
     <name>RegionsChooserWindow</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2258,11 +2260,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Passwords don&apos;t match</source>
@@ -2273,15 +2275,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spara</translation>
     </message>
 </context>
 <context>
@@ -2316,155 +2318,155 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>10 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">10 minuter</translation>
     </message>
     <message>
         <source>15 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">15 minuter</translation>
     </message>
     <message>
         <source>30 minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">30 minuter</translation>
     </message>
     <message>
         <source>1 hour</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">1 timme</translation>
     </message>
     <message>
         <source>never</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">aldrig</translation>
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SearchableListViewPopup</name>
     <message>
         <source>Search</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutSettingDialog</name>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Command:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click Add to replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Shortcuts</name>
     <message>
         <source>Shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System shortcut, custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Anpassat</translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">färdig</translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">redigera</translation>
     </message>
     <message>
         <source>Please enter a new shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>or</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Restore default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SoundDevicemanagesPage</name>
     <message>
         <source>Output Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Utdatatransferer</translation>
     </message>
     <message>
         <source>Select whether to enable the devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
@@ -2565,7 +2567,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Output</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No output device for sound found</source>
@@ -2600,15 +2602,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>SyncInfoListModel</name>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Update</source>
@@ -2654,7 +2656,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Required</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The ntp server address cannot be empty</source>
@@ -2723,11 +2725,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Spara</translation>
     </message>
 </context>
 <context>
@@ -2749,19 +2751,19 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Pointer Speed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Pekarhastighet</translation>
     </message>
     <message>
         <source>Slow</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fast</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable touchpad during input</source>
@@ -2769,11 +2771,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Tap to Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Natural Scrolling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Naturlig Scrollning</translation>
     </message>
     <message>
         <source>Gesture</source>
@@ -2796,7 +2798,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2819,11 +2821,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avbryt</translation>
     </message>
     <message>
         <source>Confirm</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2948,19 +2950,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable transparent effects when moving windows</source>
@@ -3022,6 +3020,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Extremely small</source>
         <translation>Överallt små</translation>
     </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>accounts</name>
@@ -3064,7 +3072,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identifying user identity through scanning fingerprints</source>
@@ -3096,7 +3104,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3114,7 +3122,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>commonInfoMain</name>
     <message>
         <source>Boot Menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Manage your boot menu</source>
@@ -3176,7 +3184,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Wrong password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard User</source>
@@ -3184,7 +3192,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Administrator</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customized</source>
@@ -3195,27 +3203,27 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>dccV25::AccountsWorker</name>
     <message>
         <source>Your host was removed from the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host joins the domain server successfully</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to leave the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Your host failed to join the domain server</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AD domain settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password not match</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3346,15 +3354,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>dccV25::ShortcutModel</name>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Window</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Workspace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>AssistiveTools</source>
@@ -3366,7 +3374,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3399,31 +3407,31 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>defaultappMain</name>
     <message>
         <source>Webpage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mail</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Text</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Music</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Video</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Terminal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3437,7 +3445,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>display</name>
     <message>
         <source>Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Brightness,resolution,scaling</source>
@@ -3484,15 +3492,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Duplicate</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fit</source>
@@ -3532,7 +3540,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Läge</translation>
     </message>
     <message>
         <source>Main Screen</source>
@@ -3544,11 +3552,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Brightness</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resolution</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resize Desktop</source>
@@ -3560,11 +3568,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Rotation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Standard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>90°</source>
@@ -3580,7 +3588,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Display Scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The monitor only supports 100% display scaling</source>
@@ -3635,7 +3643,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3668,11 +3676,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>main</name>
     <message>
         <source>Dock</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Läge</translation>
     </message>
     <message>
         <source>Classic Mode</source>
@@ -3688,11 +3696,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Small</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Large</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Position on the screen</source>
@@ -3708,11 +3716,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Left</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Vänster</translation>
     </message>
     <message>
         <source>Right</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Höger</translation>
     </message>
     <message>
         <source>Status</source>
@@ -3774,11 +3782,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Mouse</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3789,7 +3797,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Avisering</translation>
     </message>
 </context>
 <context>
@@ -3851,14 +3859,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>personalization</name>
     <message>
         <source>Personalization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>personalizationMain</name>
     <message>
         <source>Theme</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Appearance</source>
@@ -3894,7 +3902,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select light, dark or automatic theme appearance</source>
@@ -3913,14 +3921,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Power</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>powerMain</name>
     <message>
         <source>General</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
@@ -3977,7 +3985,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>sound</name>
     <message>
         <source>Sound</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output, input, sound effects, devices</source>
@@ -3992,7 +4000,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Sound Effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ljudeffekter</translation>
     </message>
     <message>
         <source>Enable/disable sound effects</source>
@@ -4004,7 +4012,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4015,7 +4023,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4065,7 +4073,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4117,11 +4125,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Pressure Sensitivity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">Ndogo</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished">Wastani</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">Kubwa</translation>
     </message>
@@ -3006,6 +3002,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Wastani</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Wastani</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="th">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="th">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ชื่อจริงยาวเกินไป</translation>
     </message>
 </context>
 <context>
@@ -110,19 +112,19 @@
     </message>
     <message>
         <source>Failed to enroll your face</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ยกเลิก</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,92 +138,92 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddFingerDialog</name>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ยกเลิก</translation>
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ฉันได้อ่านและยอมรับ</translation>
     </message>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">คำเตือน</translation>
     </message>
     <message>
         <source>Next</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ถัดไป</translation>
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AvatarSettingsDialog</name>
     <message>
         <source>Images</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Human</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Animal</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>custom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cartoon style</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -741,7 +743,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1344,15 +1346,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">คำเตือน</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ยกเลิก</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1534,15 +1536,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1824,7 +1826,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2061,7 +2063,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2259,15 +2261,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">ยกเลิก</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">บันทึก</translation>
     </message>
 </context>
 <context>
@@ -2341,7 +2343,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2782,7 +2784,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2941,10 +2943,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>เล็ก</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>กลาง</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>ใหญ่</translation>
     </message>
@@ -3007,6 +3005,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>เล็กมาก</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">กลาง</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">กลาง</translation>
     </message>
 </context>
 <context>
@@ -3082,7 +3090,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3621,7 +3629,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3888,7 +3896,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3990,7 +3998,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4051,7 +4059,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="tr">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="tr">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -11,7 +13,7 @@
     </message>
     <message>
         <source>Set fullname</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Login settings</source>
@@ -27,7 +29,7 @@
     </message>
     <message>
         <source>Delete current account</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Group setting</source>
@@ -39,7 +41,7 @@
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Group name</source>
@@ -51,7 +53,7 @@
     </message>
     <message>
         <source>Auto login, login without password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto login</source>
@@ -59,11 +61,11 @@
     </message>
     <message>
         <source>Account Information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account name, account fullname, account type</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account name</source>
@@ -71,7 +73,7 @@
     </message>
     <message>
         <source>Account fullname</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Account type</source>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Tam isim çok uzun</translation>
     </message>
 </context>
 <context>
@@ -114,7 +116,7 @@
     </message>
     <message>
         <source>Done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Tamamlandı</translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -122,7 +124,7 @@
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Before using face recognition, please note that: 
@@ -136,7 +138,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -151,11 +153,11 @@ In order to better use of face recognition, please pay attention to the followin
     </message>
     <message>
         <source>Enroll Finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>I have read and agree to the</source>
@@ -171,22 +173,22 @@ In order to better use of face recognition, please pay attention to the followin
     </message>
     <message>
         <source>Retry Enroll</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AutoLoginWarningDialog</name>
     <message>
         <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ok</source>
@@ -209,11 +211,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Scenery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Illustration</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Emoji</source>
@@ -225,15 +227,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Cartoon style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Dimensional style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -248,11 +250,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     <name>BatteryPage</name>
     <message>
         <source>Screen and Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off the monitor after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock screen after</source>
@@ -260,7 +262,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Computer suspends after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>When the lid is closed</source>
@@ -268,7 +270,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>When the power button is pressed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Low Battery</source>
@@ -276,7 +278,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Low battery notification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto suspend</source>
@@ -315,11 +317,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     <name>BlueToothAdaptersModel</name>
     <message>
         <source>Bluetooth is turned off, and the name is displayed as &quot;%1&quot;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Bluetooth is turned on, and the name is displayed as &quot;%1&quot;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -342,7 +344,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Remove Device</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Select file</source>
@@ -361,7 +363,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>To use the Bluetooth function, please turn off</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Airplane Mode</source>
@@ -369,7 +371,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -387,15 +389,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     <name>BootPage</name>
     <message>
         <source>Startup Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>grub start delay</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>theme</source>
@@ -403,15 +405,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Boot menu verification</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After opening, entering the menu editing requires a password.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change Password</source>
@@ -419,11 +421,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Change boot menu verification password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Set the boot menu authentication password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Name :</source>
@@ -459,22 +461,22 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Sure</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Start animation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the size of the logo animation on the system startup interface</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>Camera</name>
     <message>
         <source>Allow below apps to access your camera:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -621,7 +623,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -640,7 +642,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Customize your theme icon</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cursor Theme</source>
@@ -648,7 +650,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Customize your theme cursor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -721,7 +723,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Caps lock prompt</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scroll Speed</source>
@@ -741,7 +743,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -792,15 +794,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Setting new boot animation finished</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>The settings will be applied after rebooting the system</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -875,19 +877,19 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree and Join User Experience Program</source>
@@ -898,7 +900,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     <name>DateTimeSettingDialog</name>
     <message>
         <source>Date and time setting</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Date</source>
@@ -993,15 +995,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Decimal symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Digit grouping symbol</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Digit grouping</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Page size</source>
@@ -1041,7 +1043,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Unlinked</source>
@@ -1049,7 +1051,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Unbinding</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Link</source>
@@ -1057,15 +1059,15 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Are you sure you want to unbind WeChat?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Let me think it over</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Local Account Binding</source>
@@ -1077,23 +1079,23 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>WeChat Scan Code Login System</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password via %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1116,11 +1118,11 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     <message>
         <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Sign In to %1 ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1139,7 +1141,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Last sync time: %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Clear cloud data</source>
@@ -1178,14 +1180,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Go to web settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DeepinWorker</name>
     <message>
         <source>encrypt password failed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wrong password, %1 chances left</source>
@@ -1223,7 +1225,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DetailItem</name>
     <message>
         <source>Please choose the default program to open &apos;%1&apos;</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
@@ -1270,7 +1272,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Login UOS ID</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Offline</source>
@@ -1286,11 +1288,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Your UOS ID has been logged in, click to enter developer mode</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Please sign in to your UOS ID first and continue</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1.Export PC Info</source>
@@ -1302,7 +1304,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>3.Import Certificate</source>
@@ -1310,7 +1312,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Development and debugging options</source>
@@ -1318,11 +1320,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>System logging level</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Off</source>
@@ -1334,29 +1336,29 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Feragat</translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">İptal</translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FileAndFolder</name>
     <message>
         <source>Allow below apps to access these files and folders:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Documents</source>
@@ -1501,7 +1503,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1531,15 +1533,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1550,7 +1552,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>edit</source>
@@ -1558,11 +1560,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1573,7 +1575,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>edit</source>
@@ -1593,11 +1595,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Area</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region and format</source>
@@ -1605,7 +1607,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1650,23 +1652,23 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>LoginMethod</name>
     <message>
         <source>Login method</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password, wechat, biometric authentication, security key</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Parola</translation>
     </message>
     <message>
         <source>Modify password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Validity days</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Always</source>
@@ -1700,11 +1702,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>No input device for sound found</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
@@ -1765,7 +1767,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>NativeInfoPage</name>
     <message>
         <source>UOS</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">UOS</translation>
     </message>
     <message>
         <source>Computer name</source>
@@ -1797,7 +1799,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Authorization</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System installation time</source>
@@ -1809,7 +1811,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Graphics Platform</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Processor</source>
@@ -1821,7 +1823,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1894,7 +1896,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PasswordModifyDialog</name>
     <message>
         <source>Modify password</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Reset password</source>
@@ -1902,7 +1904,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Resetting the password will clear the data stored in the keyring.</source>
@@ -1977,11 +1979,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PowerPage</name>
     <message>
         <source>Screen and Suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Turn off the monitor after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lock screen after</source>
@@ -1989,7 +1991,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Computer suspends after</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>When the lid is closed</source>
@@ -1997,7 +1999,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>When the power button is pressed</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2012,7 +2014,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balanced</source>
@@ -2024,15 +2026,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2058,7 +2060,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2148,7 +2150,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>dde-control-center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Touch Screen Settings</source>
@@ -2167,7 +2169,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>RegionFormatDialog</name>
     <message>
         <source>Regions and formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search</source>
@@ -2175,7 +2177,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Default formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>First day of week</source>
@@ -2203,7 +2205,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Digit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Paper size</source>
@@ -2256,15 +2258,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">İptal</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Kaydet</translation>
     </message>
 </context>
 <context>
@@ -2275,11 +2277,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>preview</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Personalized screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>setting</source>
@@ -2287,7 +2289,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>idle time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 minute</source>
@@ -2319,11 +2321,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Password required for recovery</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Picture slideshow screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>System screensaver</source>
@@ -2338,14 +2340,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ShortcutSettingDialog</name>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Name:</source>
@@ -2381,7 +2383,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Click Add to replace</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2392,11 +2394,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>System shortcut, custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Search shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
@@ -2404,7 +2406,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>edit</source>
@@ -2416,7 +2418,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Click</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2432,11 +2434,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Restore default</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add custom shortcut</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2447,7 +2449,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select whether to enable the devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Input Devices</source>
@@ -2536,7 +2538,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left</source>
@@ -2552,27 +2554,27 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No output device for sound found</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Left Right Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mono audio</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Merge left and right channels into a single channel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Auto pause</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Output Devices</source>
@@ -2613,7 +2615,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>TimeAndDate</name>
     <message>
         <source>Auto sync time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Ntp server</source>
@@ -2621,7 +2623,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>System date and time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customize</source>
@@ -2633,7 +2635,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Server address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Required</source>
@@ -2641,19 +2643,19 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The ntp server address cannot be empty</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use 24-hour format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>system time zone</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Timezone list</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2671,11 +2673,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>TimeoutDialog</name>
     <message>
         <source>Save the display settings?</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Settings will be reverted in %1s.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Revert</source>
@@ -2694,7 +2696,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time zone:</source>
@@ -2702,7 +2704,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Nearest City:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2748,7 +2750,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Disable touchpad during input</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Tap to Click</source>
@@ -2760,15 +2762,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Gesture</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Three-finger gestures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Four-finger gestures</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2779,7 +2781,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2790,7 +2792,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The action is sensitive, please enter the login password first</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>8-64 characters</source>
@@ -2817,7 +2819,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>My pictures</source>
@@ -2829,19 +2831,19 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Solid color wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Customizable wallpapers</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>fill style</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Automatic wallpaper change</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>never</source>
@@ -2885,7 +2887,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Live Wallpaper</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>1 hour</source>
@@ -2896,7 +2898,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>WallpaperSelectView</name>
     <message>
         <source>unfold</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>show all</source>
@@ -2927,7 +2929,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Window rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>None</source>
@@ -2936,10 +2938,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Small</source>
         <translation>Küçük</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>Orta</translation>
     </message>
     <message>
         <source>Large</source>
@@ -2987,11 +2985,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Compact Display</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>If enabled, more content is displayed in the window.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Title Bar Height</source>
@@ -2999,11 +2997,21 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Only suitable for application window title bars drawn by the window manager.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Extremely small</source>
         <translation>Son derece küçük</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Orta</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Orta</translation>
     </message>
 </context>
 <context>
@@ -3021,7 +3029,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>accountsMain</name>
     <message>
         <source>Other accounts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3043,7 +3051,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Up to 5 facial data can be entered</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint</source>
@@ -3051,15 +3059,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Identifying user identity through scanning fingerprints</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identity recognition through iris scanning</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
@@ -3079,7 +3087,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3101,11 +3109,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Manage your boot menu</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer root permission management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Developer Options</source>
@@ -3116,11 +3124,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>datetime</name>
     <message>
         <source>Time and date</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time and date, time zone settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Language and region</source>
@@ -3128,7 +3136,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>System language, region format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3205,73 +3213,73 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>dccV25::AvatarTypesModel</name>
     <message>
         <source>Dimensional</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Flat</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::BiometricAuthController</name>
     <message>
         <source>Use your face to unlock the device and make settings later</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Faceprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and place it on the sensor again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Parmağınızı kaldırın ve yeniden algılayıcıya koyun</translation>
     </message>
     <message>
         <source>Scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust the position to scan the edges of your fingerprint</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Lift your finger and do that again</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Fingerprint added</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Scan Suspended</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Place the edges of your fingerprint on the sensor</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Iris</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>dccV25::KeyboardController</name>
     <message>
         <source>This shortcut conflicts with [%1]</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3341,7 +3349,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>AssistiveTools</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom</source>
@@ -3364,7 +3372,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Cloud services</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3375,7 +3383,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Set the default application for opening various types of files</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3424,7 +3432,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Brightness,resolution,scaling</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3455,7 +3463,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>250%</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>275%</source>
@@ -3491,11 +3499,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Only on %1</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source> (Recommended)</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Hz</source>
@@ -3503,15 +3511,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Multiple Displays Settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Identify</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Mode</source>
@@ -3519,11 +3527,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Main Screen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display And Layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Brightness</source>
@@ -3579,7 +3587,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time</source>
@@ -3591,7 +3599,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Sunset to Sunrise</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Custom Time</source>
@@ -3618,7 +3626,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3629,7 +3637,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>General Settings, keyboard layout, input method, shortcuts</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3644,7 +3652,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Set system default keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3746,7 +3754,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Common、Mouse、Touchpad</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3783,7 +3791,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable Do Not Disturb</source>
@@ -3795,7 +3803,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Number of notifications shown on the desktop</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>App Notifications</source>
@@ -3803,11 +3811,11 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Allow Notifications</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Display notification on desktop or show unread messages in the notification center</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Desktop</source>
@@ -3853,7 +3861,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Personalize your wallpaper and screensaver</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Screensaver</source>
@@ -3861,19 +3869,19 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Colors and icons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Adjust accent color and theme icons</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Font and font size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Change system font and size</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Wallpaper</source>
@@ -3881,18 +3889,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select light, dark or automatic theme appearance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>power</name>
     <message>
         <source>Power saving settings, screen and suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Power</source>
@@ -3907,7 +3915,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Plugged In</source>
@@ -3915,7 +3923,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Screen and suspend</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>On Battery</source>
@@ -3923,7 +3931,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>screen and suspend, low battery, battery management</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3934,7 +3942,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Camera, folder permissions</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3945,7 +3953,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Choose whether the application has access to the camera</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Files and Folders</source>
@@ -3953,7 +3961,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Choose whether the application has access to files and folders</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3964,7 +3972,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Output, input, sound effects, devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3979,15 +3987,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Enable/disable sound effects</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable/disable audio devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4005,7 +4013,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>systemInfo</name>
     <message>
         <source>Auxiliary Information</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4020,7 +4028,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View the notice of open source software</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>User Experience Program</source>
@@ -4028,7 +4036,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Join the user experience program to help improve the product</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>End User License Agreement</source>
@@ -4036,7 +4044,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View the end  user license agreement</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Privacy Policy</source>
@@ -4044,22 +4052,22 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>View information about privacy policy</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>touchscreen</name>
     <message>
         <source>Touchscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Configuring Touchscreen</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4077,7 +4085,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Configuring wacom</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4100,7 +4108,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Pressure Sensitivity</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Light</source>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished">كىچىك</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished">چوڭ</translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="uk">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="uk">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Ім&apos;я повністю є надто довгим</translation>
     </message>
 </context>
 <context>
@@ -187,7 +189,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>«Біометричне розпізнавання» — функціональна можливість розпізнавання користувачів, яка надається UnionTech Software Technology Co, Ltd. Під час «біометричного розпізнавання» зібрані біометричні дані буде порівняно із даними, які зберігаються на пристрої. Ідентичність користувача буде встановлено на основі результатів порівняння.
@@ -754,7 +756,7 @@ UnionTech Software Technology Co, Ltd працює над вивченням і 
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1835,7 +1837,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2952,10 +2954,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Малий</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Середній</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Великий</translation>
     </message>
@@ -3018,6 +3016,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Надзвичайно мала</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished">Середній</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished">Середній</translation>
     </message>
 </context>
 <context>
@@ -4062,7 +4070,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -2940,10 +2940,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3005,6 +3001,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Extremely small</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="vi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="vi">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -79,7 +81,7 @@
     </message>
     <message>
         <source>The full name is too long</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Tên đầy đủ quá dài</translation>
     </message>
 </context>
 <context>
@@ -196,7 +198,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>Biometric authentication là một chức năng xác thực danh tính người dùng cung cấp bởi UnionTech Software Technology Co., Ltd. Qua biometric authentication, dữ liệu sinh trắc học thu thập sẽ được so sánh với dữ liệu lưu trữ trong thiết bị, và danh tính người dùng sẽ được xác thực dựa trên kết quả so sánh.
@@ -393,7 +395,7 @@ UnionTech Software Technology Co., Ltd. cam kết nghiên cứu và cải thiệ
     </message>
     <message>
         <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -645,7 +647,7 @@ UnionTech Software Technology Co., Ltd. cam kết nghiên cứu và cải thiệ
     </message>
     <message>
         <source>Camera occupied!</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -765,7 +767,7 @@ UnionTech Software Technology Co., Ltd. cam kết nghiên cứu và cải thiệ
     </message>
     <message>
         <source>Enable Keyboard</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1368,15 +1370,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>DisclaimerControl</name>
     <message>
         <source>Disclaimer</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Agree</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1528,118 +1530,118 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>tap</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>HomePage</name>
     <message>
         <source>,</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>InterfaceEffectListview</name>
     <message>
         <source>Optimal Performance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Balance</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Best Visuals</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>KeyboardLayout</name>
     <message>
         <source>Keyboard layout</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Bố cục bàn phím</translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Add new keyboard layout...</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangAndFormat</name>
     <message>
         <source>Language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>done</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>edit</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Other languages</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>add</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thêm</translation>
     </message>
     <message>
         <source>Region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Area</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Region and format</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LangsChooserDialog</name>
     <message>
         <source>Add language</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Thêm ngôn ngữ</translation>
     </message>
     <message>
         <source>Search</source>
@@ -1848,7 +1850,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>1~63 characters please</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2085,7 +2087,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2283,15 +2285,15 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>ScheduledShutdownDialog</name>
     <message>
         <source>Customize repetition time</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Save</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished">Lưu</translation>
     </message>
 </context>
 <context>
@@ -2365,7 +2367,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>No search results</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2806,7 +2808,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Copy Link Address</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -2965,10 +2967,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Nhỏ</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>Trung bình</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>Lớn</translation>
     </message>
@@ -3031,6 +3029,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>Rất nhỏ</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3106,7 +3114,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>This name already exists</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3645,7 +3653,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -3912,7 +3920,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Interface and effects, rounded corners</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4014,7 +4022,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Devices</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4075,7 +4083,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_CN">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="zh_CN">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -187,7 +189,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>“生物认证”是统信软件技术有限公司提供的一种对用户进行身份认证的功能。通过“生物认证”，将采集的生物识别数据与存储在设备本地的生物识别数据进行比对，并根据比对结果来验证用户身份。
@@ -2705,19 +2707,19 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>TimezoneDialog</name>
     <message>
         <source>Add time zone</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Time zone:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Nearest City:</source>
-        <translation type="unfinished"/>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Cancel</source>
@@ -2953,10 +2955,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>小</translation>
     </message>
     <message>
-        <source>Medium</source>
-        <translation>中</translation>
-    </message>
-    <message>
         <source>Large</source>
         <translation>大</translation>
     </message>
@@ -3019,6 +3017,16 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Extremely small</source>
         <translation>极小</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation>中</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation>中</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -1,131 +1,133 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_HK">
-<context>
-    <name>AccountSettings</name>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Add new user</source>
-        <translation>添加新用户</translation>
-    </message>
-    <message>
-        <source>Set fullname</source>
-        <translation>設置全名</translation>
-    </message>
-    <message>
-        <source>Login settings</source>
-        <translation>登錄設置</translation>
-    </message>
-    <message>
-        <source>Login Settings</source>
-        <translation>登錄設置</translation>
-    </message>
-    <message>
-        <source>Login without password</source>
-        <translation>免密登錄</translation>
-    </message>
-    <message>
-        <source>Delete current account</source>
-        <translation>刪除當前賬户</translation>
-    </message>
-    <message>
-        <source>Group setting</source>
-        <translation>用户組設置</translation>
-    </message>
-    <message>
-        <source>Account groups</source>
-        <translation>用户組</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>Group name</source>
-        <translation>用户組名稱</translation>
-    </message>
-    <message>
-        <source>Add group</source>
-        <translation>添加用户組</translation>
-    </message>
-    <message>
-        <source>Auto login, login without password</source>
-        <translation>自動登錄, 免密登錄</translation>
-    </message>
-    <message>
-        <source>Auto login</source>
-        <translation>自動登錄</translation>
-    </message>
-    <message>
-        <source>Account Information</source>
-        <translation>賬户信息</translation>
-    </message>
-    <message>
-        <source>Account name, account fullname, account type</source>
-        <translation>賬户名，全名，賬户類型</translation>
-    </message>
-    <message>
-        <source>Account name</source>
-        <translation>賬户名</translation>
-    </message>
-    <message>
-        <source>Account fullname</source>
-        <translation>賬户全名</translation>
-    </message>
-    <message>
-        <source>Account type</source>
-        <translation>賬户類型</translation>
-    </message>
-    <message>
-        <source>The full name is too long</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>AddFaceinfoDialog</name>
-    <message>
-        <source>Enroll Face</source>
-        <translation>添加人臉數據</translation>
-    </message>
-    <message>
-        <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
-        <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
-    </message>
-    <message>
-        <source>I have read and agree to the</source>
-        <translation>我已閲讀並同意</translation>
-    </message>
-    <message>
-        <source>Disclaimer</source>
-        <translation>《用户免責聲明》</translation>
-    </message>
-    <message>
-        <source>Next</source>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <source>Face enrolled</source>
-        <translation>人臉錄入完成</translation>
-    </message>
-    <message>
-        <source>Failed to enroll your face</source>
-        <translation>人臉錄入失敗</translation>
-    </message>
-    <message>
-        <source>Done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Retry Enroll</source>
-        <translation>重新錄入</translation>
-    </message>
-    <message>
-        <source>Before using face recognition, please note that: 
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_HK" version="2.1">
+    <context>
+        <name>AccountSettings</name>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Add new user</source>
+            <translation>添加新用户</translation>
+        </message>
+        <message>
+            <source>Set fullname</source>
+            <translation>設置全名</translation>
+        </message>
+        <message>
+            <source>Login settings</source>
+            <translation>登錄設置</translation>
+        </message>
+        <message>
+            <source>Login Settings</source>
+            <translation>登錄設置</translation>
+        </message>
+        <message>
+            <source>Login without password</source>
+            <translation>免密登錄</translation>
+        </message>
+        <message>
+            <source>Delete current account</source>
+            <translation>刪除當前賬户</translation>
+        </message>
+        <message>
+            <source>Group setting</source>
+            <translation>用户組設置</translation>
+        </message>
+        <message>
+            <source>Account groups</source>
+            <translation>用户組</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>Group name</source>
+            <translation>用户組名稱</translation>
+        </message>
+        <message>
+            <source>Add group</source>
+            <translation>添加用户組</translation>
+        </message>
+        <message>
+            <source>Auto login, login without password</source>
+            <translation>自動登錄, 免密登錄</translation>
+        </message>
+        <message>
+            <source>Auto login</source>
+            <translation>自動登錄</translation>
+        </message>
+        <message>
+            <source>Account Information</source>
+            <translation>賬户信息</translation>
+        </message>
+        <message>
+            <source>Account name, account fullname, account type</source>
+            <translation>賬户名，全名，賬户類型</translation>
+        </message>
+        <message>
+            <source>Account name</source>
+            <translation>賬户名</translation>
+        </message>
+        <message>
+            <source>Account fullname</source>
+            <translation>賬户全名</translation>
+        </message>
+        <message>
+            <source>Account type</source>
+            <translation>賬户類型</translation>
+        </message>
+        <message>
+            <source>The full name is too long</source>
+            <translation>名稱過長</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddFaceinfoDialog</name>
+        <message>
+            <source>Enroll Face</source>
+            <translation>添加人臉數據</translation>
+        </message>
+        <message>
+            <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
+            <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
+        </message>
+        <message>
+            <source>I have read and agree to the</source>
+            <translation>我已閲讀並同意</translation>
+        </message>
+        <message>
+            <source>Disclaimer</source>
+            <translation>《用户免責聲明》</translation>
+        </message>
+        <message>
+            <source>Next</source>
+            <translation>下一步</translation>
+        </message>
+        <message>
+            <source>Face enrolled</source>
+            <translation>人臉錄入完成</translation>
+        </message>
+        <message>
+            <source>Failed to enroll your face</source>
+            <translation>人臉錄入失敗</translation>
+        </message>
+        <message>
+            <source>Done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Retry Enroll</source>
+            <translation>重新錄入</translation>
+        </message>
+        <message>
+            <source>Before using face recognition, please note that: 
 1. Your device may be unlocked by people or objects that look or appear similar to you.
 2. Face recognition is less secure than digital passwords and mixed passwords.
 3. The success rate of unlocking your device through face recognition will be reduced in a low-light, high-light, back-light, large angle scenario and other scenarios.
@@ -136,7 +138,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation>在使用人臉識別功能前，請注意以下事項：
+            <translation>在使用人臉識別功能前，請注意以下事項：
 1.您的設備可能會被容貌、外形與您相近的人或物品解鎖。
 2.人臉識別的安全性低於數字密碼、混合密碼。
 3.在暗光、強光、逆光或角度過大等場景下，人臉識別的解鎖成功率會有所降低。
@@ -147,3977 +149,3983 @@ In order to better use of face recognition, please pay attention to the followin
 1.請保證光線充足，避免陽光直射並避免其他人出現在錄入的畫面中。
 2.請注意錄入數據時的面部狀態，避免衣帽、頭髮、墨鏡、口罩、濃妝等遮擋面部信息。
 3.請避免仰頭、低頭、閉眼或僅露出側臉的情況，確保臉部正面清晰完整的出現在提示框內。</translation>
-    </message>
-</context>
-<context>
-    <name>AddFingerDialog</name>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>Enroll Finger</source>
-        <translation>添加指紋數據</translation>
-    </message>
-    <message>
-        <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation>將要錄入的手指放入指紋錄入器裏面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
-    </message>
-    <message>
-        <source>I have read and agree to the</source>
-        <translation>我已閲讀並同意</translation>
-    </message>
-    <message>
-        <source>Disclaimer</source>
-        <translation>《用户免責聲明》</translation>
-    </message>
-    <message>
-        <source>Next</source>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <source>Retry Enroll</source>
-        <translation>重新錄入</translation>
-    </message>
-    <message>
-        <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
+        </message>
+    </context>
+    <context>
+        <name>AddFingerDialog</name>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>Enroll Finger</source>
+            <translation>添加指紋數據</translation>
+        </message>
+        <message>
+            <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
+            <translation>將要錄入的手指放入指紋錄入器裏面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
+        </message>
+        <message>
+            <source>I have read and agree to the</source>
+            <translation>我已閲讀並同意</translation>
+        </message>
+        <message>
+            <source>Disclaimer</source>
+            <translation>《用户免責聲明》</translation>
+        </message>
+        <message>
+            <source>Next</source>
+            <translation>下一步</translation>
+        </message>
+        <message>
+            <source>Retry Enroll</source>
+            <translation>重新錄入</translation>
+        </message>
+        <message>
+            <source>"Biometric authentication" is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through "biometric authentication", the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
 Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
 
-UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation>「生物認證」是統信軟件技術有限公司提供的一種對用户進行身份認證的功能。通過「生物認證」，將採集的生物識別數據與存儲在設備本地的生物識別數據進行比對，並根據比對結果來驗證用户身份。
+UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through "Service and Support" in the UOS.</source>
+            <translation>「生物認證」是統信軟件技術有限公司提供的一種對用户進行身份認證的功能。通過「生物認證」，將採集的生物識別數據與存儲在設備本地的生物識別數據進行比對，並根據比對結果來驗證用户身份。
         請您注意，統信軟件不會收集或訪問您的生物識別信息，此類信息將會存儲在您的本地設備中。請您僅在您的個人設備中開啓生物認證功能，並使用您本人的生物識別信息進行相關操作，並及時在該設備上禁用或清除他人的生物識別信息，否則由此給您帶來的風險將由您承擔。
         統信軟件致力於研究與提高生物認證功能的安全性、精確性、與穩定性，但是，受限於環境、設備、技術等因素和風險控制等原因，我們暫時無法保證您一定能通過生物認證，請您不要將生物認證作為登錄統信作業系統的唯一途徑。若您在使用生物認證時有任何問題或建議的，可以通過系統內的「服務與支持」進行反饋。</translation>
-    </message>
-</context>
-<context>
-    <name>AutoLoginWarningDialog</name>
-    <message>
-        <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation>只允許一個賬户開啓自動登錄，請先關閉%1賬户的自動登錄，再進行操作</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>確 定</translation>
-    </message>
-</context>
-<context>
-    <name>AvatarSettingsDialog</name>
-    <message>
-        <source>Images</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <source>Human</source>
-        <translation>人物</translation>
-    </message>
-    <message>
-        <source>Animal</source>
-        <translation>動物</translation>
-    </message>
-    <message>
-        <source>Scenery</source>
-        <translation>靜物</translation>
-    </message>
-    <message>
-        <source>Illustration</source>
-        <translation>創意插圖</translation>
-    </message>
-    <message>
-        <source>Emoji</source>
-        <translation>表情符號</translation>
-    </message>
-    <message>
-        <source>custom</source>
-        <translation>自定義圖片</translation>
-    </message>
-    <message>
-        <source>Cartoon style</source>
-        <translation>Q版風格</translation>
-    </message>
-    <message>
-        <source>Dimensional style</source>
-        <translation>立體風格</translation>
-    </message>
-    <message>
-        <source>Flat style</source>
-        <translation>平面風格</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>保存</translation>
-    </message>
-</context>
-<context>
-    <name>BatteryPage</name>
-    <message>
-        <source>Screen and Suspend</source>
-        <translation>屏幕和待機</translation>
-    </message>
-    <message>
-        <source>Turn off the monitor after</source>
-        <translation>關閉顯示器</translation>
-    </message>
-    <message>
-        <source>Lock screen after</source>
-        <translation>自動鎖屏</translation>
-    </message>
-    <message>
-        <source>Computer suspends after</source>
-        <translation>進入待機</translation>
-    </message>
-    <message>
-        <source>When the lid is closed</source>
-        <translation>筆記本合蓋時</translation>
-    </message>
-    <message>
-        <source>When the power button is pressed</source>
-        <translation>按電源按鈕時</translation>
-    </message>
-    <message>
-        <source>Low Battery</source>
-        <translation>低電量管理</translation>
-    </message>
-    <message>
-        <source>Low battery notification</source>
-        <translation>低電量提醒</translation>
-    </message>
-    <message>
-        <source>Auto suspend</source>
-        <translation>自動待機</translation>
-    </message>
-    <message>
-        <source>Auto Hibernate</source>
-        <translation>自動休眠</translation>
-    </message>
-    <message>
-        <source>Low battery threshold</source>
-        <translation>低電量閾值</translation>
-    </message>
-    <message>
-        <source>Battery Management</source>
-        <translation>電池管理</translation>
-    </message>
-    <message>
-        <source>Display remaining using and charging time</source>
-        <translation>顯示剩餘使用時間及剩餘充電時間</translation>
-    </message>
-    <message>
-        <source>Maximum capacity</source>
-        <translation>最大容量</translation>
-    </message>
-    <message>
-        <source>Low battery level</source>
-        <translation>低電量時</translation>
-    </message>
-    <message>
-        <source>Disable</source>
-        <translation>從不</translation>
-    </message>
-</context>
-<context>
-    <name>BlueToothAdaptersModel</name>
-    <message>
-        <source>Bluetooth is turned off, and the name is displayed as &quot;%1&quot;</source>
-        <translation>藍牙已關閉，名稱顯示為&quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Bluetooth is turned on, and the name is displayed as &quot;%1&quot;</source>
-        <translation>藍牙已打開，名稱顯示為 &quot;%1&quot;</translation>
-    </message>
-</context>
-<context>
-    <name>BlueToothDeviceListView</name>
-    <message>
-        <source>Disconnect</source>
-        <translation>斷開連接</translation>
-    </message>
-    <message>
-        <source>Connect</source>
-        <translation>連接</translation>
-    </message>
-    <message>
-        <source>Send Files</source>
-        <translation>發送文件</translation>
-    </message>
-    <message>
-        <source>Rename</source>
-        <translation>重命名</translation>
-    </message>
-    <message>
-        <source>Remove Device</source>
-        <translation>移除設備</translation>
-    </message>
-    <message>
-        <source>Select file</source>
-        <translation>選擇文件</translation>
-    </message>
-</context>
-<context>
-    <name>BluetoothCtl</name>
-    <message>
-        <source>Edit</source>
-        <translation>修改</translation>
-    </message>
-    <message>
-        <source>Allow other Bluetooth devices to find this device</source>
-        <translation>允許其他藍牙設備找到該設備</translation>
-    </message>
-    <message>
-        <source>To use the Bluetooth function, please turn off</source>
-        <translation>如需使用藍牙功能，請關閉</translation>
-    </message>
-    <message>
-        <source>Airplane Mode</source>
-        <translation>飛行模式</translation>
-    </message>
-    <message>
-        <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation>藍牙名稱不能超過64個字符</translation>
-    </message>
-</context>
-<context>
-    <name>BluetoothDeviceModel</name>
-    <message>
-        <source>Connected</source>
-        <translation>已連接</translation>
-    </message>
-    <message>
-        <source>Not connected</source>
-        <translation>未連接</translation>
-    </message>
-</context>
-<context>
-    <name>BootPage</name>
-    <message>
-        <source>Startup Settings</source>
-        <translation>啓動設置</translation>
-    </message>
-    <message>
-        <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-        <translation>您可以點擊菜單改變默認啓動項，也可以拖拽圖片到窗口改變背景圖片.</translation>
-    </message>
-    <message>
-        <source>grub start delay</source>
-        <translation>啓動延時</translation>
-    </message>
-    <message>
-        <source>theme</source>
-        <translation>主題</translation>
-    </message>
-    <message>
-        <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-        <translation>開啓主題後您可以在開機時看到主題背景</translation>
-    </message>
-    <message>
-        <source>Boot menu verification</source>
-        <translation>啓動菜單驗證</translation>
-    </message>
-    <message>
-        <source>After opening, entering the menu editing requires a password.</source>
-        <translation>開啓後進入啓動菜單編輯需要密碼.</translation>
-    </message>
-    <message>
-        <source>Change Password</source>
-        <translation>修改密碼</translation>
-    </message>
-    <message>
-        <source>Change boot menu verification password</source>
-        <translation>修改啓動菜單驗證密碼</translation>
-    </message>
-    <message>
-        <source>Set the boot menu authentication password</source>
-        <translation>設置啓動菜單驗證密碼</translation>
-    </message>
-    <message>
-        <source>User Name :</source>
-        <translation>用户名：</translation>
-    </message>
-    <message>
-        <source>root</source>
-        <translation>root</translation>
-    </message>
-    <message>
-        <source>New Password :</source>
-        <translation>新密碼：</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Passwords do not match</source>
-        <translation>密碼不一致</translation>
-    </message>
-    <message>
-        <source>Repeat password:</source>
-        <translation>確認密碼：</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Sure</source>
-        <translation>確定</translation>
-    </message>
-    <message>
-        <source>Start animation</source>
-        <translation>啓動動畫</translation>
-    </message>
-    <message>
-        <source>Adjust the size of the logo animation on the system startup interface</source>
-        <translation>調整系統啓動界面的logo動畫尺寸大小</translation>
-    </message>
-</context>
-<context>
-    <name>Camera</name>
-    <message>
-        <source>Allow below apps to access your camera:</source>
-        <translation>允許下面的應用訪問您的攝像頭</translation>
-    </message>
-</context>
-<context>
-    <name>CharaMangerModel</name>
-    <message>
-        <source>Fingerprint1</source>
-        <translation>指紋1</translation>
-    </message>
-    <message>
-        <source>Fingerprint2</source>
-        <translation>指紋2</translation>
-    </message>
-    <message>
-        <source>Fingerprint3</source>
-        <translation>指紋3</translation>
-    </message>
-    <message>
-        <source>Fingerprint4</source>
-        <translation>指紋4</translation>
-    </message>
-    <message>
-        <source>Fingerprint5</source>
-        <translation>指紋5</translation>
-    </message>
-    <message>
-        <source>Fingerprint6</source>
-        <translation>指紋6</translation>
-    </message>
-    <message>
-        <source>Fingerprint7</source>
-        <translation>指紋7</translation>
-    </message>
-    <message>
-        <source>Fingerprint8</source>
-        <translation>指紋8</translation>
-    </message>
-    <message>
-        <source>Fingerprint9</source>
-        <translation>指紋9</translation>
-    </message>
-    <message>
-        <source>Fingerprint10</source>
-        <translation>指紋10</translation>
-    </message>
-    <message>
-        <source>Scan failed</source>
-        <translation>指紋錄入失敗</translation>
-    </message>
-    <message>
-        <source>The fingerprint already exists</source>
-        <translation>指紋已存在</translation>
-    </message>
-    <message>
-        <source>Please scan other fingers</source>
-        <translation>請使用其他手指錄入</translation>
-    </message>
-    <message>
-        <source>Unknown error</source>
-        <translation>未知錯誤</translation>
-    </message>
-    <message>
-        <source>Scan suspended</source>
-        <translation>指紋錄入被中斷</translation>
-    </message>
-    <message>
-        <source>Cannot recognize</source>
-        <translation>無法識別</translation>
-    </message>
-    <message>
-        <source>Moved too fast</source>
-        <translation>接觸時間短</translation>
-    </message>
-    <message>
-        <source>Finger moved too fast, please do not lift until prompted</source>
-        <translation>接觸時間短，驗證時請勿移動手指</translation>
-    </message>
-    <message>
-        <source>Unclear fingerprint</source>
-        <translation>圖像模糊</translation>
-    </message>
-    <message>
-        <source>Clean your finger or adjust the finger position, and try again</source>
-        <translation>請清潔手指或調整觸摸位置，再次按壓指紋識別器</translation>
-    </message>
-    <message>
-        <source>Already scanned</source>
-        <translation>圖像重複</translation>
-    </message>
-    <message>
-        <source>Adjust the finger position to scan your fingerprint fully</source>
-        <translation>請調整手指按壓區域以錄入更多指紋</translation>
-    </message>
-    <message>
-        <source>Finger moved too fast. Please do not lift until prompted</source>
-        <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
-    </message>
-    <message>
-        <source>Lift your finger and place it on the sensor again</source>
-        <translation>請擡起手指，再次按壓</translation>
-    </message>
-    <message>
-        <source>Position your face inside the frame</source>
-        <translation>請確保您的面部全部顯示在識別區域內</translation>
-    </message>
-    <message>
-        <source>Face enrolled</source>
-        <translation>人臉錄入完成</translation>
-    </message>
-    <message>
-        <source>Position a human face please</source>
-        <translation>請使用人類面容</translation>
-    </message>
-    <message>
-        <source>Keep away from the camera</source>
-        <translation>請遠離鏡頭</translation>
-    </message>
-    <message>
-        <source>Get closer to the camera</source>
-        <translation>請靠近鏡頭</translation>
-    </message>
-    <message>
-        <source>Do not position multiple faces inside the frame</source>
-        <translation>請不要多人入鏡</translation>
-    </message>
-    <message>
-        <source>Make sure the camera lens is clean</source>
-        <translation>請確保鏡頭清潔</translation>
-    </message>
-    <message>
-        <source>Do not enroll in dark, bright or backlit environments</source>
-        <translation>請避免在暗光、強光、逆光環境下操作</translation>
-    </message>
-    <message>
-        <source>Keep your face uncovered</source>
-        <translation>請保持面部無遮擋</translation>
-    </message>
-    <message>
-        <source>Scan timed out</source>
-        <translation>錄入超時</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Camera occupied!</source>
-        <translation>攝像頭被佔用！</translation>
-    </message>
-</context>
-<context>
-    <name>ColorAndIcons</name>
-    <message>
-        <source>Accent Color</source>
-        <translation>活動用色</translation>
-    </message>
-    <message>
-        <source>Icon Settings</source>
-        <translation>圖標設置</translation>
-    </message>
-    <message>
-        <source>Icon Theme</source>
-        <translation>圖標主題</translation>
-    </message>
-    <message>
-        <source>Customize your theme icon</source>
-        <translation>自定義您的主題圖標</translation>
-    </message>
-    <message>
-        <source>Cursor Theme</source>
-        <translation>光標主題</translation>
-    </message>
-    <message>
-        <source>Customize your theme cursor</source>
-        <translation>自定義您的主題光標</translation>
-    </message>
-</context>
-<context>
-    <name>ComfirmDeleteDialog</name>
-    <message>
-        <source>Are you sure you want to delete this account?</source>
-        <translation>您確定要刪除此賬户嗎？</translation>
-    </message>
-    <message>
-        <source>Delete account directory</source>
-        <translation>刪除賬户目錄</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation>刪除</translation>
-    </message>
-</context>
-<context>
-    <name>ComfirmSafePage</name>
-    <message>
-        <source>Go to settings</source>
-        <translation>去設置</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-</context>
-<context>
-    <name>Common</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Repeat delay</source>
-        <translation>重複延遲</translation>
-    </message>
-    <message>
-        <source>Short</source>
-        <translation>短</translation>
-    </message>
-    <message>
-        <source>Long</source>
-        <translation>長</translation>
-    </message>
-    <message>
-        <source>Repeat rate</source>
-        <translation>重複速度</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>慢</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快</translation>
-    </message>
-    <message>
-        <source>Numeric Keypad</source>
-        <translation>啓用數字鍵盤</translation>
-    </message>
-    <message>
-        <source>test here</source>
-        <translation>請在此輸入測試</translation>
-    </message>
-    <message>
-        <source>Caps lock prompt</source>
-        <translation>大寫鎖定提示</translation>
-    </message>
-    <message>
-        <source>Scroll Speed</source>
-        <translation>滾動速度</translation>
-    </message>
-    <message>
-        <source>Double Click Speed</source>
-        <translation>雙擊速度</translation>
-    </message>
-    <message>
-        <source>Double Click Test</source>
-        <translation>雙擊測試</translation>
-    </message>
-    <message>
-        <source>Left Hand Mode</source>
-        <translation>左手模式</translation>
-    </message>
-    <message>
-        <source>Enable Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-</context>
-<context>
-    <name>CommonInfoWork</name>
-    <message>
-        <source>Large size</source>
-        <translation>大尺寸</translation>
-    </message>
-    <message>
-        <source>Small size</source>
-        <translation>小尺寸</translation>
-    </message>
-    <message>
-        <source>Failed to get root access</source>
-        <translation>進入開發者模式失敗</translation>
-    </message>
-    <message>
-        <source>Please sign in to your Union ID first</source>
-        <translation>請先登錄Union ID</translation>
-    </message>
-    <message>
-        <source>Cannot read your PC information</source>
-        <translation>無法獲取硬件信息</translation>
-    </message>
-    <message>
-        <source>No network connection</source>
-        <translation>無網絡連接</translation>
-    </message>
-    <message>
-        <source>Certificate loading failed, unable to get root access</source>
-        <translation>證書加載失敗，無法進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Signature verification failed, unable to get root access</source>
-        <translation>簽名驗證失敗，無法進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Agree and Join User Experience Program</source>
-        <translation>同意並加入用户體驗計劃</translation>
-    </message>
-    <message>
-        <source>The Disclaimer of Developer Mode</source>
-        <translation>開發者模式免責聲明</translation>
-    </message>
-    <message>
-        <source>Agree and Request Root Access</source>
-        <translation>同意並進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation>開始設置啓動新動畫，請稍等一會兒</translation>
-    </message>
-    <message>
-        <source>Setting new boot animation finished</source>
-        <translation>新的啓動動畫設置完成</translation>
-    </message>
-    <message>
-        <source>The settings will be applied after rebooting the system</source>
-        <translation>新的設置會在重啓系統後生效</translation>
-    </message>
-</context>
-<context>
-    <name>ConfirmManager</name>
-    <message>
-        <source>Password must contain numbers and letters</source>
-        <translation>密碼必須包含數字和字母</translation>
-    </message>
-    <message>
-        <source>Password must be between 8 and 64 characters</source>
-        <translation>密碼長度必須為8~64個字符</translation>
-    </message>
-</context>
-<context>
-    <name>CreateAccountDialog</name>
-    <message>
-        <source>Create a new account</source>
-        <translation>創建新用户</translation>
-    </message>
-    <message>
-        <source>Account type</source>
-        <translation>賬户類型</translation>
-    </message>
-    <message>
-        <source>UserName</source>
-        <translation>用户名</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>FullName</source>
-        <translation>全名</translation>
-    </message>
-    <message>
-        <source>Optional</source>
-        <translation>選填</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Create account</source>
-        <translation>創建用户</translation>
-    </message>
-</context>
-<context>
-    <name>CustomAvatarEmpatyArea</name>
-    <message>
-        <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-        <translation>您還沒有上傳過頭像，可點擊或拖拽上傳圖片</translation>
-    </message>
-</context>
-<context>
-    <name>DCC_NAMESPACE::SystemInfoModel</name>
-    <message>
-        <source>available</source>
-        <translation>可用</translation>
-    </message>
-</context>
-<context>
-    <name>DCC_NAMESPACE::SystemInfoWork</name>
-    <message>
-        <source>https://www.deepin.org/en/agreement/privacy/</source>
-        <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
-    </message>
-    <message>
-        <source>https://www.uniontech.com/agreement/privacy-en</source>
-        <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;統信軟件非常重視您的私隱。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及存儲您的信息的私隱政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href=&quot;%1&quot;&gt;點擊此處&lt;/a&gt;查看我們最新的私隱政策和/或通過訪問 &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;在線查看。請您務必認真閲讀、充分理解我們針對客户私隱的做法，如果有任何疑問，請聯繫我們：support@uniontech.com。&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation>https://www.uniontech.com/agreement/experience-cn</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。詳細説明請參照Deepin私隱政策 (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。瞭解用户體驗計劃，請訪問：&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Agree and Join User Experience Program</source>
-        <translation>同意並加入用户體驗計劃</translation>
-    </message>
-</context>
-<context>
-    <name>DateTimeSettingDialog</name>
-    <message>
-        <source>Date and time setting</source>
-        <translation>日期和時間設置</translation>
-    </message>
-    <message>
-        <source>Date</source>
-        <translation>日期</translation>
-    </message>
-    <message>
-        <source>Year</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <source>Month</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <source>Day</source>
-        <translation>日</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>時間</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>確認</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeModel</name>
-    <message>
-        <source>Tomorrow</source>
-        <translation>明天</translation>
-    </message>
-    <message>
-        <source>Yesterday</source>
-        <translation>昨天</translation>
-    </message>
-    <message>
-        <source>Today</source>
-        <translation>今天</translation>
-    </message>
-    <message>
-        <source>%1 hours earlier than local</source>
-        <translation>比本地早了 %1 小時</translation>
-    </message>
-    <message>
-        <source>%1 hours later than local</source>
-        <translation>比本地晚了 %1 小時</translation>
-    </message>
-    <message>
-        <source>Space</source>
-        <translation>空格</translation>
-    </message>
-    <message>
-        <source>Week</source>
-        <translation>星期/周</translation>
-    </message>
-    <message>
-        <source>First day of week</source>
-        <translation>一週首日</translation>
-    </message>
-    <message>
-        <source>Short date</source>
-        <translation>短日期</translation>
-    </message>
-    <message>
-        <source>Long date</source>
-        <translation>長日期</translation>
-    </message>
-    <message>
-        <source>Short time</source>
-        <translation>短時間</translation>
-    </message>
-    <message>
-        <source>Long time</source>
-        <translation>長時間</translation>
-    </message>
-    <message>
-        <source>Currency symbol</source>
-        <translation>貨幣符號</translation>
-    </message>
-    <message>
-        <source>Positive currency</source>
-        <translation>貨幣正數</translation>
-    </message>
-    <message>
-        <source>Negative currency</source>
-        <translation>貨幣負數</translation>
-    </message>
-    <message>
-        <source>Decimal symbol</source>
-        <translation>小數點</translation>
-    </message>
-    <message>
-        <source>Digit grouping symbol</source>
-        <translation>分隔符</translation>
-    </message>
-    <message>
-        <source>Digit grouping</source>
-        <translation>數字分組</translation>
-    </message>
-    <message>
-        <source>Page size</source>
-        <translation>紙張</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWorker</name>
-    <message>
-        <source>Authentication is required to change NTP server</source>
-        <translation>修改 NTP 地址需要認證</translation>
-    </message>
-</context>
-<context>
-    <name>DccColorDialog</name>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>保存</translation>
-    </message>
-</context>
-<context>
-    <name>DccWindow</name>
-    <message>
-        <source>Control Center provides the options for system settings.</source>
-        <translation>控制中心提供作業系統的所有設置選項。</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDAccountSecurity</name>
-    <message>
-        <source>Bind WeChat</source>
-        <translation>綁定微信</translation>
-    </message>
-    <message>
-        <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-        <translation>通過綁定微信，您可以安全快速地登錄您的%1 ID和本地賬户</translation>
-    </message>
-    <message>
-        <source>Unlinked</source>
-        <translation>未綁定</translation>
-    </message>
-    <message>
-        <source>Unbinding</source>
-        <translation>解綁</translation>
-    </message>
-    <message>
-        <source>Link</source>
-        <translation>去綁定</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to unbind WeChat?</source>
-        <translation>您確定要解綁微信嗎？</translation>
-    </message>
-    <message>
-        <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-        <translation>解綁微信後，您將無法使用微信掃碼登錄%1 ID、微信掃碼登錄本地賬户</translation>
-    </message>
-    <message>
-        <source>Let me think it over</source>
-        <translation>我再想想</translation>
-    </message>
-    <message>
-        <source>Local Account Binding</source>
-        <translation>綁定本地賬户</translation>
-    </message>
-    <message>
-        <source>After binding your local account, you can use the following functions:</source>
-        <translation>綁定本地賬户後，您可以使用如下功能：</translation>
-    </message>
-    <message>
-        <source>WeChat Scan Code Login System</source>
-        <translation>微信掃碼登錄系統</translation>
-    </message>
-    <message>
-        <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-        <translation>使用%1 ID綁定的微信，掃碼登錄本地賬户</translation>
-    </message>
-    <message>
-        <source>Reset password via %1 ID</source>
-        <translation>通過%1 ID重置密碼</translation>
-    </message>
-    <message>
-        <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation>在您忘記本地賬户密碼時，通過%1 ID重置密碼</translation>
-    </message>
-    <message>
-        <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation>如需使用上述功能，請前往控制中心-賬户，開啓相應選項</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDInterface</name>
-    <message>
-        <source>deepin</source>
-        <translation>deepin</translation>
-    </message>
-    <message>
-        <source>UOS</source>
-        <translation>UOS</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDLogin</name>
-    <message>
-        <source>Cloud Sync</source>
-        <translation>雲同步</translation>
-    </message>
-    <message>
-        <source>Manage your %1 ID and sync your personal data across devices.
+        </message>
+    </context>
+    <context>
+        <name>AutoLoginWarningDialog</name>
+        <message>
+            <source>"Auto Login" can be enabled for only one account, please disable it for the account "%1" first</source>
+            <translation>只允許一個賬户開啓自動登錄，請先關閉%1賬户的自動登錄，再進行操作</translation>
+        </message>
+        <message>
+            <source>Ok</source>
+            <translation>確 定</translation>
+        </message>
+    </context>
+    <context>
+        <name>AvatarSettingsDialog</name>
+        <message>
+            <source>Images</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Human</source>
+            <translation>人物</translation>
+        </message>
+        <message>
+            <source>Animal</source>
+            <translation>動物</translation>
+        </message>
+        <message>
+            <source>Scenery</source>
+            <translation>靜物</translation>
+        </message>
+        <message>
+            <source>Illustration</source>
+            <translation>創意插圖</translation>
+        </message>
+        <message>
+            <source>Emoji</source>
+            <translation>表情符號</translation>
+        </message>
+        <message>
+            <source>custom</source>
+            <translation>自定義圖片</translation>
+        </message>
+        <message>
+            <source>Cartoon style</source>
+            <translation>Q版風格</translation>
+        </message>
+        <message>
+            <source>Dimensional style</source>
+            <translation>立體風格</translation>
+        </message>
+        <message>
+            <source>Flat style</source>
+            <translation>平面風格</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>保存</translation>
+        </message>
+    </context>
+    <context>
+        <name>BatteryPage</name>
+        <message>
+            <source>Screen and Suspend</source>
+            <translation>屏幕和待機</translation>
+        </message>
+        <message>
+            <source>Turn off the monitor after</source>
+            <translation>關閉顯示器</translation>
+        </message>
+        <message>
+            <source>Lock screen after</source>
+            <translation>自動鎖屏</translation>
+        </message>
+        <message>
+            <source>Computer suspends after</source>
+            <translation>進入待機</translation>
+        </message>
+        <message>
+            <source>When the lid is closed</source>
+            <translation>筆記本合蓋時</translation>
+        </message>
+        <message>
+            <source>When the power button is pressed</source>
+            <translation>按電源按鈕時</translation>
+        </message>
+        <message>
+            <source>Low Battery</source>
+            <translation>低電量管理</translation>
+        </message>
+        <message>
+            <source>Low battery notification</source>
+            <translation>低電量提醒</translation>
+        </message>
+        <message>
+            <source>Auto suspend</source>
+            <translation>自動待機</translation>
+        </message>
+        <message>
+            <source>Auto Hibernate</source>
+            <translation>自動休眠</translation>
+        </message>
+        <message>
+            <source>Low battery threshold</source>
+            <translation>低電量閾值</translation>
+        </message>
+        <message>
+            <source>Battery Management</source>
+            <translation>電池管理</translation>
+        </message>
+        <message>
+            <source>Display remaining using and charging time</source>
+            <translation>顯示剩餘使用時間及剩餘充電時間</translation>
+        </message>
+        <message>
+            <source>Maximum capacity</source>
+            <translation>最大容量</translation>
+        </message>
+        <message>
+            <source>Low battery level</source>
+            <translation>低電量時</translation>
+        </message>
+        <message>
+            <source>Disable</source>
+            <translation>從不</translation>
+        </message>
+    </context>
+    <context>
+        <name>BlueToothAdaptersModel</name>
+        <message>
+            <source>Bluetooth is turned off, and the name is displayed as "%1"</source>
+            <translation>藍牙已關閉，名稱顯示為"%1"</translation>
+        </message>
+        <message>
+            <source>Bluetooth is turned on, and the name is displayed as "%1"</source>
+            <translation>藍牙已打開，名稱顯示為 "%1"</translation>
+        </message>
+    </context>
+    <context>
+        <name>BlueToothDeviceListView</name>
+        <message>
+            <source>Disconnect</source>
+            <translation>斷開連接</translation>
+        </message>
+        <message>
+            <source>Connect</source>
+            <translation>連接</translation>
+        </message>
+        <message>
+            <source>Send Files</source>
+            <translation>發送文件</translation>
+        </message>
+        <message>
+            <source>Rename</source>
+            <translation>重命名</translation>
+        </message>
+        <message>
+            <source>Remove Device</source>
+            <translation>移除設備</translation>
+        </message>
+        <message>
+            <source>Select file</source>
+            <translation>選擇文件</translation>
+        </message>
+    </context>
+    <context>
+        <name>BluetoothCtl</name>
+        <message>
+            <source>Edit</source>
+            <translation>修改</translation>
+        </message>
+        <message>
+            <source>Allow other Bluetooth devices to find this device</source>
+            <translation>允許其他藍牙設備找到該設備</translation>
+        </message>
+        <message>
+            <source>To use the Bluetooth function, please turn off</source>
+            <translation>如需使用藍牙功能，請關閉</translation>
+        </message>
+        <message>
+            <source>Airplane Mode</source>
+            <translation>飛行模式</translation>
+        </message>
+        <message>
+            <source>Bluetooth name cannot exceed 64 characters</source>
+            <translation>藍牙名稱不能超過64個字符</translation>
+        </message>
+    </context>
+    <context>
+        <name>BluetoothDeviceModel</name>
+        <message>
+            <source>Connected</source>
+            <translation>已連接</translation>
+        </message>
+        <message>
+            <source>Not connected</source>
+            <translation>未連接</translation>
+        </message>
+    </context>
+    <context>
+        <name>BootPage</name>
+        <message>
+            <source>Startup Settings</source>
+            <translation>啓動設置</translation>
+        </message>
+        <message>
+            <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
+            <translation>您可以點擊菜單改變默認啓動項，也可以拖拽圖片到窗口改變背景圖片.</translation>
+        </message>
+        <message>
+            <source>grub start delay</source>
+            <translation>啓動延時</translation>
+        </message>
+        <message>
+            <source>theme</source>
+            <translation>主題</translation>
+        </message>
+        <message>
+            <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
+            <translation>開啓主題後您可以在開機時看到主題背景</translation>
+        </message>
+        <message>
+            <source>Boot menu verification</source>
+            <translation>啓動菜單驗證</translation>
+        </message>
+        <message>
+            <source>After opening, entering the menu editing requires a password.</source>
+            <translation>開啓後進入啓動菜單編輯需要密碼.</translation>
+        </message>
+        <message>
+            <source>Change Password</source>
+            <translation>修改密碼</translation>
+        </message>
+        <message>
+            <source>Change boot menu verification password</source>
+            <translation>修改啓動菜單驗證密碼</translation>
+        </message>
+        <message>
+            <source>Set the boot menu authentication password</source>
+            <translation>設置啓動菜單驗證密碼</translation>
+        </message>
+        <message>
+            <source>User Name :</source>
+            <translation>用户名：</translation>
+        </message>
+        <message>
+            <source>root</source>
+            <translation>root</translation>
+        </message>
+        <message>
+            <source>New Password :</source>
+            <translation>新密碼：</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Passwords do not match</source>
+            <translation>密碼不一致</translation>
+        </message>
+        <message>
+            <source>Repeat password:</source>
+            <translation>確認密碼：</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Sure</source>
+            <translation>確定</translation>
+        </message>
+        <message>
+            <source>Start animation</source>
+            <translation>啓動動畫</translation>
+        </message>
+        <message>
+            <source>Adjust the size of the logo animation on the system startup interface</source>
+            <translation>調整系統啓動界面的logo動畫尺寸大小</translation>
+        </message>
+    </context>
+    <context>
+        <name>Camera</name>
+        <message>
+            <source>Allow below apps to access your camera:</source>
+            <translation>允許下面的應用訪問您的攝像頭</translation>
+        </message>
+    </context>
+    <context>
+        <name>CharaMangerModel</name>
+        <message>
+            <source>Fingerprint1</source>
+            <translation>指紋1</translation>
+        </message>
+        <message>
+            <source>Fingerprint2</source>
+            <translation>指紋2</translation>
+        </message>
+        <message>
+            <source>Fingerprint3</source>
+            <translation>指紋3</translation>
+        </message>
+        <message>
+            <source>Fingerprint4</source>
+            <translation>指紋4</translation>
+        </message>
+        <message>
+            <source>Fingerprint5</source>
+            <translation>指紋5</translation>
+        </message>
+        <message>
+            <source>Fingerprint6</source>
+            <translation>指紋6</translation>
+        </message>
+        <message>
+            <source>Fingerprint7</source>
+            <translation>指紋7</translation>
+        </message>
+        <message>
+            <source>Fingerprint8</source>
+            <translation>指紋8</translation>
+        </message>
+        <message>
+            <source>Fingerprint9</source>
+            <translation>指紋9</translation>
+        </message>
+        <message>
+            <source>Fingerprint10</source>
+            <translation>指紋10</translation>
+        </message>
+        <message>
+            <source>Scan failed</source>
+            <translation>指紋錄入失敗</translation>
+        </message>
+        <message>
+            <source>The fingerprint already exists</source>
+            <translation>指紋已存在</translation>
+        </message>
+        <message>
+            <source>Please scan other fingers</source>
+            <translation>請使用其他手指錄入</translation>
+        </message>
+        <message>
+            <source>Unknown error</source>
+            <translation>未知錯誤</translation>
+        </message>
+        <message>
+            <source>Scan suspended</source>
+            <translation>指紋錄入被中斷</translation>
+        </message>
+        <message>
+            <source>Cannot recognize</source>
+            <translation>無法識別</translation>
+        </message>
+        <message>
+            <source>Moved too fast</source>
+            <translation>接觸時間短</translation>
+        </message>
+        <message>
+            <source>Finger moved too fast, please do not lift until prompted</source>
+            <translation>接觸時間短，驗證時請勿移動手指</translation>
+        </message>
+        <message>
+            <source>Unclear fingerprint</source>
+            <translation>圖像模糊</translation>
+        </message>
+        <message>
+            <source>Clean your finger or adjust the finger position, and try again</source>
+            <translation>請清潔手指或調整觸摸位置，再次按壓指紋識別器</translation>
+        </message>
+        <message>
+            <source>Already scanned</source>
+            <translation>圖像重複</translation>
+        </message>
+        <message>
+            <source>Adjust the finger position to scan your fingerprint fully</source>
+            <translation>請調整手指按壓區域以錄入更多指紋</translation>
+        </message>
+        <message>
+            <source>Finger moved too fast. Please do not lift until prompted</source>
+            <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
+        </message>
+        <message>
+            <source>Lift your finger and place it on the sensor again</source>
+            <translation>請擡起手指，再次按壓</translation>
+        </message>
+        <message>
+            <source>Position your face inside the frame</source>
+            <translation>請確保您的面部全部顯示在識別區域內</translation>
+        </message>
+        <message>
+            <source>Face enrolled</source>
+            <translation>人臉錄入完成</translation>
+        </message>
+        <message>
+            <source>Position a human face please</source>
+            <translation>請使用人類面容</translation>
+        </message>
+        <message>
+            <source>Keep away from the camera</source>
+            <translation>請遠離鏡頭</translation>
+        </message>
+        <message>
+            <source>Get closer to the camera</source>
+            <translation>請靠近鏡頭</translation>
+        </message>
+        <message>
+            <source>Do not position multiple faces inside the frame</source>
+            <translation>請不要多人入鏡</translation>
+        </message>
+        <message>
+            <source>Make sure the camera lens is clean</source>
+            <translation>請確保鏡頭清潔</translation>
+        </message>
+        <message>
+            <source>Do not enroll in dark, bright or backlit environments</source>
+            <translation>請避免在暗光、強光、逆光環境下操作</translation>
+        </message>
+        <message>
+            <source>Keep your face uncovered</source>
+            <translation>請保持面部無遮擋</translation>
+        </message>
+        <message>
+            <source>Scan timed out</source>
+            <translation>錄入超時</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Camera occupied!</source>
+            <translation>攝像頭被佔用！</translation>
+        </message>
+    </context>
+    <context>
+        <name>ColorAndIcons</name>
+        <message>
+            <source>Accent Color</source>
+            <translation>活動用色</translation>
+        </message>
+        <message>
+            <source>Icon Settings</source>
+            <translation>圖標設置</translation>
+        </message>
+        <message>
+            <source>Icon Theme</source>
+            <translation>圖標主題</translation>
+        </message>
+        <message>
+            <source>Customize your theme icon</source>
+            <translation>自定義您的主題圖標</translation>
+        </message>
+        <message>
+            <source>Cursor Theme</source>
+            <translation>光標主題</translation>
+        </message>
+        <message>
+            <source>Customize your theme cursor</source>
+            <translation>自定義您的主題光標</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComfirmDeleteDialog</name>
+        <message>
+            <source>Are you sure you want to delete this account?</source>
+            <translation>您確定要刪除此賬户嗎？</translation>
+        </message>
+        <message>
+            <source>Delete account directory</source>
+            <translation>刪除賬户目錄</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation>刪除</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComfirmSafePage</name>
+        <message>
+            <source>Go to settings</source>
+            <translation>去設置</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+    </context>
+    <context>
+        <name>Common</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Repeat delay</source>
+            <translation>重複延遲</translation>
+        </message>
+        <message>
+            <source>Short</source>
+            <translation>短</translation>
+        </message>
+        <message>
+            <source>Long</source>
+            <translation>長</translation>
+        </message>
+        <message>
+            <source>Repeat rate</source>
+            <translation>重複速度</translation>
+        </message>
+        <message>
+            <source>Slow</source>
+            <translation>慢</translation>
+        </message>
+        <message>
+            <source>Fast</source>
+            <translation>快</translation>
+        </message>
+        <message>
+            <source>Numeric Keypad</source>
+            <translation>啓用數字鍵盤</translation>
+        </message>
+        <message>
+            <source>test here</source>
+            <translation>請在此輸入測試</translation>
+        </message>
+        <message>
+            <source>Caps lock prompt</source>
+            <translation>大寫鎖定提示</translation>
+        </message>
+        <message>
+            <source>Scroll Speed</source>
+            <translation>滾動速度</translation>
+        </message>
+        <message>
+            <source>Double Click Speed</source>
+            <translation>雙擊速度</translation>
+        </message>
+        <message>
+            <source>Double Click Test</source>
+            <translation>雙擊測試</translation>
+        </message>
+        <message>
+            <source>Left Hand Mode</source>
+            <translation>左手模式</translation>
+        </message>
+        <message>
+            <source>Enable Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommonInfoWork</name>
+        <message>
+            <source>Large size</source>
+            <translation>大尺寸</translation>
+        </message>
+        <message>
+            <source>Small size</source>
+            <translation>小尺寸</translation>
+        </message>
+        <message>
+            <source>Failed to get root access</source>
+            <translation>進入開發者模式失敗</translation>
+        </message>
+        <message>
+            <source>Please sign in to your Union ID first</source>
+            <translation>請先登錄Union ID</translation>
+        </message>
+        <message>
+            <source>Cannot read your PC information</source>
+            <translation>無法獲取硬件信息</translation>
+        </message>
+        <message>
+            <source>No network connection</source>
+            <translation>無網絡連接</translation>
+        </message>
+        <message>
+            <source>Certificate loading failed, unable to get root access</source>
+            <translation>證書加載失敗，無法進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Signature verification failed, unable to get root access</source>
+            <translation>簽名驗證失敗，無法進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Agree and Join User Experience Program</source>
+            <translation>同意並加入用户體驗計劃</translation>
+        </message>
+        <message>
+            <source>The Disclaimer of Developer Mode</source>
+            <translation>開發者模式免責聲明</translation>
+        </message>
+        <message>
+            <source>Agree and Request Root Access</source>
+            <translation>同意並進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Start setting the new boot animation, please wait for a minute</source>
+            <translation>開始設置啓動新動畫，請稍等一會兒</translation>
+        </message>
+        <message>
+            <source>Setting new boot animation finished</source>
+            <translation>新的啓動動畫設置完成</translation>
+        </message>
+        <message>
+            <source>The settings will be applied after rebooting the system</source>
+            <translation>新的設置會在重啓系統後生效</translation>
+        </message>
+    </context>
+    <context>
+        <name>ConfirmManager</name>
+        <message>
+            <source>Password must contain numbers and letters</source>
+            <translation>密碼必須包含數字和字母</translation>
+        </message>
+        <message>
+            <source>Password must be between 8 and 64 characters</source>
+            <translation>密碼長度必須為8~64個字符</translation>
+        </message>
+    </context>
+    <context>
+        <name>CreateAccountDialog</name>
+        <message>
+            <source>Create a new account</source>
+            <translation>創建新用户</translation>
+        </message>
+        <message>
+            <source>Account type</source>
+            <translation>賬户類型</translation>
+        </message>
+        <message>
+            <source>UserName</source>
+            <translation>用户名</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>FullName</source>
+            <translation>全名</translation>
+        </message>
+        <message>
+            <source>Optional</source>
+            <translation>選填</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Create account</source>
+            <translation>創建用户</translation>
+        </message>
+    </context>
+    <context>
+        <name>CustomAvatarEmpatyArea</name>
+        <message>
+            <source>You haven't uploaded an avatar yet. Click or drag and drop to upload an image.</source>
+            <translation>您還沒有上傳過頭像，可點擊或拖拽上傳圖片</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCC_NAMESPACE::SystemInfoModel</name>
+        <message>
+            <source>available</source>
+            <translation>可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCC_NAMESPACE::SystemInfoWork</name>
+        <message>
+            <source>https://www.deepin.org/en/agreement/privacy/</source>
+            <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
+        </message>
+        <message>
+            <source>https://www.uniontech.com/agreement/privacy-en</source>
+            <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
+        </message>
+        <message>
+            <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href="%1"&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href="%1"&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;統信軟件非常重視您的私隱。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及存儲您的信息的私隱政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href="%1"&gt;點擊此處&lt;/a&gt;查看我們最新的私隱政策和/或通過訪問 &lt;a href="%1"&gt;%1&lt;/a&gt;在線查看。請您務必認真閲讀、充分理解我們針對客户私隱的做法，如果有任何疑問，請聯繫我們：support@uniontech.com。&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <source>https://www.uniontech.com/agreement/experience-en</source>
+            <translation>https://www.uniontech.com/agreement/experience-cn</translation>
+        </message>
+        <message>
+            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href="%1"&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
+            <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。詳細説明請參照Deepin私隱政策 (&lt;a href="%1"&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href="%1"&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。瞭解用户體驗計劃，請訪問：&lt;a href="%1"&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <source>Agree and Join User Experience Program</source>
+            <translation>同意並加入用户體驗計劃</translation>
+        </message>
+    </context>
+    <context>
+        <name>DateTimeSettingDialog</name>
+        <message>
+            <source>Date and time setting</source>
+            <translation>日期和時間設置</translation>
+        </message>
+        <message>
+            <source>Date</source>
+            <translation>日期</translation>
+        </message>
+        <message>
+            <source>Year</source>
+            <translation>年</translation>
+        </message>
+        <message>
+            <source>Month</source>
+            <translation>月</translation>
+        </message>
+        <message>
+            <source>Day</source>
+            <translation>日</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation>時間</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確認</translation>
+        </message>
+    </context>
+    <context>
+        <name>DatetimeModel</name>
+        <message>
+            <source>Tomorrow</source>
+            <translation>明天</translation>
+        </message>
+        <message>
+            <source>Yesterday</source>
+            <translation>昨天</translation>
+        </message>
+        <message>
+            <source>Today</source>
+            <translation>今天</translation>
+        </message>
+        <message>
+            <source>%1 hours earlier than local</source>
+            <translation>比本地早了 %1 小時</translation>
+        </message>
+        <message>
+            <source>%1 hours later than local</source>
+            <translation>比本地晚了 %1 小時</translation>
+        </message>
+        <message>
+            <source>Space</source>
+            <translation>空格</translation>
+        </message>
+        <message>
+            <source>Week</source>
+            <translation>星期/周</translation>
+        </message>
+        <message>
+            <source>First day of week</source>
+            <translation>一週首日</translation>
+        </message>
+        <message>
+            <source>Short date</source>
+            <translation>短日期</translation>
+        </message>
+        <message>
+            <source>Long date</source>
+            <translation>長日期</translation>
+        </message>
+        <message>
+            <source>Short time</source>
+            <translation>短時間</translation>
+        </message>
+        <message>
+            <source>Long time</source>
+            <translation>長時間</translation>
+        </message>
+        <message>
+            <source>Currency symbol</source>
+            <translation>貨幣符號</translation>
+        </message>
+        <message>
+            <source>Positive currency</source>
+            <translation>貨幣正數</translation>
+        </message>
+        <message>
+            <source>Negative currency</source>
+            <translation>貨幣負數</translation>
+        </message>
+        <message>
+            <source>Decimal symbol</source>
+            <translation>小數點</translation>
+        </message>
+        <message>
+            <source>Digit grouping symbol</source>
+            <translation>分隔符</translation>
+        </message>
+        <message>
+            <source>Digit grouping</source>
+            <translation>數字分組</translation>
+        </message>
+        <message>
+            <source>Page size</source>
+            <translation>紙張</translation>
+        </message>
+    </context>
+    <context>
+        <name>DatetimeWorker</name>
+        <message>
+            <source>Authentication is required to change NTP server</source>
+            <translation>修改 NTP 地址需要認證</translation>
+        </message>
+    </context>
+    <context>
+        <name>DccColorDialog</name>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>保存</translation>
+        </message>
+    </context>
+    <context>
+        <name>DccWindow</name>
+        <message>
+            <source>Control Center provides the options for system settings.</source>
+            <translation>控制中心提供作業系統的所有設置選項。</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDAccountSecurity</name>
+        <message>
+            <source>Bind WeChat</source>
+            <translation>綁定微信</translation>
+        </message>
+        <message>
+            <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
+            <translation>通過綁定微信，您可以安全快速地登錄您的%1 ID和本地賬户</translation>
+        </message>
+        <message>
+            <source>Unlinked</source>
+            <translation>未綁定</translation>
+        </message>
+        <message>
+            <source>Unbinding</source>
+            <translation>解綁</translation>
+        </message>
+        <message>
+            <source>Link</source>
+            <translation>去綁定</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to unbind WeChat?</source>
+            <translation>您確定要解綁微信嗎？</translation>
+        </message>
+        <message>
+            <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
+            <translation>解綁微信後，您將無法使用微信掃碼登錄%1 ID、微信掃碼登錄本地賬户</translation>
+        </message>
+        <message>
+            <source>Let me think it over</source>
+            <translation>我再想想</translation>
+        </message>
+        <message>
+            <source>Local Account Binding</source>
+            <translation>綁定本地賬户</translation>
+        </message>
+        <message>
+            <source>After binding your local account, you can use the following functions:</source>
+            <translation>綁定本地賬户後，您可以使用如下功能：</translation>
+        </message>
+        <message>
+            <source>WeChat Scan Code Login System</source>
+            <translation>微信掃碼登錄系統</translation>
+        </message>
+        <message>
+            <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
+            <translation>使用%1 ID綁定的微信，掃碼登錄本地賬户</translation>
+        </message>
+        <message>
+            <source>Reset password via %1 ID</source>
+            <translation>通過%1 ID重置密碼</translation>
+        </message>
+        <message>
+            <source>Reset your local password via %1 ID in case you forget it.</source>
+            <translation>在您忘記本地賬户密碼時，通過%1 ID重置密碼</translation>
+        </message>
+        <message>
+            <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
+            <translation>如需使用上述功能，請前往控制中心-賬户，開啓相應選項</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDInterface</name>
+        <message>
+            <source>deepin</source>
+            <translation>deepin</translation>
+        </message>
+        <message>
+            <source>UOS</source>
+            <translation>UOS</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDLogin</name>
+        <message>
+            <source>Cloud Sync</source>
+            <translation>雲同步</translation>
+        </message>
+        <message>
+            <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation>管理您的%1 ID，將您的個人數據在不同設備之間同步。
+            <translation>管理您的%1 ID，將您的個人數據在不同設備之間同步。
 登錄%1 ID以獲取瀏覽器、應用商店、服務與支持等眾多應用的個性功能和服務。</translation>
-    </message>
-    <message>
-        <source>Sign In to %1 ID</source>
-        <translation>登錄%1 ID</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDSyncService</name>
-    <message>
-        <source>Auto Sync</source>
-        <translation>自動同步</translation>
-    </message>
-    <message>
-        <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation>將您的系統設置和個人信息安全地存儲在雲端，並在您不同的設備上保持同步</translation>
-    </message>
-    <message>
-        <source>System Settings</source>
-        <translation>系統設置</translation>
-    </message>
-    <message>
-        <source>Last sync time: %1</source>
-        <translation>最近同步時間：%1</translation>
-    </message>
-    <message>
-        <source>Clear cloud data</source>
-        <translation>清除雲端數據</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation>確定要清除您保存在雲端的系統設置和個人數據嗎？</translation>
-    </message>
-    <message>
-        <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation>數據清除後將無法恢復！</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation>清除</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDUserInfo</name>
-    <message>
-        <source>Synchronization Service</source>
-        <translation>同步服務</translation>
-    </message>
-    <message>
-        <source>Account and Security</source>
-        <translation>賬户與安全</translation>
-    </message>
-    <message>
-        <source>Sign out</source>
-        <translation>退出登錄</translation>
-    </message>
-    <message>
-        <source>Go to web settings</source>
-        <translation>前往網頁設置</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinWorker</name>
-    <message>
-        <source>encrypt password failed</source>
-        <translation>加密密碼失敗</translation>
-    </message>
-    <message>
-        <source>Wrong password, %1 chances left</source>
-        <translation>密碼錯誤，您還可以嘗試%1次</translation>
-    </message>
-    <message>
-        <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
-    </message>
-    <message>
-        <source>Operation Successful</source>
-        <translation>操作成功</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinidModel</name>
-    <message>
-        <source>Mainland China</source>
-        <translation>中國大陸</translation>
-    </message>
-    <message>
-        <source>Other regions</source>
-        <translation>其他地區</translation>
-    </message>
-    <message>
-        <source>The feature is not available at present, please activate your system first</source>
-        <translation>當前系統未激活，暫無法使用該功能</translation>
-    </message>
-    <message>
-        <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-        <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
-    </message>
-</context>
-<context>
-    <name>DetailItem</name>
-    <message>
-        <source>Please choose the default program to open &apos;%1&apos;</source>
-        <translation>選擇打開「%1」的默認程序</translation>
-    </message>
-    <message>
-        <source>add</source>
-        <translation>添加</translation>
-    </message>
-    <message>
-        <source>Open Desktop file</source>
-        <translation>打開Desktop文件</translation>
-    </message>
-    <message>
-        <source>Apps (*.desktop)</source>
-        <translation>應用程式(*.desktop)</translation>
-    </message>
-    <message>
-        <source>All files (*)</source>
-        <translation>所有文件(*)</translation>
-    </message>
-</context>
-<context>
-    <name>DevelopModePage</name>
-    <message>
-        <source>Root Access</source>
-        <translation>開發者模式</translation>
-    </message>
-    <message>
-        <source>Request Root Access</source>
-        <translation>進入開發者模式</translation>
-    </message>
-    <message>
-        <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-        <translation>可獲得root使用權限，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
-    </message>
-    <message>
-        <source>Allowed</source>
-        <translation>已進入</translation>
-    </message>
-    <message>
-        <source>Enter</source>
-        <translation>進入</translation>
-    </message>
-    <message>
-        <source>Online</source>
-        <translation>在線激活</translation>
-    </message>
-    <message>
-        <source>Login UOS ID</source>
-        <translation>登錄UOS ID</translation>
-    </message>
-    <message>
-        <source>Offline</source>
-        <translation>離線激活</translation>
-    </message>
-    <message>
-        <source>Import Certificate</source>
-        <translation>導入證書</translation>
-    </message>
-    <message>
-        <source>Select file</source>
-        <translation>選擇文件</translation>
-    </message>
-    <message>
-        <source>Your UOS ID has been logged in, click to enter developer mode</source>
-        <translation>您的UOS ID已登錄，點擊進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Please sign in to your UOS ID first and continue</source>
-        <translation>進入開發者模式需要登錄UOS ID</translation>
-    </message>
-    <message>
-        <source>1.Export PC Info</source>
-        <translation>1.導出機器信息</translation>
-    </message>
-    <message>
-        <source>Export</source>
-        <translation>導出</translation>
-    </message>
-    <message>
-        <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-        <translation>2.前往 &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
-    </message>
-    <message>
-        <source>3.Import Certificate</source>
-        <translation>3.導入證書</translation>
-    </message>
-    <message>
-        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation>如需安裝非應用商店來源的應用，前往 &lt;a href=&quot;Security Center&quot;&gt;安全中心&lt;/a&gt; 進行設置。</translation>
-    </message>
-    <message>
-        <source>Development and debugging options</source>
-        <translation>開發調試選項</translation>
-    </message>
-    <message>
-        <source>System logging level</source>
-        <translation>系統日誌記錄級別</translation>
-    </message>
-    <message>
-        <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-        <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多存儲空間.</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>關閉</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation>調試</translation>
-    </message>
-    <message>
-        <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-        <translation>更改選項處理可能需要一分鐘，收到設置成功提示後，請重啓設備方可生效。</translation>
-    </message>
-</context>
-<context>
-    <name>DisclaimerControl</name>
-    <message>
-        <source>Disclaimer</source>
-        <translation>《用户免責聲明》</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Agree</source>
-        <translation>同意</translation>
-    </message>
-</context>
-<context>
-    <name>FileAndFolder</name>
-    <message>
-        <source>Allow below apps to access these files and folders:</source>
-        <translation>允許下面的應用訪問您的文件和文件夾</translation>
-    </message>
-    <message>
-        <source>Documents</source>
-        <translation>文檔</translation>
-    </message>
-    <message>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <source>Pictures</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <source>Videos</source>
-        <translation>視頻</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation>音樂</translation>
-    </message>
-    <message>
-        <source>Downloads</source>
-        <translation>下載</translation>
-    </message>
-    <message>
-        <source>folder</source>
-        <translation>文件夾</translation>
-    </message>
-</context>
-<context>
-    <name>FontSizePage</name>
-    <message>
-        <source>Size</source>
-        <translation>字號</translation>
-    </message>
-    <message>
-        <source>Standard Font</source>
-        <translation>標準字體</translation>
-    </message>
-    <message>
-        <source>Monospaced Font</source>
-        <translation>等寬字體</translation>
-    </message>
-</context>
-<context>
-    <name>GeneralPage</name>
-    <message>
-        <source>Power Plans</source>
-        <translation>性能模式</translation>
-    </message>
-    <message>
-        <source>Power Saving Settings</source>
-        <translation>節能設置</translation>
-    </message>
-    <message>
-        <source>Auto power saving on low battery</source>
-        <translation>低電量時自動開啓節能模式</translation>
-    </message>
-    <message>
-        <source>Low battery threshold</source>
-        <translation>低電量閾值</translation>
-    </message>
-    <message>
-        <source>Auto power saving on battery</source>
-        <translation>使用電池時自動開啓節能模式</translation>
-    </message>
-    <message>
-        <source>Wakeup Settings</source>
-        <translation>喚醒設置</translation>
-    </message>
-    <message>
-        <source>Password is required to wake up the computer</source>
-        <translation>待機恢復時需要密碼</translation>
-    </message>
-    <message>
-        <source>Password is required to wake up the monitor</source>
-        <translation>喚醒顯示器時需要密碼</translation>
-    </message>
-    <message>
-        <source>Shutdown Settings</source>
-        <translation>關機設置</translation>
-    </message>
-    <message>
-        <source>Scheduled Shutdown</source>
-        <translation>定時關機</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>時間</translation>
-    </message>
-    <message>
-        <source>Repeat</source>
-        <translation>重複</translation>
-    </message>
-    <message>
-        <source>Once</source>
-        <translation>一次</translation>
-    </message>
-    <message>
-        <source>Every day</source>
-        <translation>每天</translation>
-    </message>
-    <message>
-        <source>Working days</source>
-        <translation>工作日</translation>
-    </message>
-    <message>
-        <source>Custom Time</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>Decrease screen brightness on power saver</source>
-        <translation>節能模式時降低屏幕亮度</translation>
-    </message>
-</context>
-<context>
-    <name>GestureModel</name>
-    <message>
-        <source>Three-finger</source>
-        <translation>三指</translation>
-    </message>
-    <message>
-        <source>Four-finger</source>
-        <translation>四指</translation>
-    </message>
-    <message>
-        <source>Up</source>
-        <translation>向上</translation>
-    </message>
-    <message>
-        <source>Down</source>
-        <translation>向下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>向左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>向右</translation>
-    </message>
-    <message>
-        <source>tap</source>
-        <translation>點擊</translation>
-    </message>
-</context>
-<context>
-    <name>HomePage</name>
-    <message>
-        <source>,</source>
-        <translation>、</translation>
-    </message>
-    <message>
-        <source>...</source>
-        <translation>等</translation>
-    </message>
-</context>
-<context>
-    <name>InterfaceEffectListview</name>
-    <message>
-        <source>Optimal Performance</source>
-        <translation>最佳性能</translation>
-    </message>
-    <message>
-        <source>Balance</source>
-        <translation>均衡</translation>
-    </message>
-    <message>
-        <source>Best Visuals</source>
-        <translation>最佳視覺</translation>
-    </message>
-    <message>
-        <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation>關閉所有界面和窗口特效，保障系統高效運行</translation>
-    </message>
-    <message>
-        <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation>限制部分窗口特效，保障出色的視覺效果，同時維持系統流暢運行</translation>
-    </message>
-    <message>
-        <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation>啓用所有界面和窗口特效，體驗最佳視覺效果</translation>
-    </message>
-</context>
-<context>
-    <name>KeyboardLayout</name>
-    <message>
-        <source>Keyboard layout</source>
-        <translation>鍵盤佈局</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation>如需添加或切換鍵盤佈局，請同時在 &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt; 輸入法管理 &lt;/a&gt;  中添加對應的輸入法以確保生效</translation>
-    </message>
-    <message>
-        <source>Add new keyboard layout...</source>
-        <translation>添加鍵盤佈局...</translation>
-    </message>
-</context>
-<context>
-    <name>LangAndFormat</name>
-    <message>
-        <source>Language</source>
-        <translation>語言</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Other languages</source>
-        <translation>其他語言</translation>
-    </message>
-    <message>
-        <source>add</source>
-        <translation>添加</translation>
-    </message>
-    <message>
-        <source>Region</source>
-        <translation>區域</translation>
-    </message>
-    <message>
-        <source>Area</source>
-        <translation>地區</translation>
-    </message>
-    <message>
-        <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
-    </message>
-    <message>
-        <source>Region and format</source>
-        <translation>區域格式</translation>
-    </message>
-    <message>
-        <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation>作業系統和某些應用會根據區域格式設置日期和時間格式</translation>
-    </message>
-</context>
-<context>
-    <name>LangsChooserDialog</name>
-    <message>
-        <source>Add language</source>
-        <translation>添加語言</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>搜索</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>添加</translation>
-    </message>
-</context>
-<context>
-    <name>LayoutsChooser</name>
-    <message>
-        <source>Add language</source>
-        <translation>添加語言</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>搜索</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>添加</translation>
-    </message>
-</context>
-<context>
-    <name>LoginMethod</name>
-    <message>
-        <source>Login method</source>
-        <translation>登錄方式</translation>
-    </message>
-    <message>
-        <source>Password, wechat, biometric authentication, security key</source>
-        <translation>密碼，微信掃碼，生物認證，安全密鑰</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation>密碼</translation>
-    </message>
-    <message>
-        <source>Modify password</source>
-        <translation>修改密碼</translation>
-    </message>
-    <message>
-        <source>Validity days</source>
-        <translation>有效天數</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation>長期有效</translation>
-    </message>
-</context>
-<context>
-    <name>LogoModule</name>
-    <message>
-        <source>Copyright© 2011-%1 Deepin Community</source>
-        <translation>Copyright © 2011-%1 深度社區</translation>
-    </message>
-    <message>
-        <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
-        <translation>Copyright © 2019-%1 統信軟件技術有限公司</translation>
-    </message>
-</context>
-<context>
-    <name>MicrophonePage</name>
-    <message>
-        <source>Automatic Noise Suppression</source>
-        <translation>噪音抑制</translation>
-    </message>
-    <message>
-        <source>Input Volume</source>
-        <translation>輸入音量</translation>
-    </message>
-    <message>
-        <source>Input Level</source>
-        <translation>反饋音量</translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <translation>輸入</translation>
-    </message>
-    <message>
-        <source>No input device for sound found</source>
-        <translation>沒有找到聲音輸入設備</translation>
-    </message>
-    <message>
-        <source>Input Devices</source>
-        <translation>輸入設備</translation>
-    </message>
-</context>
-<context>
-    <name>Mouse</name>
-    <message>
-        <source>Mouse</source>
-        <translation>鼠標</translation>
-    </message>
-    <message>
-        <source>Pointer Speed</source>
-        <translation>指針速度</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>慢</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快</translation>
-    </message>
-    <message>
-        <source>Pointer Size</source>
-        <translation>指針大小</translation>
-    </message>
-    <message>
-        <source>Short</source>
-        <translation>短</translation>
-    </message>
-    <message>
-        <source>Long</source>
-        <translation>長</translation>
-    </message>
-    <message>
-        <source>Mouse Acceleration</source>
-        <translation>鼠標加速</translation>
-    </message>
-    <message>
-        <source>Disable touchpad when a mouse is connected</source>
-        <translation>插入鼠標時禁用觸摸板</translation>
-    </message>
-    <message>
-        <source>Natural Scrolling</source>
-        <translation>自然滾動</translation>
-    </message>
-</context>
-<context>
-    <name>MyDevice</name>
-    <message>
-        <source>My Devices</source>
-        <translation>我的設備</translation>
-    </message>
-</context>
-<context>
-    <name>NativeInfoPage</name>
-    <message>
-        <source>UOS</source>
-        <translation>UOS</translation>
-    </message>
-    <message>
-        <source>Computer name</source>
-        <translation>計算機名</translation>
-    </message>
-    <message>
-        <source>It cannot start or end with dashes</source>
-        <translation>計算機名不能以 - 開頭結尾</translation>
-    </message>
-    <message>
-        <source>OS Name</source>
-        <translation>產品名稱</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation>版本號</translation>
-    </message>
-    <message>
-        <source>Edition</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation>類型</translation>
-    </message>
-    <message>
-        <source>bit</source>
-        <translation>位</translation>
-    </message>
-    <message>
-        <source>Authorization</source>
-        <translation>版本授權</translation>
-    </message>
-    <message>
-        <source>System installation time</source>
-        <translation>系統安裝日期</translation>
-    </message>
-    <message>
-        <source>Kernel</source>
-        <translation>內核版本</translation>
-    </message>
-    <message>
-        <source>Graphics Platform</source>
-        <translation>圖形平台</translation>
-    </message>
-    <message>
-        <source>Processor</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <source>Memory</source>
-        <translation>內存</translation>
-    </message>
-    <message>
-        <source>1~63 characters please</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>OtherDevice</name>
-    <message>
-        <source>Other Devices</source>
-        <translation>其他設備</translation>
-    </message>
-    <message>
-        <source>Show Bluetooth devices without names</source>
-        <translation>顯示沒有名稱的藍牙設備</translation>
-    </message>
-</context>
-<context>
-    <name>PasswordLayout</name>
-    <message>
-        <source>Current password</source>
-        <translation>當前密碼</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>Weak</source>
-        <translation>強度低</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>強度中</translation>
-    </message>
-    <message>
-        <source>Strong</source>
-        <translation>強度高</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation>密碼</translation>
-    </message>
-    <message>
-        <source>Repeat Password</source>
-        <translation>重複密碼</translation>
-    </message>
-    <message>
-        <source>Password hint</source>
-        <translation>密碼提示</translation>
-    </message>
-    <message>
-        <source>Optional</source>
-        <translation>選填</translation>
-    </message>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Passwords do not match</source>
-        <translation>密碼不一致</translation>
-    </message>
-    <message>
-        <source>New password should differ from the current one</source>
-        <translation>新密碼和舊密碼不能相同</translation>
-    </message>
-    <message>
-        <source>The hint is visible to all users. Do not include the password here.</source>
-        <translation>密碼提示對所有人可見，切勿包含具體密碼信息</translation>
-    </message>
-</context>
-<context>
-    <name>PasswordModifyDialog</name>
-    <message>
-        <source>Modify password</source>
-        <translation>修改密碼</translation>
-    </message>
-    <message>
-        <source>Reset password</source>
-        <translation>重置密碼</translation>
-    </message>
-    <message>
-        <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-        <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
-    </message>
-    <message>
-        <source>Resetting the password will clear the data stored in the keyring.</source>
-        <translation>重設密碼將會清除密鑰環內已存儲的數據</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-</context>
-<context>
-    <name>PersonalizationInterface</name>
-    <message>
-        <source>Light</source>
-        <translation>淺色</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>自動</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>深色</translation>
-    </message>
-</context>
-<context>
-    <name>PersonalizationWorker</name>
-    <message>
-        <source>Custom</source>
-        <translation>自定義</translation>
-    </message>
-</context>
-<context>
-    <name>PluginArea</name>
-    <message>
-        <source>Plugin Area</source>
-        <translation>插件區域</translation>
-    </message>
-    <message>
-        <source>Select which icons appear in the Dock</source>
-        <translation>選擇顯示在任務欄插件區域的圖標</translation>
-    </message>
-</context>
-<context>
-    <name>PowerOperatorModel</name>
-    <message>
-        <source>Shut down</source>
-        <translation>關機</translation>
-    </message>
-    <message>
-        <source>Suspend</source>
-        <translation>待機</translation>
-    </message>
-    <message>
-        <source>Hibernate</source>
-        <translation>休眠</translation>
-    </message>
-    <message>
-        <source>Turn off the monitor</source>
-        <translation>關閉顯示器</translation>
-    </message>
-    <message>
-        <source>Show the shutdown Interface</source>
-        <translation>進入關機界面</translation>
-    </message>
-    <message>
-        <source>Do nothing</source>
-        <translation>無任何操作</translation>
-    </message>
-</context>
-<context>
-    <name>PowerPage</name>
-    <message>
-        <source>Screen and Suspend</source>
-        <translation>屏幕和待機</translation>
-    </message>
-    <message>
-        <source>Turn off the monitor after</source>
-        <translation>關閉顯示器</translation>
-    </message>
-    <message>
-        <source>Lock screen after</source>
-        <translation>自動鎖屏</translation>
-    </message>
-    <message>
-        <source>Computer suspends after</source>
-        <translation>進入待機</translation>
-    </message>
-    <message>
-        <source>When the lid is closed</source>
-        <translation>筆記本合蓋時</translation>
-    </message>
-    <message>
-        <source>When the power button is pressed</source>
-        <translation>按電源按鈕時</translation>
-    </message>
-</context>
-<context>
-    <name>PowerPlansListview</name>
-    <message>
-        <source>High Performance</source>
-        <translation>高性能模式</translation>
-    </message>
-    <message>
-        <source>Balance Performance</source>
-        <translation>性能模式</translation>
-    </message>
-    <message>
-        <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation>根據負載情況積極調整運行頻率</translation>
-    </message>
-    <message>
-        <source>Balanced</source>
-        <translation>平衡模式</translation>
-    </message>
-    <message>
-        <source>Power Saver</source>
-        <translation>節能模式</translation>
-    </message>
-    <message>
-        <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-        <translation>性能優先，會顯著提升功耗和發熱</translation>
-    </message>
-    <message>
-        <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-        <translation>兼顧性能和續航，根據使用情況自動調節</translation>
-    </message>
-    <message>
-        <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-        <translation>續航優先，系統會犧牲一些性能表現來降低功耗</translation>
-    </message>
-</context>
-<context>
-    <name>PowerWorker</name>
-    <message>
-        <source>Minutes</source>
-        <translation>分鐘</translation>
-    </message>
-    <message>
-        <source>Hour</source>
-        <translation>小時</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation>從不</translation>
-    </message>
-</context>
-<context>
-    <name>PrivacyPolicyPage</name>
-    <message>
-        <source>Privacy Policy</source>
-        <translation>私隱政策</translation>
-    </message>
-    <message>
-        <source>Copy Link Address</source>
-        <translation>複製連結地址</translation>
-    </message>
-</context>
-<context>
-    <name>PwqualityManager</name>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Password must have at least %1 characters</source>
-        <translation>密碼長度不能少於%1個字符</translation>
-    </message>
-    <message>
-        <source>Password must be no more than %1 characters</source>
-        <translation>密碼長度不能超過%1個字符</translation>
-    </message>
-    <message>
-        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
-    </message>
-    <message>
-        <source>No more than %1 palindrome characters please</source>
-        <translation>迴文字符長度不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 monotonic characters please</source>
-        <translation>單調性字符不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 repeating characters please</source>
-        <translation>重複字符不超過%1位</translation>
-    </message>
-    <message>
-        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
-    </message>
-    <message>
-        <source>Password must not contain more than 4 palindrome characters</source>
-        <translation>密碼不得含有連續4個以上的迴文字符</translation>
-    </message>
-    <message>
-        <source>Do not use common words and combinations as password</source>
-        <translation>密碼不能是常見單詞及組合</translation>
-    </message>
-    <message>
-        <source>Create a strong password please</source>
-        <translation>密碼過於簡單，請增加密碼複雜度</translation>
-    </message>
-    <message>
-        <source>It does not meet password rules</source>
-        <translation>密碼不符合安全要求</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <source>Control Center</source>
-        <translation>控制中心</translation>
-    </message>
-    <message>
-        <source>Activated</source>
-        <translation>已激活</translation>
-    </message>
-    <message>
-        <source>View</source>
-        <translation>查看</translation>
-    </message>
-    <message>
-        <source>To be activated</source>
-        <translation>待激活</translation>
-    </message>
-    <message>
-        <source>Activate</source>
-        <translation>激活</translation>
-    </message>
-    <message>
-        <source>Expired</source>
-        <translation>已過期</translation>
-    </message>
-    <message>
-        <source>In trial period</source>
-        <translation>試用期</translation>
-    </message>
-    <message>
-        <source>Trial expired</source>
-        <translation>試用期過期</translation>
-    </message>
-    <message>
-        <source>dde-control-center</source>
-        <translation>控制中心</translation>
-    </message>
-    <message>
-        <source>Touch Screen Settings</source>
-        <translation>觸控屏設置</translation>
-    </message>
-    <message>
-        <source>The settings of touch screen changed</source>
-        <translation>已變更觸控屏設置</translation>
-    </message>
-    <message>
-        <source>This system wallpaper is locked. Please contact your admin.</source>
-        <translation>當前系統壁紙已被鎖定，請聯繫管理員</translation>
-    </message>
-</context>
-<context>
-    <name>RegionFormatDialog</name>
-    <message>
-        <source>Regions and formats</source>
-        <translation>區域和格式</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>搜索</translation>
-    </message>
-    <message>
-        <source>Default formats</source>
-        <translation>默認格式</translation>
-    </message>
-    <message>
-        <source>First day of week</source>
-        <translation>一週第一天</translation>
-    </message>
-    <message>
-        <source>Short date</source>
-        <translation>短日期</translation>
-    </message>
-    <message>
-        <source>Long date</source>
-        <translation>長日期</translation>
-    </message>
-    <message>
-        <source>Short time</source>
-        <translation>短時間</translation>
-    </message>
-    <message>
-        <source>Long time</source>
-        <translation>長時間</translation>
-    </message>
-    <message>
-        <source>Currency symbol</source>
-        <translation>貨幣符號</translation>
-    </message>
-    <message>
-        <source>Digit</source>
-        <translation>數字</translation>
-    </message>
-    <message>
-        <source>Paper size</source>
-        <translation>紙張</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>保存</translation>
-    </message>
-</context>
-<context>
-    <name>RegionsChooserWindow</name>
-    <message>
-        <source>Search</source>
-        <translation>搜索</translation>
-    </message>
-</context>
-<context>
-    <name>RegisterDialog</name>
-    <message>
-        <source>Set a Password</source>
-        <translation>設置密碼</translation>
-    </message>
-    <message>
-        <source>8-64 characters</source>
-        <translation>請輸入8-64位密碼</translation>
-    </message>
-    <message>
-        <source>Repeat the password</source>
-        <translation>請再次輸入密碼</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>確定</translation>
-    </message>
-    <message>
-        <source>Passwords don&apos;t match</source>
-        <translation>兩次密碼輸入不一致</translation>
-    </message>
-</context>
-<context>
-    <name>ScheduledShutdownDialog</name>
-    <message>
-        <source>Customize repetition time</source>
-        <translation>自定義重複時間</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>保存</translation>
-    </message>
-</context>
-<context>
-    <name>ScreenSaverPage</name>
-    <message>
-        <source>Screensaver</source>
-        <translation>屏幕保護</translation>
-    </message>
-    <message>
-        <source>preview</source>
-        <translation>全屏預覽</translation>
-    </message>
-    <message>
-        <source>Personalized screensaver</source>
-        <translation>個性化屏保</translation>
-    </message>
-    <message>
-        <source>setting</source>
-        <translation>設置</translation>
-    </message>
-    <message>
-        <source>idle time</source>
-        <translation>閒置時間</translation>
-    </message>
-    <message>
-        <source>1 minute</source>
-        <translation>1分鐘</translation>
-    </message>
-    <message>
-        <source>5 minute</source>
-        <translation>5分鐘</translation>
-    </message>
-    <message>
-        <source>10 minute</source>
-        <translation>10分鐘</translation>
-    </message>
-    <message>
-        <source>15 minute</source>
-        <translation>15分鐘</translation>
-    </message>
-    <message>
-        <source>30 minute</source>
-        <translation>30分鐘</translation>
-    </message>
-    <message>
-        <source>1 hour</source>
-        <translation>1小時</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>從不</translation>
-    </message>
-    <message>
-        <source>Password required for recovery</source>
-        <translation>恢復時需要密碼</translation>
-    </message>
-    <message>
-        <source>Picture slideshow screensaver</source>
-        <translation>圖片輪播屏保</translation>
-    </message>
-    <message>
-        <source>System screensaver</source>
-        <translation>系統屏保</translation>
-    </message>
-</context>
-<context>
-    <name>SearchableListViewPopup</name>
-    <message>
-        <source>Search</source>
-        <translation>搜索</translation>
-    </message>
-    <message>
-        <source>No search results</source>
-        <translation>無搜索結果</translation>
-    </message>
-</context>
-<context>
-    <name>ShortcutSettingDialog</name>
-    <message>
-        <source>Add custom shortcut</source>
-        <translation>添加自定義快捷鍵</translation>
-    </message>
-    <message>
-        <source>Name:</source>
-        <translation>名稱：</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>Command:</source>
-        <translation>命令：</translation>
-    </message>
-    <message>
-        <source>Shortcut</source>
-        <translation>快捷鍵</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>無</translation>
-    </message>
-    <message>
-        <source>Please enter a new shortcut</source>
-        <translation>請輸入新的快捷鍵</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>添加</translation>
-    </message>
-    <message>
-        <source>Click Add to replace</source>
-        <translation>點擊添加替換</translation>
-    </message>
-</context>
-<context>
-    <name>Shortcuts</name>
-    <message>
-        <source>Shortcuts</source>
-        <translation>快捷鍵</translation>
-    </message>
-    <message>
-        <source>System shortcut, custom shortcut</source>
-        <translation>系統快捷鍵、自定義快捷鍵</translation>
-    </message>
-    <message>
-        <source>Search shortcuts</source>
-        <translation>搜索快捷鍵</translation>
-    </message>
-    <message>
-        <source>Custom</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Please enter a new shortcut</source>
-        <translation>請輸入新的快捷鍵</translation>
-    </message>
-    <message>
-        <source>Click</source>
-        <translation>點擊</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation>或</translation>
-    </message>
-    <message>
-        <source>Replace</source>
-        <translation>替換</translation>
-    </message>
-    <message>
-        <source>Restore default</source>
-        <translation>恢復默認</translation>
-    </message>
-    <message>
-        <source>Add custom shortcut</source>
-        <translation>添加快捷鍵</translation>
-    </message>
-</context>
-<context>
-    <name>SoundDevicemanagesPage</name>
-    <message>
-        <source>Output Devices</source>
-        <translation>輸出設備</translation>
-    </message>
-    <message>
-        <source>Select whether to enable the devices</source>
-        <translation>選擇是否啓用設備</translation>
-    </message>
-    <message>
-        <source>Input Devices</source>
-        <translation>輸入設備</translation>
-    </message>
-</context>
-<context>
-    <name>SoundEffectsPage</name>
-    <message>
-        <source>Sound Effects</source>
-        <translation>系統音效</translation>
-    </message>
-</context>
-<context>
-    <name>SoundModel</name>
-    <message>
-        <source>Boot up</source>
-        <translation>開機</translation>
-    </message>
-    <message>
-        <source>Shut down</source>
-        <translation>關機</translation>
-    </message>
-    <message>
-        <source>Log out</source>
-        <translation>註銷</translation>
-    </message>
-    <message>
-        <source>Wake up</source>
-        <translation>喚醒</translation>
-    </message>
-    <message>
-        <source>Volume +/-</source>
-        <translation>音量調節</translation>
-    </message>
-    <message>
-        <source>Notification</source>
-        <translation>通知</translation>
-    </message>
-    <message>
-        <source>Low battery</source>
-        <translation>電量不足</translation>
-    </message>
-    <message>
-        <source>Send icon in Launcher to Desktop</source>
-        <translation>從啓動器發送圖標到桌面</translation>
-    </message>
-    <message>
-        <source>Empty Trash</source>
-        <translation>清空回收站</translation>
-    </message>
-    <message>
-        <source>Plug in</source>
-        <translation>電源接入</translation>
-    </message>
-    <message>
-        <source>Plug out</source>
-        <translation>電源拔出</translation>
-    </message>
-    <message>
-        <source>Removable device connected</source>
-        <translation>流動裝置接入</translation>
-    </message>
-    <message>
-        <source>Removable device removed</source>
-        <translation>流動裝置拔出</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation>錯誤提示</translation>
-    </message>
-</context>
-<context>
-    <name>SpeakerPage</name>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Output Volume</source>
-        <translation>輸出音量</translation>
-    </message>
-    <message>
-        <source>Volume Boost</source>
-        <translation>音量增強</translation>
-    </message>
-    <message>
-        <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
-        <translation>音量大於100%時可能會導致音效失真，同時損害您的音頻輸出設備</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Output</source>
-        <translation>輸出</translation>
-    </message>
-    <message>
-        <source>No output device for sound found</source>
-        <translation>沒有找到聲音輸出設備</translation>
-    </message>
-    <message>
-        <source>Left Right Balance</source>
-        <translation>左右平衡</translation>
-    </message>
-    <message>
-        <source>Mono audio</source>
-        <translation>單聲道音頻</translation>
-    </message>
-    <message>
-        <source>Merge left and right channels into a single channel</source>
-        <translation>將左聲道和右聲道合併成一個聲道</translation>
-    </message>
-    <message>
-        <source>Auto pause</source>
-        <translation>插拔管理</translation>
-    </message>
-    <message>
-        <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-        <translation>外設插拔時音頻輸出是否自動暫停</translation>
-    </message>
-    <message>
-        <source>Output Devices</source>
-        <translation>輸出設備</translation>
-    </message>
-</context>
-<context>
-    <name>SyncInfoListModel</name>
-    <message>
-        <source>Sound</source>
-        <translation>聲音</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation>電源</translation>
-    </message>
-    <message>
-        <source>Mouse</source>
-        <translation>鼠標</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation>更新</translation>
-    </message>
-    <message>
-        <source>Screensaver</source>
-        <translation>屏幕保護</translation>
-    </message>
-</context>
-<context>
-    <name>ThemeSelectView</name>
-    <message>
-        <source>More Wallpapers</source>
-        <translation>下載更多</translation>
-    </message>
-</context>
-<context>
-    <name>TimeAndDate</name>
-    <message>
-        <source>Auto sync time</source>
-        <translation>自動同步配置</translation>
-    </message>
-    <message>
-        <source>Ntp server</source>
-        <translation>伺服器</translation>
-    </message>
-    <message>
-        <source>System date and time</source>
-        <translation>系統日期和時間</translation>
-    </message>
-    <message>
-        <source>Customize</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation>設置</translation>
-    </message>
-    <message>
-        <source>Server address</source>
-        <translation>伺服器地址</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>The ntp server address cannot be empty</source>
-        <translation>NTP 服務地址不能為空</translation>
-    </message>
-    <message>
-        <source>Use 24-hour format</source>
-        <translation>24小時制</translation>
-    </message>
-    <message>
-        <source>system time zone</source>
-        <translation>系統時區</translation>
-    </message>
-    <message>
-        <source>Timezone list</source>
-        <translation>時區列表</translation>
-    </message>
-</context>
-<context>
-    <name>TimeRange</name>
-    <message>
-        <source>from</source>
-        <translation>從</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation>至</translation>
-    </message>
-</context>
-<context>
-    <name>TimeoutDialog</name>
-    <message>
-        <source>Save the display settings?</source>
-        <translation>是否要保存顯示設置？</translation>
-    </message>
-    <message>
-        <source>Settings will be reverted in %1s.</source>
-        <translation>如無任何操作將在%1秒後還原。</translation>
-    </message>
-    <message>
-        <source>Revert</source>
-        <translation>還原</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>保存</translation>
-    </message>
-</context>
-<context>
-    <name>TimezoneDialog</name>
-    <message>
-        <source>Add time zone</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Time zone:</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Nearest City:</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>保存</translation>
-    </message>
-</context>
-<context>
-    <name>TouchScreen</name>
-    <message>
-        <source>TouchScreen</source>
-        <translation>觸控屏</translation>
-    </message>
-    <message>
-        <source>Set up here when connecting the touch screen</source>
-        <translation>連接觸摸屏時在此處設置</translation>
-    </message>
-</context>
-<context>
-    <name>Touchpad</name>
-    <message>
-        <source>Basic Settings</source>
-        <translation>基礎設置</translation>
-    </message>
-    <message>
-        <source>Touchpad</source>
-        <translation>觸控板</translation>
-    </message>
-    <message>
-        <source>Pointer Speed</source>
-        <translation>指針速度</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>慢</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快</translation>
-    </message>
-    <message>
-        <source>Disable touchpad during input</source>
-        <translation>輸入時禁用觸摸板</translation>
-    </message>
-    <message>
-        <source>Tap to Click</source>
-        <translation>輕觸以點擊</translation>
-    </message>
-    <message>
-        <source>Natural Scrolling</source>
-        <translation>自然滾動</translation>
-    </message>
-    <message>
-        <source>Gesture</source>
-        <translation>手勢</translation>
-    </message>
-    <message>
-        <source>Three-finger gestures</source>
-        <translation>三指手勢</translation>
-    </message>
-    <message>
-        <source>Four-finger gestures</source>
-        <translation>四指手勢</translation>
-    </message>
-</context>
-<context>
-    <name>UserExperienceProgramPage</name>
-    <message>
-        <source>Join User Experience Program</source>
-        <translation>加入用户體驗計劃</translation>
-    </message>
-    <message>
-        <source>Copy Link Address</source>
-        <translation>複製連結地址</translation>
-    </message>
-</context>
-<context>
-    <name>VerifyDialog</name>
-    <message>
-        <source>Security Verification</source>
-        <translation>安全驗證</translation>
-    </message>
-    <message>
-        <source>The action is sensitive, please enter the login password first</source>
-        <translation>您正在進行敏感操作，請進行登錄密碼認證</translation>
-    </message>
-    <message>
-        <source>8-64 characters</source>
-        <translation>請輸入8-64位密碼</translation>
-    </message>
-    <message>
-        <source>Forgot Password?</source>
-        <translation>忘記密碼？</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>確定</translation>
-    </message>
-</context>
-<context>
-    <name>WallpaperPage</name>
-    <message>
-        <source>wallpaper</source>
-        <translation>壁紙</translation>
-    </message>
-    <message>
-        <source>Window rounded corners</source>
-        <translation>窗口圓角</translation>
-    </message>
-    <message>
-        <source>My pictures</source>
-        <translation>我的圖片</translation>
-    </message>
-    <message>
-        <source>System Wallpaper</source>
-        <translation>系統壁紙</translation>
-    </message>
-    <message>
-        <source>Solid color wallpaper</source>
-        <translation>純色壁紙</translation>
-    </message>
-    <message>
-        <source>Customizable wallpapers</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>fill style</source>
-        <translation>填充方式</translation>
-    </message>
-    <message>
-        <source>Automatic wallpaper change</source>
-        <translation>自動切換壁紙</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>從不</translation>
-    </message>
-    <message>
-        <source>30 second</source>
-        <translation>30秒</translation>
-    </message>
-    <message>
-        <source>1 minute</source>
-        <translation>1分鐘</translation>
-    </message>
-    <message>
-        <source>5 minute</source>
-        <translation>5分鐘</translation>
-    </message>
-    <message>
-        <source>10 minute</source>
-        <translation>10分鐘</translation>
-    </message>
-    <message>
-        <source>15 minute</source>
-        <translation>15分鐘</translation>
-    </message>
-    <message>
-        <source>30 minute</source>
-        <translation>30分鐘</translation>
-    </message>
-    <message>
-        <source>login</source>
-        <translation>登錄時</translation>
-    </message>
-    <message>
-        <source>wake up</source>
-        <translation>喚醒時</translation>
-    </message>
-    <message>
-        <source>System Wallapers</source>
-        <translation>系統壁紙</translation>
-    </message>
-    <message>
-        <source>Live Wallpaper</source>
-        <translation>動態壁紙</translation>
-    </message>
-    <message>
-        <source>1 hour</source>
-        <translation>1小時</translation>
-    </message>
-</context>
-<context>
-    <name>WallpaperSelectView</name>
-    <message>
-        <source>unfold</source>
-        <translation>收起</translation>
-    </message>
-    <message>
-        <source>show all</source>
-        <translation>顯示全部</translation>
-    </message>
-    <message>
-        <source>items</source>
-        <translation>張</translation>
-    </message>
-    <message>
-        <source>Set lock screen</source>
-        <translation>設置鎖屏</translation>
-    </message>
-    <message>
-        <source>Set desktop</source>
-        <translation>設置桌面</translation>
-    </message>
-</context>
-<context>
-    <name>WindowEffectPage</name>
-    <message>
-        <source>Interface and Effects</source>
-        <translation>界面效果</translation>
-    </message>
-    <message>
-        <source>Window Settings</source>
-        <translation>窗口設置</translation>
-    </message>
-    <message>
-        <source>Window rounded corners</source>
-        <translation>窗口圓角</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>無</translation>
-    </message>
-    <message>
-        <source>Small</source>
-        <translation>小</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>中</translation>
-    </message>
-    <message>
-        <source>Large</source>
-        <translation>大</translation>
-    </message>
-    <message>
-        <source>Enable transparent effects when moving windows</source>
-        <translation>窗口移動時啓用透明特效</translation>
-    </message>
-    <message>
-        <source>Window Minimize Effect</source>
-        <translation>最小化時效果</translation>
-    </message>
-    <message>
-        <source>Scale</source>
-        <translation>縮放</translation>
-    </message>
-    <message>
-        <source>Magic Lamp</source>
-        <translation>魔燈</translation>
-    </message>
-    <message>
-        <source>Opacity</source>
-        <translation>不透明度調節</translation>
-    </message>
-    <message>
-        <source>Low</source>
-        <translation>低</translation>
-    </message>
-    <message>
-        <source>High</source>
-        <translation>高</translation>
-    </message>
-    <message>
-        <source>Scroll Bars</source>
-        <translation>滾動條</translation>
-    </message>
-    <message>
-        <source>Show on scrolling</source>
-        <translation>滾動時顯示</translation>
-    </message>
-    <message>
-        <source>Keep shown</source>
-        <translation>一直顯示</translation>
-    </message>
-    <message>
-        <source>Compact Display</source>
-        <translation>緊湊模式</translation>
-    </message>
-    <message>
-        <source>If enabled, more content is displayed in the window.</source>
-        <translation>開啓後，窗口將顯示更多內容</translation>
-    </message>
-    <message>
-        <source>Title Bar Height</source>
-        <translation>標題欄高度</translation>
-    </message>
-    <message>
-        <source>Only suitable for application window title bars drawn by the window manager.</source>
-        <translation>僅適用於窗口管理器繪製的應用標題欄</translation>
-    </message>
-    <message>
-        <source>Extremely small</source>
-        <translation>極小</translation>
-    </message>
-</context>
-<context>
-    <name>accounts</name>
-    <message>
-        <source>Account</source>
-        <translation>賬户</translation>
-    </message>
-    <message>
-        <source>Account manager</source>
-        <translation>賬户管理</translation>
-    </message>
-</context>
-<context>
-    <name>accountsMain</name>
-    <message>
-        <source>Other accounts</source>
-        <translation>其他賬户</translation>
-    </message>
-</context>
-<context>
-    <name>authentication</name>
-    <message>
-        <source>Biometric Authentication</source>
-        <translation>生物認證</translation>
-    </message>
-</context>
-<context>
-    <name>authenticationMain</name>
-    <message>
-        <source>Biometric Authentication</source>
-        <translation>生物認證</translation>
-    </message>
-    <message>
-        <source>Face</source>
-        <translation>人臉</translation>
-    </message>
-    <message>
-        <source>Up to 5 facial data can be entered</source>
-        <translation>最多可錄入5個人臉數據</translation>
-    </message>
-    <message>
-        <source>Fingerprint</source>
-        <translation>指紋</translation>
-    </message>
-    <message>
-        <source>Identifying user identity through scanning fingerprints</source>
-        <translation>通過對指紋的掃描進行用户身份的識別</translation>
-    </message>
-    <message>
-        <source>Iris</source>
-        <translation>虹膜</translation>
-    </message>
-    <message>
-        <source>Identity recognition through iris scanning</source>
-        <translation>通過掃描虹膜進行身份識別</translation>
-    </message>
-    <message>
-        <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-        <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字符</translation>
-    </message>
-    <message>
-        <source>Use letters, numbers and underscores only</source>
-        <translation>只能由字母、數字、中文、下劃線組成</translation>
-    </message>
-    <message>
-        <source>No more than 15 characters</source>
-        <translation>不得超過15個字符</translation>
-    </message>
-    <message>
-        <source>Add a new </source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>This name already exists</source>
-        <translation>該名稱已存在</translation>
-    </message>
-</context>
-<context>
-    <name>blueTooth</name>
-    <message>
-        <source>bluetooth</source>
-        <translation>藍牙</translation>
-    </message>
-    <message>
-        <source>Bluetooth settings, devices</source>
-        <translation>藍牙設置、設備管理</translation>
-    </message>
-</context>
-<context>
-    <name>commonInfoMain</name>
-    <message>
-        <source>Boot Menu</source>
-        <translation>啓動菜單</translation>
-    </message>
-    <message>
-        <source>Manage your boot menu</source>
-        <translation>管理您的開機啓動菜單</translation>
-    </message>
-    <message>
-        <source>Developer root permission management</source>
-        <translation>開發者Root權限管理</translation>
-    </message>
-    <message>
-        <source>Developer Options</source>
-        <translation>開發者選項</translation>
-    </message>
-</context>
-<context>
-    <name>datetime</name>
-    <message>
-        <source>Time and date</source>
-        <translation>時間和日期</translation>
-    </message>
-    <message>
-        <source>Time and date, time zone settings</source>
-        <translation>時間日期、時區設置</translation>
-    </message>
-    <message>
-        <source>Language and region</source>
-        <translation>語言和區域</translation>
-    </message>
-    <message>
-        <source>System language, region format</source>
-        <translation>系統語言、區域格式</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::AccountsController</name>
-    <message>
-        <source>Username must be between 3 and 32 characters</source>
-        <translation>用户名長度必須介於 3 到 32 個字符之間</translation>
-    </message>
-    <message>
-        <source>The first character must be a letter or number</source>
-        <translation>必須字母或者數字開頭</translation>
-    </message>
-    <message>
-        <source>Your username should not only have numbers</source>
-        <translation>用户名不能僅僅是數字</translation>
-    </message>
-    <message>
-        <source>The username has been used by other user accounts</source>
-        <translation>用户名和其他用户名重複</translation>
-    </message>
-    <message>
-        <source>The full name is too long</source>
-        <translation>全名太長了</translation>
-    </message>
-    <message>
-        <source>The full name has been used by other user accounts</source>
-        <translation>全名和其他用户名重複</translation>
-    </message>
-    <message>
-        <source>Wrong password</source>
-        <translation>密碼錯誤</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation>標準用户</translation>
-    </message>
-    <message>
-        <source>Administrator</source>
-        <translation>管理員</translation>
-    </message>
-    <message>
-        <source>Customized</source>
-        <translation>自定義</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::AccountsWorker</name>
-    <message>
-        <source>Your host was removed from the domain server successfully</source>
-        <translation>您的主機成功退出了域伺服器</translation>
-    </message>
-    <message>
-        <source>Your host joins the domain server successfully</source>
-        <translation>您的主機成功加入了域伺服器</translation>
-    </message>
-    <message>
-        <source>Your host failed to leave the domain server</source>
-        <translation>您的主機退出域伺服器失敗</translation>
-    </message>
-    <message>
-        <source>Your host failed to join the domain server</source>
-        <translation>您的主機加入域伺服器失敗</translation>
-    </message>
-    <message>
-        <source>AD domain settings</source>
-        <translation>AD域設置</translation>
-    </message>
-    <message>
-        <source>Password not match</source>
-        <translation>密碼不一致</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::AvatarTypesModel</name>
-    <message>
-        <source>Dimensional</source>
-        <translation>立體風格</translation>
-    </message>
-    <message>
-        <source>Flat</source>
-        <translation>平面風格</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::BiometricAuthController</name>
-    <message>
-        <source>Use your face to unlock the device and make settings later</source>
-        <translation>使用人臉數據解鎖您的設備，之後還可進行更多設置</translation>
-    </message>
-    <message>
-        <source>Faceprint</source>
-        <translation>面紋</translation>
-    </message>
-    <message>
-        <source>Place your finger</source>
-        <translation>放置手指</translation>
-    </message>
-    <message>
-        <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
-        <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
-    </message>
-    <message>
-        <source>Lift your finger</source>
-        <translation>擡起手指</translation>
-    </message>
-    <message>
-        <source>Lift your finger and place it on the sensor again</source>
-        <translation>請擡起手指，再次按壓</translation>
-    </message>
-    <message>
-        <source>Scan the edges of your fingerprint</source>
-        <translation>錄入邊緣指紋</translation>
-    </message>
-    <message>
-        <source>Adjust the position to scan the edges of your fingerprint</source>
-        <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
-    </message>
-    <message>
-        <source>Lift your finger and do that again</source>
-        <translation>請擡起手指，再次按壓</translation>
-    </message>
-    <message>
-        <source>Fingerprint added</source>
-        <translation>成功添加指紋</translation>
-    </message>
-    <message>
-        <source>Scan Suspended</source>
-        <translation>錄入中斷</translation>
-    </message>
-    <message>
-        <source>Place the edges of your fingerprint on the sensor</source>
-        <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
-    </message>
-    <message>
-        <source>Iris</source>
-        <translation>虹膜</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::KeyboardController</name>
-    <message>
-        <source>This shortcut conflicts with [%1]</source>
-        <translation>此快捷鍵與[%1]衝突</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::PwqualityManager</name>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Password must have at least %1 characters</source>
-        <translation>密碼長度不能少於%1個字符</translation>
-    </message>
-    <message>
-        <source>Password must be no more than %1 characters</source>
-        <translation>密碼長度不能超過%1個字符</translation>
-    </message>
-    <message>
-        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
-    </message>
-    <message>
-        <source>No more than %1 palindrome characters please</source>
-        <translation>迴文字符長度不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 monotonic characters please</source>
-        <translation>單調性字符不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 repeating characters please</source>
-        <translation>重複字符不超過%1位</translation>
-    </message>
-    <message>
-        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
-    </message>
-    <message>
-        <source>Password must not contain more than 4 palindrome characters</source>
-        <translation>密碼不得含有連續4個以上的迴文字符</translation>
-    </message>
-    <message>
-        <source>Do not use common words and combinations as password</source>
-        <translation>密碼不能是常見單詞及組合</translation>
-    </message>
-    <message>
-        <source>Create a strong password please</source>
-        <translation>密碼過於簡單，請增加密碼複雜度</translation>
-    </message>
-    <message>
-        <source>It does not meet password rules</source>
-        <translation>密碼不符合安全要求</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::ShortcutModel</name>
-    <message>
-        <source>System</source>
-        <translation>系統</translation>
-    </message>
-    <message>
-        <source>Window</source>
-        <translation>窗口</translation>
-    </message>
-    <message>
-        <source>Workspace</source>
-        <translation>工作區</translation>
-    </message>
-    <message>
-        <source>AssistiveTools</source>
-        <translation>輔助功能</translation>
-    </message>
-    <message>
-        <source>Custom</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>無</translation>
-    </message>
-</context>
-<context>
-    <name>deepinid</name>
-    <message>
-        <source>deepin ID</source>
-        <translation>deepin ID</translation>
-    </message>
-    <message>
-        <source>UOS ID</source>
-        <translation>UOS ID</translation>
-    </message>
-    <message>
-        <source>Cloud services</source>
-        <translation>雲服務</translation>
-    </message>
-</context>
-<context>
-    <name>defaultapp</name>
-    <message>
-        <source>Default App</source>
-        <translation>默認程序</translation>
-    </message>
-    <message>
-        <source>Set the default application for opening various types of files</source>
-        <translation>設置打開各類文件的默認程序</translation>
-    </message>
-</context>
-<context>
-    <name>defaultappMain</name>
-    <message>
-        <source>Webpage</source>
-        <translation>網頁</translation>
-    </message>
-    <message>
-        <source>Mail</source>
-        <translation>郵件</translation>
-    </message>
-    <message>
-        <source>Text</source>
-        <translation>文本</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation>音樂</translation>
-    </message>
-    <message>
-        <source>Video</source>
-        <translation>視頻</translation>
-    </message>
-    <message>
-        <source>Picture</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <source>Terminal</source>
-        <translation>終端</translation>
-    </message>
-</context>
-<context>
-    <name>device</name>
-    <message>
-        <source>Device</source>
-        <translation>設備</translation>
-    </message>
-</context>
-<context>
-    <name>display</name>
-    <message>
-        <source>Display</source>
-        <translation>顯示</translation>
-    </message>
-    <message>
-        <source>Brightness,resolution,scaling</source>
-        <translation>亮度、解像度、縮放</translation>
-    </message>
-</context>
-<context>
-    <name>displayMain</name>
-    <message>
-        <source>100%</source>
-        <translation>100%</translation>
-    </message>
-    <message>
-        <source>125%</source>
-        <translation>125%</translation>
-    </message>
-    <message>
-        <source>150%</source>
-        <translation>150%</translation>
-    </message>
-    <message>
-        <source>175%</source>
-        <translation>175%</translation>
-    </message>
-    <message>
-        <source>200%</source>
-        <translation>200%</translation>
-    </message>
-    <message>
-        <source>225%</source>
-        <translation>225%</translation>
-    </message>
-    <message>
-        <source>250%</source>
-        <translation>250%</translation>
-    </message>
-    <message>
-        <source>275%</source>
-        <translation>275%</translation>
-    </message>
-    <message>
-        <source>300%</source>
-        <translation>300%</translation>
-    </message>
-    <message>
-        <source>Duplicate</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <source>Extend</source>
-        <translation>擴展</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation>默認</translation>
-    </message>
-    <message>
-        <source>Fit</source>
-        <translation>適應</translation>
-    </message>
-    <message>
-        <source>Stretch</source>
-        <translation>拉伸</translation>
-    </message>
-    <message>
-        <source>Center</source>
-        <translation>居中</translation>
-    </message>
-    <message>
-        <source>Only on %1</source>
-        <translation>僅%1屏</translation>
-    </message>
-    <message>
-        <source> (Recommended)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Hz</source>
-        <translation>赫茲</translation>
-    </message>
-    <message>
-        <source>Multiple Displays Settings</source>
-        <translation>多屏設置</translation>
-    </message>
-    <message>
-        <source>Identify</source>
-        <translation>識別</translation>
-    </message>
-    <message>
-        <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation>屏幕拼接將在修改完成%1s後生效</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Main Screen</source>
-        <translation>主屏幕</translation>
-    </message>
-    <message>
-        <source>Display And Layout</source>
-        <translation>顯示和佈局</translation>
-    </message>
-    <message>
-        <source>Brightness</source>
-        <translation>亮度</translation>
-    </message>
-    <message>
-        <source>Resolution</source>
-        <translation>解像度</translation>
-    </message>
-    <message>
-        <source>Resize Desktop</source>
-        <translation>桌面顯示</translation>
-    </message>
-    <message>
-        <source>Refresh Rate</source>
-        <translation>刷新率</translation>
-    </message>
-    <message>
-        <source>Rotation</source>
-        <translation>方向</translation>
-    </message>
-    <message>
-        <source>Standard</source>
-        <translation>標準</translation>
-    </message>
-    <message>
-        <source>90°</source>
-        <translation>90度</translation>
-    </message>
-    <message>
-        <source>180°</source>
-        <translation>180度</translation>
-    </message>
-    <message>
-        <source>270°</source>
-        <translation>270度</translation>
-    </message>
-    <message>
-        <source>Display Scaling</source>
-        <translation>縮放</translation>
-    </message>
-    <message>
-        <source>The monitor only supports 100% display scaling</source>
-        <translation>當前屏幕僅支持1倍縮放</translation>
-    </message>
-    <message>
-        <source>Eye Comfort</source>
-        <translation>護眼模式</translation>
-    </message>
-    <message>
-        <source>Enable eye comfort</source>
-        <translation>開啓護眼模式</translation>
-    </message>
-    <message>
-        <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-        <translation>調整屏幕顯示較暖的顏色，減少屏幕藍光</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>時間</translation>
-    </message>
-    <message>
-        <source>All day</source>
-        <translation>全天</translation>
-    </message>
-    <message>
-        <source>Sunset to Sunrise</source>
-        <translation>日落到日出</translation>
-    </message>
-    <message>
-        <source>Custom Time</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>from</source>
-        <translation>從</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation>至</translation>
-    </message>
-    <message>
-        <source>Color Temperature</source>
-        <translation>色温</translation>
-    </message>
-</context>
-<context>
-    <name>dock</name>
-    <message>
-        <source>Desktop and taskbar</source>
-        <translation>桌面和任務欄</translation>
-    </message>
-    <message>
-        <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation>桌面整理、任務欄模式、插件區域設置</translation>
-    </message>
-</context>
-<context>
-    <name>keyboard</name>
-    <message>
-        <source>Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-    <message>
-        <source>General Settings, keyboard layout, input method, shortcuts</source>
-        <translation>通用設置、鍵盤佈局、輸入法、快捷鍵</translation>
-    </message>
-</context>
-<context>
-    <name>keyboardMain</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Keyboard layout</source>
-        <translation>鍵盤佈局</translation>
-    </message>
-    <message>
-        <source>Set system default keyboard layout</source>
-        <translation>設置系統默認鍵盤佈局</translation>
-    </message>
-</context>
-<context>
-    <name>main</name>
-    <message>
-        <source>Dock</source>
-        <translation>任務欄</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Classic Mode</source>
-        <translation>經典模式</translation>
-    </message>
-    <message>
-        <source>Centered Mode</source>
-        <translation>居中模式</translation>
-    </message>
-    <message>
-        <source>Dock size</source>
-        <translation>任務欄大小</translation>
-    </message>
-    <message>
-        <source>Small</source>
-        <translation>小</translation>
-    </message>
-    <message>
-        <source>Large</source>
-        <translation>大</translation>
-    </message>
-    <message>
-        <source>Position on the screen</source>
-        <translation>屏幕中的位置</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>上</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <source>Keep shown</source>
-        <translation>一直顯示</translation>
-    </message>
-    <message>
-        <source>Keep hidden</source>
-        <translation>一直隱藏</translation>
-    </message>
-    <message>
-        <source>Smart hide</source>
-        <translation>智能隱藏</translation>
-    </message>
-    <message>
-        <source>Multiple Displays</source>
-        <translation>多屏顯示</translation>
-    </message>
-    <message>
-        <source>Set the position of the taskbar on the screen</source>
-        <translation>設置任務欄在屏幕中的位置</translation>
-    </message>
-    <message>
-        <source>Only on main</source>
-        <translation>僅主屏顯示</translation>
-    </message>
-    <message>
-        <source>On screen where the cursor is</source>
-        <translation>跟隨鼠標位置顯示</translation>
-    </message>
-    <message>
-        <source>Plugin Area</source>
-        <translation>插件區域</translation>
-    </message>
-    <message>
-        <source>Select which icons appear in the Dock</source>
-        <translation>選擇顯示在任務欄插件區域的圖標</translation>
-    </message>
-</context>
-<context>
-    <name>mouse</name>
-    <message>
-        <source>Mouse and Touchpad</source>
-        <translation>鼠標與觸控板</translation>
-    </message>
-    <message>
-        <source>Common、Mouse、Touchpad</source>
-        <translation>通用、鼠標、觸控板</translation>
-    </message>
-</context>
-<context>
-    <name>mouseMain</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Mouse</source>
-        <translation>鼠標</translation>
-    </message>
-    <message>
-        <source>Touchpad</source>
-        <translation>觸控板</translation>
-    </message>
-</context>
-<context>
-    <name>notification</name>
-    <message>
-        <source>DND mode, app notifications</source>
-        <translation>勿擾模式、應用通知</translation>
-    </message>
-    <message>
-        <source>Notification</source>
-        <translation>通知</translation>
-    </message>
-</context>
-<context>
-    <name>notificationMain</name>
-    <message>
-        <source>Do Not Disturb Settings</source>
-        <translation>勿擾設置</translation>
-    </message>
-    <message>
-        <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-        <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心查看所有消息。</translation>
-    </message>
-    <message>
-        <source>Enable Do Not Disturb</source>
-        <translation>啓用勿擾模式</translation>
-    </message>
-    <message>
-        <source>When the screen is locked</source>
-        <translation>在屏幕鎖屏時</translation>
-    </message>
-    <message>
-        <source>Number of notifications shown on the desktop</source>
-        <translation>通知橫幅展示數量</translation>
-    </message>
-    <message>
-        <source>App Notifications</source>
-        <translation>應用通知</translation>
-    </message>
-    <message>
-        <source>Allow Notifications</source>
-        <translation>允許通知</translation>
-    </message>
-    <message>
-        <source>Display notification on desktop or show unread messages in the notification center</source>
-        <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
-    </message>
-    <message>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <source>Lock Screen</source>
-        <translation>鎖屏</translation>
-    </message>
-    <message>
-        <source>Notification Center</source>
-        <translation>通知中心</translation>
-    </message>
-    <message>
-        <source>Show message preview</source>
-        <translation>顯示消息預覽</translation>
-    </message>
-    <message>
-        <source>Play a sound</source>
-        <translation>通知時提示聲音</translation>
-    </message>
-</context>
-<context>
-    <name>personalization</name>
-    <message>
-        <source>Personalization</source>
-        <translation>個性化</translation>
-    </message>
-</context>
-<context>
-    <name>personalizationMain</name>
-    <message>
-        <source>Theme</source>
-        <translation>主題</translation>
-    </message>
-    <message>
-        <source>Appearance</source>
-        <translation>外觀</translation>
-    </message>
-    <message>
-        <source>Window effect</source>
-        <translation>窗口效果</translation>
-    </message>
-    <message>
-        <source>Personalize your wallpaper and screensaver</source>
-        <translation>個性化您的壁紙和屏保</translation>
-    </message>
-    <message>
-        <source>Screensaver</source>
-        <translation>屏幕保護</translation>
-    </message>
-    <message>
-        <source>Colors and icons</source>
-        <translation>顏色和圖標</translation>
-    </message>
-    <message>
-        <source>Adjust accent color and theme icons</source>
-        <translation>調整活動色和主題圖標</translation>
-    </message>
-    <message>
-        <source>Font and font size</source>
-        <translation>字體和字號</translation>
-    </message>
-    <message>
-        <source>Change system font and size</source>
-        <translation>修改系統字體與字號</translation>
-    </message>
-    <message>
-        <source>Wallpaper</source>
-        <translation>壁紙</translation>
-    </message>
-    <message>
-        <source>Select light, dark or automatic theme appearance</source>
-        <translation>選擇淺色、深色或自動切換主題外觀</translation>
-    </message>
-    <message>
-        <source>Interface and effects, rounded corners</source>
-        <translation>界面和效果、窗口圓角</translation>
-    </message>
-</context>
-<context>
-    <name>power</name>
-    <message>
-        <source>Power saving settings, screen and suspend</source>
-        <translation>節能設置、屏幕和待機管理</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation>電源管理</translation>
-    </message>
-</context>
-<context>
-    <name>powerMain</name>
-    <message>
-        <source>General</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-        <translation>性能模式、節能設置、喚醒設置、關機設置</translation>
-    </message>
-    <message>
-        <source>Plugged In</source>
-        <translation>使用電源</translation>
-    </message>
-    <message>
-        <source>Screen and suspend</source>
-        <translation>屏幕和待機管理</translation>
-    </message>
-    <message>
-        <source>On Battery</source>
-        <translation>使用電池</translation>
-    </message>
-    <message>
-        <source>screen and suspend, low battery, battery management</source>
-        <translation>屏幕和待機管理、低電量管理、電池管理</translation>
-    </message>
-</context>
-<context>
-    <name>privacy</name>
-    <message>
-        <source>Privacy and Security</source>
-        <translation>私隱和安全</translation>
-    </message>
-    <message>
-        <source>Camera, folder permissions</source>
-        <translation>攝像頭、文件夾權限</translation>
-    </message>
-</context>
-<context>
-    <name>privacyMain</name>
-    <message>
-        <source>Camera</source>
-        <translation>攝像頭</translation>
-    </message>
-    <message>
-        <source>Choose whether the application has access to the camera</source>
-        <translation>選擇應用是否有攝像頭的訪問權限</translation>
-    </message>
-    <message>
-        <source>Files and Folders</source>
-        <translation>文件和文件夾</translation>
-    </message>
-    <message>
-        <source>Choose whether the application has access to files and folders</source>
-        <translation>選擇應用是否有文件和文件夾的訪問權限</translation>
-    </message>
-</context>
-<context>
-    <name>sound</name>
-    <message>
-        <source>Sound</source>
-        <translation>聲音</translation>
-    </message>
-    <message>
-        <source>Output, input, sound effects, devices</source>
-        <translation>輸入、輸出、系統音效、設備管理</translation>
-    </message>
-</context>
-<context>
-    <name>soundMain</name>
-    <message>
-        <source>Settings</source>
-        <translation>設置</translation>
-    </message>
-    <message>
-        <source>Sound Effects</source>
-        <translation>系統音效</translation>
-    </message>
-    <message>
-        <source>Enable/disable sound effects</source>
-        <translation>開啓/關閉系統音效</translation>
-    </message>
-    <message>
-        <source>Enable/disable audio devices</source>
-        <translation>啓用/禁用音頻設備</translation>
-    </message>
-    <message>
-        <source>Devices</source>
-        <translation>設備管理</translation>
-    </message>
-</context>
-<context>
-    <name>system</name>
-    <message>
-        <source>Common settings</source>
-        <translation>常用設置</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation>系統</translation>
-    </message>
-</context>
-<context>
-    <name>systemInfo</name>
-    <message>
-        <source>Auxiliary Information</source>
-        <translation>輔助信息</translation>
-    </message>
-</context>
-<context>
-    <name>systemInfoMain</name>
-    <message>
-        <source>About This PC</source>
-        <translation>關於本機</translation>
-    </message>
-    <message>
-        <source>System version, device information</source>
-        <translation>系統版本、設備信息</translation>
-    </message>
-    <message>
-        <source>View the notice of open source software</source>
-        <translation>查看開源軟件聲明</translation>
-    </message>
-    <message>
-        <source>User Experience Program</source>
-        <translation>用户體驗計劃</translation>
-    </message>
-    <message>
-        <source>Join the user experience program to help improve the product</source>
-        <translation>加入用户體驗計劃，幫助改進產品</translation>
-    </message>
-    <message>
-        <source>End User License Agreement</source>
-        <translation>用户許可協議</translation>
-    </message>
-    <message>
-        <source>View the end  user license agreement</source>
-        <translation>查看最終用户許可協議</translation>
-    </message>
-    <message>
-        <source>Privacy Policy</source>
-        <translation>私隱政策</translation>
-    </message>
-    <message>
-        <source>View information about privacy policy</source>
-        <translation>查看私隱政策相關信息</translation>
-    </message>
-    <message>
-        <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>touchscreen</name>
-    <message>
-        <source>Touchscreen</source>
-        <translation>觸控屏</translation>
-    </message>
-    <message>
-        <source>Configuring Touchscreen</source>
-        <translation>觸控屏設置</translation>
-    </message>
-</context>
-<context>
-    <name>touchscreenMain</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-</context>
-<context>
-    <name>wacom</name>
-    <message>
-        <source>wacom</source>
-        <translation>數位板</translation>
-    </message>
-    <message>
-        <source>Configuring wacom</source>
-        <translation>數位板選項設置</translation>
-    </message>
-</context>
-<context>
-    <name>wacomMain</name>
-    <message>
-        <source>wacom</source>
-        <translation>數位板</translation>
-    </message>
-    <message>
-        <source>Wacom Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Pen Mode</source>
-        <translation>筆模式</translation>
-    </message>
-    <message>
-        <source>Mouse Mode</source>
-        <translation>鼠標模式</translation>
-    </message>
-    <message>
-        <source>Pressure Sensitivity</source>
-        <translation>壓感</translation>
-    </message>
-    <message>
-        <source>Light</source>
-        <translation>輕</translation>
-    </message>
-</context>
+        </message>
+        <message>
+            <source>Sign In to %1 ID</source>
+            <translation>登錄%1 ID</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDSyncService</name>
+        <message>
+            <source>Auto Sync</source>
+            <translation>自動同步</translation>
+        </message>
+        <message>
+            <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
+            <translation>將您的系統設置和個人信息安全地存儲在雲端，並在您不同的設備上保持同步</translation>
+        </message>
+        <message>
+            <source>System Settings</source>
+            <translation>系統設置</translation>
+        </message>
+        <message>
+            <source>Last sync time: %1</source>
+            <translation>最近同步時間：%1</translation>
+        </message>
+        <message>
+            <source>Clear cloud data</source>
+            <translation>清除雲端數據</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
+            <translation>確定要清除您保存在雲端的系統設置和個人數據嗎？</translation>
+        </message>
+        <message>
+            <source>Once the data is cleared, it cannot be recovered!</source>
+            <translation>數據清除後將無法恢復！</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Clear</source>
+            <translation>清除</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDUserInfo</name>
+        <message>
+            <source>Synchronization Service</source>
+            <translation>同步服務</translation>
+        </message>
+        <message>
+            <source>Account and Security</source>
+            <translation>賬户與安全</translation>
+        </message>
+        <message>
+            <source>Sign out</source>
+            <translation>退出登錄</translation>
+        </message>
+        <message>
+            <source>Go to web settings</source>
+            <translation>前往網頁設置</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinWorker</name>
+        <message>
+            <source>encrypt password failed</source>
+            <translation>加密密碼失敗</translation>
+        </message>
+        <message>
+            <source>Wrong password, %1 chances left</source>
+            <translation>密碼錯誤，您還可以嘗試%1次</translation>
+        </message>
+        <message>
+            <source>The login error has reached the limit today. You can reset the password and try again.</source>
+            <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
+        </message>
+        <message>
+            <source>Operation Successful</source>
+            <translation>操作成功</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinidModel</name>
+        <message>
+            <source>Mainland China</source>
+            <translation>中國大陸</translation>
+        </message>
+        <message>
+            <source>Other regions</source>
+            <translation>其他地區</translation>
+        </message>
+        <message>
+            <source>The feature is not available at present, please activate your system first</source>
+            <translation>當前系統未激活，暫無法使用該功能</translation>
+        </message>
+        <message>
+            <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
+            <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailItem</name>
+        <message>
+            <source>Please choose the default program to open '%1'</source>
+            <translation>選擇打開「%1」的默認程序</translation>
+        </message>
+        <message>
+            <source>add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <source>Open Desktop file</source>
+            <translation>打開Desktop文件</translation>
+        </message>
+        <message>
+            <source>Apps (*.desktop)</source>
+            <translation>應用程式(*.desktop)</translation>
+        </message>
+        <message>
+            <source>All files (*)</source>
+            <translation>所有文件(*)</translation>
+        </message>
+    </context>
+    <context>
+        <name>DevelopModePage</name>
+        <message>
+            <source>Root Access</source>
+            <translation>開發者模式</translation>
+        </message>
+        <message>
+            <source>Request Root Access</source>
+            <translation>進入開發者模式</translation>
+        </message>
+        <message>
+            <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
+            <translation>可獲得root使用權限，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
+        </message>
+        <message>
+            <source>Allowed</source>
+            <translation>已進入</translation>
+        </message>
+        <message>
+            <source>Enter</source>
+            <translation>進入</translation>
+        </message>
+        <message>
+            <source>Online</source>
+            <translation>在線激活</translation>
+        </message>
+        <message>
+            <source>Login UOS ID</source>
+            <translation>登錄UOS ID</translation>
+        </message>
+        <message>
+            <source>Offline</source>
+            <translation>離線激活</translation>
+        </message>
+        <message>
+            <source>Import Certificate</source>
+            <translation>導入證書</translation>
+        </message>
+        <message>
+            <source>Select file</source>
+            <translation>選擇文件</translation>
+        </message>
+        <message>
+            <source>Your UOS ID has been logged in, click to enter developer mode</source>
+            <translation>您的UOS ID已登錄，點擊進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Please sign in to your UOS ID first and continue</source>
+            <translation>進入開發者模式需要登錄UOS ID</translation>
+        </message>
+        <message>
+            <source>1.Export PC Info</source>
+            <translation>1.導出機器信息</translation>
+        </message>
+        <message>
+            <source>Export</source>
+            <translation>導出</translation>
+        </message>
+        <message>
+            <source>2.please go to &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
+            <translation>2.前往 &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
+        </message>
+        <message>
+            <source>3.Import Certificate</source>
+            <translation>3.導入證書</translation>
+        </message>
+        <message>
+            <source>To install and run unsigned apps, please go to &lt;a href="Security Center"&gt;Security Center&lt;/a&gt; to change the settings.</source>
+            <translation>如需安裝非應用商店來源的應用，前往 &lt;a href="Security Center"&gt;安全中心&lt;/a&gt; 進行設置。</translation>
+        </message>
+        <message>
+            <source>Development and debugging options</source>
+            <translation>開發調試選項</translation>
+        </message>
+        <message>
+            <source>System logging level</source>
+            <translation>系統日誌記錄級別</translation>
+        </message>
+        <message>
+            <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
+            <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多存儲空間.</translation>
+        </message>
+        <message>
+            <source>Off</source>
+            <translation>關閉</translation>
+        </message>
+        <message>
+            <source>Debug</source>
+            <translation>調試</translation>
+        </message>
+        <message>
+            <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
+            <translation>更改選項處理可能需要一分鐘，收到設置成功提示後，請重啓設備方可生效。</translation>
+        </message>
+    </context>
+    <context>
+        <name>DisclaimerControl</name>
+        <message>
+            <source>Disclaimer</source>
+            <translation>《用户免責聲明》</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Agree</source>
+            <translation>同意</translation>
+        </message>
+    </context>
+    <context>
+        <name>FileAndFolder</name>
+        <message>
+            <source>Allow below apps to access these files and folders:</source>
+            <translation>允許下面的應用訪問您的文件和文件夾</translation>
+        </message>
+        <message>
+            <source>Documents</source>
+            <translation>文檔</translation>
+        </message>
+        <message>
+            <source>Desktop</source>
+            <translation>桌面</translation>
+        </message>
+        <message>
+            <source>Pictures</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Videos</source>
+            <translation>視頻</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂</translation>
+        </message>
+        <message>
+            <source>Downloads</source>
+            <translation>下載</translation>
+        </message>
+        <message>
+            <source>folder</source>
+            <translation>文件夾</translation>
+        </message>
+    </context>
+    <context>
+        <name>FontSizePage</name>
+        <message>
+            <source>Size</source>
+            <translation>字號</translation>
+        </message>
+        <message>
+            <source>Standard Font</source>
+            <translation>標準字體</translation>
+        </message>
+        <message>
+            <source>Monospaced Font</source>
+            <translation>等寬字體</translation>
+        </message>
+    </context>
+    <context>
+        <name>GeneralPage</name>
+        <message>
+            <source>Power Plans</source>
+            <translation>性能模式</translation>
+        </message>
+        <message>
+            <source>Power Saving Settings</source>
+            <translation>節能設置</translation>
+        </message>
+        <message>
+            <source>Auto power saving on low battery</source>
+            <translation>低電量時自動開啓節能模式</translation>
+        </message>
+        <message>
+            <source>Low battery threshold</source>
+            <translation>低電量閾值</translation>
+        </message>
+        <message>
+            <source>Auto power saving on battery</source>
+            <translation>使用電池時自動開啓節能模式</translation>
+        </message>
+        <message>
+            <source>Wakeup Settings</source>
+            <translation>喚醒設置</translation>
+        </message>
+        <message>
+            <source>Password is required to wake up the computer</source>
+            <translation>待機恢復時需要密碼</translation>
+        </message>
+        <message>
+            <source>Password is required to wake up the monitor</source>
+            <translation>喚醒顯示器時需要密碼</translation>
+        </message>
+        <message>
+            <source>Shutdown Settings</source>
+            <translation>關機設置</translation>
+        </message>
+        <message>
+            <source>Scheduled Shutdown</source>
+            <translation>定時關機</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation>時間</translation>
+        </message>
+        <message>
+            <source>Repeat</source>
+            <translation>重複</translation>
+        </message>
+        <message>
+            <source>Once</source>
+            <translation>一次</translation>
+        </message>
+        <message>
+            <source>Every day</source>
+            <translation>每天</translation>
+        </message>
+        <message>
+            <source>Working days</source>
+            <translation>工作日</translation>
+        </message>
+        <message>
+            <source>Custom Time</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>Decrease screen brightness on power saver</source>
+            <translation>節能模式時降低屏幕亮度</translation>
+        </message>
+    </context>
+    <context>
+        <name>GestureModel</name>
+        <message>
+            <source>Three-finger</source>
+            <translation>三指</translation>
+        </message>
+        <message>
+            <source>Four-finger</source>
+            <translation>四指</translation>
+        </message>
+        <message>
+            <source>Up</source>
+            <translation>向上</translation>
+        </message>
+        <message>
+            <source>Down</source>
+            <translation>向下</translation>
+        </message>
+        <message>
+            <source>Left</source>
+            <translation>向左</translation>
+        </message>
+        <message>
+            <source>Right</source>
+            <translation>向右</translation>
+        </message>
+        <message>
+            <source>tap</source>
+            <translation>點擊</translation>
+        </message>
+    </context>
+    <context>
+        <name>HomePage</name>
+        <message>
+            <source>,</source>
+            <translation>、</translation>
+        </message>
+        <message>
+            <source>...</source>
+            <translation>等</translation>
+        </message>
+    </context>
+    <context>
+        <name>InterfaceEffectListview</name>
+        <message>
+            <source>Optimal Performance</source>
+            <translation>最佳性能</translation>
+        </message>
+        <message>
+            <source>Balance</source>
+            <translation>均衡</translation>
+        </message>
+        <message>
+            <source>Best Visuals</source>
+            <translation>最佳視覺</translation>
+        </message>
+        <message>
+            <source>Disable all interface and window effects for efficient system performance.</source>
+            <translation>關閉所有界面和窗口特效，保障系統高效運行</translation>
+        </message>
+        <message>
+            <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
+            <translation>限制部分窗口特效，保障出色的視覺效果，同時維持系統流暢運行</translation>
+        </message>
+        <message>
+            <source>Enable all interface and window effects for the best visual experience.</source>
+            <translation>啓用所有界面和窗口特效，體驗最佳視覺效果</translation>
+        </message>
+    </context>
+    <context>
+        <name>KeyboardLayout</name>
+        <message>
+            <source>Keyboard layout</source>
+            <translation>鍵盤佈局</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Add the corresponding input method in &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
+            <translation>如需添加或切換鍵盤佈局，請同時在 &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt; 輸入法管理 &lt;/a&gt;  中添加對應的輸入法以確保生效</translation>
+        </message>
+        <message>
+            <source>Add new keyboard layout...</source>
+            <translation>添加鍵盤佈局...</translation>
+        </message>
+    </context>
+    <context>
+        <name>LangAndFormat</name>
+        <message>
+            <source>Language</source>
+            <translation>語言</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Other languages</source>
+            <translation>其他語言</translation>
+        </message>
+        <message>
+            <source>add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <source>Region</source>
+            <translation>區域</translation>
+        </message>
+        <message>
+            <source>Area</source>
+            <translation>地區</translation>
+        </message>
+        <message>
+            <source>Operating system and applications may provide you with local content based on your country and region</source>
+            <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
+        </message>
+        <message>
+            <source>Region and format</source>
+            <translation>區域格式</translation>
+        </message>
+        <message>
+            <source>Operating system and applications may set date and time formats based on regional formats</source>
+            <translation>作業系統和某些應用會根據區域格式設置日期和時間格式</translation>
+        </message>
+    </context>
+    <context>
+        <name>LangsChooserDialog</name>
+        <message>
+            <source>Add language</source>
+            <translation>添加語言</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜索</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+    </context>
+    <context>
+        <name>LayoutsChooser</name>
+        <message>
+            <source>Add language</source>
+            <translation>添加語言</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜索</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+    </context>
+    <context>
+        <name>LoginMethod</name>
+        <message>
+            <source>Login method</source>
+            <translation>登錄方式</translation>
+        </message>
+        <message>
+            <source>Password, wechat, biometric authentication, security key</source>
+            <translation>密碼，微信掃碼，生物認證，安全密鑰</translation>
+        </message>
+        <message>
+            <source>Password</source>
+            <translation>密碼</translation>
+        </message>
+        <message>
+            <source>Modify password</source>
+            <translation>修改密碼</translation>
+        </message>
+        <message>
+            <source>Validity days</source>
+            <translation>有效天數</translation>
+        </message>
+        <message>
+            <source>Always</source>
+            <translation>長期有效</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogoModule</name>
+        <message>
+            <source>Copyright© 2011-%1 Deepin Community</source>
+            <translation>Copyright © 2011-%1 深度社區</translation>
+        </message>
+        <message>
+            <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
+            <translation>Copyright © 2019-%1 統信軟件技術有限公司</translation>
+        </message>
+    </context>
+    <context>
+        <name>MicrophonePage</name>
+        <message>
+            <source>Automatic Noise Suppression</source>
+            <translation>噪音抑制</translation>
+        </message>
+        <message>
+            <source>Input Volume</source>
+            <translation>輸入音量</translation>
+        </message>
+        <message>
+            <source>Input Level</source>
+            <translation>反饋音量</translation>
+        </message>
+        <message>
+            <source>Input</source>
+            <translation>輸入</translation>
+        </message>
+        <message>
+            <source>No input device for sound found</source>
+            <translation>沒有找到聲音輸入設備</translation>
+        </message>
+        <message>
+            <source>Input Devices</source>
+            <translation>輸入設備</translation>
+        </message>
+    </context>
+    <context>
+        <name>Mouse</name>
+        <message>
+            <source>Mouse</source>
+            <translation>鼠標</translation>
+        </message>
+        <message>
+            <source>Pointer Speed</source>
+            <translation>指針速度</translation>
+        </message>
+        <message>
+            <source>Slow</source>
+            <translation>慢</translation>
+        </message>
+        <message>
+            <source>Fast</source>
+            <translation>快</translation>
+        </message>
+        <message>
+            <source>Pointer Size</source>
+            <translation>指針大小</translation>
+        </message>
+        <message>
+            <source>Short</source>
+            <translation>短</translation>
+        </message>
+        <message>
+            <source>Long</source>
+            <translation>長</translation>
+        </message>
+        <message>
+            <source>Mouse Acceleration</source>
+            <translation>鼠標加速</translation>
+        </message>
+        <message>
+            <source>Disable touchpad when a mouse is connected</source>
+            <translation>插入鼠標時禁用觸摸板</translation>
+        </message>
+        <message>
+            <source>Natural Scrolling</source>
+            <translation>自然滾動</translation>
+        </message>
+    </context>
+    <context>
+        <name>MyDevice</name>
+        <message>
+            <source>My Devices</source>
+            <translation>我的設備</translation>
+        </message>
+    </context>
+    <context>
+        <name>NativeInfoPage</name>
+        <message>
+            <source>UOS</source>
+            <translation>UOS</translation>
+        </message>
+        <message>
+            <source>Computer name</source>
+            <translation>計算機名</translation>
+        </message>
+        <message>
+            <source>It cannot start or end with dashes</source>
+            <translation>計算機名不能以 - 開頭結尾</translation>
+        </message>
+        <message>
+            <source>OS Name</source>
+            <translation>產品名稱</translation>
+        </message>
+        <message>
+            <source>Version</source>
+            <translation>版本號</translation>
+        </message>
+        <message>
+            <source>Edition</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <source>Type</source>
+            <translation>類型</translation>
+        </message>
+        <message>
+            <source>bit</source>
+            <translation>位</translation>
+        </message>
+        <message>
+            <source>Authorization</source>
+            <translation>版本授權</translation>
+        </message>
+        <message>
+            <source>System installation time</source>
+            <translation>系統安裝日期</translation>
+        </message>
+        <message>
+            <source>Kernel</source>
+            <translation>內核版本</translation>
+        </message>
+        <message>
+            <source>Graphics Platform</source>
+            <translation>圖形平台</translation>
+        </message>
+        <message>
+            <source>Processor</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <source>Memory</source>
+            <translation>內存</translation>
+        </message>
+        <message>
+            <source>1~63 characters please</source>
+            <translation>計算機名長度必須介於1到63個字符之間</translation>
+        </message>
+    </context>
+    <context>
+        <name>OtherDevice</name>
+        <message>
+            <source>Other Devices</source>
+            <translation>其他設備</translation>
+        </message>
+        <message>
+            <source>Show Bluetooth devices without names</source>
+            <translation>顯示沒有名稱的藍牙設備</translation>
+        </message>
+    </context>
+    <context>
+        <name>PasswordLayout</name>
+        <message>
+            <source>Current password</source>
+            <translation>當前密碼</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>Weak</source>
+            <translation>強度低</translation>
+        </message>
+        <message>
+            <source>Medium</source>
+            <translation>強度中</translation>
+        </message>
+        <message>
+            <source>Strong</source>
+            <translation>強度高</translation>
+        </message>
+        <message>
+            <source>Password</source>
+            <translation>密碼</translation>
+        </message>
+        <message>
+            <source>Repeat Password</source>
+            <translation>重複密碼</translation>
+        </message>
+        <message>
+            <source>Password hint</source>
+            <translation>密碼提示</translation>
+        </message>
+        <message>
+            <source>Optional</source>
+            <translation>選填</translation>
+        </message>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Passwords do not match</source>
+            <translation>密碼不一致</translation>
+        </message>
+        <message>
+            <source>New password should differ from the current one</source>
+            <translation>新密碼和舊密碼不能相同</translation>
+        </message>
+        <message>
+            <source>The hint is visible to all users. Do not include the password here.</source>
+            <translation>密碼提示對所有人可見，切勿包含具體密碼信息</translation>
+        </message>
+    </context>
+    <context>
+        <name>PasswordModifyDialog</name>
+        <message>
+            <source>Modify password</source>
+            <translation>修改密碼</translation>
+        </message>
+        <message>
+            <source>Reset password</source>
+            <translation>重置密碼</translation>
+        </message>
+        <message>
+            <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
+            <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
+        </message>
+        <message>
+            <source>Resetting the password will clear the data stored in the keyring.</source>
+            <translation>重設密碼將會清除密鑰環內已存儲的數據</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+    </context>
+    <context>
+        <name>PersonalizationInterface</name>
+        <message>
+            <source>Light</source>
+            <translation>淺色</translation>
+        </message>
+        <message>
+            <source>Auto</source>
+            <translation>自動</translation>
+        </message>
+        <message>
+            <source>Dark</source>
+            <translation>深色</translation>
+        </message>
+    </context>
+    <context>
+        <name>PersonalizationWorker</name>
+        <message>
+            <source>Custom</source>
+            <translation>自定義</translation>
+        </message>
+    </context>
+    <context>
+        <name>PluginArea</name>
+        <message>
+            <source>Plugin Area</source>
+            <translation>插件區域</translation>
+        </message>
+        <message>
+            <source>Select which icons appear in the Dock</source>
+            <translation>選擇顯示在任務欄插件區域的圖標</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerOperatorModel</name>
+        <message>
+            <source>Shut down</source>
+            <translation>關機</translation>
+        </message>
+        <message>
+            <source>Suspend</source>
+            <translation>待機</translation>
+        </message>
+        <message>
+            <source>Hibernate</source>
+            <translation>休眠</translation>
+        </message>
+        <message>
+            <source>Turn off the monitor</source>
+            <translation>關閉顯示器</translation>
+        </message>
+        <message>
+            <source>Show the shutdown Interface</source>
+            <translation>進入關機界面</translation>
+        </message>
+        <message>
+            <source>Do nothing</source>
+            <translation>無任何操作</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerPage</name>
+        <message>
+            <source>Screen and Suspend</source>
+            <translation>屏幕和待機</translation>
+        </message>
+        <message>
+            <source>Turn off the monitor after</source>
+            <translation>關閉顯示器</translation>
+        </message>
+        <message>
+            <source>Lock screen after</source>
+            <translation>自動鎖屏</translation>
+        </message>
+        <message>
+            <source>Computer suspends after</source>
+            <translation>進入待機</translation>
+        </message>
+        <message>
+            <source>When the lid is closed</source>
+            <translation>筆記本合蓋時</translation>
+        </message>
+        <message>
+            <source>When the power button is pressed</source>
+            <translation>按電源按鈕時</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerPlansListview</name>
+        <message>
+            <source>High Performance</source>
+            <translation>高性能模式</translation>
+        </message>
+        <message>
+            <source>Balance Performance</source>
+            <translation>性能模式</translation>
+        </message>
+        <message>
+            <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
+            <translation>根據負載情況積極調整運行頻率</translation>
+        </message>
+        <message>
+            <source>Balanced</source>
+            <translation>平衡模式</translation>
+        </message>
+        <message>
+            <source>Power Saver</source>
+            <translation>節能模式</translation>
+        </message>
+        <message>
+            <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
+            <translation>性能優先，會顯著提升功耗和發熱</translation>
+        </message>
+        <message>
+            <source>Balancing performance and battery life, automatically adjusted according to usage</source>
+            <translation>兼顧性能和續航，根據使用情況自動調節</translation>
+        </message>
+        <message>
+            <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
+            <translation>續航優先，系統會犧牲一些性能表現來降低功耗</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerWorker</name>
+        <message>
+            <source>Minutes</source>
+            <translation>分鐘</translation>
+        </message>
+        <message>
+            <source>Hour</source>
+            <translation>小時</translation>
+        </message>
+        <message>
+            <source>Never</source>
+            <translation>從不</translation>
+        </message>
+    </context>
+    <context>
+        <name>PrivacyPolicyPage</name>
+        <message>
+            <source>Privacy Policy</source>
+            <translation>私隱政策</translation>
+        </message>
+        <message>
+            <source>Copy Link Address</source>
+            <translation>複製連結地址</translation>
+        </message>
+    </context>
+    <context>
+        <name>PwqualityManager</name>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Password must have at least %1 characters</source>
+            <translation>密碼長度不能少於%1個字符</translation>
+        </message>
+        <message>
+            <source>Password must be no more than %1 characters</source>
+            <translation>密碼長度不能超過%1個字符</translation>
+        </message>
+        <message>
+            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
+        </message>
+        <message>
+            <source>No more than %1 palindrome characters please</source>
+            <translation>迴文字符長度不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 monotonic characters please</source>
+            <translation>單調性字符不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 repeating characters please</source>
+            <translation>重複字符不超過%1位</translation>
+        </message>
+        <message>
+            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
+        </message>
+        <message>
+            <source>Password must not contain more than 4 palindrome characters</source>
+            <translation>密碼不得含有連續4個以上的迴文字符</translation>
+        </message>
+        <message>
+            <source>Do not use common words and combinations as password</source>
+            <translation>密碼不能是常見單詞及組合</translation>
+        </message>
+        <message>
+            <source>Create a strong password please</source>
+            <translation>密碼過於簡單，請增加密碼複雜度</translation>
+        </message>
+        <message>
+            <source>It does not meet password rules</source>
+            <translation>密碼不符合安全要求</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <source>Control Center</source>
+            <translation>控制中心</translation>
+        </message>
+        <message>
+            <source>Activated</source>
+            <translation>已激活</translation>
+        </message>
+        <message>
+            <source>View</source>
+            <translation>查看</translation>
+        </message>
+        <message>
+            <source>To be activated</source>
+            <translation>待激活</translation>
+        </message>
+        <message>
+            <source>Activate</source>
+            <translation>激活</translation>
+        </message>
+        <message>
+            <source>Expired</source>
+            <translation>已過期</translation>
+        </message>
+        <message>
+            <source>In trial period</source>
+            <translation>試用期</translation>
+        </message>
+        <message>
+            <source>Trial expired</source>
+            <translation>試用期過期</translation>
+        </message>
+        <message>
+            <source>dde-control-center</source>
+            <translation>控制中心</translation>
+        </message>
+        <message>
+            <source>Touch Screen Settings</source>
+            <translation>觸控屏設置</translation>
+        </message>
+        <message>
+            <source>The settings of touch screen changed</source>
+            <translation>已變更觸控屏設置</translation>
+        </message>
+        <message>
+            <source>This system wallpaper is locked. Please contact your admin.</source>
+            <translation>當前系統壁紙已被鎖定，請聯繫管理員</translation>
+        </message>
+    </context>
+    <context>
+        <name>RegionFormatDialog</name>
+        <message>
+            <source>Regions and formats</source>
+            <translation>區域和格式</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜索</translation>
+        </message>
+        <message>
+            <source>Default formats</source>
+            <translation>默認格式</translation>
+        </message>
+        <message>
+            <source>First day of week</source>
+            <translation>一週第一天</translation>
+        </message>
+        <message>
+            <source>Short date</source>
+            <translation>短日期</translation>
+        </message>
+        <message>
+            <source>Long date</source>
+            <translation>長日期</translation>
+        </message>
+        <message>
+            <source>Short time</source>
+            <translation>短時間</translation>
+        </message>
+        <message>
+            <source>Long time</source>
+            <translation>長時間</translation>
+        </message>
+        <message>
+            <source>Currency symbol</source>
+            <translation>貨幣符號</translation>
+        </message>
+        <message>
+            <source>Digit</source>
+            <translation>數字</translation>
+        </message>
+        <message>
+            <source>Paper size</source>
+            <translation>紙張</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>保存</translation>
+        </message>
+    </context>
+    <context>
+        <name>RegionsChooserWindow</name>
+        <message>
+            <source>Search</source>
+            <translation>搜索</translation>
+        </message>
+    </context>
+    <context>
+        <name>RegisterDialog</name>
+        <message>
+            <source>Set a Password</source>
+            <translation>設置密碼</translation>
+        </message>
+        <message>
+            <source>8-64 characters</source>
+            <translation>請輸入8-64位密碼</translation>
+        </message>
+        <message>
+            <source>Repeat the password</source>
+            <translation>請再次輸入密碼</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確定</translation>
+        </message>
+        <message>
+            <source>Passwords don't match</source>
+            <translation>兩次密碼輸入不一致</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScheduledShutdownDialog</name>
+        <message>
+            <source>Customize repetition time</source>
+            <translation>自定義重複時間</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>保存</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScreenSaverPage</name>
+        <message>
+            <source>Screensaver</source>
+            <translation>屏幕保護</translation>
+        </message>
+        <message>
+            <source>preview</source>
+            <translation>全屏預覽</translation>
+        </message>
+        <message>
+            <source>Personalized screensaver</source>
+            <translation>個性化屏保</translation>
+        </message>
+        <message>
+            <source>setting</source>
+            <translation>設置</translation>
+        </message>
+        <message>
+            <source>idle time</source>
+            <translation>閒置時間</translation>
+        </message>
+        <message>
+            <source>1 minute</source>
+            <translation>1分鐘</translation>
+        </message>
+        <message>
+            <source>5 minute</source>
+            <translation>5分鐘</translation>
+        </message>
+        <message>
+            <source>10 minute</source>
+            <translation>10分鐘</translation>
+        </message>
+        <message>
+            <source>15 minute</source>
+            <translation>15分鐘</translation>
+        </message>
+        <message>
+            <source>30 minute</source>
+            <translation>30分鐘</translation>
+        </message>
+        <message>
+            <source>1 hour</source>
+            <translation>1小時</translation>
+        </message>
+        <message>
+            <source>never</source>
+            <translation>從不</translation>
+        </message>
+        <message>
+            <source>Password required for recovery</source>
+            <translation>恢復時需要密碼</translation>
+        </message>
+        <message>
+            <source>Picture slideshow screensaver</source>
+            <translation>圖片輪播屏保</translation>
+        </message>
+        <message>
+            <source>System screensaver</source>
+            <translation>系統屏保</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchableListViewPopup</name>
+        <message>
+            <source>Search</source>
+            <translation>搜索</translation>
+        </message>
+        <message>
+            <source>No search results</source>
+            <translation>無搜索結果</translation>
+        </message>
+    </context>
+    <context>
+        <name>ShortcutSettingDialog</name>
+        <message>
+            <source>Add custom shortcut</source>
+            <translation>添加自定義快捷鍵</translation>
+        </message>
+        <message>
+            <source>Name:</source>
+            <translation>名稱：</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>Command:</source>
+            <translation>命令：</translation>
+        </message>
+        <message>
+            <source>Shortcut</source>
+            <translation>快捷鍵</translation>
+        </message>
+        <message>
+            <source>None</source>
+            <translation>無</translation>
+        </message>
+        <message>
+            <source>Please enter a new shortcut</source>
+            <translation>請輸入新的快捷鍵</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Add</source>
+            <translation>添加</translation>
+        </message>
+        <message>
+            <source>Click Add to replace</source>
+            <translation>點擊添加替換</translation>
+        </message>
+    </context>
+    <context>
+        <name>Shortcuts</name>
+        <message>
+            <source>Shortcuts</source>
+            <translation>快捷鍵</translation>
+        </message>
+        <message>
+            <source>System shortcut, custom shortcut</source>
+            <translation>系統快捷鍵、自定義快捷鍵</translation>
+        </message>
+        <message>
+            <source>Search shortcuts</source>
+            <translation>搜索快捷鍵</translation>
+        </message>
+        <message>
+            <source>Custom</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Please enter a new shortcut</source>
+            <translation>請輸入新的快捷鍵</translation>
+        </message>
+        <message>
+            <source>Click</source>
+            <translation>點擊</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>or</source>
+            <translation>或</translation>
+        </message>
+        <message>
+            <source>Replace</source>
+            <translation>替換</translation>
+        </message>
+        <message>
+            <source>Restore default</source>
+            <translation>恢復默認</translation>
+        </message>
+        <message>
+            <source>Add custom shortcut</source>
+            <translation>添加快捷鍵</translation>
+        </message>
+    </context>
+    <context>
+        <name>SoundDevicemanagesPage</name>
+        <message>
+            <source>Output Devices</source>
+            <translation>輸出設備</translation>
+        </message>
+        <message>
+            <source>Select whether to enable the devices</source>
+            <translation>選擇是否啓用設備</translation>
+        </message>
+        <message>
+            <source>Input Devices</source>
+            <translation>輸入設備</translation>
+        </message>
+    </context>
+    <context>
+        <name>SoundEffectsPage</name>
+        <message>
+            <source>Sound Effects</source>
+            <translation>系統音效</translation>
+        </message>
+    </context>
+    <context>
+        <name>SoundModel</name>
+        <message>
+            <source>Boot up</source>
+            <translation>開機</translation>
+        </message>
+        <message>
+            <source>Shut down</source>
+            <translation>關機</translation>
+        </message>
+        <message>
+            <source>Log out</source>
+            <translation>註銷</translation>
+        </message>
+        <message>
+            <source>Wake up</source>
+            <translation>喚醒</translation>
+        </message>
+        <message>
+            <source>Volume +/-</source>
+            <translation>音量調節</translation>
+        </message>
+        <message>
+            <source>Notification</source>
+            <translation>通知</translation>
+        </message>
+        <message>
+            <source>Low battery</source>
+            <translation>電量不足</translation>
+        </message>
+        <message>
+            <source>Send icon in Launcher to Desktop</source>
+            <translation>從啓動器發送圖標到桌面</translation>
+        </message>
+        <message>
+            <source>Empty Trash</source>
+            <translation>清空回收站</translation>
+        </message>
+        <message>
+            <source>Plug in</source>
+            <translation>電源接入</translation>
+        </message>
+        <message>
+            <source>Plug out</source>
+            <translation>電源拔出</translation>
+        </message>
+        <message>
+            <source>Removable device connected</source>
+            <translation>流動裝置接入</translation>
+        </message>
+        <message>
+            <source>Removable device removed</source>
+            <translation>流動裝置拔出</translation>
+        </message>
+        <message>
+            <source>Error</source>
+            <translation>錯誤提示</translation>
+        </message>
+    </context>
+    <context>
+        <name>SpeakerPage</name>
+        <message>
+            <source>Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Output Volume</source>
+            <translation>輸出音量</translation>
+        </message>
+        <message>
+            <source>Volume Boost</source>
+            <translation>音量增強</translation>
+        </message>
+        <message>
+            <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
+            <translation>音量大於100%時可能會導致音效失真，同時損害您的音頻輸出設備</translation>
+        </message>
+        <message>
+            <source>Left</source>
+            <translation>左</translation>
+        </message>
+        <message>
+            <source>Right</source>
+            <translation>右</translation>
+        </message>
+        <message>
+            <source>Output</source>
+            <translation>輸出</translation>
+        </message>
+        <message>
+            <source>No output device for sound found</source>
+            <translation>沒有找到聲音輸出設備</translation>
+        </message>
+        <message>
+            <source>Left Right Balance</source>
+            <translation>左右平衡</translation>
+        </message>
+        <message>
+            <source>Mono audio</source>
+            <translation>單聲道音頻</translation>
+        </message>
+        <message>
+            <source>Merge left and right channels into a single channel</source>
+            <translation>將左聲道和右聲道合併成一個聲道</translation>
+        </message>
+        <message>
+            <source>Auto pause</source>
+            <translation>插拔管理</translation>
+        </message>
+        <message>
+            <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
+            <translation>外設插拔時音頻輸出是否自動暫停</translation>
+        </message>
+        <message>
+            <source>Output Devices</source>
+            <translation>輸出設備</translation>
+        </message>
+    </context>
+    <context>
+        <name>SyncInfoListModel</name>
+        <message>
+            <source>Sound</source>
+            <translation>聲音</translation>
+        </message>
+        <message>
+            <source>Power</source>
+            <translation>電源</translation>
+        </message>
+        <message>
+            <source>Mouse</source>
+            <translation>鼠標</translation>
+        </message>
+        <message>
+            <source>Update</source>
+            <translation>更新</translation>
+        </message>
+        <message>
+            <source>Screensaver</source>
+            <translation>屏幕保護</translation>
+        </message>
+    </context>
+    <context>
+        <name>ThemeSelectView</name>
+        <message>
+            <source>More Wallpapers</source>
+            <translation>下載更多</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeAndDate</name>
+        <message>
+            <source>Auto sync time</source>
+            <translation>自動同步配置</translation>
+        </message>
+        <message>
+            <source>Ntp server</source>
+            <translation>伺服器</translation>
+        </message>
+        <message>
+            <source>System date and time</source>
+            <translation>系統日期和時間</translation>
+        </message>
+        <message>
+            <source>Customize</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>Settings</source>
+            <translation>設置</translation>
+        </message>
+        <message>
+            <source>Server address</source>
+            <translation>伺服器地址</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>The ntp server address cannot be empty</source>
+            <translation>NTP 服務地址不能為空</translation>
+        </message>
+        <message>
+            <source>Use 24-hour format</source>
+            <translation>24小時制</translation>
+        </message>
+        <message>
+            <source>system time zone</source>
+            <translation>系統時區</translation>
+        </message>
+        <message>
+            <source>Timezone list</source>
+            <translation>時區列表</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeRange</name>
+        <message>
+            <source>from</source>
+            <translation>從</translation>
+        </message>
+        <message>
+            <source>to</source>
+            <translation>至</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeoutDialog</name>
+        <message>
+            <source>Save the display settings?</source>
+            <translation>是否要保存顯示設置？</translation>
+        </message>
+        <message>
+            <source>Settings will be reverted in %1s.</source>
+            <translation>如無任何操作將在%1秒後還原。</translation>
+        </message>
+        <message>
+            <source>Revert</source>
+            <translation>還原</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>保存</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimezoneDialog</name>
+        <message>
+            <source>Add time zone</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Determine the time zone based on the current location</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Time zone:</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Nearest City:</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>保存</translation>
+        </message>
+    </context>
+    <context>
+        <name>TouchScreen</name>
+        <message>
+            <source>TouchScreen</source>
+            <translation>觸控屏</translation>
+        </message>
+        <message>
+            <source>Set up here when connecting the touch screen</source>
+            <translation>連接觸摸屏時在此處設置</translation>
+        </message>
+    </context>
+    <context>
+        <name>Touchpad</name>
+        <message>
+            <source>Basic Settings</source>
+            <translation>基礎設置</translation>
+        </message>
+        <message>
+            <source>Touchpad</source>
+            <translation>觸控板</translation>
+        </message>
+        <message>
+            <source>Pointer Speed</source>
+            <translation>指針速度</translation>
+        </message>
+        <message>
+            <source>Slow</source>
+            <translation>慢</translation>
+        </message>
+        <message>
+            <source>Fast</source>
+            <translation>快</translation>
+        </message>
+        <message>
+            <source>Disable touchpad during input</source>
+            <translation>輸入時禁用觸摸板</translation>
+        </message>
+        <message>
+            <source>Tap to Click</source>
+            <translation>輕觸以點擊</translation>
+        </message>
+        <message>
+            <source>Natural Scrolling</source>
+            <translation>自然滾動</translation>
+        </message>
+        <message>
+            <source>Gesture</source>
+            <translation>手勢</translation>
+        </message>
+        <message>
+            <source>Three-finger gestures</source>
+            <translation>三指手勢</translation>
+        </message>
+        <message>
+            <source>Four-finger gestures</source>
+            <translation>四指手勢</translation>
+        </message>
+    </context>
+    <context>
+        <name>UserExperienceProgramPage</name>
+        <message>
+            <source>Join User Experience Program</source>
+            <translation>加入用户體驗計劃</translation>
+        </message>
+        <message>
+            <source>Copy Link Address</source>
+            <translation>複製連結地址</translation>
+        </message>
+    </context>
+    <context>
+        <name>VerifyDialog</name>
+        <message>
+            <source>Security Verification</source>
+            <translation>安全驗證</translation>
+        </message>
+        <message>
+            <source>The action is sensitive, please enter the login password first</source>
+            <translation>您正在進行敏感操作，請進行登錄密碼認證</translation>
+        </message>
+        <message>
+            <source>8-64 characters</source>
+            <translation>請輸入8-64位密碼</translation>
+        </message>
+        <message>
+            <source>Forgot Password?</source>
+            <translation>忘記密碼？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確定</translation>
+        </message>
+    </context>
+    <context>
+        <name>WallpaperPage</name>
+        <message>
+            <source>wallpaper</source>
+            <translation>壁紙</translation>
+        </message>
+        <message>
+            <source>Window rounded corners</source>
+            <translation>窗口圓角</translation>
+        </message>
+        <message>
+            <source>My pictures</source>
+            <translation>我的圖片</translation>
+        </message>
+        <message>
+            <source>System Wallpaper</source>
+            <translation>系統壁紙</translation>
+        </message>
+        <message>
+            <source>Solid color wallpaper</source>
+            <translation>純色壁紙</translation>
+        </message>
+        <message>
+            <source>Customizable wallpapers</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>fill style</source>
+            <translation>填充方式</translation>
+        </message>
+        <message>
+            <source>Automatic wallpaper change</source>
+            <translation>自動切換壁紙</translation>
+        </message>
+        <message>
+            <source>never</source>
+            <translation>從不</translation>
+        </message>
+        <message>
+            <source>30 second</source>
+            <translation>30秒</translation>
+        </message>
+        <message>
+            <source>1 minute</source>
+            <translation>1分鐘</translation>
+        </message>
+        <message>
+            <source>5 minute</source>
+            <translation>5分鐘</translation>
+        </message>
+        <message>
+            <source>10 minute</source>
+            <translation>10分鐘</translation>
+        </message>
+        <message>
+            <source>15 minute</source>
+            <translation>15分鐘</translation>
+        </message>
+        <message>
+            <source>30 minute</source>
+            <translation>30分鐘</translation>
+        </message>
+        <message>
+            <source>login</source>
+            <translation>登錄時</translation>
+        </message>
+        <message>
+            <source>wake up</source>
+            <translation>喚醒時</translation>
+        </message>
+        <message>
+            <source>System Wallapers</source>
+            <translation>系統壁紙</translation>
+        </message>
+        <message>
+            <source>Live Wallpaper</source>
+            <translation>動態壁紙</translation>
+        </message>
+        <message>
+            <source>1 hour</source>
+            <translation>1小時</translation>
+        </message>
+    </context>
+    <context>
+        <name>WallpaperSelectView</name>
+        <message>
+            <source>unfold</source>
+            <translation>收起</translation>
+        </message>
+        <message>
+            <source>show all</source>
+            <translation>顯示全部</translation>
+        </message>
+        <message>
+            <source>items</source>
+            <translation>張</translation>
+        </message>
+        <message>
+            <source>Set lock screen</source>
+            <translation>設置鎖屏</translation>
+        </message>
+        <message>
+            <source>Set desktop</source>
+            <translation>設置桌面</translation>
+        </message>
+    </context>
+    <context>
+        <name>WindowEffectPage</name>
+        <message>
+            <source>Interface and Effects</source>
+            <translation>界面效果</translation>
+        </message>
+        <message>
+            <source>Window Settings</source>
+            <translation>窗口設置</translation>
+        </message>
+        <message>
+            <source>Window rounded corners</source>
+            <translation>窗口圓角</translation>
+        </message>
+        <message>
+            <source>None</source>
+            <translation>無</translation>
+        </message>
+        <message>
+            <source>Small</source>
+            <translation>小</translation>
+        </message>
+        <message>
+            <source>Large</source>
+            <translation>大</translation>
+        </message>
+        <message>
+            <source>Enable transparent effects when moving windows</source>
+            <translation>窗口移動時啓用透明特效</translation>
+        </message>
+        <message>
+            <source>Window Minimize Effect</source>
+            <translation>最小化時效果</translation>
+        </message>
+        <message>
+            <source>Scale</source>
+            <translation>縮放</translation>
+        </message>
+        <message>
+            <source>Magic Lamp</source>
+            <translation>魔燈</translation>
+        </message>
+        <message>
+            <source>Opacity</source>
+            <translation>不透明度調節</translation>
+        </message>
+        <message>
+            <source>Low</source>
+            <translation>低</translation>
+        </message>
+        <message>
+            <source>High</source>
+            <translation>高</translation>
+        </message>
+        <message>
+            <source>Scroll Bars</source>
+            <translation>滾動條</translation>
+        </message>
+        <message>
+            <source>Show on scrolling</source>
+            <translation>滾動時顯示</translation>
+        </message>
+        <message>
+            <source>Keep shown</source>
+            <translation>一直顯示</translation>
+        </message>
+        <message>
+            <source>Compact Display</source>
+            <translation>緊湊模式</translation>
+        </message>
+        <message>
+            <source>If enabled, more content is displayed in the window.</source>
+            <translation>開啓後，窗口將顯示更多內容</translation>
+        </message>
+        <message>
+            <source>Title Bar Height</source>
+            <translation>標題欄高度</translation>
+        </message>
+        <message>
+            <source>Only suitable for application window title bars drawn by the window manager.</source>
+            <translation>僅適用於窗口管理器繪製的應用標題欄</translation>
+        </message>
+        <message>
+            <source>Extremely small</source>
+            <translation>極小</translation>
+        </message>
+        <message>
+            <source>Medium</source>
+            <translation>中</translation>
+            <comment>describe size of window rounded corners</comment>
+        </message>
+        <message>
+            <source>Medium</source>
+            <translation>中</translation>
+            <comment>describe height of window title bar</comment>
+        </message>
+    </context>
+    <context>
+        <name>accounts</name>
+        <message>
+            <source>Account</source>
+            <translation>賬户</translation>
+        </message>
+        <message>
+            <source>Account manager</source>
+            <translation>賬户管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>accountsMain</name>
+        <message>
+            <source>Other accounts</source>
+            <translation>其他賬户</translation>
+        </message>
+    </context>
+    <context>
+        <name>authentication</name>
+        <message>
+            <source>Biometric Authentication</source>
+            <translation>生物認證</translation>
+        </message>
+    </context>
+    <context>
+        <name>authenticationMain</name>
+        <message>
+            <source>Biometric Authentication</source>
+            <translation>生物認證</translation>
+        </message>
+        <message>
+            <source>Face</source>
+            <translation>人臉</translation>
+        </message>
+        <message>
+            <source>Up to 5 facial data can be entered</source>
+            <translation>最多可錄入5個人臉數據</translation>
+        </message>
+        <message>
+            <source>Fingerprint</source>
+            <translation>指紋</translation>
+        </message>
+        <message>
+            <source>Identifying user identity through scanning fingerprints</source>
+            <translation>通過對指紋的掃描進行用户身份的識別</translation>
+        </message>
+        <message>
+            <source>Iris</source>
+            <translation>虹膜</translation>
+        </message>
+        <message>
+            <source>Identity recognition through iris scanning</source>
+            <translation>通過掃描虹膜進行身份識別</translation>
+        </message>
+        <message>
+            <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
+            <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字符</translation>
+        </message>
+        <message>
+            <source>Use letters, numbers and underscores only</source>
+            <translation>只能由字母、數字、中文、下劃線組成</translation>
+        </message>
+        <message>
+            <source>No more than 15 characters</source>
+            <translation>不得超過15個字符</translation>
+        </message>
+        <message>
+            <source>Add a new</source>
+            <translation>添加新的</translation>
+        </message>
+        <message>
+            <source>This name already exists</source>
+            <translation>該名稱已存在</translation>
+        </message>
+    </context>
+    <context>
+        <name>blueTooth</name>
+        <message>
+            <source>bluetooth</source>
+            <translation>藍牙</translation>
+        </message>
+        <message>
+            <source>Bluetooth settings, devices</source>
+            <translation>藍牙設置、設備管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>commonInfoMain</name>
+        <message>
+            <source>Boot Menu</source>
+            <translation>啓動菜單</translation>
+        </message>
+        <message>
+            <source>Manage your boot menu</source>
+            <translation>管理您的開機啓動菜單</translation>
+        </message>
+        <message>
+            <source>Developer root permission management</source>
+            <translation>開發者Root權限管理</translation>
+        </message>
+        <message>
+            <source>Developer Options</source>
+            <translation>開發者選項</translation>
+        </message>
+    </context>
+    <context>
+        <name>datetime</name>
+        <message>
+            <source>Time and date</source>
+            <translation>時間和日期</translation>
+        </message>
+        <message>
+            <source>Time and date, time zone settings</source>
+            <translation>時間日期、時區設置</translation>
+        </message>
+        <message>
+            <source>Language and region</source>
+            <translation>語言和區域</translation>
+        </message>
+        <message>
+            <source>System language, region format</source>
+            <translation>系統語言、區域格式</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::AccountsController</name>
+        <message>
+            <source>Username must be between 3 and 32 characters</source>
+            <translation>用户名長度必須介於 3 到 32 個字符之間</translation>
+        </message>
+        <message>
+            <source>The first character must be a letter or number</source>
+            <translation>必須字母或者數字開頭</translation>
+        </message>
+        <message>
+            <source>Your username should not only have numbers</source>
+            <translation>用户名不能僅僅是數字</translation>
+        </message>
+        <message>
+            <source>The username has been used by other user accounts</source>
+            <translation>用户名和其他用户名重複</translation>
+        </message>
+        <message>
+            <source>The full name is too long</source>
+            <translation>全名太長了</translation>
+        </message>
+        <message>
+            <source>The full name has been used by other user accounts</source>
+            <translation>全名和其他用户名重複</translation>
+        </message>
+        <message>
+            <source>Wrong password</source>
+            <translation>密碼錯誤</translation>
+        </message>
+        <message>
+            <source>Standard User</source>
+            <translation>標準用户</translation>
+        </message>
+        <message>
+            <source>Administrator</source>
+            <translation>管理員</translation>
+        </message>
+        <message>
+            <source>Customized</source>
+            <translation>自定義</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::AccountsWorker</name>
+        <message>
+            <source>Your host was removed from the domain server successfully</source>
+            <translation>您的主機成功退出了域伺服器</translation>
+        </message>
+        <message>
+            <source>Your host joins the domain server successfully</source>
+            <translation>您的主機成功加入了域伺服器</translation>
+        </message>
+        <message>
+            <source>Your host failed to leave the domain server</source>
+            <translation>您的主機退出域伺服器失敗</translation>
+        </message>
+        <message>
+            <source>Your host failed to join the domain server</source>
+            <translation>您的主機加入域伺服器失敗</translation>
+        </message>
+        <message>
+            <source>AD domain settings</source>
+            <translation>AD域設置</translation>
+        </message>
+        <message>
+            <source>Password not match</source>
+            <translation>密碼不一致</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::AvatarTypesModel</name>
+        <message>
+            <source>Dimensional</source>
+            <translation>立體風格</translation>
+        </message>
+        <message>
+            <source>Flat</source>
+            <translation>平面風格</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::BiometricAuthController</name>
+        <message>
+            <source>Use your face to unlock the device and make settings later</source>
+            <translation>使用人臉數據解鎖您的設備，之後還可進行更多設置</translation>
+        </message>
+        <message>
+            <source>Faceprint</source>
+            <translation>面紋</translation>
+        </message>
+        <message>
+            <source>Place your finger</source>
+            <translation>放置手指</translation>
+        </message>
+        <message>
+            <source>Place your finger firmly on the sensor until you're asked to lift it</source>
+            <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
+        </message>
+        <message>
+            <source>Lift your finger</source>
+            <translation>擡起手指</translation>
+        </message>
+        <message>
+            <source>Lift your finger and place it on the sensor again</source>
+            <translation>請擡起手指，再次按壓</translation>
+        </message>
+        <message>
+            <source>Scan the edges of your fingerprint</source>
+            <translation>錄入邊緣指紋</translation>
+        </message>
+        <message>
+            <source>Adjust the position to scan the edges of your fingerprint</source>
+            <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
+        </message>
+        <message>
+            <source>Lift your finger and do that again</source>
+            <translation>請擡起手指，再次按壓</translation>
+        </message>
+        <message>
+            <source>Fingerprint added</source>
+            <translation>成功添加指紋</translation>
+        </message>
+        <message>
+            <source>Scan Suspended</source>
+            <translation>錄入中斷</translation>
+        </message>
+        <message>
+            <source>Place the edges of your fingerprint on the sensor</source>
+            <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
+        </message>
+        <message>
+            <source>Iris</source>
+            <translation>虹膜</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::KeyboardController</name>
+        <message>
+            <source>This shortcut conflicts with [%1]</source>
+            <translation>此快捷鍵與[%1]衝突</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::PwqualityManager</name>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Password must have at least %1 characters</source>
+            <translation>密碼長度不能少於%1個字符</translation>
+        </message>
+        <message>
+            <source>Password must be no more than %1 characters</source>
+            <translation>密碼長度不能超過%1個字符</translation>
+        </message>
+        <message>
+            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
+        </message>
+        <message>
+            <source>No more than %1 palindrome characters please</source>
+            <translation>迴文字符長度不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 monotonic characters please</source>
+            <translation>單調性字符不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 repeating characters please</source>
+            <translation>重複字符不超過%1位</translation>
+        </message>
+        <message>
+            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
+        </message>
+        <message>
+            <source>Password must not contain more than 4 palindrome characters</source>
+            <translation>密碼不得含有連續4個以上的迴文字符</translation>
+        </message>
+        <message>
+            <source>Do not use common words and combinations as password</source>
+            <translation>密碼不能是常見單詞及組合</translation>
+        </message>
+        <message>
+            <source>Create a strong password please</source>
+            <translation>密碼過於簡單，請增加密碼複雜度</translation>
+        </message>
+        <message>
+            <source>It does not meet password rules</source>
+            <translation>密碼不符合安全要求</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::ShortcutModel</name>
+        <message>
+            <source>System</source>
+            <translation>系統</translation>
+        </message>
+        <message>
+            <source>Window</source>
+            <translation>窗口</translation>
+        </message>
+        <message>
+            <source>Workspace</source>
+            <translation>工作區</translation>
+        </message>
+        <message>
+            <source>AssistiveTools</source>
+            <translation>輔助功能</translation>
+        </message>
+        <message>
+            <source>Custom</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>None</source>
+            <translation>無</translation>
+        </message>
+    </context>
+    <context>
+        <name>deepinid</name>
+        <message>
+            <source>deepin ID</source>
+            <translation>deepin ID</translation>
+        </message>
+        <message>
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <source>Cloud services</source>
+            <translation>雲服務</translation>
+        </message>
+    </context>
+    <context>
+        <name>defaultapp</name>
+        <message>
+            <source>Default App</source>
+            <translation>默認程序</translation>
+        </message>
+        <message>
+            <source>Set the default application for opening various types of files</source>
+            <translation>設置打開各類文件的默認程序</translation>
+        </message>
+    </context>
+    <context>
+        <name>defaultappMain</name>
+        <message>
+            <source>Webpage</source>
+            <translation>網頁</translation>
+        </message>
+        <message>
+            <source>Mail</source>
+            <translation>郵件</translation>
+        </message>
+        <message>
+            <source>Text</source>
+            <translation>文本</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂</translation>
+        </message>
+        <message>
+            <source>Video</source>
+            <translation>視頻</translation>
+        </message>
+        <message>
+            <source>Picture</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Terminal</source>
+            <translation>終端</translation>
+        </message>
+    </context>
+    <context>
+        <name>device</name>
+        <message>
+            <source>Device</source>
+            <translation>設備</translation>
+        </message>
+    </context>
+    <context>
+        <name>display</name>
+        <message>
+            <source>Display</source>
+            <translation>顯示</translation>
+        </message>
+        <message>
+            <source>Brightness,resolution,scaling</source>
+            <translation>亮度、解像度、縮放</translation>
+        </message>
+    </context>
+    <context>
+        <name>displayMain</name>
+        <message>
+            <source>100%</source>
+            <translation>100%</translation>
+        </message>
+        <message>
+            <source>125%</source>
+            <translation>125%</translation>
+        </message>
+        <message>
+            <source>150%</source>
+            <translation>150%</translation>
+        </message>
+        <message>
+            <source>175%</source>
+            <translation>175%</translation>
+        </message>
+        <message>
+            <source>200%</source>
+            <translation>200%</translation>
+        </message>
+        <message>
+            <source>225%</source>
+            <translation>225%</translation>
+        </message>
+        <message>
+            <source>250%</source>
+            <translation>250%</translation>
+        </message>
+        <message>
+            <source>275%</source>
+            <translation>275%</translation>
+        </message>
+        <message>
+            <source>300%</source>
+            <translation>300%</translation>
+        </message>
+        <message>
+            <source>Duplicate</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <source>Extend</source>
+            <translation>擴展</translation>
+        </message>
+        <message>
+            <source>Default</source>
+            <translation>默認</translation>
+        </message>
+        <message>
+            <source>Fit</source>
+            <translation>適應</translation>
+        </message>
+        <message>
+            <source>Stretch</source>
+            <translation>拉伸</translation>
+        </message>
+        <message>
+            <source>Center</source>
+            <translation>居中</translation>
+        </message>
+        <message>
+            <source>Only on %1</source>
+            <translation>僅%1屏</translation>
+        </message>
+        <message>
+            <source>(Recommended)</source>
+            <translation>（推薦）</translation>
+        </message>
+        <message>
+            <source>Hz</source>
+            <translation>赫茲</translation>
+        </message>
+        <message>
+            <source>Multiple Displays Settings</source>
+            <translation>多屏設置</translation>
+        </message>
+        <message>
+            <source>Identify</source>
+            <translation>識別</translation>
+        </message>
+        <message>
+            <source>Screen rearrangement will take effect in %1s after changes</source>
+            <translation>屏幕拼接將在修改完成%1s後生效</translation>
+        </message>
+        <message>
+            <source>Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Main Screen</source>
+            <translation>主屏幕</translation>
+        </message>
+        <message>
+            <source>Display And Layout</source>
+            <translation>顯示和佈局</translation>
+        </message>
+        <message>
+            <source>Brightness</source>
+            <translation>亮度</translation>
+        </message>
+        <message>
+            <source>Resolution</source>
+            <translation>解像度</translation>
+        </message>
+        <message>
+            <source>Resize Desktop</source>
+            <translation>桌面顯示</translation>
+        </message>
+        <message>
+            <source>Refresh Rate</source>
+            <translation>刷新率</translation>
+        </message>
+        <message>
+            <source>Rotation</source>
+            <translation>方向</translation>
+        </message>
+        <message>
+            <source>Standard</source>
+            <translation>標準</translation>
+        </message>
+        <message>
+            <source>90°</source>
+            <translation>90度</translation>
+        </message>
+        <message>
+            <source>180°</source>
+            <translation>180度</translation>
+        </message>
+        <message>
+            <source>270°</source>
+            <translation>270度</translation>
+        </message>
+        <message>
+            <source>Display Scaling</source>
+            <translation>縮放</translation>
+        </message>
+        <message>
+            <source>The monitor only supports 100% display scaling</source>
+            <translation>當前屏幕僅支持1倍縮放</translation>
+        </message>
+        <message>
+            <source>Eye Comfort</source>
+            <translation>護眼模式</translation>
+        </message>
+        <message>
+            <source>Enable eye comfort</source>
+            <translation>開啓護眼模式</translation>
+        </message>
+        <message>
+            <source>Adjust screen display to warmer colors, reducing screen blue light</source>
+            <translation>調整屏幕顯示較暖的顏色，減少屏幕藍光</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation>時間</translation>
+        </message>
+        <message>
+            <source>All day</source>
+            <translation>全天</translation>
+        </message>
+        <message>
+            <source>Sunset to Sunrise</source>
+            <translation>日落到日出</translation>
+        </message>
+        <message>
+            <source>Custom Time</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>from</source>
+            <translation>從</translation>
+        </message>
+        <message>
+            <source>to</source>
+            <translation>至</translation>
+        </message>
+        <message>
+            <source>Color Temperature</source>
+            <translation>色温</translation>
+        </message>
+    </context>
+    <context>
+        <name>dock</name>
+        <message>
+            <source>Desktop and taskbar</source>
+            <translation>桌面和任務欄</translation>
+        </message>
+        <message>
+            <source>Desktop organization, taskbar mode, plugin area settings</source>
+            <translation>桌面整理、任務欄模式、插件區域設置</translation>
+        </message>
+    </context>
+    <context>
+        <name>keyboard</name>
+        <message>
+            <source>Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+        <message>
+            <source>General Settings, keyboard layout, input method, shortcuts</source>
+            <translation>通用設置、鍵盤佈局、輸入法、快捷鍵</translation>
+        </message>
+    </context>
+    <context>
+        <name>keyboardMain</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Keyboard layout</source>
+            <translation>鍵盤佈局</translation>
+        </message>
+        <message>
+            <source>Set system default keyboard layout</source>
+            <translation>設置系統默認鍵盤佈局</translation>
+        </message>
+    </context>
+    <context>
+        <name>main</name>
+        <message>
+            <source>Dock</source>
+            <translation>任務欄</translation>
+        </message>
+        <message>
+            <source>Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Classic Mode</source>
+            <translation>經典模式</translation>
+        </message>
+        <message>
+            <source>Centered Mode</source>
+            <translation>居中模式</translation>
+        </message>
+        <message>
+            <source>Dock size</source>
+            <translation>任務欄大小</translation>
+        </message>
+        <message>
+            <source>Small</source>
+            <translation>小</translation>
+        </message>
+        <message>
+            <source>Large</source>
+            <translation>大</translation>
+        </message>
+        <message>
+            <source>Position on the screen</source>
+            <translation>屏幕中的位置</translation>
+        </message>
+        <message>
+            <source>Top</source>
+            <translation>上</translation>
+        </message>
+        <message>
+            <source>Bottom</source>
+            <translation>下</translation>
+        </message>
+        <message>
+            <source>Left</source>
+            <translation>左</translation>
+        </message>
+        <message>
+            <source>Right</source>
+            <translation>右</translation>
+        </message>
+        <message>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <source>Keep shown</source>
+            <translation>一直顯示</translation>
+        </message>
+        <message>
+            <source>Keep hidden</source>
+            <translation>一直隱藏</translation>
+        </message>
+        <message>
+            <source>Smart hide</source>
+            <translation>智能隱藏</translation>
+        </message>
+        <message>
+            <source>Multiple Displays</source>
+            <translation>多屏顯示</translation>
+        </message>
+        <message>
+            <source>Set the position of the taskbar on the screen</source>
+            <translation>設置任務欄在屏幕中的位置</translation>
+        </message>
+        <message>
+            <source>Only on main</source>
+            <translation>僅主屏顯示</translation>
+        </message>
+        <message>
+            <source>On screen where the cursor is</source>
+            <translation>跟隨鼠標位置顯示</translation>
+        </message>
+        <message>
+            <source>Plugin Area</source>
+            <translation>插件區域</translation>
+        </message>
+        <message>
+            <source>Select which icons appear in the Dock</source>
+            <translation>選擇顯示在任務欄插件區域的圖標</translation>
+        </message>
+    </context>
+    <context>
+        <name>mouse</name>
+        <message>
+            <source>Mouse and Touchpad</source>
+            <translation>鼠標與觸控板</translation>
+        </message>
+        <message>
+            <source>Common、Mouse、Touchpad</source>
+            <translation>通用、鼠標、觸控板</translation>
+        </message>
+    </context>
+    <context>
+        <name>mouseMain</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Mouse</source>
+            <translation>鼠標</translation>
+        </message>
+        <message>
+            <source>Touchpad</source>
+            <translation>觸控板</translation>
+        </message>
+    </context>
+    <context>
+        <name>notification</name>
+        <message>
+            <source>DND mode, app notifications</source>
+            <translation>勿擾模式、應用通知</translation>
+        </message>
+        <message>
+            <source>Notification</source>
+            <translation>通知</translation>
+        </message>
+    </context>
+    <context>
+        <name>notificationMain</name>
+        <message>
+            <source>Do Not Disturb Settings</source>
+            <translation>勿擾設置</translation>
+        </message>
+        <message>
+            <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
+            <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心查看所有消息。</translation>
+        </message>
+        <message>
+            <source>Enable Do Not Disturb</source>
+            <translation>啓用勿擾模式</translation>
+        </message>
+        <message>
+            <source>When the screen is locked</source>
+            <translation>在屏幕鎖屏時</translation>
+        </message>
+        <message>
+            <source>Number of notifications shown on the desktop</source>
+            <translation>通知橫幅展示數量</translation>
+        </message>
+        <message>
+            <source>App Notifications</source>
+            <translation>應用通知</translation>
+        </message>
+        <message>
+            <source>Allow Notifications</source>
+            <translation>允許通知</translation>
+        </message>
+        <message>
+            <source>Display notification on desktop or show unread messages in the notification center</source>
+            <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
+        </message>
+        <message>
+            <source>Desktop</source>
+            <translation>桌面</translation>
+        </message>
+        <message>
+            <source>Lock Screen</source>
+            <translation>鎖屏</translation>
+        </message>
+        <message>
+            <source>Notification Center</source>
+            <translation>通知中心</translation>
+        </message>
+        <message>
+            <source>Show message preview</source>
+            <translation>顯示消息預覽</translation>
+        </message>
+        <message>
+            <source>Play a sound</source>
+            <translation>通知時提示聲音</translation>
+        </message>
+    </context>
+    <context>
+        <name>personalization</name>
+        <message>
+            <source>Personalization</source>
+            <translation>個性化</translation>
+        </message>
+    </context>
+    <context>
+        <name>personalizationMain</name>
+        <message>
+            <source>Theme</source>
+            <translation>主題</translation>
+        </message>
+        <message>
+            <source>Appearance</source>
+            <translation>外觀</translation>
+        </message>
+        <message>
+            <source>Window effect</source>
+            <translation>窗口效果</translation>
+        </message>
+        <message>
+            <source>Personalize your wallpaper and screensaver</source>
+            <translation>個性化您的壁紙和屏保</translation>
+        </message>
+        <message>
+            <source>Screensaver</source>
+            <translation>屏幕保護</translation>
+        </message>
+        <message>
+            <source>Colors and icons</source>
+            <translation>顏色和圖標</translation>
+        </message>
+        <message>
+            <source>Adjust accent color and theme icons</source>
+            <translation>調整活動色和主題圖標</translation>
+        </message>
+        <message>
+            <source>Font and font size</source>
+            <translation>字體和字號</translation>
+        </message>
+        <message>
+            <source>Change system font and size</source>
+            <translation>修改系統字體與字號</translation>
+        </message>
+        <message>
+            <source>Wallpaper</source>
+            <translation>壁紙</translation>
+        </message>
+        <message>
+            <source>Select light, dark or automatic theme appearance</source>
+            <translation>選擇淺色、深色或自動切換主題外觀</translation>
+        </message>
+        <message>
+            <source>Interface and effects, rounded corners</source>
+            <translation>界面和效果、窗口圓角</translation>
+        </message>
+    </context>
+    <context>
+        <name>power</name>
+        <message>
+            <source>Power saving settings, screen and suspend</source>
+            <translation>節能設置、屏幕和待機管理</translation>
+        </message>
+        <message>
+            <source>Power</source>
+            <translation>電源管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>powerMain</name>
+        <message>
+            <source>General</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
+            <translation>性能模式、節能設置、喚醒設置、關機設置</translation>
+        </message>
+        <message>
+            <source>Plugged In</source>
+            <translation>使用電源</translation>
+        </message>
+        <message>
+            <source>Screen and suspend</source>
+            <translation>屏幕和待機管理</translation>
+        </message>
+        <message>
+            <source>On Battery</source>
+            <translation>使用電池</translation>
+        </message>
+        <message>
+            <source>screen and suspend, low battery, battery management</source>
+            <translation>屏幕和待機管理、低電量管理、電池管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>privacy</name>
+        <message>
+            <source>Privacy and Security</source>
+            <translation>私隱和安全</translation>
+        </message>
+        <message>
+            <source>Camera, folder permissions</source>
+            <translation>攝像頭、文件夾權限</translation>
+        </message>
+    </context>
+    <context>
+        <name>privacyMain</name>
+        <message>
+            <source>Camera</source>
+            <translation>攝像頭</translation>
+        </message>
+        <message>
+            <source>Choose whether the application has access to the camera</source>
+            <translation>選擇應用是否有攝像頭的訪問權限</translation>
+        </message>
+        <message>
+            <source>Files and Folders</source>
+            <translation>文件和文件夾</translation>
+        </message>
+        <message>
+            <source>Choose whether the application has access to files and folders</source>
+            <translation>選擇應用是否有文件和文件夾的訪問權限</translation>
+        </message>
+    </context>
+    <context>
+        <name>sound</name>
+        <message>
+            <source>Sound</source>
+            <translation>聲音</translation>
+        </message>
+        <message>
+            <source>Output, input, sound effects, devices</source>
+            <translation>輸入、輸出、系統音效、設備管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>soundMain</name>
+        <message>
+            <source>Settings</source>
+            <translation>設置</translation>
+        </message>
+        <message>
+            <source>Sound Effects</source>
+            <translation>系統音效</translation>
+        </message>
+        <message>
+            <source>Enable/disable sound effects</source>
+            <translation>開啓/關閉系統音效</translation>
+        </message>
+        <message>
+            <source>Enable/disable audio devices</source>
+            <translation>啓用/禁用音頻設備</translation>
+        </message>
+        <message>
+            <source>Devices</source>
+            <translation>設備管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>system</name>
+        <message>
+            <source>Common settings</source>
+            <translation>常用設置</translation>
+        </message>
+        <message>
+            <source>System</source>
+            <translation>系統</translation>
+        </message>
+    </context>
+    <context>
+        <name>systemInfo</name>
+        <message>
+            <source>Auxiliary Information</source>
+            <translation>輔助信息</translation>
+        </message>
+    </context>
+    <context>
+        <name>systemInfoMain</name>
+        <message>
+            <source>About This PC</source>
+            <translation>關於本機</translation>
+        </message>
+        <message>
+            <source>System version, device information</source>
+            <translation>系統版本、設備信息</translation>
+        </message>
+        <message>
+            <source>View the notice of open source software</source>
+            <translation>查看開源軟件聲明</translation>
+        </message>
+        <message>
+            <source>User Experience Program</source>
+            <translation>用户體驗計劃</translation>
+        </message>
+        <message>
+            <source>Join the user experience program to help improve the product</source>
+            <translation>加入用户體驗計劃，幫助改進產品</translation>
+        </message>
+        <message>
+            <source>End User License Agreement</source>
+            <translation>用户許可協議</translation>
+        </message>
+        <message>
+            <source>View the end  user license agreement</source>
+            <translation>查看最終用户許可協議</translation>
+        </message>
+        <message>
+            <source>Privacy Policy</source>
+            <translation>私隱政策</translation>
+        </message>
+        <message>
+            <source>View information about privacy policy</source>
+            <translation>查看私隱政策相關信息</translation>
+        </message>
+        <message>
+            <source>Open Source Software Notice</source>
+            <translation>開源軟件聲明</translation>
+        </message>
+    </context>
+    <context>
+        <name>touchscreen</name>
+        <message>
+            <source>Touchscreen</source>
+            <translation>觸控屏</translation>
+        </message>
+        <message>
+            <source>Configuring Touchscreen</source>
+            <translation>觸控屏設置</translation>
+        </message>
+    </context>
+    <context>
+        <name>touchscreenMain</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+    </context>
+    <context>
+        <name>wacom</name>
+        <message>
+            <source>wacom</source>
+            <translation>數位板</translation>
+        </message>
+        <message>
+            <source>Configuring wacom</source>
+            <translation>數位板選項設置</translation>
+        </message>
+    </context>
+    <context>
+        <name>wacomMain</name>
+        <message>
+            <source>wacom</source>
+            <translation>數位板</translation>
+        </message>
+        <message>
+            <source>Wacom Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Pen Mode</source>
+            <translation>筆模式</translation>
+        </message>
+        <message>
+            <source>Mouse Mode</source>
+            <translation>鼠標模式</translation>
+        </message>
+        <message>
+            <source>Pressure Sensitivity</source>
+            <translation>壓感</translation>
+        </message>
+        <message>
+            <source>Light</source>
+            <translation>輕</translation>
+        </message>
+    </context>
 </TS>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -1,131 +1,133 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="zh_TW">
-<context>
-    <name>AccountSettings</name>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Add new user</source>
-        <translation>新增新使用者</translation>
-    </message>
-    <message>
-        <source>Set fullname</source>
-        <translation>設定全名</translation>
-    </message>
-    <message>
-        <source>Login settings</source>
-        <translation>登入設定</translation>
-    </message>
-    <message>
-        <source>Login Settings</source>
-        <translation>登入設定</translation>
-    </message>
-    <message>
-        <source>Login without password</source>
-        <translation>免密登入</translation>
-    </message>
-    <message>
-        <source>Delete current account</source>
-        <translation>刪除當前帳戶</translation>
-    </message>
-    <message>
-        <source>Group setting</source>
-        <translation>使用者組設定</translation>
-    </message>
-    <message>
-        <source>Account groups</source>
-        <translation>使用者組</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>Group name</source>
-        <translation>使用者組名稱</translation>
-    </message>
-    <message>
-        <source>Add group</source>
-        <translation>新增使用者組</translation>
-    </message>
-    <message>
-        <source>Auto login, login without password</source>
-        <translation>自動登入, 免密登入</translation>
-    </message>
-    <message>
-        <source>Auto login</source>
-        <translation>自動登入</translation>
-    </message>
-    <message>
-        <source>Account Information</source>
-        <translation>帳戶資訊</translation>
-    </message>
-    <message>
-        <source>Account name, account fullname, account type</source>
-        <translation>帳戶名，全名，帳戶型別</translation>
-    </message>
-    <message>
-        <source>Account name</source>
-        <translation>帳戶名</translation>
-    </message>
-    <message>
-        <source>Account fullname</source>
-        <translation>帳戶全名</translation>
-    </message>
-    <message>
-        <source>Account type</source>
-        <translation>帳戶型別</translation>
-    </message>
-    <message>
-        <source>The full name is too long</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>AddFaceinfoDialog</name>
-    <message>
-        <source>Enroll Face</source>
-        <translation>新增人臉資料</translation>
-    </message>
-    <message>
-        <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
-        <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
-    </message>
-    <message>
-        <source>I have read and agree to the</source>
-        <translation>我已閱讀並同意</translation>
-    </message>
-    <message>
-        <source>Disclaimer</source>
-        <translation>《使用者免責宣告》</translation>
-    </message>
-    <message>
-        <source>Next</source>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <source>Face enrolled</source>
-        <translation>人臉錄入完成</translation>
-    </message>
-    <message>
-        <source>Failed to enroll your face</source>
-        <translation>人臉錄入失敗</translation>
-    </message>
-    <message>
-        <source>Done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Retry Enroll</source>
-        <translation>重新錄入</translation>
-    </message>
-    <message>
-        <source>Before using face recognition, please note that: 
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE TS>
+<TS language="zh_TW" version="2.1">
+    <context>
+        <name>AccountSettings</name>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Add new user</source>
+            <translation>新增新使用者</translation>
+        </message>
+        <message>
+            <source>Set fullname</source>
+            <translation>設定全名</translation>
+        </message>
+        <message>
+            <source>Login settings</source>
+            <translation>登入設定</translation>
+        </message>
+        <message>
+            <source>Login Settings</source>
+            <translation>登入設定</translation>
+        </message>
+        <message>
+            <source>Login without password</source>
+            <translation>免密登入</translation>
+        </message>
+        <message>
+            <source>Delete current account</source>
+            <translation>刪除當前帳戶</translation>
+        </message>
+        <message>
+            <source>Group setting</source>
+            <translation>使用者組設定</translation>
+        </message>
+        <message>
+            <source>Account groups</source>
+            <translation>使用者組</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>Group name</source>
+            <translation>使用者組名稱</translation>
+        </message>
+        <message>
+            <source>Add group</source>
+            <translation>新增使用者組</translation>
+        </message>
+        <message>
+            <source>Auto login, login without password</source>
+            <translation>自動登入, 免密登入</translation>
+        </message>
+        <message>
+            <source>Auto login</source>
+            <translation>自動登入</translation>
+        </message>
+        <message>
+            <source>Account Information</source>
+            <translation>帳戶資訊</translation>
+        </message>
+        <message>
+            <source>Account name, account fullname, account type</source>
+            <translation>帳戶名，全名，帳戶型別</translation>
+        </message>
+        <message>
+            <source>Account name</source>
+            <translation>帳戶名</translation>
+        </message>
+        <message>
+            <source>Account fullname</source>
+            <translation>帳戶全名</translation>
+        </message>
+        <message>
+            <source>Account type</source>
+            <translation>帳戶型別</translation>
+        </message>
+        <message>
+            <source>The full name is too long</source>
+            <translation>名稱過長</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddFaceinfoDialog</name>
+        <message>
+            <source>Enroll Face</source>
+            <translation>新增人臉資料</translation>
+        </message>
+        <message>
+            <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
+            <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
+        </message>
+        <message>
+            <source>I have read and agree to the</source>
+            <translation>我已閱讀並同意</translation>
+        </message>
+        <message>
+            <source>Disclaimer</source>
+            <translation>《使用者免責宣告》</translation>
+        </message>
+        <message>
+            <source>Next</source>
+            <translation>下一步</translation>
+        </message>
+        <message>
+            <source>Face enrolled</source>
+            <translation>人臉錄入完成</translation>
+        </message>
+        <message>
+            <source>Failed to enroll your face</source>
+            <translation>人臉錄入失敗</translation>
+        </message>
+        <message>
+            <source>Done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Retry Enroll</source>
+            <translation>重新錄入</translation>
+        </message>
+        <message>
+            <source>Before using face recognition, please note that: 
 1. Your device may be unlocked by people or objects that look or appear similar to you.
 2. Face recognition is less secure than digital passwords and mixed passwords.
 3. The success rate of unlocking your device through face recognition will be reduced in a low-light, high-light, back-light, large angle scenario and other scenarios.
@@ -136,7 +138,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-        <translation>在使用人臉識別功能前，請注意以下事項：
+            <translation>在使用人臉識別功能前，請注意以下事項：
 1.您的裝置可能會被容貌、外形與您相近的人或物品解鎖。
 2.人臉識別的安全性低於數字密碼、混合密碼。
 3.在暗光、強光、逆光或角度過大等場景下，人臉識別的解鎖成功率會有所降低。
@@ -147,3977 +149,3983 @@ In order to better use of face recognition, please pay attention to the followin
 1.請保證光線充足，避免陽光直射並避免其他人出現在錄入的畫面中。
 2.請注意錄入資料時的面部狀態，避免衣帽、頭髮、墨鏡、口罩、濃妝等遮擋面部資訊。
 3.請避免仰頭、低頭、閉眼或僅露出側臉的情況，確保臉部正面清晰完整的出現在提示框內。</translation>
-    </message>
-</context>
-<context>
-    <name>AddFingerDialog</name>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>Enroll Finger</source>
-        <translation>新增指紋資料</translation>
-    </message>
-    <message>
-        <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-        <translation>將要錄入的手指放入指紋錄入器裡面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
-    </message>
-    <message>
-        <source>I have read and agree to the</source>
-        <translation>我已閱讀並同意</translation>
-    </message>
-    <message>
-        <source>Disclaimer</source>
-        <translation>《使用者免責宣告》</translation>
-    </message>
-    <message>
-        <source>Next</source>
-        <translation>下一步</translation>
-    </message>
-    <message>
-        <source>Retry Enroll</source>
-        <translation>重新錄入</translation>
-    </message>
-    <message>
-        <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
+        </message>
+    </context>
+    <context>
+        <name>AddFingerDialog</name>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>Enroll Finger</source>
+            <translation>新增指紋資料</translation>
+        </message>
+        <message>
+            <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
+            <translation>將要錄入的手指放入指紋錄入器裡面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
+        </message>
+        <message>
+            <source>I have read and agree to the</source>
+            <translation>我已閱讀並同意</translation>
+        </message>
+        <message>
+            <source>Disclaimer</source>
+            <translation>《使用者免責宣告》</translation>
+        </message>
+        <message>
+            <source>Next</source>
+            <translation>下一步</translation>
+        </message>
+        <message>
+            <source>Retry Enroll</source>
+            <translation>重新錄入</translation>
+        </message>
+        <message>
+            <source>"Biometric authentication" is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through "biometric authentication", the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
 Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
 
-UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
-        <translation>「生物認證」是統信軟體技術有限公司提供的一種對使用者進行身份認證的功能。通過「生物認證」，將採集的生物識別資料與儲存在裝置本地的生物識別資料進行比對，並根據比對結果來驗證使用者身份。
+UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through "Service and Support" in the UOS.</source>
+            <translation>「生物認證」是統信軟體技術有限公司提供的一種對使用者進行身份認證的功能。通過「生物認證」，將採集的生物識別資料與儲存在裝置本地的生物識別資料進行比對，並根據比對結果來驗證使用者身份。
         請您注意，統信軟體不會收集或訪問您的生物識別資訊，此類資訊將會儲存在您的本地裝置中。請您僅在您的個人裝置中開啟生物認證功能，並使用您本人的生物識別資訊進行相關操作，並及時在該裝置上停用或清除他人的生物識別資訊，否則由此給您帶來的風險將由您承擔。
         統信軟體致力於研究與提高生物認證功能的安全性、精確性、與穩定性，但是，受限於環境、裝置、技術等因素和風險控制等原因，我們暫時無法保證您一定能通過生物認證，請您不要將生物認證作為登入統信作業系統的唯一途徑。若您在使用生物認證時有任何問題或建議的，可以通過系統內的「服務與支援」進行反饋。</translation>
-    </message>
-</context>
-<context>
-    <name>AutoLoginWarningDialog</name>
-    <message>
-        <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
-        <translation>只允許一個帳戶開啟自動登入，請先關閉%1帳戶的自動登入，再進行操作</translation>
-    </message>
-    <message>
-        <source>Ok</source>
-        <translation>確 定</translation>
-    </message>
-</context>
-<context>
-    <name>AvatarSettingsDialog</name>
-    <message>
-        <source>Images</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <source>Human</source>
-        <translation>人物</translation>
-    </message>
-    <message>
-        <source>Animal</source>
-        <translation>動物</translation>
-    </message>
-    <message>
-        <source>Scenery</source>
-        <translation>靜物</translation>
-    </message>
-    <message>
-        <source>Illustration</source>
-        <translation>創意插圖</translation>
-    </message>
-    <message>
-        <source>Emoji</source>
-        <translation>表情符號</translation>
-    </message>
-    <message>
-        <source>custom</source>
-        <translation>自定義圖片</translation>
-    </message>
-    <message>
-        <source>Cartoon style</source>
-        <translation>Q版風格</translation>
-    </message>
-    <message>
-        <source>Dimensional style</source>
-        <translation>立體風格</translation>
-    </message>
-    <message>
-        <source>Flat style</source>
-        <translation>平面風格</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>儲存</translation>
-    </message>
-</context>
-<context>
-    <name>BatteryPage</name>
-    <message>
-        <source>Screen and Suspend</source>
-        <translation>螢幕和待機</translation>
-    </message>
-    <message>
-        <source>Turn off the monitor after</source>
-        <translation>關閉顯示器</translation>
-    </message>
-    <message>
-        <source>Lock screen after</source>
-        <translation>自動鎖屏</translation>
-    </message>
-    <message>
-        <source>Computer suspends after</source>
-        <translation>進入待機</translation>
-    </message>
-    <message>
-        <source>When the lid is closed</source>
-        <translation>筆記本合蓋時</translation>
-    </message>
-    <message>
-        <source>When the power button is pressed</source>
-        <translation>按電源按鈕時</translation>
-    </message>
-    <message>
-        <source>Low Battery</source>
-        <translation>低電量管理</translation>
-    </message>
-    <message>
-        <source>Low battery notification</source>
-        <translation>低電量提醒</translation>
-    </message>
-    <message>
-        <source>Auto suspend</source>
-        <translation>自動待機</translation>
-    </message>
-    <message>
-        <source>Auto Hibernate</source>
-        <translation>自動休眠</translation>
-    </message>
-    <message>
-        <source>Low battery threshold</source>
-        <translation>低電量閾值</translation>
-    </message>
-    <message>
-        <source>Battery Management</source>
-        <translation>電池管理</translation>
-    </message>
-    <message>
-        <source>Display remaining using and charging time</source>
-        <translation>顯示剩餘使用時間及剩餘充電時間</translation>
-    </message>
-    <message>
-        <source>Maximum capacity</source>
-        <translation>最大容量</translation>
-    </message>
-    <message>
-        <source>Low battery level</source>
-        <translation>低電量時</translation>
-    </message>
-    <message>
-        <source>Disable</source>
-        <translation>從不</translation>
-    </message>
-</context>
-<context>
-    <name>BlueToothAdaptersModel</name>
-    <message>
-        <source>Bluetooth is turned off, and the name is displayed as &quot;%1&quot;</source>
-        <translation>藍牙已關閉，名稱顯示為&quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Bluetooth is turned on, and the name is displayed as &quot;%1&quot;</source>
-        <translation>藍牙已打開，名稱顯示為 &quot;%1&quot;</translation>
-    </message>
-</context>
-<context>
-    <name>BlueToothDeviceListView</name>
-    <message>
-        <source>Disconnect</source>
-        <translation>斷開連線</translation>
-    </message>
-    <message>
-        <source>Connect</source>
-        <translation>連線</translation>
-    </message>
-    <message>
-        <source>Send Files</source>
-        <translation>傳送檔案</translation>
-    </message>
-    <message>
-        <source>Rename</source>
-        <translation>重新命名</translation>
-    </message>
-    <message>
-        <source>Remove Device</source>
-        <translation>移除裝置</translation>
-    </message>
-    <message>
-        <source>Select file</source>
-        <translation>選擇檔案</translation>
-    </message>
-</context>
-<context>
-    <name>BluetoothCtl</name>
-    <message>
-        <source>Edit</source>
-        <translation>修改</translation>
-    </message>
-    <message>
-        <source>Allow other Bluetooth devices to find this device</source>
-        <translation>允許其他藍牙裝置找到該裝置</translation>
-    </message>
-    <message>
-        <source>To use the Bluetooth function, please turn off</source>
-        <translation>如需使用藍牙功能，請關閉</translation>
-    </message>
-    <message>
-        <source>Airplane Mode</source>
-        <translation>飛航模式</translation>
-    </message>
-    <message>
-        <source>Bluetooth name cannot exceed 64 characters</source>
-        <translation>藍牙名稱不能超過64個字元</translation>
-    </message>
-</context>
-<context>
-    <name>BluetoothDeviceModel</name>
-    <message>
-        <source>Connected</source>
-        <translation>已連線</translation>
-    </message>
-    <message>
-        <source>Not connected</source>
-        <translation>未連線</translation>
-    </message>
-</context>
-<context>
-    <name>BootPage</name>
-    <message>
-        <source>Startup Settings</source>
-        <translation>啟動設定</translation>
-    </message>
-    <message>
-        <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-        <translation>您可以點選菜單改變預設啟動項，也可以拖拽圖片到視窗改變背景圖片.</translation>
-    </message>
-    <message>
-        <source>grub start delay</source>
-        <translation>啟動延時</translation>
-    </message>
-    <message>
-        <source>theme</source>
-        <translation>主題</translation>
-    </message>
-    <message>
-        <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-        <translation>開啟主題後您可以在開機時看到主題背景</translation>
-    </message>
-    <message>
-        <source>Boot menu verification</source>
-        <translation>啟動菜單驗證</translation>
-    </message>
-    <message>
-        <source>After opening, entering the menu editing requires a password.</source>
-        <translation>開啟後進入啟動菜單編輯需要密碼.</translation>
-    </message>
-    <message>
-        <source>Change Password</source>
-        <translation>修改密碼</translation>
-    </message>
-    <message>
-        <source>Change boot menu verification password</source>
-        <translation>修改啟動菜單驗證密碼</translation>
-    </message>
-    <message>
-        <source>Set the boot menu authentication password</source>
-        <translation>設定啟動菜單驗證密碼</translation>
-    </message>
-    <message>
-        <source>User Name :</source>
-        <translation>使用者名稱：</translation>
-    </message>
-    <message>
-        <source>root</source>
-        <translation>root</translation>
-    </message>
-    <message>
-        <source>New Password :</source>
-        <translation>新密碼：</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Passwords do not match</source>
-        <translation>密碼不一致</translation>
-    </message>
-    <message>
-        <source>Repeat password:</source>
-        <translation>確認密碼：</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Sure</source>
-        <translation>確定</translation>
-    </message>
-    <message>
-        <source>Start animation</source>
-        <translation>啟動動畫</translation>
-    </message>
-    <message>
-        <source>Adjust the size of the logo animation on the system startup interface</source>
-        <translation>調整系統啟動介面的logo動畫尺寸大小</translation>
-    </message>
-</context>
-<context>
-    <name>Camera</name>
-    <message>
-        <source>Allow below apps to access your camera:</source>
-        <translation>允許下麵的應用訪問您的攝像頭</translation>
-    </message>
-</context>
-<context>
-    <name>CharaMangerModel</name>
-    <message>
-        <source>Fingerprint1</source>
-        <translation>指紋1</translation>
-    </message>
-    <message>
-        <source>Fingerprint2</source>
-        <translation>指紋2</translation>
-    </message>
-    <message>
-        <source>Fingerprint3</source>
-        <translation>指紋3</translation>
-    </message>
-    <message>
-        <source>Fingerprint4</source>
-        <translation>指紋4</translation>
-    </message>
-    <message>
-        <source>Fingerprint5</source>
-        <translation>指紋5</translation>
-    </message>
-    <message>
-        <source>Fingerprint6</source>
-        <translation>指紋6</translation>
-    </message>
-    <message>
-        <source>Fingerprint7</source>
-        <translation>指紋7</translation>
-    </message>
-    <message>
-        <source>Fingerprint8</source>
-        <translation>指紋8</translation>
-    </message>
-    <message>
-        <source>Fingerprint9</source>
-        <translation>指紋9</translation>
-    </message>
-    <message>
-        <source>Fingerprint10</source>
-        <translation>指紋10</translation>
-    </message>
-    <message>
-        <source>Scan failed</source>
-        <translation>指紋錄入失敗</translation>
-    </message>
-    <message>
-        <source>The fingerprint already exists</source>
-        <translation>指紋已存在</translation>
-    </message>
-    <message>
-        <source>Please scan other fingers</source>
-        <translation>請使用其他手指錄入</translation>
-    </message>
-    <message>
-        <source>Unknown error</source>
-        <translation>未知錯誤</translation>
-    </message>
-    <message>
-        <source>Scan suspended</source>
-        <translation>指紋錄入被中斷</translation>
-    </message>
-    <message>
-        <source>Cannot recognize</source>
-        <translation>無法識別</translation>
-    </message>
-    <message>
-        <source>Moved too fast</source>
-        <translation>接觸時間短</translation>
-    </message>
-    <message>
-        <source>Finger moved too fast, please do not lift until prompted</source>
-        <translation>接觸時間短，驗證時請勿移動手指</translation>
-    </message>
-    <message>
-        <source>Unclear fingerprint</source>
-        <translation>影像模糊</translation>
-    </message>
-    <message>
-        <source>Clean your finger or adjust the finger position, and try again</source>
-        <translation>請清潔手指或調整觸控位置，再次按壓指紋識別器</translation>
-    </message>
-    <message>
-        <source>Already scanned</source>
-        <translation>影像重複</translation>
-    </message>
-    <message>
-        <source>Adjust the finger position to scan your fingerprint fully</source>
-        <translation>請調整手指按壓區域以錄入更多指紋</translation>
-    </message>
-    <message>
-        <source>Finger moved too fast. Please do not lift until prompted</source>
-        <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
-    </message>
-    <message>
-        <source>Lift your finger and place it on the sensor again</source>
-        <translation>請擡起手指，再次按壓</translation>
-    </message>
-    <message>
-        <source>Position your face inside the frame</source>
-        <translation>請確保您的面部全部顯示在識別區域內</translation>
-    </message>
-    <message>
-        <source>Face enrolled</source>
-        <translation>人臉錄入完成</translation>
-    </message>
-    <message>
-        <source>Position a human face please</source>
-        <translation>請使用人類面容</translation>
-    </message>
-    <message>
-        <source>Keep away from the camera</source>
-        <translation>請遠離鏡頭</translation>
-    </message>
-    <message>
-        <source>Get closer to the camera</source>
-        <translation>請靠近鏡頭</translation>
-    </message>
-    <message>
-        <source>Do not position multiple faces inside the frame</source>
-        <translation>請不要多人入鏡</translation>
-    </message>
-    <message>
-        <source>Make sure the camera lens is clean</source>
-        <translation>請確保鏡頭清潔</translation>
-    </message>
-    <message>
-        <source>Do not enroll in dark, bright or backlit environments</source>
-        <translation>請避免在暗光、強光、逆光環境下操作</translation>
-    </message>
-    <message>
-        <source>Keep your face uncovered</source>
-        <translation>請保持面部無遮擋</translation>
-    </message>
-    <message>
-        <source>Scan timed out</source>
-        <translation>錄入超時</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Camera occupied!</source>
-        <translation>攝像頭被佔用！</translation>
-    </message>
-</context>
-<context>
-    <name>ColorAndIcons</name>
-    <message>
-        <source>Accent Color</source>
-        <translation>活動用色</translation>
-    </message>
-    <message>
-        <source>Icon Settings</source>
-        <translation>圖示設定</translation>
-    </message>
-    <message>
-        <source>Icon Theme</source>
-        <translation>圖示主題</translation>
-    </message>
-    <message>
-        <source>Customize your theme icon</source>
-        <translation>自定義您的主題圖示</translation>
-    </message>
-    <message>
-        <source>Cursor Theme</source>
-        <translation>游標主題</translation>
-    </message>
-    <message>
-        <source>Customize your theme cursor</source>
-        <translation>自定義您的主題游標</translation>
-    </message>
-</context>
-<context>
-    <name>ComfirmDeleteDialog</name>
-    <message>
-        <source>Are you sure you want to delete this account?</source>
-        <translation>您確定要刪除此帳戶嗎？</translation>
-    </message>
-    <message>
-        <source>Delete account directory</source>
-        <translation>刪除帳戶目錄</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Delete</source>
-        <translation>刪除</translation>
-    </message>
-</context>
-<context>
-    <name>ComfirmSafePage</name>
-    <message>
-        <source>Go to settings</source>
-        <translation>去設定</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-</context>
-<context>
-    <name>Common</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Repeat delay</source>
-        <translation>重複延遲</translation>
-    </message>
-    <message>
-        <source>Short</source>
-        <translation>短</translation>
-    </message>
-    <message>
-        <source>Long</source>
-        <translation>長</translation>
-    </message>
-    <message>
-        <source>Repeat rate</source>
-        <translation>重複速度</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>慢</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快</translation>
-    </message>
-    <message>
-        <source>Numeric Keypad</source>
-        <translation>啟用數字鍵盤</translation>
-    </message>
-    <message>
-        <source>test here</source>
-        <translation>請在此輸入測試</translation>
-    </message>
-    <message>
-        <source>Caps lock prompt</source>
-        <translation>大寫鎖定提示</translation>
-    </message>
-    <message>
-        <source>Scroll Speed</source>
-        <translation>滾動速度</translation>
-    </message>
-    <message>
-        <source>Double Click Speed</source>
-        <translation>雙擊速度</translation>
-    </message>
-    <message>
-        <source>Double Click Test</source>
-        <translation>雙擊測試</translation>
-    </message>
-    <message>
-        <source>Left Hand Mode</source>
-        <translation>左手模式</translation>
-    </message>
-    <message>
-        <source>Enable Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-</context>
-<context>
-    <name>CommonInfoWork</name>
-    <message>
-        <source>Large size</source>
-        <translation>大尺寸</translation>
-    </message>
-    <message>
-        <source>Small size</source>
-        <translation>小尺寸</translation>
-    </message>
-    <message>
-        <source>Failed to get root access</source>
-        <translation>進入開發者模式失敗</translation>
-    </message>
-    <message>
-        <source>Please sign in to your Union ID first</source>
-        <translation>請先登入Union ID</translation>
-    </message>
-    <message>
-        <source>Cannot read your PC information</source>
-        <translation>無法獲取硬體資訊</translation>
-    </message>
-    <message>
-        <source>No network connection</source>
-        <translation>無網路連線</translation>
-    </message>
-    <message>
-        <source>Certificate loading failed, unable to get root access</source>
-        <translation>證書載入失敗，無法進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Signature verification failed, unable to get root access</source>
-        <translation>簽名驗證失敗，無法進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Agree and Join User Experience Program</source>
-        <translation>同意並加入使用者體驗計劃</translation>
-    </message>
-    <message>
-        <source>The Disclaimer of Developer Mode</source>
-        <translation>開發者模式免責宣告</translation>
-    </message>
-    <message>
-        <source>Agree and Request Root Access</source>
-        <translation>同意並進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Start setting the new boot animation, please wait for a minute</source>
-        <translation>開始設定啟動新動畫，請稍等一會兒</translation>
-    </message>
-    <message>
-        <source>Setting new boot animation finished</source>
-        <translation>新的啟動動畫設定完成</translation>
-    </message>
-    <message>
-        <source>The settings will be applied after rebooting the system</source>
-        <translation>新的設定會在重啟系統後生效</translation>
-    </message>
-</context>
-<context>
-    <name>ConfirmManager</name>
-    <message>
-        <source>Password must contain numbers and letters</source>
-        <translation>密碼必須包含數字和字母</translation>
-    </message>
-    <message>
-        <source>Password must be between 8 and 64 characters</source>
-        <translation>密碼長度必須為8~64個字元</translation>
-    </message>
-</context>
-<context>
-    <name>CreateAccountDialog</name>
-    <message>
-        <source>Create a new account</source>
-        <translation>建立新使用者</translation>
-    </message>
-    <message>
-        <source>Account type</source>
-        <translation>帳戶型別</translation>
-    </message>
-    <message>
-        <source>UserName</source>
-        <translation>使用者名稱</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>FullName</source>
-        <translation>全名</translation>
-    </message>
-    <message>
-        <source>Optional</source>
-        <translation>選填</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Create account</source>
-        <translation>建立使用者</translation>
-    </message>
-</context>
-<context>
-    <name>CustomAvatarEmpatyArea</name>
-    <message>
-        <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-        <translation>您還沒有上傳過頭像，可點選或拖拽上傳圖片</translation>
-    </message>
-</context>
-<context>
-    <name>DCC_NAMESPACE::SystemInfoModel</name>
-    <message>
-        <source>available</source>
-        <translation>可用</translation>
-    </message>
-</context>
-<context>
-    <name>DCC_NAMESPACE::SystemInfoWork</name>
-    <message>
-        <source>https://www.deepin.org/en/agreement/privacy/</source>
-        <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
-    </message>
-    <message>
-        <source>https://www.uniontech.com/agreement/privacy-en</source>
-        <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;統信軟體非常重視您的隱私。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及儲存您的資訊的隱私政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href=&quot;%1&quot;&gt;點選此處&lt;/a&gt;檢視我們最新的隱私政策和/或通過訪問 &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;線上檢視。請您務必認真閱讀、充分理解我們針對客戶隱私的做法，如果有任何疑問，請聯絡我們：support@uniontech.com。&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>https://www.uniontech.com/agreement/experience-en</source>
-        <translation>https://www.uniontech.com/agreement/experience-cn</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-        <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。詳細說明請參照Deepin隱私政策 (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-        <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。瞭解使用者體驗計劃，請訪問：&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Agree and Join User Experience Program</source>
-        <translation>同意並加入使用者體驗計劃</translation>
-    </message>
-</context>
-<context>
-    <name>DateTimeSettingDialog</name>
-    <message>
-        <source>Date and time setting</source>
-        <translation>日期和時間設定</translation>
-    </message>
-    <message>
-        <source>Date</source>
-        <translation>日期</translation>
-    </message>
-    <message>
-        <source>Year</source>
-        <translation>年</translation>
-    </message>
-    <message>
-        <source>Month</source>
-        <translation>月</translation>
-    </message>
-    <message>
-        <source>Day</source>
-        <translation>日</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>時間</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>確認</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeModel</name>
-    <message>
-        <source>Tomorrow</source>
-        <translation>明天</translation>
-    </message>
-    <message>
-        <source>Yesterday</source>
-        <translation>昨天</translation>
-    </message>
-    <message>
-        <source>Today</source>
-        <translation>今天</translation>
-    </message>
-    <message>
-        <source>%1 hours earlier than local</source>
-        <translation>比本地早了 %1 小時</translation>
-    </message>
-    <message>
-        <source>%1 hours later than local</source>
-        <translation>比本地晚了 %1 小時</translation>
-    </message>
-    <message>
-        <source>Space</source>
-        <translation>空格</translation>
-    </message>
-    <message>
-        <source>Week</source>
-        <translation>星期/周</translation>
-    </message>
-    <message>
-        <source>First day of week</source>
-        <translation>一週首日</translation>
-    </message>
-    <message>
-        <source>Short date</source>
-        <translation>短日期</translation>
-    </message>
-    <message>
-        <source>Long date</source>
-        <translation>長日期</translation>
-    </message>
-    <message>
-        <source>Short time</source>
-        <translation>短時間</translation>
-    </message>
-    <message>
-        <source>Long time</source>
-        <translation>長時間</translation>
-    </message>
-    <message>
-        <source>Currency symbol</source>
-        <translation>貨幣符號</translation>
-    </message>
-    <message>
-        <source>Positive currency</source>
-        <translation>貨幣正數</translation>
-    </message>
-    <message>
-        <source>Negative currency</source>
-        <translation>貨幣負數</translation>
-    </message>
-    <message>
-        <source>Decimal symbol</source>
-        <translation>小數點</translation>
-    </message>
-    <message>
-        <source>Digit grouping symbol</source>
-        <translation>分隔符</translation>
-    </message>
-    <message>
-        <source>Digit grouping</source>
-        <translation>數字分組</translation>
-    </message>
-    <message>
-        <source>Page size</source>
-        <translation>紙張</translation>
-    </message>
-</context>
-<context>
-    <name>DatetimeWorker</name>
-    <message>
-        <source>Authentication is required to change NTP server</source>
-        <translation>修改 NTP 地址需要認證</translation>
-    </message>
-</context>
-<context>
-    <name>DccColorDialog</name>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>儲存</translation>
-    </message>
-</context>
-<context>
-    <name>DccWindow</name>
-    <message>
-        <source>Control Center provides the options for system settings.</source>
-        <translation>控制中心提供作業系統的所有設定選項。</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDAccountSecurity</name>
-    <message>
-        <source>Bind WeChat</source>
-        <translation>繫結微信</translation>
-    </message>
-    <message>
-        <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-        <translation>通過繫結微信，您可以安全快速地登入您的%1 ID和本地帳戶</translation>
-    </message>
-    <message>
-        <source>Unlinked</source>
-        <translation>未繫結</translation>
-    </message>
-    <message>
-        <source>Unbinding</source>
-        <translation>解綁</translation>
-    </message>
-    <message>
-        <source>Link</source>
-        <translation>去繫結</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to unbind WeChat?</source>
-        <translation>您確定要解綁微信嗎？</translation>
-    </message>
-    <message>
-        <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-        <translation>解綁微信後，您將無法使用微信掃碼登入%1 ID、微信掃碼登入本地帳戶</translation>
-    </message>
-    <message>
-        <source>Let me think it over</source>
-        <translation>我再想想</translation>
-    </message>
-    <message>
-        <source>Local Account Binding</source>
-        <translation>繫結本地帳戶</translation>
-    </message>
-    <message>
-        <source>After binding your local account, you can use the following functions:</source>
-        <translation>繫結本地帳戶後，您可以使用如下功能：</translation>
-    </message>
-    <message>
-        <source>WeChat Scan Code Login System</source>
-        <translation>微信掃碼登入系統</translation>
-    </message>
-    <message>
-        <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-        <translation>使用%1 ID繫結的微信，掃碼登入本地帳戶</translation>
-    </message>
-    <message>
-        <source>Reset password via %1 ID</source>
-        <translation>通過%1 ID重置密碼</translation>
-    </message>
-    <message>
-        <source>Reset your local password via %1 ID in case you forget it.</source>
-        <translation>在您忘記本地帳戶密碼時，通過%1 ID重置密碼</translation>
-    </message>
-    <message>
-        <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-        <translation>如需使用上述功能，請前往控制中心-帳戶，開啟相應選項</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDInterface</name>
-    <message>
-        <source>deepin</source>
-        <translation>deepin</translation>
-    </message>
-    <message>
-        <source>UOS</source>
-        <translation>UOS</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDLogin</name>
-    <message>
-        <source>Cloud Sync</source>
-        <translation>雲同步</translation>
-    </message>
-    <message>
-        <source>Manage your %1 ID and sync your personal data across devices.
+        </message>
+    </context>
+    <context>
+        <name>AutoLoginWarningDialog</name>
+        <message>
+            <source>"Auto Login" can be enabled for only one account, please disable it for the account "%1" first</source>
+            <translation>只允許一個帳戶開啟自動登入，請先關閉%1帳戶的自動登入，再進行操作</translation>
+        </message>
+        <message>
+            <source>Ok</source>
+            <translation>確 定</translation>
+        </message>
+    </context>
+    <context>
+        <name>AvatarSettingsDialog</name>
+        <message>
+            <source>Images</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Human</source>
+            <translation>人物</translation>
+        </message>
+        <message>
+            <source>Animal</source>
+            <translation>動物</translation>
+        </message>
+        <message>
+            <source>Scenery</source>
+            <translation>靜物</translation>
+        </message>
+        <message>
+            <source>Illustration</source>
+            <translation>創意插圖</translation>
+        </message>
+        <message>
+            <source>Emoji</source>
+            <translation>表情符號</translation>
+        </message>
+        <message>
+            <source>custom</source>
+            <translation>自定義圖片</translation>
+        </message>
+        <message>
+            <source>Cartoon style</source>
+            <translation>Q版風格</translation>
+        </message>
+        <message>
+            <source>Dimensional style</source>
+            <translation>立體風格</translation>
+        </message>
+        <message>
+            <source>Flat style</source>
+            <translation>平面風格</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>儲存</translation>
+        </message>
+    </context>
+    <context>
+        <name>BatteryPage</name>
+        <message>
+            <source>Screen and Suspend</source>
+            <translation>螢幕和待機</translation>
+        </message>
+        <message>
+            <source>Turn off the monitor after</source>
+            <translation>關閉顯示器</translation>
+        </message>
+        <message>
+            <source>Lock screen after</source>
+            <translation>自動鎖屏</translation>
+        </message>
+        <message>
+            <source>Computer suspends after</source>
+            <translation>進入待機</translation>
+        </message>
+        <message>
+            <source>When the lid is closed</source>
+            <translation>筆記本合蓋時</translation>
+        </message>
+        <message>
+            <source>When the power button is pressed</source>
+            <translation>按電源按鈕時</translation>
+        </message>
+        <message>
+            <source>Low Battery</source>
+            <translation>低電量管理</translation>
+        </message>
+        <message>
+            <source>Low battery notification</source>
+            <translation>低電量提醒</translation>
+        </message>
+        <message>
+            <source>Auto suspend</source>
+            <translation>自動待機</translation>
+        </message>
+        <message>
+            <source>Auto Hibernate</source>
+            <translation>自動休眠</translation>
+        </message>
+        <message>
+            <source>Low battery threshold</source>
+            <translation>低電量閾值</translation>
+        </message>
+        <message>
+            <source>Battery Management</source>
+            <translation>電池管理</translation>
+        </message>
+        <message>
+            <source>Display remaining using and charging time</source>
+            <translation>顯示剩餘使用時間及剩餘充電時間</translation>
+        </message>
+        <message>
+            <source>Maximum capacity</source>
+            <translation>最大容量</translation>
+        </message>
+        <message>
+            <source>Low battery level</source>
+            <translation>低電量時</translation>
+        </message>
+        <message>
+            <source>Disable</source>
+            <translation>從不</translation>
+        </message>
+    </context>
+    <context>
+        <name>BlueToothAdaptersModel</name>
+        <message>
+            <source>Bluetooth is turned off, and the name is displayed as "%1"</source>
+            <translation>藍牙已關閉，名稱顯示為"%1"</translation>
+        </message>
+        <message>
+            <source>Bluetooth is turned on, and the name is displayed as "%1"</source>
+            <translation>藍牙已打開，名稱顯示為 "%1"</translation>
+        </message>
+    </context>
+    <context>
+        <name>BlueToothDeviceListView</name>
+        <message>
+            <source>Disconnect</source>
+            <translation>斷開連線</translation>
+        </message>
+        <message>
+            <source>Connect</source>
+            <translation>連線</translation>
+        </message>
+        <message>
+            <source>Send Files</source>
+            <translation>傳送檔案</translation>
+        </message>
+        <message>
+            <source>Rename</source>
+            <translation>重新命名</translation>
+        </message>
+        <message>
+            <source>Remove Device</source>
+            <translation>移除裝置</translation>
+        </message>
+        <message>
+            <source>Select file</source>
+            <translation>選擇檔案</translation>
+        </message>
+    </context>
+    <context>
+        <name>BluetoothCtl</name>
+        <message>
+            <source>Edit</source>
+            <translation>修改</translation>
+        </message>
+        <message>
+            <source>Allow other Bluetooth devices to find this device</source>
+            <translation>允許其他藍牙裝置找到該裝置</translation>
+        </message>
+        <message>
+            <source>To use the Bluetooth function, please turn off</source>
+            <translation>如需使用藍牙功能，請關閉</translation>
+        </message>
+        <message>
+            <source>Airplane Mode</source>
+            <translation>飛航模式</translation>
+        </message>
+        <message>
+            <source>Bluetooth name cannot exceed 64 characters</source>
+            <translation>藍牙名稱不能超過64個字元</translation>
+        </message>
+    </context>
+    <context>
+        <name>BluetoothDeviceModel</name>
+        <message>
+            <source>Connected</source>
+            <translation>已連線</translation>
+        </message>
+        <message>
+            <source>Not connected</source>
+            <translation>未連線</translation>
+        </message>
+    </context>
+    <context>
+        <name>BootPage</name>
+        <message>
+            <source>Startup Settings</source>
+            <translation>啟動設定</translation>
+        </message>
+        <message>
+            <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
+            <translation>您可以點選菜單改變預設啟動項，也可以拖拽圖片到視窗改變背景圖片.</translation>
+        </message>
+        <message>
+            <source>grub start delay</source>
+            <translation>啟動延時</translation>
+        </message>
+        <message>
+            <source>theme</source>
+            <translation>主題</translation>
+        </message>
+        <message>
+            <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
+            <translation>開啟主題後您可以在開機時看到主題背景</translation>
+        </message>
+        <message>
+            <source>Boot menu verification</source>
+            <translation>啟動菜單驗證</translation>
+        </message>
+        <message>
+            <source>After opening, entering the menu editing requires a password.</source>
+            <translation>開啟後進入啟動菜單編輯需要密碼.</translation>
+        </message>
+        <message>
+            <source>Change Password</source>
+            <translation>修改密碼</translation>
+        </message>
+        <message>
+            <source>Change boot menu verification password</source>
+            <translation>修改啟動菜單驗證密碼</translation>
+        </message>
+        <message>
+            <source>Set the boot menu authentication password</source>
+            <translation>設定啟動菜單驗證密碼</translation>
+        </message>
+        <message>
+            <source>User Name :</source>
+            <translation>使用者名稱：</translation>
+        </message>
+        <message>
+            <source>root</source>
+            <translation>root</translation>
+        </message>
+        <message>
+            <source>New Password :</source>
+            <translation>新密碼：</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Passwords do not match</source>
+            <translation>密碼不一致</translation>
+        </message>
+        <message>
+            <source>Repeat password:</source>
+            <translation>確認密碼：</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Sure</source>
+            <translation>確定</translation>
+        </message>
+        <message>
+            <source>Start animation</source>
+            <translation>啟動動畫</translation>
+        </message>
+        <message>
+            <source>Adjust the size of the logo animation on the system startup interface</source>
+            <translation>調整系統啟動介面的logo動畫尺寸大小</translation>
+        </message>
+    </context>
+    <context>
+        <name>Camera</name>
+        <message>
+            <source>Allow below apps to access your camera:</source>
+            <translation>允許下麵的應用訪問您的攝像頭</translation>
+        </message>
+    </context>
+    <context>
+        <name>CharaMangerModel</name>
+        <message>
+            <source>Fingerprint1</source>
+            <translation>指紋1</translation>
+        </message>
+        <message>
+            <source>Fingerprint2</source>
+            <translation>指紋2</translation>
+        </message>
+        <message>
+            <source>Fingerprint3</source>
+            <translation>指紋3</translation>
+        </message>
+        <message>
+            <source>Fingerprint4</source>
+            <translation>指紋4</translation>
+        </message>
+        <message>
+            <source>Fingerprint5</source>
+            <translation>指紋5</translation>
+        </message>
+        <message>
+            <source>Fingerprint6</source>
+            <translation>指紋6</translation>
+        </message>
+        <message>
+            <source>Fingerprint7</source>
+            <translation>指紋7</translation>
+        </message>
+        <message>
+            <source>Fingerprint8</source>
+            <translation>指紋8</translation>
+        </message>
+        <message>
+            <source>Fingerprint9</source>
+            <translation>指紋9</translation>
+        </message>
+        <message>
+            <source>Fingerprint10</source>
+            <translation>指紋10</translation>
+        </message>
+        <message>
+            <source>Scan failed</source>
+            <translation>指紋錄入失敗</translation>
+        </message>
+        <message>
+            <source>The fingerprint already exists</source>
+            <translation>指紋已存在</translation>
+        </message>
+        <message>
+            <source>Please scan other fingers</source>
+            <translation>請使用其他手指錄入</translation>
+        </message>
+        <message>
+            <source>Unknown error</source>
+            <translation>未知錯誤</translation>
+        </message>
+        <message>
+            <source>Scan suspended</source>
+            <translation>指紋錄入被中斷</translation>
+        </message>
+        <message>
+            <source>Cannot recognize</source>
+            <translation>無法識別</translation>
+        </message>
+        <message>
+            <source>Moved too fast</source>
+            <translation>接觸時間短</translation>
+        </message>
+        <message>
+            <source>Finger moved too fast, please do not lift until prompted</source>
+            <translation>接觸時間短，驗證時請勿移動手指</translation>
+        </message>
+        <message>
+            <source>Unclear fingerprint</source>
+            <translation>影像模糊</translation>
+        </message>
+        <message>
+            <source>Clean your finger or adjust the finger position, and try again</source>
+            <translation>請清潔手指或調整觸控位置，再次按壓指紋識別器</translation>
+        </message>
+        <message>
+            <source>Already scanned</source>
+            <translation>影像重複</translation>
+        </message>
+        <message>
+            <source>Adjust the finger position to scan your fingerprint fully</source>
+            <translation>請調整手指按壓區域以錄入更多指紋</translation>
+        </message>
+        <message>
+            <source>Finger moved too fast. Please do not lift until prompted</source>
+            <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
+        </message>
+        <message>
+            <source>Lift your finger and place it on the sensor again</source>
+            <translation>請擡起手指，再次按壓</translation>
+        </message>
+        <message>
+            <source>Position your face inside the frame</source>
+            <translation>請確保您的面部全部顯示在識別區域內</translation>
+        </message>
+        <message>
+            <source>Face enrolled</source>
+            <translation>人臉錄入完成</translation>
+        </message>
+        <message>
+            <source>Position a human face please</source>
+            <translation>請使用人類面容</translation>
+        </message>
+        <message>
+            <source>Keep away from the camera</source>
+            <translation>請遠離鏡頭</translation>
+        </message>
+        <message>
+            <source>Get closer to the camera</source>
+            <translation>請靠近鏡頭</translation>
+        </message>
+        <message>
+            <source>Do not position multiple faces inside the frame</source>
+            <translation>請不要多人入鏡</translation>
+        </message>
+        <message>
+            <source>Make sure the camera lens is clean</source>
+            <translation>請確保鏡頭清潔</translation>
+        </message>
+        <message>
+            <source>Do not enroll in dark, bright or backlit environments</source>
+            <translation>請避免在暗光、強光、逆光環境下操作</translation>
+        </message>
+        <message>
+            <source>Keep your face uncovered</source>
+            <translation>請保持面部無遮擋</translation>
+        </message>
+        <message>
+            <source>Scan timed out</source>
+            <translation>錄入超時</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Camera occupied!</source>
+            <translation>攝像頭被佔用！</translation>
+        </message>
+    </context>
+    <context>
+        <name>ColorAndIcons</name>
+        <message>
+            <source>Accent Color</source>
+            <translation>活動用色</translation>
+        </message>
+        <message>
+            <source>Icon Settings</source>
+            <translation>圖示設定</translation>
+        </message>
+        <message>
+            <source>Icon Theme</source>
+            <translation>圖示主題</translation>
+        </message>
+        <message>
+            <source>Customize your theme icon</source>
+            <translation>自定義您的主題圖示</translation>
+        </message>
+        <message>
+            <source>Cursor Theme</source>
+            <translation>游標主題</translation>
+        </message>
+        <message>
+            <source>Customize your theme cursor</source>
+            <translation>自定義您的主題游標</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComfirmDeleteDialog</name>
+        <message>
+            <source>Are you sure you want to delete this account?</source>
+            <translation>您確定要刪除此帳戶嗎？</translation>
+        </message>
+        <message>
+            <source>Delete account directory</source>
+            <translation>刪除帳戶目錄</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Delete</source>
+            <translation>刪除</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComfirmSafePage</name>
+        <message>
+            <source>Go to settings</source>
+            <translation>去設定</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+    </context>
+    <context>
+        <name>Common</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Repeat delay</source>
+            <translation>重複延遲</translation>
+        </message>
+        <message>
+            <source>Short</source>
+            <translation>短</translation>
+        </message>
+        <message>
+            <source>Long</source>
+            <translation>長</translation>
+        </message>
+        <message>
+            <source>Repeat rate</source>
+            <translation>重複速度</translation>
+        </message>
+        <message>
+            <source>Slow</source>
+            <translation>慢</translation>
+        </message>
+        <message>
+            <source>Fast</source>
+            <translation>快</translation>
+        </message>
+        <message>
+            <source>Numeric Keypad</source>
+            <translation>啟用數字鍵盤</translation>
+        </message>
+        <message>
+            <source>test here</source>
+            <translation>請在此輸入測試</translation>
+        </message>
+        <message>
+            <source>Caps lock prompt</source>
+            <translation>大寫鎖定提示</translation>
+        </message>
+        <message>
+            <source>Scroll Speed</source>
+            <translation>滾動速度</translation>
+        </message>
+        <message>
+            <source>Double Click Speed</source>
+            <translation>雙擊速度</translation>
+        </message>
+        <message>
+            <source>Double Click Test</source>
+            <translation>雙擊測試</translation>
+        </message>
+        <message>
+            <source>Left Hand Mode</source>
+            <translation>左手模式</translation>
+        </message>
+        <message>
+            <source>Enable Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+    </context>
+    <context>
+        <name>CommonInfoWork</name>
+        <message>
+            <source>Large size</source>
+            <translation>大尺寸</translation>
+        </message>
+        <message>
+            <source>Small size</source>
+            <translation>小尺寸</translation>
+        </message>
+        <message>
+            <source>Failed to get root access</source>
+            <translation>進入開發者模式失敗</translation>
+        </message>
+        <message>
+            <source>Please sign in to your Union ID first</source>
+            <translation>請先登入Union ID</translation>
+        </message>
+        <message>
+            <source>Cannot read your PC information</source>
+            <translation>無法獲取硬體資訊</translation>
+        </message>
+        <message>
+            <source>No network connection</source>
+            <translation>無網路連線</translation>
+        </message>
+        <message>
+            <source>Certificate loading failed, unable to get root access</source>
+            <translation>證書載入失敗，無法進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Signature verification failed, unable to get root access</source>
+            <translation>簽名驗證失敗，無法進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Agree and Join User Experience Program</source>
+            <translation>同意並加入使用者體驗計劃</translation>
+        </message>
+        <message>
+            <source>The Disclaimer of Developer Mode</source>
+            <translation>開發者模式免責宣告</translation>
+        </message>
+        <message>
+            <source>Agree and Request Root Access</source>
+            <translation>同意並進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Start setting the new boot animation, please wait for a minute</source>
+            <translation>開始設定啟動新動畫，請稍等一會兒</translation>
+        </message>
+        <message>
+            <source>Setting new boot animation finished</source>
+            <translation>新的啟動動畫設定完成</translation>
+        </message>
+        <message>
+            <source>The settings will be applied after rebooting the system</source>
+            <translation>新的設定會在重啟系統後生效</translation>
+        </message>
+    </context>
+    <context>
+        <name>ConfirmManager</name>
+        <message>
+            <source>Password must contain numbers and letters</source>
+            <translation>密碼必須包含數字和字母</translation>
+        </message>
+        <message>
+            <source>Password must be between 8 and 64 characters</source>
+            <translation>密碼長度必須為8~64個字元</translation>
+        </message>
+    </context>
+    <context>
+        <name>CreateAccountDialog</name>
+        <message>
+            <source>Create a new account</source>
+            <translation>建立新使用者</translation>
+        </message>
+        <message>
+            <source>Account type</source>
+            <translation>帳戶型別</translation>
+        </message>
+        <message>
+            <source>UserName</source>
+            <translation>使用者名稱</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>FullName</source>
+            <translation>全名</translation>
+        </message>
+        <message>
+            <source>Optional</source>
+            <translation>選填</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Create account</source>
+            <translation>建立使用者</translation>
+        </message>
+    </context>
+    <context>
+        <name>CustomAvatarEmpatyArea</name>
+        <message>
+            <source>You haven't uploaded an avatar yet. Click or drag and drop to upload an image.</source>
+            <translation>您還沒有上傳過頭像，可點選或拖拽上傳圖片</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCC_NAMESPACE::SystemInfoModel</name>
+        <message>
+            <source>available</source>
+            <translation>可用</translation>
+        </message>
+    </context>
+    <context>
+        <name>DCC_NAMESPACE::SystemInfoWork</name>
+        <message>
+            <source>https://www.deepin.org/en/agreement/privacy/</source>
+            <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
+        </message>
+        <message>
+            <source>https://www.uniontech.com/agreement/privacy-en</source>
+            <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
+        </message>
+        <message>
+            <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href="%1"&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href="%1"&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;統信軟體非常重視您的隱私。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及儲存您的資訊的隱私政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href="%1"&gt;點選此處&lt;/a&gt;檢視我們最新的隱私政策和/或通過訪問 &lt;a href="%1"&gt;%1&lt;/a&gt;線上檢視。請您務必認真閱讀、充分理解我們針對客戶隱私的做法，如果有任何疑問，請聯絡我們：support@uniontech.com。&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <source>https://www.uniontech.com/agreement/experience-en</source>
+            <translation>https://www.uniontech.com/agreement/experience-cn</translation>
+        </message>
+        <message>
+            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href="%1"&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
+            <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。詳細說明請參照Deepin隱私政策 (&lt;a href="%1"&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href="%1"&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。瞭解使用者體驗計劃，請訪問：&lt;a href="%1"&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <source>Agree and Join User Experience Program</source>
+            <translation>同意並加入使用者體驗計劃</translation>
+        </message>
+    </context>
+    <context>
+        <name>DateTimeSettingDialog</name>
+        <message>
+            <source>Date and time setting</source>
+            <translation>日期和時間設定</translation>
+        </message>
+        <message>
+            <source>Date</source>
+            <translation>日期</translation>
+        </message>
+        <message>
+            <source>Year</source>
+            <translation>年</translation>
+        </message>
+        <message>
+            <source>Month</source>
+            <translation>月</translation>
+        </message>
+        <message>
+            <source>Day</source>
+            <translation>日</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation>時間</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確認</translation>
+        </message>
+    </context>
+    <context>
+        <name>DatetimeModel</name>
+        <message>
+            <source>Tomorrow</source>
+            <translation>明天</translation>
+        </message>
+        <message>
+            <source>Yesterday</source>
+            <translation>昨天</translation>
+        </message>
+        <message>
+            <source>Today</source>
+            <translation>今天</translation>
+        </message>
+        <message>
+            <source>%1 hours earlier than local</source>
+            <translation>比本地早了 %1 小時</translation>
+        </message>
+        <message>
+            <source>%1 hours later than local</source>
+            <translation>比本地晚了 %1 小時</translation>
+        </message>
+        <message>
+            <source>Space</source>
+            <translation>空格</translation>
+        </message>
+        <message>
+            <source>Week</source>
+            <translation>星期/周</translation>
+        </message>
+        <message>
+            <source>First day of week</source>
+            <translation>一週首日</translation>
+        </message>
+        <message>
+            <source>Short date</source>
+            <translation>短日期</translation>
+        </message>
+        <message>
+            <source>Long date</source>
+            <translation>長日期</translation>
+        </message>
+        <message>
+            <source>Short time</source>
+            <translation>短時間</translation>
+        </message>
+        <message>
+            <source>Long time</source>
+            <translation>長時間</translation>
+        </message>
+        <message>
+            <source>Currency symbol</source>
+            <translation>貨幣符號</translation>
+        </message>
+        <message>
+            <source>Positive currency</source>
+            <translation>貨幣正數</translation>
+        </message>
+        <message>
+            <source>Negative currency</source>
+            <translation>貨幣負數</translation>
+        </message>
+        <message>
+            <source>Decimal symbol</source>
+            <translation>小數點</translation>
+        </message>
+        <message>
+            <source>Digit grouping symbol</source>
+            <translation>分隔符</translation>
+        </message>
+        <message>
+            <source>Digit grouping</source>
+            <translation>數字分組</translation>
+        </message>
+        <message>
+            <source>Page size</source>
+            <translation>紙張</translation>
+        </message>
+    </context>
+    <context>
+        <name>DatetimeWorker</name>
+        <message>
+            <source>Authentication is required to change NTP server</source>
+            <translation>修改 NTP 地址需要認證</translation>
+        </message>
+    </context>
+    <context>
+        <name>DccColorDialog</name>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>儲存</translation>
+        </message>
+    </context>
+    <context>
+        <name>DccWindow</name>
+        <message>
+            <source>Control Center provides the options for system settings.</source>
+            <translation>控制中心提供作業系統的所有設定選項。</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDAccountSecurity</name>
+        <message>
+            <source>Bind WeChat</source>
+            <translation>繫結微信</translation>
+        </message>
+        <message>
+            <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
+            <translation>通過繫結微信，您可以安全快速地登入您的%1 ID和本地帳戶</translation>
+        </message>
+        <message>
+            <source>Unlinked</source>
+            <translation>未繫結</translation>
+        </message>
+        <message>
+            <source>Unbinding</source>
+            <translation>解綁</translation>
+        </message>
+        <message>
+            <source>Link</source>
+            <translation>去繫結</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to unbind WeChat?</source>
+            <translation>您確定要解綁微信嗎？</translation>
+        </message>
+        <message>
+            <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
+            <translation>解綁微信後，您將無法使用微信掃碼登入%1 ID、微信掃碼登入本地帳戶</translation>
+        </message>
+        <message>
+            <source>Let me think it over</source>
+            <translation>我再想想</translation>
+        </message>
+        <message>
+            <source>Local Account Binding</source>
+            <translation>繫結本地帳戶</translation>
+        </message>
+        <message>
+            <source>After binding your local account, you can use the following functions:</source>
+            <translation>繫結本地帳戶後，您可以使用如下功能：</translation>
+        </message>
+        <message>
+            <source>WeChat Scan Code Login System</source>
+            <translation>微信掃碼登入系統</translation>
+        </message>
+        <message>
+            <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
+            <translation>使用%1 ID繫結的微信，掃碼登入本地帳戶</translation>
+        </message>
+        <message>
+            <source>Reset password via %1 ID</source>
+            <translation>通過%1 ID重置密碼</translation>
+        </message>
+        <message>
+            <source>Reset your local password via %1 ID in case you forget it.</source>
+            <translation>在您忘記本地帳戶密碼時，通過%1 ID重置密碼</translation>
+        </message>
+        <message>
+            <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
+            <translation>如需使用上述功能，請前往控制中心-帳戶，開啟相應選項</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDInterface</name>
+        <message>
+            <source>deepin</source>
+            <translation>deepin</translation>
+        </message>
+        <message>
+            <source>UOS</source>
+            <translation>UOS</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDLogin</name>
+        <message>
+            <source>Cloud Sync</source>
+            <translation>雲同步</translation>
+        </message>
+        <message>
+            <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-        <translation>管理您的%1 ID，將您的個人資料在不同裝置之間同步。
+            <translation>管理您的%1 ID，將您的個人資料在不同裝置之間同步。
 登入%1 ID以獲取瀏覽器、應用商店、服務與支援等眾多應用的個性功能和服務。</translation>
-    </message>
-    <message>
-        <source>Sign In to %1 ID</source>
-        <translation>登入%1 ID</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDSyncService</name>
-    <message>
-        <source>Auto Sync</source>
-        <translation>自動同步</translation>
-    </message>
-    <message>
-        <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-        <translation>將您的系統設定和個人資訊安全地儲存在雲端，並在您不同的裝置上保持同步</translation>
-    </message>
-    <message>
-        <source>System Settings</source>
-        <translation>系統設定</translation>
-    </message>
-    <message>
-        <source>Last sync time: %1</source>
-        <translation>最近同步時間：%1</translation>
-    </message>
-    <message>
-        <source>Clear cloud data</source>
-        <translation>清除雲端資料</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-        <translation>確定要清除您儲存在雲端的系統設定和個人資料嗎？</translation>
-    </message>
-    <message>
-        <source>Once the data is cleared, it cannot be recovered!</source>
-        <translation>資料清除後將無法恢復！</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation>清除</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinIDUserInfo</name>
-    <message>
-        <source>Synchronization Service</source>
-        <translation>同步服務</translation>
-    </message>
-    <message>
-        <source>Account and Security</source>
-        <translation>帳戶與安全</translation>
-    </message>
-    <message>
-        <source>Sign out</source>
-        <translation>退出登入</translation>
-    </message>
-    <message>
-        <source>Go to web settings</source>
-        <translation>前往網頁設定</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinWorker</name>
-    <message>
-        <source>encrypt password failed</source>
-        <translation>加密密碼失敗</translation>
-    </message>
-    <message>
-        <source>Wrong password, %1 chances left</source>
-        <translation>密碼錯誤，您還可以嘗試%1次</translation>
-    </message>
-    <message>
-        <source>The login error has reached the limit today. You can reset the password and try again.</source>
-        <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
-    </message>
-    <message>
-        <source>Operation Successful</source>
-        <translation>操作成功</translation>
-    </message>
-</context>
-<context>
-    <name>DeepinidModel</name>
-    <message>
-        <source>Mainland China</source>
-        <translation>中國大陸</translation>
-    </message>
-    <message>
-        <source>Other regions</source>
-        <translation>其他地區</translation>
-    </message>
-    <message>
-        <source>The feature is not available at present, please activate your system first</source>
-        <translation>當前系統未啟用，暫無法使用該功能</translation>
-    </message>
-    <message>
-        <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-        <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
-    </message>
-</context>
-<context>
-    <name>DetailItem</name>
-    <message>
-        <source>Please choose the default program to open &apos;%1&apos;</source>
-        <translation>選擇打開「%1」的預設程式</translation>
-    </message>
-    <message>
-        <source>add</source>
-        <translation>新增</translation>
-    </message>
-    <message>
-        <source>Open Desktop file</source>
-        <translation>打開Desktop檔案</translation>
-    </message>
-    <message>
-        <source>Apps (*.desktop)</source>
-        <translation>應用程式(*.desktop)</translation>
-    </message>
-    <message>
-        <source>All files (*)</source>
-        <translation>所有檔案(*)</translation>
-    </message>
-</context>
-<context>
-    <name>DevelopModePage</name>
-    <message>
-        <source>Root Access</source>
-        <translation>開發者模式</translation>
-    </message>
-    <message>
-        <source>Request Root Access</source>
-        <translation>進入開發者模式</translation>
-    </message>
-    <message>
-        <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-        <translation>可獲得root使用許可權，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
-    </message>
-    <message>
-        <source>Allowed</source>
-        <translation>已進入</translation>
-    </message>
-    <message>
-        <source>Enter</source>
-        <translation>進入</translation>
-    </message>
-    <message>
-        <source>Online</source>
-        <translation>線上啟用</translation>
-    </message>
-    <message>
-        <source>Login UOS ID</source>
-        <translation>登入UOS ID</translation>
-    </message>
-    <message>
-        <source>Offline</source>
-        <translation>離線啟用</translation>
-    </message>
-    <message>
-        <source>Import Certificate</source>
-        <translation>匯入證書</translation>
-    </message>
-    <message>
-        <source>Select file</source>
-        <translation>選擇檔案</translation>
-    </message>
-    <message>
-        <source>Your UOS ID has been logged in, click to enter developer mode</source>
-        <translation>您的UOS ID已登入，點選進入開發者模式</translation>
-    </message>
-    <message>
-        <source>Please sign in to your UOS ID first and continue</source>
-        <translation>進入開發者模式需要登入UOS ID</translation>
-    </message>
-    <message>
-        <source>1.Export PC Info</source>
-        <translation>1.匯出機器資訊</translation>
-    </message>
-    <message>
-        <source>Export</source>
-        <translation>匯出</translation>
-    </message>
-    <message>
-        <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-        <translation>2.前往 &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
-    </message>
-    <message>
-        <source>3.Import Certificate</source>
-        <translation>3.匯入證書</translation>
-    </message>
-    <message>
-        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation>如需安裝非應用商店來源的應用，前往 &lt;a href=&quot;Security Center&quot;&gt;安全中心&lt;/a&gt; 進行設定。</translation>
-    </message>
-    <message>
-        <source>Development and debugging options</source>
-        <translation>開發除錯選項</translation>
-    </message>
-    <message>
-        <source>System logging level</source>
-        <translation>系統日誌記錄級別</translation>
-    </message>
-    <message>
-        <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-        <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多儲存空間.</translation>
-    </message>
-    <message>
-        <source>Off</source>
-        <translation>關閉</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation>除錯</translation>
-    </message>
-    <message>
-        <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-        <translation>更改選項處理可能需要一分鐘，收到設定成功提示後，請重啟裝置方可生效。</translation>
-    </message>
-</context>
-<context>
-    <name>DisclaimerControl</name>
-    <message>
-        <source>Disclaimer</source>
-        <translation>《使用者免責宣告》</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Agree</source>
-        <translation>同意</translation>
-    </message>
-</context>
-<context>
-    <name>FileAndFolder</name>
-    <message>
-        <source>Allow below apps to access these files and folders:</source>
-        <translation>允許下麵的應用訪問您的檔案和資料夾</translation>
-    </message>
-    <message>
-        <source>Documents</source>
-        <translation>文件</translation>
-    </message>
-    <message>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <source>Pictures</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <source>Videos</source>
-        <translation>影片</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation>音樂</translation>
-    </message>
-    <message>
-        <source>Downloads</source>
-        <translation>下載</translation>
-    </message>
-    <message>
-        <source>folder</source>
-        <translation>資料夾</translation>
-    </message>
-</context>
-<context>
-    <name>FontSizePage</name>
-    <message>
-        <source>Size</source>
-        <translation>字號</translation>
-    </message>
-    <message>
-        <source>Standard Font</source>
-        <translation>標準字型</translation>
-    </message>
-    <message>
-        <source>Monospaced Font</source>
-        <translation>等寬字型</translation>
-    </message>
-</context>
-<context>
-    <name>GeneralPage</name>
-    <message>
-        <source>Power Plans</source>
-        <translation>效能模式</translation>
-    </message>
-    <message>
-        <source>Power Saving Settings</source>
-        <translation>節能設定</translation>
-    </message>
-    <message>
-        <source>Auto power saving on low battery</source>
-        <translation>低電量時自動開啟節能模式</translation>
-    </message>
-    <message>
-        <source>Low battery threshold</source>
-        <translation>低電量閾值</translation>
-    </message>
-    <message>
-        <source>Auto power saving on battery</source>
-        <translation>使用電池時自動開啟節能模式</translation>
-    </message>
-    <message>
-        <source>Wakeup Settings</source>
-        <translation>喚醒設定</translation>
-    </message>
-    <message>
-        <source>Password is required to wake up the computer</source>
-        <translation>待機恢復時需要密碼</translation>
-    </message>
-    <message>
-        <source>Password is required to wake up the monitor</source>
-        <translation>喚醒顯示器時需要密碼</translation>
-    </message>
-    <message>
-        <source>Shutdown Settings</source>
-        <translation>關機設定</translation>
-    </message>
-    <message>
-        <source>Scheduled Shutdown</source>
-        <translation>定時關機</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>時間</translation>
-    </message>
-    <message>
-        <source>Repeat</source>
-        <translation>重複</translation>
-    </message>
-    <message>
-        <source>Once</source>
-        <translation>一次</translation>
-    </message>
-    <message>
-        <source>Every day</source>
-        <translation>每天</translation>
-    </message>
-    <message>
-        <source>Working days</source>
-        <translation>工作日</translation>
-    </message>
-    <message>
-        <source>Custom Time</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>Decrease screen brightness on power saver</source>
-        <translation>節能模式時降低螢幕亮度</translation>
-    </message>
-</context>
-<context>
-    <name>GestureModel</name>
-    <message>
-        <source>Three-finger</source>
-        <translation>三指</translation>
-    </message>
-    <message>
-        <source>Four-finger</source>
-        <translation>四指</translation>
-    </message>
-    <message>
-        <source>Up</source>
-        <translation>向上</translation>
-    </message>
-    <message>
-        <source>Down</source>
-        <translation>向下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>向左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>向右</translation>
-    </message>
-    <message>
-        <source>tap</source>
-        <translation>點選</translation>
-    </message>
-</context>
-<context>
-    <name>HomePage</name>
-    <message>
-        <source>,</source>
-        <translation>、</translation>
-    </message>
-    <message>
-        <source>...</source>
-        <translation>等</translation>
-    </message>
-</context>
-<context>
-    <name>InterfaceEffectListview</name>
-    <message>
-        <source>Optimal Performance</source>
-        <translation>最佳效能</translation>
-    </message>
-    <message>
-        <source>Balance</source>
-        <translation>均衡</translation>
-    </message>
-    <message>
-        <source>Best Visuals</source>
-        <translation>最佳視覺</translation>
-    </message>
-    <message>
-        <source>Disable all interface and window effects for efficient system performance.</source>
-        <translation>關閉所有介面和視窗特效，保障系統高效執行</translation>
-    </message>
-    <message>
-        <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-        <translation>限制部分視窗特效，保障出色的視覺效果，同時維持系統流暢執行</translation>
-    </message>
-    <message>
-        <source>Enable all interface and window effects for the best visual experience.</source>
-        <translation>啟用所有介面和視窗特效，體驗最佳視覺效果</translation>
-    </message>
-</context>
-<context>
-    <name>KeyboardLayout</name>
-    <message>
-        <source>Keyboard layout</source>
-        <translation>鍵盤佈局</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-        <translation>如需新增或切換鍵盤佈局，請同時在 &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt; 輸入法管理 &lt;/a&gt;  中新增對應的輸入法以確保生效</translation>
-    </message>
-    <message>
-        <source>Add new keyboard layout...</source>
-        <translation>新增鍵盤佈局...</translation>
-    </message>
-</context>
-<context>
-    <name>LangAndFormat</name>
-    <message>
-        <source>Language</source>
-        <translation>語言</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Other languages</source>
-        <translation>其他語言</translation>
-    </message>
-    <message>
-        <source>add</source>
-        <translation>新增</translation>
-    </message>
-    <message>
-        <source>Region</source>
-        <translation>區域</translation>
-    </message>
-    <message>
-        <source>Area</source>
-        <translation>地區</translation>
-    </message>
-    <message>
-        <source>Operating system and applications may provide you with local content based on your country and region</source>
-        <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
-    </message>
-    <message>
-        <source>Region and format</source>
-        <translation>區域格式</translation>
-    </message>
-    <message>
-        <source>Operating system and applications may set date and time formats based on regional formats</source>
-        <translation>作業系統和某些應用會根據區域格式設定日期和時間格式</translation>
-    </message>
-</context>
-<context>
-    <name>LangsChooserDialog</name>
-    <message>
-        <source>Add language</source>
-        <translation>新增語言</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>新增</translation>
-    </message>
-</context>
-<context>
-    <name>LayoutsChooser</name>
-    <message>
-        <source>Add language</source>
-        <translation>新增語言</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>新增</translation>
-    </message>
-</context>
-<context>
-    <name>LoginMethod</name>
-    <message>
-        <source>Login method</source>
-        <translation>登入方式</translation>
-    </message>
-    <message>
-        <source>Password, wechat, biometric authentication, security key</source>
-        <translation>密碼，微信掃碼，生物認證，安全金鑰</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation>密碼</translation>
-    </message>
-    <message>
-        <source>Modify password</source>
-        <translation>修改密碼</translation>
-    </message>
-    <message>
-        <source>Validity days</source>
-        <translation>有效天數</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation>長期有效</translation>
-    </message>
-</context>
-<context>
-    <name>LogoModule</name>
-    <message>
-        <source>Copyright© 2011-%1 Deepin Community</source>
-        <translation>Copyright © 2011-%1 深度社區</translation>
-    </message>
-    <message>
-        <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
-        <translation>Copyright © 2019-%1 統信軟體技術有限公司</translation>
-    </message>
-</context>
-<context>
-    <name>MicrophonePage</name>
-    <message>
-        <source>Automatic Noise Suppression</source>
-        <translation>噪音抑制</translation>
-    </message>
-    <message>
-        <source>Input Volume</source>
-        <translation>輸入音量</translation>
-    </message>
-    <message>
-        <source>Input Level</source>
-        <translation>反饋音量</translation>
-    </message>
-    <message>
-        <source>Input</source>
-        <translation>輸入</translation>
-    </message>
-    <message>
-        <source>No input device for sound found</source>
-        <translation>沒有找到聲音輸入裝置</translation>
-    </message>
-    <message>
-        <source>Input Devices</source>
-        <translation>輸入裝置</translation>
-    </message>
-</context>
-<context>
-    <name>Mouse</name>
-    <message>
-        <source>Mouse</source>
-        <translation>滑鼠</translation>
-    </message>
-    <message>
-        <source>Pointer Speed</source>
-        <translation>指標速度</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>慢</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快</translation>
-    </message>
-    <message>
-        <source>Pointer Size</source>
-        <translation>指標大小</translation>
-    </message>
-    <message>
-        <source>Short</source>
-        <translation>短</translation>
-    </message>
-    <message>
-        <source>Long</source>
-        <translation>長</translation>
-    </message>
-    <message>
-        <source>Mouse Acceleration</source>
-        <translation>滑鼠加速</translation>
-    </message>
-    <message>
-        <source>Disable touchpad when a mouse is connected</source>
-        <translation>插入滑鼠時停用觸控板</translation>
-    </message>
-    <message>
-        <source>Natural Scrolling</source>
-        <translation>自然滾動</translation>
-    </message>
-</context>
-<context>
-    <name>MyDevice</name>
-    <message>
-        <source>My Devices</source>
-        <translation>我的裝置</translation>
-    </message>
-</context>
-<context>
-    <name>NativeInfoPage</name>
-    <message>
-        <source>UOS</source>
-        <translation>UOS</translation>
-    </message>
-    <message>
-        <source>Computer name</source>
-        <translation>計算機名</translation>
-    </message>
-    <message>
-        <source>It cannot start or end with dashes</source>
-        <translation>計算機名不能以 - 開頭結尾</translation>
-    </message>
-    <message>
-        <source>OS Name</source>
-        <translation>產品名稱</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation>版本號</translation>
-    </message>
-    <message>
-        <source>Edition</source>
-        <translation>版本</translation>
-    </message>
-    <message>
-        <source>Type</source>
-        <translation>型別</translation>
-    </message>
-    <message>
-        <source>bit</source>
-        <translation>位</translation>
-    </message>
-    <message>
-        <source>Authorization</source>
-        <translation>版本授權</translation>
-    </message>
-    <message>
-        <source>System installation time</source>
-        <translation>系統安裝日期</translation>
-    </message>
-    <message>
-        <source>Kernel</source>
-        <translation>核心版本</translation>
-    </message>
-    <message>
-        <source>Graphics Platform</source>
-        <translation>圖形平臺</translation>
-    </message>
-    <message>
-        <source>Processor</source>
-        <translation>處理器</translation>
-    </message>
-    <message>
-        <source>Memory</source>
-        <translation>記憶體</translation>
-    </message>
-    <message>
-        <source>1~63 characters please</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>OtherDevice</name>
-    <message>
-        <source>Other Devices</source>
-        <translation>其他裝置</translation>
-    </message>
-    <message>
-        <source>Show Bluetooth devices without names</source>
-        <translation>顯示沒有名稱的藍牙裝置</translation>
-    </message>
-</context>
-<context>
-    <name>PasswordLayout</name>
-    <message>
-        <source>Current password</source>
-        <translation>當前密碼</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>Weak</source>
-        <translation>強度低</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>強度中</translation>
-    </message>
-    <message>
-        <source>Strong</source>
-        <translation>強度高</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation>密碼</translation>
-    </message>
-    <message>
-        <source>Repeat Password</source>
-        <translation>重複密碼</translation>
-    </message>
-    <message>
-        <source>Password hint</source>
-        <translation>密碼提示</translation>
-    </message>
-    <message>
-        <source>Optional</source>
-        <translation>選填</translation>
-    </message>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Passwords do not match</source>
-        <translation>密碼不一致</translation>
-    </message>
-    <message>
-        <source>New password should differ from the current one</source>
-        <translation>新密碼和舊密碼不能相同</translation>
-    </message>
-    <message>
-        <source>The hint is visible to all users. Do not include the password here.</source>
-        <translation>密碼提示對所有人可見，切勿包含具體密碼資訊</translation>
-    </message>
-</context>
-<context>
-    <name>PasswordModifyDialog</name>
-    <message>
-        <source>Modify password</source>
-        <translation>修改密碼</translation>
-    </message>
-    <message>
-        <source>Reset password</source>
-        <translation>重置密碼</translation>
-    </message>
-    <message>
-        <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-        <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
-    </message>
-    <message>
-        <source>Resetting the password will clear the data stored in the keyring.</source>
-        <translation>重設密碼將會清除金鑰環內已儲存的資料</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-</context>
-<context>
-    <name>PersonalizationInterface</name>
-    <message>
-        <source>Light</source>
-        <translation>淺色</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>自動</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>深色</translation>
-    </message>
-</context>
-<context>
-    <name>PersonalizationWorker</name>
-    <message>
-        <source>Custom</source>
-        <translation>自定義</translation>
-    </message>
-</context>
-<context>
-    <name>PluginArea</name>
-    <message>
-        <source>Plugin Area</source>
-        <translation>外掛區域</translation>
-    </message>
-    <message>
-        <source>Select which icons appear in the Dock</source>
-        <translation>選擇顯示在工作列外掛區域的圖示</translation>
-    </message>
-</context>
-<context>
-    <name>PowerOperatorModel</name>
-    <message>
-        <source>Shut down</source>
-        <translation>關機</translation>
-    </message>
-    <message>
-        <source>Suspend</source>
-        <translation>待機</translation>
-    </message>
-    <message>
-        <source>Hibernate</source>
-        <translation>休眠</translation>
-    </message>
-    <message>
-        <source>Turn off the monitor</source>
-        <translation>關閉顯示器</translation>
-    </message>
-    <message>
-        <source>Show the shutdown Interface</source>
-        <translation>進入關機介面</translation>
-    </message>
-    <message>
-        <source>Do nothing</source>
-        <translation>無任何操作</translation>
-    </message>
-</context>
-<context>
-    <name>PowerPage</name>
-    <message>
-        <source>Screen and Suspend</source>
-        <translation>螢幕和待機</translation>
-    </message>
-    <message>
-        <source>Turn off the monitor after</source>
-        <translation>關閉顯示器</translation>
-    </message>
-    <message>
-        <source>Lock screen after</source>
-        <translation>自動鎖屏</translation>
-    </message>
-    <message>
-        <source>Computer suspends after</source>
-        <translation>進入待機</translation>
-    </message>
-    <message>
-        <source>When the lid is closed</source>
-        <translation>筆記本合蓋時</translation>
-    </message>
-    <message>
-        <source>When the power button is pressed</source>
-        <translation>按電源按鈕時</translation>
-    </message>
-</context>
-<context>
-    <name>PowerPlansListview</name>
-    <message>
-        <source>High Performance</source>
-        <translation>高效能模式</translation>
-    </message>
-    <message>
-        <source>Balance Performance</source>
-        <translation>效能模式</translation>
-    </message>
-    <message>
-        <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-        <translation>根據負載情況積極調整執行頻率</translation>
-    </message>
-    <message>
-        <source>Balanced</source>
-        <translation>平衡模式</translation>
-    </message>
-    <message>
-        <source>Power Saver</source>
-        <translation>節能模式</translation>
-    </message>
-    <message>
-        <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-        <translation>效能優先，會顯著提升功耗和發熱</translation>
-    </message>
-    <message>
-        <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-        <translation>兼顧效能和續航，根據使用情況自動調節</translation>
-    </message>
-    <message>
-        <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-        <translation>續航優先，系統會犧牲一些效能表現來降低功耗</translation>
-    </message>
-</context>
-<context>
-    <name>PowerWorker</name>
-    <message>
-        <source>Minutes</source>
-        <translation>分鐘</translation>
-    </message>
-    <message>
-        <source>Hour</source>
-        <translation>小時</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation>從不</translation>
-    </message>
-</context>
-<context>
-    <name>PrivacyPolicyPage</name>
-    <message>
-        <source>Privacy Policy</source>
-        <translation>隱私政策</translation>
-    </message>
-    <message>
-        <source>Copy Link Address</source>
-        <translation>複製連結地址</translation>
-    </message>
-</context>
-<context>
-    <name>PwqualityManager</name>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Password must have at least %1 characters</source>
-        <translation>密碼長度不能少於%1個字元</translation>
-    </message>
-    <message>
-        <source>Password must be no more than %1 characters</source>
-        <translation>密碼長度不能超過%1個字元</translation>
-    </message>
-    <message>
-        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
-    </message>
-    <message>
-        <source>No more than %1 palindrome characters please</source>
-        <translation>迴文字元長度不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 monotonic characters please</source>
-        <translation>單調性字元不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 repeating characters please</source>
-        <translation>重複字元不超過%1位</translation>
-    </message>
-    <message>
-        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
-    </message>
-    <message>
-        <source>Password must not contain more than 4 palindrome characters</source>
-        <translation>密碼不得含有連續4個以上的迴文字元</translation>
-    </message>
-    <message>
-        <source>Do not use common words and combinations as password</source>
-        <translation>密碼不能是常見單詞及組合</translation>
-    </message>
-    <message>
-        <source>Create a strong password please</source>
-        <translation>密碼過於簡單，請增加密碼複雜度</translation>
-    </message>
-    <message>
-        <source>It does not meet password rules</source>
-        <translation>密碼不符合安全要求</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <source>Control Center</source>
-        <translation>控制中心</translation>
-    </message>
-    <message>
-        <source>Activated</source>
-        <translation>已啟用</translation>
-    </message>
-    <message>
-        <source>View</source>
-        <translation>檢視</translation>
-    </message>
-    <message>
-        <source>To be activated</source>
-        <translation>待啟用</translation>
-    </message>
-    <message>
-        <source>Activate</source>
-        <translation>啟用</translation>
-    </message>
-    <message>
-        <source>Expired</source>
-        <translation>已過期</translation>
-    </message>
-    <message>
-        <source>In trial period</source>
-        <translation>試用期</translation>
-    </message>
-    <message>
-        <source>Trial expired</source>
-        <translation>試用期過期</translation>
-    </message>
-    <message>
-        <source>dde-control-center</source>
-        <translation>控制中心</translation>
-    </message>
-    <message>
-        <source>Touch Screen Settings</source>
-        <translation>觸控屏設定</translation>
-    </message>
-    <message>
-        <source>The settings of touch screen changed</source>
-        <translation>已變更觸控屏設定</translation>
-    </message>
-    <message>
-        <source>This system wallpaper is locked. Please contact your admin.</source>
-        <translation>當前系統壁紙已被鎖定，請聯絡管理員</translation>
-    </message>
-</context>
-<context>
-    <name>RegionFormatDialog</name>
-    <message>
-        <source>Regions and formats</source>
-        <translation>區域和格式</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-    <message>
-        <source>Default formats</source>
-        <translation>預設格式</translation>
-    </message>
-    <message>
-        <source>First day of week</source>
-        <translation>一週第一天</translation>
-    </message>
-    <message>
-        <source>Short date</source>
-        <translation>短日期</translation>
-    </message>
-    <message>
-        <source>Long date</source>
-        <translation>長日期</translation>
-    </message>
-    <message>
-        <source>Short time</source>
-        <translation>短時間</translation>
-    </message>
-    <message>
-        <source>Long time</source>
-        <translation>長時間</translation>
-    </message>
-    <message>
-        <source>Currency symbol</source>
-        <translation>貨幣符號</translation>
-    </message>
-    <message>
-        <source>Digit</source>
-        <translation>數字</translation>
-    </message>
-    <message>
-        <source>Paper size</source>
-        <translation>紙張</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>儲存</translation>
-    </message>
-</context>
-<context>
-    <name>RegionsChooserWindow</name>
-    <message>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-</context>
-<context>
-    <name>RegisterDialog</name>
-    <message>
-        <source>Set a Password</source>
-        <translation>設定密碼</translation>
-    </message>
-    <message>
-        <source>8-64 characters</source>
-        <translation>請輸入8-64位密碼</translation>
-    </message>
-    <message>
-        <source>Repeat the password</source>
-        <translation>請再次輸入密碼</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>確定</translation>
-    </message>
-    <message>
-        <source>Passwords don&apos;t match</source>
-        <translation>兩次密碼輸入不一致</translation>
-    </message>
-</context>
-<context>
-    <name>ScheduledShutdownDialog</name>
-    <message>
-        <source>Customize repetition time</source>
-        <translation>自定義重複時間</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>儲存</translation>
-    </message>
-</context>
-<context>
-    <name>ScreenSaverPage</name>
-    <message>
-        <source>Screensaver</source>
-        <translation>螢幕保護</translation>
-    </message>
-    <message>
-        <source>preview</source>
-        <translation>全屏預覽</translation>
-    </message>
-    <message>
-        <source>Personalized screensaver</source>
-        <translation>個性化屏保</translation>
-    </message>
-    <message>
-        <source>setting</source>
-        <translation>設定</translation>
-    </message>
-    <message>
-        <source>idle time</source>
-        <translation>閒置時間</translation>
-    </message>
-    <message>
-        <source>1 minute</source>
-        <translation>1分鐘</translation>
-    </message>
-    <message>
-        <source>5 minute</source>
-        <translation>5分鐘</translation>
-    </message>
-    <message>
-        <source>10 minute</source>
-        <translation>10分鐘</translation>
-    </message>
-    <message>
-        <source>15 minute</source>
-        <translation>15分鐘</translation>
-    </message>
-    <message>
-        <source>30 minute</source>
-        <translation>30分鐘</translation>
-    </message>
-    <message>
-        <source>1 hour</source>
-        <translation>1小時</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>從不</translation>
-    </message>
-    <message>
-        <source>Password required for recovery</source>
-        <translation>恢復時需要密碼</translation>
-    </message>
-    <message>
-        <source>Picture slideshow screensaver</source>
-        <translation>圖片輪播屏保</translation>
-    </message>
-    <message>
-        <source>System screensaver</source>
-        <translation>系統屏保</translation>
-    </message>
-</context>
-<context>
-    <name>SearchableListViewPopup</name>
-    <message>
-        <source>Search</source>
-        <translation>搜尋</translation>
-    </message>
-    <message>
-        <source>No search results</source>
-        <translation>無搜尋結果</translation>
-    </message>
-</context>
-<context>
-    <name>ShortcutSettingDialog</name>
-    <message>
-        <source>Add custom shortcut</source>
-        <translation>新增自定義快捷鍵</translation>
-    </message>
-    <message>
-        <source>Name:</source>
-        <translation>名稱：</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>Command:</source>
-        <translation>命令：</translation>
-    </message>
-    <message>
-        <source>Shortcut</source>
-        <translation>快捷鍵</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>無</translation>
-    </message>
-    <message>
-        <source>Please enter a new shortcut</source>
-        <translation>請輸入新的快捷鍵</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation>新增</translation>
-    </message>
-    <message>
-        <source>Click Add to replace</source>
-        <translation>點選新增替換</translation>
-    </message>
-</context>
-<context>
-    <name>Shortcuts</name>
-    <message>
-        <source>Shortcuts</source>
-        <translation>快捷鍵</translation>
-    </message>
-    <message>
-        <source>System shortcut, custom shortcut</source>
-        <translation>系統快捷鍵、自定義快捷鍵</translation>
-    </message>
-    <message>
-        <source>Search shortcuts</source>
-        <translation>搜尋快捷鍵</translation>
-    </message>
-    <message>
-        <source>Custom</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>done</source>
-        <translation>完成</translation>
-    </message>
-    <message>
-        <source>edit</source>
-        <translation>編輯</translation>
-    </message>
-    <message>
-        <source>Please enter a new shortcut</source>
-        <translation>請輸入新的快捷鍵</translation>
-    </message>
-    <message>
-        <source>Click</source>
-        <translation>點選</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>or</source>
-        <translation>或</translation>
-    </message>
-    <message>
-        <source>Replace</source>
-        <translation>替換</translation>
-    </message>
-    <message>
-        <source>Restore default</source>
-        <translation>恢復預設</translation>
-    </message>
-    <message>
-        <source>Add custom shortcut</source>
-        <translation>新增快捷鍵</translation>
-    </message>
-</context>
-<context>
-    <name>SoundDevicemanagesPage</name>
-    <message>
-        <source>Output Devices</source>
-        <translation>輸出裝置</translation>
-    </message>
-    <message>
-        <source>Select whether to enable the devices</source>
-        <translation>選擇是否啟用裝置</translation>
-    </message>
-    <message>
-        <source>Input Devices</source>
-        <translation>輸入裝置</translation>
-    </message>
-</context>
-<context>
-    <name>SoundEffectsPage</name>
-    <message>
-        <source>Sound Effects</source>
-        <translation>系統音效</translation>
-    </message>
-</context>
-<context>
-    <name>SoundModel</name>
-    <message>
-        <source>Boot up</source>
-        <translation>開機</translation>
-    </message>
-    <message>
-        <source>Shut down</source>
-        <translation>關機</translation>
-    </message>
-    <message>
-        <source>Log out</source>
-        <translation>登出</translation>
-    </message>
-    <message>
-        <source>Wake up</source>
-        <translation>喚醒</translation>
-    </message>
-    <message>
-        <source>Volume +/-</source>
-        <translation>音量調節</translation>
-    </message>
-    <message>
-        <source>Notification</source>
-        <translation>通知</translation>
-    </message>
-    <message>
-        <source>Low battery</source>
-        <translation>電量不足</translation>
-    </message>
-    <message>
-        <source>Send icon in Launcher to Desktop</source>
-        <translation>從啟動器傳送圖示到桌面</translation>
-    </message>
-    <message>
-        <source>Empty Trash</source>
-        <translation>清空回收站</translation>
-    </message>
-    <message>
-        <source>Plug in</source>
-        <translation>電源接入</translation>
-    </message>
-    <message>
-        <source>Plug out</source>
-        <translation>電源拔出</translation>
-    </message>
-    <message>
-        <source>Removable device connected</source>
-        <translation>行動裝置接入</translation>
-    </message>
-    <message>
-        <source>Removable device removed</source>
-        <translation>行動裝置拔出</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation>錯誤提示</translation>
-    </message>
-</context>
-<context>
-    <name>SpeakerPage</name>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Output Volume</source>
-        <translation>輸出音量</translation>
-    </message>
-    <message>
-        <source>Volume Boost</source>
-        <translation>音量增強</translation>
-    </message>
-    <message>
-        <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
-        <translation>音量大於100%時可能會導致音效失真，同時損害您的音訊輸出裝置</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Output</source>
-        <translation>輸出</translation>
-    </message>
-    <message>
-        <source>No output device for sound found</source>
-        <translation>沒有找到聲音輸出裝置</translation>
-    </message>
-    <message>
-        <source>Left Right Balance</source>
-        <translation>左右平衡</translation>
-    </message>
-    <message>
-        <source>Mono audio</source>
-        <translation>單聲道音訊</translation>
-    </message>
-    <message>
-        <source>Merge left and right channels into a single channel</source>
-        <translation>將左聲道和右聲道合併成一個聲道</translation>
-    </message>
-    <message>
-        <source>Auto pause</source>
-        <translation>插拔管理</translation>
-    </message>
-    <message>
-        <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-        <translation>外設插拔時音訊輸出是否自動暫停</translation>
-    </message>
-    <message>
-        <source>Output Devices</source>
-        <translation>輸出裝置</translation>
-    </message>
-</context>
-<context>
-    <name>SyncInfoListModel</name>
-    <message>
-        <source>Sound</source>
-        <translation>聲音</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation>電源</translation>
-    </message>
-    <message>
-        <source>Mouse</source>
-        <translation>滑鼠</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation>更新</translation>
-    </message>
-    <message>
-        <source>Screensaver</source>
-        <translation>螢幕保護</translation>
-    </message>
-</context>
-<context>
-    <name>ThemeSelectView</name>
-    <message>
-        <source>More Wallpapers</source>
-        <translation>下載更多</translation>
-    </message>
-</context>
-<context>
-    <name>TimeAndDate</name>
-    <message>
-        <source>Auto sync time</source>
-        <translation>自動同步配置</translation>
-    </message>
-    <message>
-        <source>Ntp server</source>
-        <translation>伺服器</translation>
-    </message>
-    <message>
-        <source>System date and time</source>
-        <translation>系統日期和時間</translation>
-    </message>
-    <message>
-        <source>Customize</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <translation>設定</translation>
-    </message>
-    <message>
-        <source>Server address</source>
-        <translation>伺服器地址</translation>
-    </message>
-    <message>
-        <source>Required</source>
-        <translation>必填</translation>
-    </message>
-    <message>
-        <source>The ntp server address cannot be empty</source>
-        <translation>NTP 服務地址不能為空</translation>
-    </message>
-    <message>
-        <source>Use 24-hour format</source>
-        <translation>24小時制</translation>
-    </message>
-    <message>
-        <source>system time zone</source>
-        <translation>系統時區</translation>
-    </message>
-    <message>
-        <source>Timezone list</source>
-        <translation>時區列表</translation>
-    </message>
-</context>
-<context>
-    <name>TimeRange</name>
-    <message>
-        <source>from</source>
-        <translation>從</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation>至</translation>
-    </message>
-</context>
-<context>
-    <name>TimeoutDialog</name>
-    <message>
-        <source>Save the display settings?</source>
-        <translation>是否要儲存顯示設定？</translation>
-    </message>
-    <message>
-        <source>Settings will be reverted in %1s.</source>
-        <translation>如無任何操作將在%1秒後還原。</translation>
-    </message>
-    <message>
-        <source>Revert</source>
-        <translation>還原</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>儲存</translation>
-    </message>
-</context>
-<context>
-    <name>TimezoneDialog</name>
-    <message>
-        <source>Add time zone</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Determine the time zone based on the current location</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Time zone:</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Nearest City:</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation>儲存</translation>
-    </message>
-</context>
-<context>
-    <name>TouchScreen</name>
-    <message>
-        <source>TouchScreen</source>
-        <translation>觸控屏</translation>
-    </message>
-    <message>
-        <source>Set up here when connecting the touch screen</source>
-        <translation>連線觸控螢幕時在此處設定</translation>
-    </message>
-</context>
-<context>
-    <name>Touchpad</name>
-    <message>
-        <source>Basic Settings</source>
-        <translation>基礎設定</translation>
-    </message>
-    <message>
-        <source>Touchpad</source>
-        <translation>觸控板</translation>
-    </message>
-    <message>
-        <source>Pointer Speed</source>
-        <translation>指標速度</translation>
-    </message>
-    <message>
-        <source>Slow</source>
-        <translation>慢</translation>
-    </message>
-    <message>
-        <source>Fast</source>
-        <translation>快</translation>
-    </message>
-    <message>
-        <source>Disable touchpad during input</source>
-        <translation>輸入時停用觸控板</translation>
-    </message>
-    <message>
-        <source>Tap to Click</source>
-        <translation>輕觸以點選</translation>
-    </message>
-    <message>
-        <source>Natural Scrolling</source>
-        <translation>自然滾動</translation>
-    </message>
-    <message>
-        <source>Gesture</source>
-        <translation>手勢</translation>
-    </message>
-    <message>
-        <source>Three-finger gestures</source>
-        <translation>三指手勢</translation>
-    </message>
-    <message>
-        <source>Four-finger gestures</source>
-        <translation>四指手勢</translation>
-    </message>
-</context>
-<context>
-    <name>UserExperienceProgramPage</name>
-    <message>
-        <source>Join User Experience Program</source>
-        <translation>加入使用者體驗計劃</translation>
-    </message>
-    <message>
-        <source>Copy Link Address</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>VerifyDialog</name>
-    <message>
-        <source>Security Verification</source>
-        <translation>安全驗證</translation>
-    </message>
-    <message>
-        <source>The action is sensitive, please enter the login password first</source>
-        <translation>您正在進行敏感操作，請進行登入密碼認證</translation>
-    </message>
-    <message>
-        <source>8-64 characters</source>
-        <translation>請輸入8-64位密碼</translation>
-    </message>
-    <message>
-        <source>Forgot Password?</source>
-        <translation>忘記密碼？</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation>取消</translation>
-    </message>
-    <message>
-        <source>Confirm</source>
-        <translation>確定</translation>
-    </message>
-</context>
-<context>
-    <name>WallpaperPage</name>
-    <message>
-        <source>wallpaper</source>
-        <translation>壁紙</translation>
-    </message>
-    <message>
-        <source>Window rounded corners</source>
-        <translation>視窗圓角</translation>
-    </message>
-    <message>
-        <source>My pictures</source>
-        <translation>我的圖片</translation>
-    </message>
-    <message>
-        <source>System Wallpaper</source>
-        <translation>系統壁紙</translation>
-    </message>
-    <message>
-        <source>Solid color wallpaper</source>
-        <translation>純色壁紙</translation>
-    </message>
-    <message>
-        <source>Customizable wallpapers</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>fill style</source>
-        <translation>填充方式</translation>
-    </message>
-    <message>
-        <source>Automatic wallpaper change</source>
-        <translation>自動切換壁紙</translation>
-    </message>
-    <message>
-        <source>never</source>
-        <translation>從不</translation>
-    </message>
-    <message>
-        <source>30 second</source>
-        <translation>30秒</translation>
-    </message>
-    <message>
-        <source>1 minute</source>
-        <translation>1分鐘</translation>
-    </message>
-    <message>
-        <source>5 minute</source>
-        <translation>5分鐘</translation>
-    </message>
-    <message>
-        <source>10 minute</source>
-        <translation>10分鐘</translation>
-    </message>
-    <message>
-        <source>15 minute</source>
-        <translation>15分鐘</translation>
-    </message>
-    <message>
-        <source>30 minute</source>
-        <translation>30分鐘</translation>
-    </message>
-    <message>
-        <source>login</source>
-        <translation>登入時</translation>
-    </message>
-    <message>
-        <source>wake up</source>
-        <translation>喚醒時</translation>
-    </message>
-    <message>
-        <source>System Wallapers</source>
-        <translation>系統壁紙</translation>
-    </message>
-    <message>
-        <source>Live Wallpaper</source>
-        <translation>動態壁紙</translation>
-    </message>
-    <message>
-        <source>1 hour</source>
-        <translation>1小時</translation>
-    </message>
-</context>
-<context>
-    <name>WallpaperSelectView</name>
-    <message>
-        <source>unfold</source>
-        <translation>收起</translation>
-    </message>
-    <message>
-        <source>show all</source>
-        <translation>顯示全部</translation>
-    </message>
-    <message>
-        <source>items</source>
-        <translation>張</translation>
-    </message>
-    <message>
-        <source>Set lock screen</source>
-        <translation>設定鎖屏</translation>
-    </message>
-    <message>
-        <source>Set desktop</source>
-        <translation>設定桌面</translation>
-    </message>
-</context>
-<context>
-    <name>WindowEffectPage</name>
-    <message>
-        <source>Interface and Effects</source>
-        <translation>介面效果</translation>
-    </message>
-    <message>
-        <source>Window Settings</source>
-        <translation>視窗設定</translation>
-    </message>
-    <message>
-        <source>Window rounded corners</source>
-        <translation>視窗圓角</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>無</translation>
-    </message>
-    <message>
-        <source>Small</source>
-        <translation>小</translation>
-    </message>
-    <message>
-        <source>Medium</source>
-        <translation>中</translation>
-    </message>
-    <message>
-        <source>Large</source>
-        <translation>大</translation>
-    </message>
-    <message>
-        <source>Enable transparent effects when moving windows</source>
-        <translation>視窗移動時啟用透明特效</translation>
-    </message>
-    <message>
-        <source>Window Minimize Effect</source>
-        <translation>最小化時效果</translation>
-    </message>
-    <message>
-        <source>Scale</source>
-        <translation>縮放</translation>
-    </message>
-    <message>
-        <source>Magic Lamp</source>
-        <translation>魔燈</translation>
-    </message>
-    <message>
-        <source>Opacity</source>
-        <translation>不透明度調節</translation>
-    </message>
-    <message>
-        <source>Low</source>
-        <translation>低</translation>
-    </message>
-    <message>
-        <source>High</source>
-        <translation>高</translation>
-    </message>
-    <message>
-        <source>Scroll Bars</source>
-        <translation>捲軸</translation>
-    </message>
-    <message>
-        <source>Show on scrolling</source>
-        <translation>滾動時顯示</translation>
-    </message>
-    <message>
-        <source>Keep shown</source>
-        <translation>一直顯示</translation>
-    </message>
-    <message>
-        <source>Compact Display</source>
-        <translation>緊湊模式</translation>
-    </message>
-    <message>
-        <source>If enabled, more content is displayed in the window.</source>
-        <translation>開啟後，視窗將顯示更多內容</translation>
-    </message>
-    <message>
-        <source>Title Bar Height</source>
-        <translation>標題欄高度</translation>
-    </message>
-    <message>
-        <source>Only suitable for application window title bars drawn by the window manager.</source>
-        <translation>僅適用於視窗管理器繪製的應用標題欄</translation>
-    </message>
-    <message>
-        <source>Extremely small</source>
-        <translation>極小</translation>
-    </message>
-</context>
-<context>
-    <name>accounts</name>
-    <message>
-        <source>Account</source>
-        <translation>帳戶</translation>
-    </message>
-    <message>
-        <source>Account manager</source>
-        <translation>帳戶管理</translation>
-    </message>
-</context>
-<context>
-    <name>accountsMain</name>
-    <message>
-        <source>Other accounts</source>
-        <translation>其他帳戶</translation>
-    </message>
-</context>
-<context>
-    <name>authentication</name>
-    <message>
-        <source>Biometric Authentication</source>
-        <translation>生物認證</translation>
-    </message>
-</context>
-<context>
-    <name>authenticationMain</name>
-    <message>
-        <source>Biometric Authentication</source>
-        <translation>生物認證</translation>
-    </message>
-    <message>
-        <source>Face</source>
-        <translation>人臉</translation>
-    </message>
-    <message>
-        <source>Up to 5 facial data can be entered</source>
-        <translation>最多可錄入5個人臉資料</translation>
-    </message>
-    <message>
-        <source>Fingerprint</source>
-        <translation>指紋</translation>
-    </message>
-    <message>
-        <source>Identifying user identity through scanning fingerprints</source>
-        <translation>通過對指紋的掃描進行使用者身份的識別</translation>
-    </message>
-    <message>
-        <source>Iris</source>
-        <translation>虹膜</translation>
-    </message>
-    <message>
-        <source>Identity recognition through iris scanning</source>
-        <translation>通過掃描虹膜進行身份識別</translation>
-    </message>
-    <message>
-        <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-        <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字元</translation>
-    </message>
-    <message>
-        <source>Use letters, numbers and underscores only</source>
-        <translation>只能由字母、數字、中文、下劃線組成</translation>
-    </message>
-    <message>
-        <source>No more than 15 characters</source>
-        <translation>不得超過15個字元</translation>
-    </message>
-    <message>
-        <source>Add a new </source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>This name already exists</source>
-        <translation>該名稱已存在</translation>
-    </message>
-</context>
-<context>
-    <name>blueTooth</name>
-    <message>
-        <source>bluetooth</source>
-        <translation>藍牙</translation>
-    </message>
-    <message>
-        <source>Bluetooth settings, devices</source>
-        <translation>藍牙設定、裝置管理</translation>
-    </message>
-</context>
-<context>
-    <name>commonInfoMain</name>
-    <message>
-        <source>Boot Menu</source>
-        <translation>啟動菜單</translation>
-    </message>
-    <message>
-        <source>Manage your boot menu</source>
-        <translation>管理您的開機啟動菜單</translation>
-    </message>
-    <message>
-        <source>Developer root permission management</source>
-        <translation>開發者Root許可權管理</translation>
-    </message>
-    <message>
-        <source>Developer Options</source>
-        <translation>開發者選項</translation>
-    </message>
-</context>
-<context>
-    <name>datetime</name>
-    <message>
-        <source>Time and date</source>
-        <translation>時間和日期</translation>
-    </message>
-    <message>
-        <source>Time and date, time zone settings</source>
-        <translation>時間日期、時區設定</translation>
-    </message>
-    <message>
-        <source>Language and region</source>
-        <translation>語言和區域</translation>
-    </message>
-    <message>
-        <source>System language, region format</source>
-        <translation>系統語言、區域格式</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::AccountsController</name>
-    <message>
-        <source>Username must be between 3 and 32 characters</source>
-        <translation>使用者名稱長度必須介於 3 到 32 個字元之間</translation>
-    </message>
-    <message>
-        <source>The first character must be a letter or number</source>
-        <translation>必須字母或者數字開頭</translation>
-    </message>
-    <message>
-        <source>Your username should not only have numbers</source>
-        <translation>使用者名稱不能僅僅是數字</translation>
-    </message>
-    <message>
-        <source>The username has been used by other user accounts</source>
-        <translation>使用者名稱和其他使用者名稱重複</translation>
-    </message>
-    <message>
-        <source>The full name is too long</source>
-        <translation>全名太長了</translation>
-    </message>
-    <message>
-        <source>The full name has been used by other user accounts</source>
-        <translation>全名和其他使用者名稱重複</translation>
-    </message>
-    <message>
-        <source>Wrong password</source>
-        <translation>密碼錯誤</translation>
-    </message>
-    <message>
-        <source>Standard User</source>
-        <translation>標準使用者</translation>
-    </message>
-    <message>
-        <source>Administrator</source>
-        <translation>管理員</translation>
-    </message>
-    <message>
-        <source>Customized</source>
-        <translation>自定義</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::AccountsWorker</name>
-    <message>
-        <source>Your host was removed from the domain server successfully</source>
-        <translation>您的主機成功退出了域伺服器</translation>
-    </message>
-    <message>
-        <source>Your host joins the domain server successfully</source>
-        <translation>您的主機成功加入了域伺服器</translation>
-    </message>
-    <message>
-        <source>Your host failed to leave the domain server</source>
-        <translation>您的主機退出域伺服器失敗</translation>
-    </message>
-    <message>
-        <source>Your host failed to join the domain server</source>
-        <translation>您的主機加入域伺服器失敗</translation>
-    </message>
-    <message>
-        <source>AD domain settings</source>
-        <translation>AD域設定</translation>
-    </message>
-    <message>
-        <source>Password not match</source>
-        <translation>密碼不一致</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::AvatarTypesModel</name>
-    <message>
-        <source>Dimensional</source>
-        <translation>立體風格</translation>
-    </message>
-    <message>
-        <source>Flat</source>
-        <translation>平面風格</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::BiometricAuthController</name>
-    <message>
-        <source>Use your face to unlock the device and make settings later</source>
-        <translation>使用人臉資料解鎖您的裝置，之後還可進行更多設定</translation>
-    </message>
-    <message>
-        <source>Faceprint</source>
-        <translation>麵紋</translation>
-    </message>
-    <message>
-        <source>Place your finger</source>
-        <translation>放置手指</translation>
-    </message>
-    <message>
-        <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
-        <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
-    </message>
-    <message>
-        <source>Lift your finger</source>
-        <translation>擡起手指</translation>
-    </message>
-    <message>
-        <source>Lift your finger and place it on the sensor again</source>
-        <translation>請擡起手指，再次按壓</translation>
-    </message>
-    <message>
-        <source>Scan the edges of your fingerprint</source>
-        <translation>錄入邊緣指紋</translation>
-    </message>
-    <message>
-        <source>Adjust the position to scan the edges of your fingerprint</source>
-        <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
-    </message>
-    <message>
-        <source>Lift your finger and do that again</source>
-        <translation>請擡起手指，再次按壓</translation>
-    </message>
-    <message>
-        <source>Fingerprint added</source>
-        <translation>成功新增指紋</translation>
-    </message>
-    <message>
-        <source>Scan Suspended</source>
-        <translation>錄入中斷</translation>
-    </message>
-    <message>
-        <source>Place the edges of your fingerprint on the sensor</source>
-        <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
-    </message>
-    <message>
-        <source>Iris</source>
-        <translation>虹膜</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::KeyboardController</name>
-    <message>
-        <source>This shortcut conflicts with [%1]</source>
-        <translation>此快捷鍵與[%1]衝突</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::PwqualityManager</name>
-    <message>
-        <source>Password cannot be empty</source>
-        <translation>密碼不能為空</translation>
-    </message>
-    <message>
-        <source>Password must have at least %1 characters</source>
-        <translation>密碼長度不能少於%1個字元</translation>
-    </message>
-    <message>
-        <source>Password must be no more than %1 characters</source>
-        <translation>密碼長度不能超過%1個字元</translation>
-    </message>
-    <message>
-        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
-    </message>
-    <message>
-        <source>No more than %1 palindrome characters please</source>
-        <translation>迴文字元長度不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 monotonic characters please</source>
-        <translation>單調性字元不超過%1位</translation>
-    </message>
-    <message>
-        <source>No more than %1 repeating characters please</source>
-        <translation>重複字元不超過%1位</translation>
-    </message>
-    <message>
-        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
-        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
-    </message>
-    <message>
-        <source>Password must not contain more than 4 palindrome characters</source>
-        <translation>密碼不得含有連續4個以上的迴文字元</translation>
-    </message>
-    <message>
-        <source>Do not use common words and combinations as password</source>
-        <translation>密碼不能是常見單詞及組合</translation>
-    </message>
-    <message>
-        <source>Create a strong password please</source>
-        <translation>密碼過於簡單，請增加密碼複雜度</translation>
-    </message>
-    <message>
-        <source>It does not meet password rules</source>
-        <translation>密碼不符合安全要求</translation>
-    </message>
-</context>
-<context>
-    <name>dccV25::ShortcutModel</name>
-    <message>
-        <source>System</source>
-        <translation>系統</translation>
-    </message>
-    <message>
-        <source>Window</source>
-        <translation>視窗</translation>
-    </message>
-    <message>
-        <source>Workspace</source>
-        <translation>工作區</translation>
-    </message>
-    <message>
-        <source>AssistiveTools</source>
-        <translation>輔助功能</translation>
-    </message>
-    <message>
-        <source>Custom</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>None</source>
-        <translation>無</translation>
-    </message>
-</context>
-<context>
-    <name>deepinid</name>
-    <message>
-        <source>deepin ID</source>
-        <translation>deepin ID</translation>
-    </message>
-    <message>
-        <source>UOS ID</source>
-        <translation>UOS ID</translation>
-    </message>
-    <message>
-        <source>Cloud services</source>
-        <translation>雲服務</translation>
-    </message>
-</context>
-<context>
-    <name>defaultapp</name>
-    <message>
-        <source>Default App</source>
-        <translation>預設程式</translation>
-    </message>
-    <message>
-        <source>Set the default application for opening various types of files</source>
-        <translation>設定打開各類檔案的預設程式</translation>
-    </message>
-</context>
-<context>
-    <name>defaultappMain</name>
-    <message>
-        <source>Webpage</source>
-        <translation>網頁</translation>
-    </message>
-    <message>
-        <source>Mail</source>
-        <translation>郵件</translation>
-    </message>
-    <message>
-        <source>Text</source>
-        <translation>文字</translation>
-    </message>
-    <message>
-        <source>Music</source>
-        <translation>音樂</translation>
-    </message>
-    <message>
-        <source>Video</source>
-        <translation>影片</translation>
-    </message>
-    <message>
-        <source>Picture</source>
-        <translation>圖片</translation>
-    </message>
-    <message>
-        <source>Terminal</source>
-        <translation>終端</translation>
-    </message>
-</context>
-<context>
-    <name>device</name>
-    <message>
-        <source>Device</source>
-        <translation>裝置</translation>
-    </message>
-</context>
-<context>
-    <name>display</name>
-    <message>
-        <source>Display</source>
-        <translation>顯示</translation>
-    </message>
-    <message>
-        <source>Brightness,resolution,scaling</source>
-        <translation>亮度、解析度、縮放</translation>
-    </message>
-</context>
-<context>
-    <name>displayMain</name>
-    <message>
-        <source>100%</source>
-        <translation>100%</translation>
-    </message>
-    <message>
-        <source>125%</source>
-        <translation>125%</translation>
-    </message>
-    <message>
-        <source>150%</source>
-        <translation>150%</translation>
-    </message>
-    <message>
-        <source>175%</source>
-        <translation>175%</translation>
-    </message>
-    <message>
-        <source>200%</source>
-        <translation>200%</translation>
-    </message>
-    <message>
-        <source>225%</source>
-        <translation>225%</translation>
-    </message>
-    <message>
-        <source>250%</source>
-        <translation>250%</translation>
-    </message>
-    <message>
-        <source>275%</source>
-        <translation>275%</translation>
-    </message>
-    <message>
-        <source>300%</source>
-        <translation>300%</translation>
-    </message>
-    <message>
-        <source>Duplicate</source>
-        <translation>複製</translation>
-    </message>
-    <message>
-        <source>Extend</source>
-        <translation>擴充套件</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation>預設</translation>
-    </message>
-    <message>
-        <source>Fit</source>
-        <translation>適應</translation>
-    </message>
-    <message>
-        <source>Stretch</source>
-        <translation>拉伸</translation>
-    </message>
-    <message>
-        <source>Center</source>
-        <translation>居中</translation>
-    </message>
-    <message>
-        <source>Only on %1</source>
-        <translation>僅%1屏</translation>
-    </message>
-    <message>
-        <source> (Recommended)</source>
-        <translation type="unfinished"/>
-    </message>
-    <message>
-        <source>Hz</source>
-        <translation>赫茲</translation>
-    </message>
-    <message>
-        <source>Multiple Displays Settings</source>
-        <translation>多屏設定</translation>
-    </message>
-    <message>
-        <source>Identify</source>
-        <translation>識別</translation>
-    </message>
-    <message>
-        <source>Screen rearrangement will take effect in %1s after changes</source>
-        <translation>螢幕拼接將在修改完成%1s後生效</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Main Screen</source>
-        <translation>主螢幕</translation>
-    </message>
-    <message>
-        <source>Display And Layout</source>
-        <translation>顯示和佈局</translation>
-    </message>
-    <message>
-        <source>Brightness</source>
-        <translation>亮度</translation>
-    </message>
-    <message>
-        <source>Resolution</source>
-        <translation>解析度</translation>
-    </message>
-    <message>
-        <source>Resize Desktop</source>
-        <translation>桌面顯示</translation>
-    </message>
-    <message>
-        <source>Refresh Rate</source>
-        <translation>重新整理率</translation>
-    </message>
-    <message>
-        <source>Rotation</source>
-        <translation>方向</translation>
-    </message>
-    <message>
-        <source>Standard</source>
-        <translation>標準</translation>
-    </message>
-    <message>
-        <source>90°</source>
-        <translation>90度</translation>
-    </message>
-    <message>
-        <source>180°</source>
-        <translation>180度</translation>
-    </message>
-    <message>
-        <source>270°</source>
-        <translation>270度</translation>
-    </message>
-    <message>
-        <source>Display Scaling</source>
-        <translation>縮放</translation>
-    </message>
-    <message>
-        <source>The monitor only supports 100% display scaling</source>
-        <translation>當前螢幕僅支援1倍縮放</translation>
-    </message>
-    <message>
-        <source>Eye Comfort</source>
-        <translation>護眼模式</translation>
-    </message>
-    <message>
-        <source>Enable eye comfort</source>
-        <translation>開啟護眼模式</translation>
-    </message>
-    <message>
-        <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-        <translation>調整螢幕顯示較暖的顏色，減少螢幕藍光</translation>
-    </message>
-    <message>
-        <source>Time</source>
-        <translation>時間</translation>
-    </message>
-    <message>
-        <source>All day</source>
-        <translation>全天</translation>
-    </message>
-    <message>
-        <source>Sunset to Sunrise</source>
-        <translation>日落到日出</translation>
-    </message>
-    <message>
-        <source>Custom Time</source>
-        <translation>自定義</translation>
-    </message>
-    <message>
-        <source>from</source>
-        <translation>從</translation>
-    </message>
-    <message>
-        <source>to</source>
-        <translation>至</translation>
-    </message>
-    <message>
-        <source>Color Temperature</source>
-        <translation>色溫</translation>
-    </message>
-</context>
-<context>
-    <name>dock</name>
-    <message>
-        <source>Desktop and taskbar</source>
-        <translation>桌面和工作列</translation>
-    </message>
-    <message>
-        <source>Desktop organization, taskbar mode, plugin area settings</source>
-        <translation>桌面整理、工作列模式、外掛區域設定</translation>
-    </message>
-</context>
-<context>
-    <name>keyboard</name>
-    <message>
-        <source>Keyboard</source>
-        <translation>鍵盤</translation>
-    </message>
-    <message>
-        <source>General Settings, keyboard layout, input method, shortcuts</source>
-        <translation>通用設定、鍵盤佈局、輸入法、快捷鍵</translation>
-    </message>
-</context>
-<context>
-    <name>keyboardMain</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Keyboard layout</source>
-        <translation>鍵盤佈局</translation>
-    </message>
-    <message>
-        <source>Set system default keyboard layout</source>
-        <translation>設定系統預設鍵盤佈局</translation>
-    </message>
-</context>
-<context>
-    <name>main</name>
-    <message>
-        <source>Dock</source>
-        <translation>工作列</translation>
-    </message>
-    <message>
-        <source>Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Classic Mode</source>
-        <translation>經典模式</translation>
-    </message>
-    <message>
-        <source>Centered Mode</source>
-        <translation>居中模式</translation>
-    </message>
-    <message>
-        <source>Dock size</source>
-        <translation>工作列大小</translation>
-    </message>
-    <message>
-        <source>Small</source>
-        <translation>小</translation>
-    </message>
-    <message>
-        <source>Large</source>
-        <translation>大</translation>
-    </message>
-    <message>
-        <source>Position on the screen</source>
-        <translation>螢幕中的位置</translation>
-    </message>
-    <message>
-        <source>Top</source>
-        <translation>上</translation>
-    </message>
-    <message>
-        <source>Bottom</source>
-        <translation>下</translation>
-    </message>
-    <message>
-        <source>Left</source>
-        <translation>左</translation>
-    </message>
-    <message>
-        <source>Right</source>
-        <translation>右</translation>
-    </message>
-    <message>
-        <source>Status</source>
-        <translation>狀態</translation>
-    </message>
-    <message>
-        <source>Keep shown</source>
-        <translation>一直顯示</translation>
-    </message>
-    <message>
-        <source>Keep hidden</source>
-        <translation>一直隱藏</translation>
-    </message>
-    <message>
-        <source>Smart hide</source>
-        <translation>智慧隱藏</translation>
-    </message>
-    <message>
-        <source>Multiple Displays</source>
-        <translation>多屏顯示</translation>
-    </message>
-    <message>
-        <source>Set the position of the taskbar on the screen</source>
-        <translation>設定工作列在螢幕中的位置</translation>
-    </message>
-    <message>
-        <source>Only on main</source>
-        <translation>僅主屏顯示</translation>
-    </message>
-    <message>
-        <source>On screen where the cursor is</source>
-        <translation>跟隨滑鼠位置顯示</translation>
-    </message>
-    <message>
-        <source>Plugin Area</source>
-        <translation>外掛區域</translation>
-    </message>
-    <message>
-        <source>Select which icons appear in the Dock</source>
-        <translation>選擇顯示在工作列外掛區域的圖示</translation>
-    </message>
-</context>
-<context>
-    <name>mouse</name>
-    <message>
-        <source>Mouse and Touchpad</source>
-        <translation>滑鼠與觸控板</translation>
-    </message>
-    <message>
-        <source>Common、Mouse、Touchpad</source>
-        <translation>通用、滑鼠、觸控板</translation>
-    </message>
-</context>
-<context>
-    <name>mouseMain</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Mouse</source>
-        <translation>滑鼠</translation>
-    </message>
-    <message>
-        <source>Touchpad</source>
-        <translation>觸控板</translation>
-    </message>
-</context>
-<context>
-    <name>notification</name>
-    <message>
-        <source>DND mode, app notifications</source>
-        <translation>勿擾模式、應用通知</translation>
-    </message>
-    <message>
-        <source>Notification</source>
-        <translation>通知</translation>
-    </message>
-</context>
-<context>
-    <name>notificationMain</name>
-    <message>
-        <source>Do Not Disturb Settings</source>
-        <translation>勿擾設定</translation>
-    </message>
-    <message>
-        <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-        <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心檢視所有消息。</translation>
-    </message>
-    <message>
-        <source>Enable Do Not Disturb</source>
-        <translation>啟用勿擾模式</translation>
-    </message>
-    <message>
-        <source>When the screen is locked</source>
-        <translation>在螢幕鎖屏時</translation>
-    </message>
-    <message>
-        <source>Number of notifications shown on the desktop</source>
-        <translation>通知橫幅展示數量</translation>
-    </message>
-    <message>
-        <source>App Notifications</source>
-        <translation>應用通知</translation>
-    </message>
-    <message>
-        <source>Allow Notifications</source>
-        <translation>允許通知</translation>
-    </message>
-    <message>
-        <source>Display notification on desktop or show unread messages in the notification center</source>
-        <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
-    </message>
-    <message>
-        <source>Desktop</source>
-        <translation>桌面</translation>
-    </message>
-    <message>
-        <source>Lock Screen</source>
-        <translation>鎖屏</translation>
-    </message>
-    <message>
-        <source>Notification Center</source>
-        <translation>通知中心</translation>
-    </message>
-    <message>
-        <source>Show message preview</source>
-        <translation>顯示消息預覽</translation>
-    </message>
-    <message>
-        <source>Play a sound</source>
-        <translation>通知時提示聲音</translation>
-    </message>
-</context>
-<context>
-    <name>personalization</name>
-    <message>
-        <source>Personalization</source>
-        <translation>個性化</translation>
-    </message>
-</context>
-<context>
-    <name>personalizationMain</name>
-    <message>
-        <source>Theme</source>
-        <translation>主題</translation>
-    </message>
-    <message>
-        <source>Appearance</source>
-        <translation>外觀</translation>
-    </message>
-    <message>
-        <source>Window effect</source>
-        <translation>視窗效果</translation>
-    </message>
-    <message>
-        <source>Personalize your wallpaper and screensaver</source>
-        <translation>個性化您的壁紙和屏保</translation>
-    </message>
-    <message>
-        <source>Screensaver</source>
-        <translation>螢幕保護</translation>
-    </message>
-    <message>
-        <source>Colors and icons</source>
-        <translation>顏色和圖示</translation>
-    </message>
-    <message>
-        <source>Adjust accent color and theme icons</source>
-        <translation>調整活動色和主題圖示</translation>
-    </message>
-    <message>
-        <source>Font and font size</source>
-        <translation>字型和字號</translation>
-    </message>
-    <message>
-        <source>Change system font and size</source>
-        <translation>修改系統字型與字號</translation>
-    </message>
-    <message>
-        <source>Wallpaper</source>
-        <translation>壁紙</translation>
-    </message>
-    <message>
-        <source>Select light, dark or automatic theme appearance</source>
-        <translation>選擇淺色、深色或自動切換主題外觀</translation>
-    </message>
-    <message>
-        <source>Interface and effects, rounded corners</source>
-        <translation>介面和效果、視窗圓角</translation>
-    </message>
-</context>
-<context>
-    <name>power</name>
-    <message>
-        <source>Power saving settings, screen and suspend</source>
-        <translation>節能設定、螢幕和待機管理</translation>
-    </message>
-    <message>
-        <source>Power</source>
-        <translation>電源管理</translation>
-    </message>
-</context>
-<context>
-    <name>powerMain</name>
-    <message>
-        <source>General</source>
-        <translation>通用</translation>
-    </message>
-    <message>
-        <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-        <translation>效能模式、節能設定、喚醒設定、關機設定</translation>
-    </message>
-    <message>
-        <source>Plugged In</source>
-        <translation>使用電源</translation>
-    </message>
-    <message>
-        <source>Screen and suspend</source>
-        <translation>螢幕和待機管理</translation>
-    </message>
-    <message>
-        <source>On Battery</source>
-        <translation>使用電池</translation>
-    </message>
-    <message>
-        <source>screen and suspend, low battery, battery management</source>
-        <translation>螢幕和待機管理、低電量管理、電池管理</translation>
-    </message>
-</context>
-<context>
-    <name>privacy</name>
-    <message>
-        <source>Privacy and Security</source>
-        <translation>隱私和安全</translation>
-    </message>
-    <message>
-        <source>Camera, folder permissions</source>
-        <translation>攝像頭、資料夾許可權</translation>
-    </message>
-</context>
-<context>
-    <name>privacyMain</name>
-    <message>
-        <source>Camera</source>
-        <translation>攝像頭</translation>
-    </message>
-    <message>
-        <source>Choose whether the application has access to the camera</source>
-        <translation>選擇應用是否有攝像頭的訪問許可權</translation>
-    </message>
-    <message>
-        <source>Files and Folders</source>
-        <translation>檔案和資料夾</translation>
-    </message>
-    <message>
-        <source>Choose whether the application has access to files and folders</source>
-        <translation>選擇應用是否有檔案和資料夾的訪問許可權</translation>
-    </message>
-</context>
-<context>
-    <name>sound</name>
-    <message>
-        <source>Sound</source>
-        <translation>聲音</translation>
-    </message>
-    <message>
-        <source>Output, input, sound effects, devices</source>
-        <translation>輸入、輸出、系統音效、裝置管理</translation>
-    </message>
-</context>
-<context>
-    <name>soundMain</name>
-    <message>
-        <source>Settings</source>
-        <translation>設定</translation>
-    </message>
-    <message>
-        <source>Sound Effects</source>
-        <translation>系統音效</translation>
-    </message>
-    <message>
-        <source>Enable/disable sound effects</source>
-        <translation>開啟/關閉系統音效</translation>
-    </message>
-    <message>
-        <source>Enable/disable audio devices</source>
-        <translation>啟用/停用音訊裝置</translation>
-    </message>
-    <message>
-        <source>Devices</source>
-        <translation>裝置管理</translation>
-    </message>
-</context>
-<context>
-    <name>system</name>
-    <message>
-        <source>Common settings</source>
-        <translation>常用設定</translation>
-    </message>
-    <message>
-        <source>System</source>
-        <translation>系統</translation>
-    </message>
-</context>
-<context>
-    <name>systemInfo</name>
-    <message>
-        <source>Auxiliary Information</source>
-        <translation>輔助資訊</translation>
-    </message>
-</context>
-<context>
-    <name>systemInfoMain</name>
-    <message>
-        <source>About This PC</source>
-        <translation>關於本機</translation>
-    </message>
-    <message>
-        <source>System version, device information</source>
-        <translation>系統版本、裝置資訊</translation>
-    </message>
-    <message>
-        <source>View the notice of open source software</source>
-        <translation>檢視開源軟體宣告</translation>
-    </message>
-    <message>
-        <source>User Experience Program</source>
-        <translation>使用者體驗計劃</translation>
-    </message>
-    <message>
-        <source>Join the user experience program to help improve the product</source>
-        <translation>加入使用者體驗計劃，幫助改進產品</translation>
-    </message>
-    <message>
-        <source>End User License Agreement</source>
-        <translation>使用者許可協議</translation>
-    </message>
-    <message>
-        <source>View the end  user license agreement</source>
-        <translation>檢視終端使用者許可協議</translation>
-    </message>
-    <message>
-        <source>Privacy Policy</source>
-        <translation>隱私政策</translation>
-    </message>
-    <message>
-        <source>View information about privacy policy</source>
-        <translation>檢視隱私政策相關資訊</translation>
-    </message>
-    <message>
-        <source>Open Source Software Notice</source>
-        <translation type="unfinished"/>
-    </message>
-</context>
-<context>
-    <name>touchscreen</name>
-    <message>
-        <source>Touchscreen</source>
-        <translation>觸控屏</translation>
-    </message>
-    <message>
-        <source>Configuring Touchscreen</source>
-        <translation>觸控屏設定</translation>
-    </message>
-</context>
-<context>
-    <name>touchscreenMain</name>
-    <message>
-        <source>Common</source>
-        <translation>通用</translation>
-    </message>
-</context>
-<context>
-    <name>wacom</name>
-    <message>
-        <source>wacom</source>
-        <translation>數位板</translation>
-    </message>
-    <message>
-        <source>Configuring wacom</source>
-        <translation>數位板選項設定</translation>
-    </message>
-</context>
-<context>
-    <name>wacomMain</name>
-    <message>
-        <source>wacom</source>
-        <translation>數位板</translation>
-    </message>
-    <message>
-        <source>Wacom Mode</source>
-        <translation>模式</translation>
-    </message>
-    <message>
-        <source>Pen Mode</source>
-        <translation>筆模式</translation>
-    </message>
-    <message>
-        <source>Mouse Mode</source>
-        <translation>滑鼠模式</translation>
-    </message>
-    <message>
-        <source>Pressure Sensitivity</source>
-        <translation>壓感</translation>
-    </message>
-    <message>
-        <source>Light</source>
-        <translation>輕</translation>
-    </message>
-</context>
+        </message>
+        <message>
+            <source>Sign In to %1 ID</source>
+            <translation>登入%1 ID</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDSyncService</name>
+        <message>
+            <source>Auto Sync</source>
+            <translation>自動同步</translation>
+        </message>
+        <message>
+            <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
+            <translation>將您的系統設定和個人資訊安全地儲存在雲端，並在您不同的裝置上保持同步</translation>
+        </message>
+        <message>
+            <source>System Settings</source>
+            <translation>系統設定</translation>
+        </message>
+        <message>
+            <source>Last sync time: %1</source>
+            <translation>最近同步時間：%1</translation>
+        </message>
+        <message>
+            <source>Clear cloud data</source>
+            <translation>清除雲端資料</translation>
+        </message>
+        <message>
+            <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
+            <translation>確定要清除您儲存在雲端的系統設定和個人資料嗎？</translation>
+        </message>
+        <message>
+            <source>Once the data is cleared, it cannot be recovered!</source>
+            <translation>資料清除後將無法恢復！</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Clear</source>
+            <translation>清除</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinIDUserInfo</name>
+        <message>
+            <source>Synchronization Service</source>
+            <translation>同步服務</translation>
+        </message>
+        <message>
+            <source>Account and Security</source>
+            <translation>帳戶與安全</translation>
+        </message>
+        <message>
+            <source>Sign out</source>
+            <translation>退出登入</translation>
+        </message>
+        <message>
+            <source>Go to web settings</source>
+            <translation>前往網頁設定</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinWorker</name>
+        <message>
+            <source>encrypt password failed</source>
+            <translation>加密密碼失敗</translation>
+        </message>
+        <message>
+            <source>Wrong password, %1 chances left</source>
+            <translation>密碼錯誤，您還可以嘗試%1次</translation>
+        </message>
+        <message>
+            <source>The login error has reached the limit today. You can reset the password and try again.</source>
+            <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
+        </message>
+        <message>
+            <source>Operation Successful</source>
+            <translation>操作成功</translation>
+        </message>
+    </context>
+    <context>
+        <name>DeepinidModel</name>
+        <message>
+            <source>Mainland China</source>
+            <translation>中國大陸</translation>
+        </message>
+        <message>
+            <source>Other regions</source>
+            <translation>其他地區</translation>
+        </message>
+        <message>
+            <source>The feature is not available at present, please activate your system first</source>
+            <translation>當前系統未啟用，暫無法使用該功能</translation>
+        </message>
+        <message>
+            <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
+            <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
+        </message>
+    </context>
+    <context>
+        <name>DetailItem</name>
+        <message>
+            <source>Please choose the default program to open '%1'</source>
+            <translation>選擇打開「%1」的預設程式</translation>
+        </message>
+        <message>
+            <source>add</source>
+            <translation>新增</translation>
+        </message>
+        <message>
+            <source>Open Desktop file</source>
+            <translation>打開Desktop檔案</translation>
+        </message>
+        <message>
+            <source>Apps (*.desktop)</source>
+            <translation>應用程式(*.desktop)</translation>
+        </message>
+        <message>
+            <source>All files (*)</source>
+            <translation>所有檔案(*)</translation>
+        </message>
+    </context>
+    <context>
+        <name>DevelopModePage</name>
+        <message>
+            <source>Root Access</source>
+            <translation>開發者模式</translation>
+        </message>
+        <message>
+            <source>Request Root Access</source>
+            <translation>進入開發者模式</translation>
+        </message>
+        <message>
+            <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
+            <translation>可獲得root使用許可權，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
+        </message>
+        <message>
+            <source>Allowed</source>
+            <translation>已進入</translation>
+        </message>
+        <message>
+            <source>Enter</source>
+            <translation>進入</translation>
+        </message>
+        <message>
+            <source>Online</source>
+            <translation>線上啟用</translation>
+        </message>
+        <message>
+            <source>Login UOS ID</source>
+            <translation>登入UOS ID</translation>
+        </message>
+        <message>
+            <source>Offline</source>
+            <translation>離線啟用</translation>
+        </message>
+        <message>
+            <source>Import Certificate</source>
+            <translation>匯入證書</translation>
+        </message>
+        <message>
+            <source>Select file</source>
+            <translation>選擇檔案</translation>
+        </message>
+        <message>
+            <source>Your UOS ID has been logged in, click to enter developer mode</source>
+            <translation>您的UOS ID已登入，點選進入開發者模式</translation>
+        </message>
+        <message>
+            <source>Please sign in to your UOS ID first and continue</source>
+            <translation>進入開發者模式需要登入UOS ID</translation>
+        </message>
+        <message>
+            <source>1.Export PC Info</source>
+            <translation>1.匯出機器資訊</translation>
+        </message>
+        <message>
+            <source>Export</source>
+            <translation>匯出</translation>
+        </message>
+        <message>
+            <source>2.please go to &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
+            <translation>2.前往 &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
+        </message>
+        <message>
+            <source>3.Import Certificate</source>
+            <translation>3.匯入證書</translation>
+        </message>
+        <message>
+            <source>To install and run unsigned apps, please go to &lt;a href="Security Center"&gt;Security Center&lt;/a&gt; to change the settings.</source>
+            <translation>如需安裝非應用商店來源的應用，前往 &lt;a href="Security Center"&gt;安全中心&lt;/a&gt; 進行設定。</translation>
+        </message>
+        <message>
+            <source>Development and debugging options</source>
+            <translation>開發除錯選項</translation>
+        </message>
+        <message>
+            <source>System logging level</source>
+            <translation>系統日誌記錄級別</translation>
+        </message>
+        <message>
+            <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
+            <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多儲存空間.</translation>
+        </message>
+        <message>
+            <source>Off</source>
+            <translation>關閉</translation>
+        </message>
+        <message>
+            <source>Debug</source>
+            <translation>除錯</translation>
+        </message>
+        <message>
+            <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
+            <translation>更改選項處理可能需要一分鐘，收到設定成功提示後，請重啟裝置方可生效。</translation>
+        </message>
+    </context>
+    <context>
+        <name>DisclaimerControl</name>
+        <message>
+            <source>Disclaimer</source>
+            <translation>《使用者免責宣告》</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Agree</source>
+            <translation>同意</translation>
+        </message>
+    </context>
+    <context>
+        <name>FileAndFolder</name>
+        <message>
+            <source>Allow below apps to access these files and folders:</source>
+            <translation>允許下麵的應用訪問您的檔案和資料夾</translation>
+        </message>
+        <message>
+            <source>Documents</source>
+            <translation>文件</translation>
+        </message>
+        <message>
+            <source>Desktop</source>
+            <translation>桌面</translation>
+        </message>
+        <message>
+            <source>Pictures</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Videos</source>
+            <translation>影片</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂</translation>
+        </message>
+        <message>
+            <source>Downloads</source>
+            <translation>下載</translation>
+        </message>
+        <message>
+            <source>folder</source>
+            <translation>資料夾</translation>
+        </message>
+    </context>
+    <context>
+        <name>FontSizePage</name>
+        <message>
+            <source>Size</source>
+            <translation>字號</translation>
+        </message>
+        <message>
+            <source>Standard Font</source>
+            <translation>標準字型</translation>
+        </message>
+        <message>
+            <source>Monospaced Font</source>
+            <translation>等寬字型</translation>
+        </message>
+    </context>
+    <context>
+        <name>GeneralPage</name>
+        <message>
+            <source>Power Plans</source>
+            <translation>效能模式</translation>
+        </message>
+        <message>
+            <source>Power Saving Settings</source>
+            <translation>節能設定</translation>
+        </message>
+        <message>
+            <source>Auto power saving on low battery</source>
+            <translation>低電量時自動開啟節能模式</translation>
+        </message>
+        <message>
+            <source>Low battery threshold</source>
+            <translation>低電量閾值</translation>
+        </message>
+        <message>
+            <source>Auto power saving on battery</source>
+            <translation>使用電池時自動開啟節能模式</translation>
+        </message>
+        <message>
+            <source>Wakeup Settings</source>
+            <translation>喚醒設定</translation>
+        </message>
+        <message>
+            <source>Password is required to wake up the computer</source>
+            <translation>待機恢復時需要密碼</translation>
+        </message>
+        <message>
+            <source>Password is required to wake up the monitor</source>
+            <translation>喚醒顯示器時需要密碼</translation>
+        </message>
+        <message>
+            <source>Shutdown Settings</source>
+            <translation>關機設定</translation>
+        </message>
+        <message>
+            <source>Scheduled Shutdown</source>
+            <translation>定時關機</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation>時間</translation>
+        </message>
+        <message>
+            <source>Repeat</source>
+            <translation>重複</translation>
+        </message>
+        <message>
+            <source>Once</source>
+            <translation>一次</translation>
+        </message>
+        <message>
+            <source>Every day</source>
+            <translation>每天</translation>
+        </message>
+        <message>
+            <source>Working days</source>
+            <translation>工作日</translation>
+        </message>
+        <message>
+            <source>Custom Time</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>Decrease screen brightness on power saver</source>
+            <translation>節能模式時降低螢幕亮度</translation>
+        </message>
+    </context>
+    <context>
+        <name>GestureModel</name>
+        <message>
+            <source>Three-finger</source>
+            <translation>三指</translation>
+        </message>
+        <message>
+            <source>Four-finger</source>
+            <translation>四指</translation>
+        </message>
+        <message>
+            <source>Up</source>
+            <translation>向上</translation>
+        </message>
+        <message>
+            <source>Down</source>
+            <translation>向下</translation>
+        </message>
+        <message>
+            <source>Left</source>
+            <translation>向左</translation>
+        </message>
+        <message>
+            <source>Right</source>
+            <translation>向右</translation>
+        </message>
+        <message>
+            <source>tap</source>
+            <translation>點選</translation>
+        </message>
+    </context>
+    <context>
+        <name>HomePage</name>
+        <message>
+            <source>,</source>
+            <translation>、</translation>
+        </message>
+        <message>
+            <source>...</source>
+            <translation>等</translation>
+        </message>
+    </context>
+    <context>
+        <name>InterfaceEffectListview</name>
+        <message>
+            <source>Optimal Performance</source>
+            <translation>最佳效能</translation>
+        </message>
+        <message>
+            <source>Balance</source>
+            <translation>均衡</translation>
+        </message>
+        <message>
+            <source>Best Visuals</source>
+            <translation>最佳視覺</translation>
+        </message>
+        <message>
+            <source>Disable all interface and window effects for efficient system performance.</source>
+            <translation>關閉所有介面和視窗特效，保障系統高效執行</translation>
+        </message>
+        <message>
+            <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
+            <translation>限制部分視窗特效，保障出色的視覺效果，同時維持系統流暢執行</translation>
+        </message>
+        <message>
+            <source>Enable all interface and window effects for the best visual experience.</source>
+            <translation>啟用所有介面和視窗特效，體驗最佳視覺效果</translation>
+        </message>
+    </context>
+    <context>
+        <name>KeyboardLayout</name>
+        <message>
+            <source>Keyboard layout</source>
+            <translation>鍵盤佈局</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Add the corresponding input method in &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
+            <translation>如需新增或切換鍵盤佈局，請同時在 &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt; 輸入法管理 &lt;/a&gt;  中新增對應的輸入法以確保生效</translation>
+        </message>
+        <message>
+            <source>Add new keyboard layout...</source>
+            <translation>新增鍵盤佈局...</translation>
+        </message>
+    </context>
+    <context>
+        <name>LangAndFormat</name>
+        <message>
+            <source>Language</source>
+            <translation>語言</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Other languages</source>
+            <translation>其他語言</translation>
+        </message>
+        <message>
+            <source>add</source>
+            <translation>新增</translation>
+        </message>
+        <message>
+            <source>Region</source>
+            <translation>區域</translation>
+        </message>
+        <message>
+            <source>Area</source>
+            <translation>地區</translation>
+        </message>
+        <message>
+            <source>Operating system and applications may provide you with local content based on your country and region</source>
+            <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
+        </message>
+        <message>
+            <source>Region and format</source>
+            <translation>區域格式</translation>
+        </message>
+        <message>
+            <source>Operating system and applications may set date and time formats based on regional formats</source>
+            <translation>作業系統和某些應用會根據區域格式設定日期和時間格式</translation>
+        </message>
+    </context>
+    <context>
+        <name>LangsChooserDialog</name>
+        <message>
+            <source>Add language</source>
+            <translation>新增語言</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Add</source>
+            <translation>新增</translation>
+        </message>
+    </context>
+    <context>
+        <name>LayoutsChooser</name>
+        <message>
+            <source>Add language</source>
+            <translation>新增語言</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Add</source>
+            <translation>新增</translation>
+        </message>
+    </context>
+    <context>
+        <name>LoginMethod</name>
+        <message>
+            <source>Login method</source>
+            <translation>登入方式</translation>
+        </message>
+        <message>
+            <source>Password, wechat, biometric authentication, security key</source>
+            <translation>密碼，微信掃碼，生物認證，安全金鑰</translation>
+        </message>
+        <message>
+            <source>Password</source>
+            <translation>密碼</translation>
+        </message>
+        <message>
+            <source>Modify password</source>
+            <translation>修改密碼</translation>
+        </message>
+        <message>
+            <source>Validity days</source>
+            <translation>有效天數</translation>
+        </message>
+        <message>
+            <source>Always</source>
+            <translation>長期有效</translation>
+        </message>
+    </context>
+    <context>
+        <name>LogoModule</name>
+        <message>
+            <source>Copyright© 2011-%1 Deepin Community</source>
+            <translation>Copyright © 2011-%1 深度社區</translation>
+        </message>
+        <message>
+            <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
+            <translation>Copyright © 2019-%1 統信軟體技術有限公司</translation>
+        </message>
+    </context>
+    <context>
+        <name>MicrophonePage</name>
+        <message>
+            <source>Automatic Noise Suppression</source>
+            <translation>噪音抑制</translation>
+        </message>
+        <message>
+            <source>Input Volume</source>
+            <translation>輸入音量</translation>
+        </message>
+        <message>
+            <source>Input Level</source>
+            <translation>反饋音量</translation>
+        </message>
+        <message>
+            <source>Input</source>
+            <translation>輸入</translation>
+        </message>
+        <message>
+            <source>No input device for sound found</source>
+            <translation>沒有找到聲音輸入裝置</translation>
+        </message>
+        <message>
+            <source>Input Devices</source>
+            <translation>輸入裝置</translation>
+        </message>
+    </context>
+    <context>
+        <name>Mouse</name>
+        <message>
+            <source>Mouse</source>
+            <translation>滑鼠</translation>
+        </message>
+        <message>
+            <source>Pointer Speed</source>
+            <translation>指標速度</translation>
+        </message>
+        <message>
+            <source>Slow</source>
+            <translation>慢</translation>
+        </message>
+        <message>
+            <source>Fast</source>
+            <translation>快</translation>
+        </message>
+        <message>
+            <source>Pointer Size</source>
+            <translation>指標大小</translation>
+        </message>
+        <message>
+            <source>Short</source>
+            <translation>短</translation>
+        </message>
+        <message>
+            <source>Long</source>
+            <translation>長</translation>
+        </message>
+        <message>
+            <source>Mouse Acceleration</source>
+            <translation>滑鼠加速</translation>
+        </message>
+        <message>
+            <source>Disable touchpad when a mouse is connected</source>
+            <translation>插入滑鼠時停用觸控板</translation>
+        </message>
+        <message>
+            <source>Natural Scrolling</source>
+            <translation>自然滾動</translation>
+        </message>
+    </context>
+    <context>
+        <name>MyDevice</name>
+        <message>
+            <source>My Devices</source>
+            <translation>我的裝置</translation>
+        </message>
+    </context>
+    <context>
+        <name>NativeInfoPage</name>
+        <message>
+            <source>UOS</source>
+            <translation>UOS</translation>
+        </message>
+        <message>
+            <source>Computer name</source>
+            <translation>計算機名</translation>
+        </message>
+        <message>
+            <source>It cannot start or end with dashes</source>
+            <translation>計算機名不能以 - 開頭結尾</translation>
+        </message>
+        <message>
+            <source>OS Name</source>
+            <translation>產品名稱</translation>
+        </message>
+        <message>
+            <source>Version</source>
+            <translation>版本號</translation>
+        </message>
+        <message>
+            <source>Edition</source>
+            <translation>版本</translation>
+        </message>
+        <message>
+            <source>Type</source>
+            <translation>型別</translation>
+        </message>
+        <message>
+            <source>bit</source>
+            <translation>位</translation>
+        </message>
+        <message>
+            <source>Authorization</source>
+            <translation>版本授權</translation>
+        </message>
+        <message>
+            <source>System installation time</source>
+            <translation>系統安裝日期</translation>
+        </message>
+        <message>
+            <source>Kernel</source>
+            <translation>核心版本</translation>
+        </message>
+        <message>
+            <source>Graphics Platform</source>
+            <translation>圖形平臺</translation>
+        </message>
+        <message>
+            <source>Processor</source>
+            <translation>處理器</translation>
+        </message>
+        <message>
+            <source>Memory</source>
+            <translation>記憶體</translation>
+        </message>
+        <message>
+            <source>1~63 characters please</source>
+            <translation>計算機名長度必須介於1到63個字元之間</translation>
+        </message>
+    </context>
+    <context>
+        <name>OtherDevice</name>
+        <message>
+            <source>Other Devices</source>
+            <translation>其他裝置</translation>
+        </message>
+        <message>
+            <source>Show Bluetooth devices without names</source>
+            <translation>顯示沒有名稱的藍牙裝置</translation>
+        </message>
+    </context>
+    <context>
+        <name>PasswordLayout</name>
+        <message>
+            <source>Current password</source>
+            <translation>當前密碼</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>Weak</source>
+            <translation>強度低</translation>
+        </message>
+        <message>
+            <source>Medium</source>
+            <translation>強度中</translation>
+        </message>
+        <message>
+            <source>Strong</source>
+            <translation>強度高</translation>
+        </message>
+        <message>
+            <source>Password</source>
+            <translation>密碼</translation>
+        </message>
+        <message>
+            <source>Repeat Password</source>
+            <translation>重複密碼</translation>
+        </message>
+        <message>
+            <source>Password hint</source>
+            <translation>密碼提示</translation>
+        </message>
+        <message>
+            <source>Optional</source>
+            <translation>選填</translation>
+        </message>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Passwords do not match</source>
+            <translation>密碼不一致</translation>
+        </message>
+        <message>
+            <source>New password should differ from the current one</source>
+            <translation>新密碼和舊密碼不能相同</translation>
+        </message>
+        <message>
+            <source>The hint is visible to all users. Do not include the password here.</source>
+            <translation>密碼提示對所有人可見，切勿包含具體密碼資訊</translation>
+        </message>
+    </context>
+    <context>
+        <name>PasswordModifyDialog</name>
+        <message>
+            <source>Modify password</source>
+            <translation>修改密碼</translation>
+        </message>
+        <message>
+            <source>Reset password</source>
+            <translation>重置密碼</translation>
+        </message>
+        <message>
+            <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
+            <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
+        </message>
+        <message>
+            <source>Resetting the password will clear the data stored in the keyring.</source>
+            <translation>重設密碼將會清除金鑰環內已儲存的資料</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+    </context>
+    <context>
+        <name>PersonalizationInterface</name>
+        <message>
+            <source>Light</source>
+            <translation>淺色</translation>
+        </message>
+        <message>
+            <source>Auto</source>
+            <translation>自動</translation>
+        </message>
+        <message>
+            <source>Dark</source>
+            <translation>深色</translation>
+        </message>
+    </context>
+    <context>
+        <name>PersonalizationWorker</name>
+        <message>
+            <source>Custom</source>
+            <translation>自定義</translation>
+        </message>
+    </context>
+    <context>
+        <name>PluginArea</name>
+        <message>
+            <source>Plugin Area</source>
+            <translation>外掛區域</translation>
+        </message>
+        <message>
+            <source>Select which icons appear in the Dock</source>
+            <translation>選擇顯示在工作列外掛區域的圖示</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerOperatorModel</name>
+        <message>
+            <source>Shut down</source>
+            <translation>關機</translation>
+        </message>
+        <message>
+            <source>Suspend</source>
+            <translation>待機</translation>
+        </message>
+        <message>
+            <source>Hibernate</source>
+            <translation>休眠</translation>
+        </message>
+        <message>
+            <source>Turn off the monitor</source>
+            <translation>關閉顯示器</translation>
+        </message>
+        <message>
+            <source>Show the shutdown Interface</source>
+            <translation>進入關機介面</translation>
+        </message>
+        <message>
+            <source>Do nothing</source>
+            <translation>無任何操作</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerPage</name>
+        <message>
+            <source>Screen and Suspend</source>
+            <translation>螢幕和待機</translation>
+        </message>
+        <message>
+            <source>Turn off the monitor after</source>
+            <translation>關閉顯示器</translation>
+        </message>
+        <message>
+            <source>Lock screen after</source>
+            <translation>自動鎖屏</translation>
+        </message>
+        <message>
+            <source>Computer suspends after</source>
+            <translation>進入待機</translation>
+        </message>
+        <message>
+            <source>When the lid is closed</source>
+            <translation>筆記本合蓋時</translation>
+        </message>
+        <message>
+            <source>When the power button is pressed</source>
+            <translation>按電源按鈕時</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerPlansListview</name>
+        <message>
+            <source>High Performance</source>
+            <translation>高效能模式</translation>
+        </message>
+        <message>
+            <source>Balance Performance</source>
+            <translation>效能模式</translation>
+        </message>
+        <message>
+            <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
+            <translation>根據負載情況積極調整執行頻率</translation>
+        </message>
+        <message>
+            <source>Balanced</source>
+            <translation>平衡模式</translation>
+        </message>
+        <message>
+            <source>Power Saver</source>
+            <translation>節能模式</translation>
+        </message>
+        <message>
+            <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
+            <translation>效能優先，會顯著提升功耗和發熱</translation>
+        </message>
+        <message>
+            <source>Balancing performance and battery life, automatically adjusted according to usage</source>
+            <translation>兼顧效能和續航，根據使用情況自動調節</translation>
+        </message>
+        <message>
+            <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
+            <translation>續航優先，系統會犧牲一些效能表現來降低功耗</translation>
+        </message>
+    </context>
+    <context>
+        <name>PowerWorker</name>
+        <message>
+            <source>Minutes</source>
+            <translation>分鐘</translation>
+        </message>
+        <message>
+            <source>Hour</source>
+            <translation>小時</translation>
+        </message>
+        <message>
+            <source>Never</source>
+            <translation>從不</translation>
+        </message>
+    </context>
+    <context>
+        <name>PrivacyPolicyPage</name>
+        <message>
+            <source>Privacy Policy</source>
+            <translation>隱私政策</translation>
+        </message>
+        <message>
+            <source>Copy Link Address</source>
+            <translation>複製連結地址</translation>
+        </message>
+    </context>
+    <context>
+        <name>PwqualityManager</name>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Password must have at least %1 characters</source>
+            <translation>密碼長度不能少於%1個字元</translation>
+        </message>
+        <message>
+            <source>Password must be no more than %1 characters</source>
+            <translation>密碼長度不能超過%1個字元</translation>
+        </message>
+        <message>
+            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
+        </message>
+        <message>
+            <source>No more than %1 palindrome characters please</source>
+            <translation>迴文字元長度不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 monotonic characters please</source>
+            <translation>單調性字元不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 repeating characters please</source>
+            <translation>重複字元不超過%1位</translation>
+        </message>
+        <message>
+            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
+        </message>
+        <message>
+            <source>Password must not contain more than 4 palindrome characters</source>
+            <translation>密碼不得含有連續4個以上的迴文字元</translation>
+        </message>
+        <message>
+            <source>Do not use common words and combinations as password</source>
+            <translation>密碼不能是常見單詞及組合</translation>
+        </message>
+        <message>
+            <source>Create a strong password please</source>
+            <translation>密碼過於簡單，請增加密碼複雜度</translation>
+        </message>
+        <message>
+            <source>It does not meet password rules</source>
+            <translation>密碼不符合安全要求</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <source>Control Center</source>
+            <translation>控制中心</translation>
+        </message>
+        <message>
+            <source>Activated</source>
+            <translation>已啟用</translation>
+        </message>
+        <message>
+            <source>View</source>
+            <translation>檢視</translation>
+        </message>
+        <message>
+            <source>To be activated</source>
+            <translation>待啟用</translation>
+        </message>
+        <message>
+            <source>Activate</source>
+            <translation>啟用</translation>
+        </message>
+        <message>
+            <source>Expired</source>
+            <translation>已過期</translation>
+        </message>
+        <message>
+            <source>In trial period</source>
+            <translation>試用期</translation>
+        </message>
+        <message>
+            <source>Trial expired</source>
+            <translation>試用期過期</translation>
+        </message>
+        <message>
+            <source>dde-control-center</source>
+            <translation>控制中心</translation>
+        </message>
+        <message>
+            <source>Touch Screen Settings</source>
+            <translation>觸控屏設定</translation>
+        </message>
+        <message>
+            <source>The settings of touch screen changed</source>
+            <translation>已變更觸控屏設定</translation>
+        </message>
+        <message>
+            <source>This system wallpaper is locked. Please contact your admin.</source>
+            <translation>當前系統壁紙已被鎖定，請聯絡管理員</translation>
+        </message>
+    </context>
+    <context>
+        <name>RegionFormatDialog</name>
+        <message>
+            <source>Regions and formats</source>
+            <translation>區域和格式</translation>
+        </message>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+        <message>
+            <source>Default formats</source>
+            <translation>預設格式</translation>
+        </message>
+        <message>
+            <source>First day of week</source>
+            <translation>一週第一天</translation>
+        </message>
+        <message>
+            <source>Short date</source>
+            <translation>短日期</translation>
+        </message>
+        <message>
+            <source>Long date</source>
+            <translation>長日期</translation>
+        </message>
+        <message>
+            <source>Short time</source>
+            <translation>短時間</translation>
+        </message>
+        <message>
+            <source>Long time</source>
+            <translation>長時間</translation>
+        </message>
+        <message>
+            <source>Currency symbol</source>
+            <translation>貨幣符號</translation>
+        </message>
+        <message>
+            <source>Digit</source>
+            <translation>數字</translation>
+        </message>
+        <message>
+            <source>Paper size</source>
+            <translation>紙張</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>儲存</translation>
+        </message>
+    </context>
+    <context>
+        <name>RegionsChooserWindow</name>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+    </context>
+    <context>
+        <name>RegisterDialog</name>
+        <message>
+            <source>Set a Password</source>
+            <translation>設定密碼</translation>
+        </message>
+        <message>
+            <source>8-64 characters</source>
+            <translation>請輸入8-64位密碼</translation>
+        </message>
+        <message>
+            <source>Repeat the password</source>
+            <translation>請再次輸入密碼</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確定</translation>
+        </message>
+        <message>
+            <source>Passwords don't match</source>
+            <translation>兩次密碼輸入不一致</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScheduledShutdownDialog</name>
+        <message>
+            <source>Customize repetition time</source>
+            <translation>自定義重複時間</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>儲存</translation>
+        </message>
+    </context>
+    <context>
+        <name>ScreenSaverPage</name>
+        <message>
+            <source>Screensaver</source>
+            <translation>螢幕保護</translation>
+        </message>
+        <message>
+            <source>preview</source>
+            <translation>全屏預覽</translation>
+        </message>
+        <message>
+            <source>Personalized screensaver</source>
+            <translation>個性化屏保</translation>
+        </message>
+        <message>
+            <source>setting</source>
+            <translation>設定</translation>
+        </message>
+        <message>
+            <source>idle time</source>
+            <translation>閒置時間</translation>
+        </message>
+        <message>
+            <source>1 minute</source>
+            <translation>1分鐘</translation>
+        </message>
+        <message>
+            <source>5 minute</source>
+            <translation>5分鐘</translation>
+        </message>
+        <message>
+            <source>10 minute</source>
+            <translation>10分鐘</translation>
+        </message>
+        <message>
+            <source>15 minute</source>
+            <translation>15分鐘</translation>
+        </message>
+        <message>
+            <source>30 minute</source>
+            <translation>30分鐘</translation>
+        </message>
+        <message>
+            <source>1 hour</source>
+            <translation>1小時</translation>
+        </message>
+        <message>
+            <source>never</source>
+            <translation>從不</translation>
+        </message>
+        <message>
+            <source>Password required for recovery</source>
+            <translation>恢復時需要密碼</translation>
+        </message>
+        <message>
+            <source>Picture slideshow screensaver</source>
+            <translation>圖片輪播屏保</translation>
+        </message>
+        <message>
+            <source>System screensaver</source>
+            <translation>系統屏保</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchableListViewPopup</name>
+        <message>
+            <source>Search</source>
+            <translation>搜尋</translation>
+        </message>
+        <message>
+            <source>No search results</source>
+            <translation>無搜尋結果</translation>
+        </message>
+    </context>
+    <context>
+        <name>ShortcutSettingDialog</name>
+        <message>
+            <source>Add custom shortcut</source>
+            <translation>新增自定義快捷鍵</translation>
+        </message>
+        <message>
+            <source>Name:</source>
+            <translation>名稱：</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>Command:</source>
+            <translation>命令：</translation>
+        </message>
+        <message>
+            <source>Shortcut</source>
+            <translation>快捷鍵</translation>
+        </message>
+        <message>
+            <source>None</source>
+            <translation>無</translation>
+        </message>
+        <message>
+            <source>Please enter a new shortcut</source>
+            <translation>請輸入新的快捷鍵</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Add</source>
+            <translation>新增</translation>
+        </message>
+        <message>
+            <source>Click Add to replace</source>
+            <translation>點選新增替換</translation>
+        </message>
+    </context>
+    <context>
+        <name>Shortcuts</name>
+        <message>
+            <source>Shortcuts</source>
+            <translation>快捷鍵</translation>
+        </message>
+        <message>
+            <source>System shortcut, custom shortcut</source>
+            <translation>系統快捷鍵、自定義快捷鍵</translation>
+        </message>
+        <message>
+            <source>Search shortcuts</source>
+            <translation>搜尋快捷鍵</translation>
+        </message>
+        <message>
+            <source>Custom</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>done</source>
+            <translation>完成</translation>
+        </message>
+        <message>
+            <source>edit</source>
+            <translation>編輯</translation>
+        </message>
+        <message>
+            <source>Please enter a new shortcut</source>
+            <translation>請輸入新的快捷鍵</translation>
+        </message>
+        <message>
+            <source>Click</source>
+            <translation>點選</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>or</source>
+            <translation>或</translation>
+        </message>
+        <message>
+            <source>Replace</source>
+            <translation>替換</translation>
+        </message>
+        <message>
+            <source>Restore default</source>
+            <translation>恢復預設</translation>
+        </message>
+        <message>
+            <source>Add custom shortcut</source>
+            <translation>新增快捷鍵</translation>
+        </message>
+    </context>
+    <context>
+        <name>SoundDevicemanagesPage</name>
+        <message>
+            <source>Output Devices</source>
+            <translation>輸出裝置</translation>
+        </message>
+        <message>
+            <source>Select whether to enable the devices</source>
+            <translation>選擇是否啟用裝置</translation>
+        </message>
+        <message>
+            <source>Input Devices</source>
+            <translation>輸入裝置</translation>
+        </message>
+    </context>
+    <context>
+        <name>SoundEffectsPage</name>
+        <message>
+            <source>Sound Effects</source>
+            <translation>系統音效</translation>
+        </message>
+    </context>
+    <context>
+        <name>SoundModel</name>
+        <message>
+            <source>Boot up</source>
+            <translation>開機</translation>
+        </message>
+        <message>
+            <source>Shut down</source>
+            <translation>關機</translation>
+        </message>
+        <message>
+            <source>Log out</source>
+            <translation>登出</translation>
+        </message>
+        <message>
+            <source>Wake up</source>
+            <translation>喚醒</translation>
+        </message>
+        <message>
+            <source>Volume +/-</source>
+            <translation>音量調節</translation>
+        </message>
+        <message>
+            <source>Notification</source>
+            <translation>通知</translation>
+        </message>
+        <message>
+            <source>Low battery</source>
+            <translation>電量不足</translation>
+        </message>
+        <message>
+            <source>Send icon in Launcher to Desktop</source>
+            <translation>從啟動器傳送圖示到桌面</translation>
+        </message>
+        <message>
+            <source>Empty Trash</source>
+            <translation>清空回收站</translation>
+        </message>
+        <message>
+            <source>Plug in</source>
+            <translation>電源接入</translation>
+        </message>
+        <message>
+            <source>Plug out</source>
+            <translation>電源拔出</translation>
+        </message>
+        <message>
+            <source>Removable device connected</source>
+            <translation>行動裝置接入</translation>
+        </message>
+        <message>
+            <source>Removable device removed</source>
+            <translation>行動裝置拔出</translation>
+        </message>
+        <message>
+            <source>Error</source>
+            <translation>錯誤提示</translation>
+        </message>
+    </context>
+    <context>
+        <name>SpeakerPage</name>
+        <message>
+            <source>Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Output Volume</source>
+            <translation>輸出音量</translation>
+        </message>
+        <message>
+            <source>Volume Boost</source>
+            <translation>音量增強</translation>
+        </message>
+        <message>
+            <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
+            <translation>音量大於100%時可能會導致音效失真，同時損害您的音訊輸出裝置</translation>
+        </message>
+        <message>
+            <source>Left</source>
+            <translation>左</translation>
+        </message>
+        <message>
+            <source>Right</source>
+            <translation>右</translation>
+        </message>
+        <message>
+            <source>Output</source>
+            <translation>輸出</translation>
+        </message>
+        <message>
+            <source>No output device for sound found</source>
+            <translation>沒有找到聲音輸出裝置</translation>
+        </message>
+        <message>
+            <source>Left Right Balance</source>
+            <translation>左右平衡</translation>
+        </message>
+        <message>
+            <source>Mono audio</source>
+            <translation>單聲道音訊</translation>
+        </message>
+        <message>
+            <source>Merge left and right channels into a single channel</source>
+            <translation>將左聲道和右聲道合併成一個聲道</translation>
+        </message>
+        <message>
+            <source>Auto pause</source>
+            <translation>插拔管理</translation>
+        </message>
+        <message>
+            <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
+            <translation>外設插拔時音訊輸出是否自動暫停</translation>
+        </message>
+        <message>
+            <source>Output Devices</source>
+            <translation>輸出裝置</translation>
+        </message>
+    </context>
+    <context>
+        <name>SyncInfoListModel</name>
+        <message>
+            <source>Sound</source>
+            <translation>聲音</translation>
+        </message>
+        <message>
+            <source>Power</source>
+            <translation>電源</translation>
+        </message>
+        <message>
+            <source>Mouse</source>
+            <translation>滑鼠</translation>
+        </message>
+        <message>
+            <source>Update</source>
+            <translation>更新</translation>
+        </message>
+        <message>
+            <source>Screensaver</source>
+            <translation>螢幕保護</translation>
+        </message>
+    </context>
+    <context>
+        <name>ThemeSelectView</name>
+        <message>
+            <source>More Wallpapers</source>
+            <translation>下載更多</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeAndDate</name>
+        <message>
+            <source>Auto sync time</source>
+            <translation>自動同步配置</translation>
+        </message>
+        <message>
+            <source>Ntp server</source>
+            <translation>伺服器</translation>
+        </message>
+        <message>
+            <source>System date and time</source>
+            <translation>系統日期和時間</translation>
+        </message>
+        <message>
+            <source>Customize</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>Settings</source>
+            <translation>設定</translation>
+        </message>
+        <message>
+            <source>Server address</source>
+            <translation>伺服器地址</translation>
+        </message>
+        <message>
+            <source>Required</source>
+            <translation>必填</translation>
+        </message>
+        <message>
+            <source>The ntp server address cannot be empty</source>
+            <translation>NTP 服務地址不能為空</translation>
+        </message>
+        <message>
+            <source>Use 24-hour format</source>
+            <translation>24小時制</translation>
+        </message>
+        <message>
+            <source>system time zone</source>
+            <translation>系統時區</translation>
+        </message>
+        <message>
+            <source>Timezone list</source>
+            <translation>時區列表</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeRange</name>
+        <message>
+            <source>from</source>
+            <translation>從</translation>
+        </message>
+        <message>
+            <source>to</source>
+            <translation>至</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimeoutDialog</name>
+        <message>
+            <source>Save the display settings?</source>
+            <translation>是否要儲存顯示設定？</translation>
+        </message>
+        <message>
+            <source>Settings will be reverted in %1s.</source>
+            <translation>如無任何操作將在%1秒後還原。</translation>
+        </message>
+        <message>
+            <source>Revert</source>
+            <translation>還原</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>儲存</translation>
+        </message>
+    </context>
+    <context>
+        <name>TimezoneDialog</name>
+        <message>
+            <source>Add time zone</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Determine the time zone based on the current location</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Time zone:</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Nearest City:</source>
+            <translation type="unfinished"/>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Save</source>
+            <translation>儲存</translation>
+        </message>
+    </context>
+    <context>
+        <name>TouchScreen</name>
+        <message>
+            <source>TouchScreen</source>
+            <translation>觸控屏</translation>
+        </message>
+        <message>
+            <source>Set up here when connecting the touch screen</source>
+            <translation>連線觸控螢幕時在此處設定</translation>
+        </message>
+    </context>
+    <context>
+        <name>Touchpad</name>
+        <message>
+            <source>Basic Settings</source>
+            <translation>基礎設定</translation>
+        </message>
+        <message>
+            <source>Touchpad</source>
+            <translation>觸控板</translation>
+        </message>
+        <message>
+            <source>Pointer Speed</source>
+            <translation>指標速度</translation>
+        </message>
+        <message>
+            <source>Slow</source>
+            <translation>慢</translation>
+        </message>
+        <message>
+            <source>Fast</source>
+            <translation>快</translation>
+        </message>
+        <message>
+            <source>Disable touchpad during input</source>
+            <translation>輸入時停用觸控板</translation>
+        </message>
+        <message>
+            <source>Tap to Click</source>
+            <translation>輕觸以點選</translation>
+        </message>
+        <message>
+            <source>Natural Scrolling</source>
+            <translation>自然滾動</translation>
+        </message>
+        <message>
+            <source>Gesture</source>
+            <translation>手勢</translation>
+        </message>
+        <message>
+            <source>Three-finger gestures</source>
+            <translation>三指手勢</translation>
+        </message>
+        <message>
+            <source>Four-finger gestures</source>
+            <translation>四指手勢</translation>
+        </message>
+    </context>
+    <context>
+        <name>UserExperienceProgramPage</name>
+        <message>
+            <source>Join User Experience Program</source>
+            <translation>加入使用者體驗計劃</translation>
+        </message>
+        <message>
+            <source>Copy Link Address</source>
+            <translation>複製連結地址</translation>
+        </message>
+    </context>
+    <context>
+        <name>VerifyDialog</name>
+        <message>
+            <source>Security Verification</source>
+            <translation>安全驗證</translation>
+        </message>
+        <message>
+            <source>The action is sensitive, please enter the login password first</source>
+            <translation>您正在進行敏感操作，請進行登入密碼認證</translation>
+        </message>
+        <message>
+            <source>8-64 characters</source>
+            <translation>請輸入8-64位密碼</translation>
+        </message>
+        <message>
+            <source>Forgot Password?</source>
+            <translation>忘記密碼？</translation>
+        </message>
+        <message>
+            <source>Cancel</source>
+            <translation>取消</translation>
+        </message>
+        <message>
+            <source>Confirm</source>
+            <translation>確定</translation>
+        </message>
+    </context>
+    <context>
+        <name>WallpaperPage</name>
+        <message>
+            <source>wallpaper</source>
+            <translation>壁紙</translation>
+        </message>
+        <message>
+            <source>Window rounded corners</source>
+            <translation>視窗圓角</translation>
+        </message>
+        <message>
+            <source>My pictures</source>
+            <translation>我的圖片</translation>
+        </message>
+        <message>
+            <source>System Wallpaper</source>
+            <translation>系統壁紙</translation>
+        </message>
+        <message>
+            <source>Solid color wallpaper</source>
+            <translation>純色壁紙</translation>
+        </message>
+        <message>
+            <source>Customizable wallpapers</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>fill style</source>
+            <translation>填充方式</translation>
+        </message>
+        <message>
+            <source>Automatic wallpaper change</source>
+            <translation>自動切換壁紙</translation>
+        </message>
+        <message>
+            <source>never</source>
+            <translation>從不</translation>
+        </message>
+        <message>
+            <source>30 second</source>
+            <translation>30秒</translation>
+        </message>
+        <message>
+            <source>1 minute</source>
+            <translation>1分鐘</translation>
+        </message>
+        <message>
+            <source>5 minute</source>
+            <translation>5分鐘</translation>
+        </message>
+        <message>
+            <source>10 minute</source>
+            <translation>10分鐘</translation>
+        </message>
+        <message>
+            <source>15 minute</source>
+            <translation>15分鐘</translation>
+        </message>
+        <message>
+            <source>30 minute</source>
+            <translation>30分鐘</translation>
+        </message>
+        <message>
+            <source>login</source>
+            <translation>登入時</translation>
+        </message>
+        <message>
+            <source>wake up</source>
+            <translation>喚醒時</translation>
+        </message>
+        <message>
+            <source>System Wallapers</source>
+            <translation>系統壁紙</translation>
+        </message>
+        <message>
+            <source>Live Wallpaper</source>
+            <translation>動態壁紙</translation>
+        </message>
+        <message>
+            <source>1 hour</source>
+            <translation>1小時</translation>
+        </message>
+    </context>
+    <context>
+        <name>WallpaperSelectView</name>
+        <message>
+            <source>unfold</source>
+            <translation>收起</translation>
+        </message>
+        <message>
+            <source>show all</source>
+            <translation>顯示全部</translation>
+        </message>
+        <message>
+            <source>items</source>
+            <translation>張</translation>
+        </message>
+        <message>
+            <source>Set lock screen</source>
+            <translation>設定鎖屏</translation>
+        </message>
+        <message>
+            <source>Set desktop</source>
+            <translation>設定桌面</translation>
+        </message>
+    </context>
+    <context>
+        <name>WindowEffectPage</name>
+        <message>
+            <source>Interface and Effects</source>
+            <translation>介面效果</translation>
+        </message>
+        <message>
+            <source>Window Settings</source>
+            <translation>視窗設定</translation>
+        </message>
+        <message>
+            <source>Window rounded corners</source>
+            <translation>視窗圓角</translation>
+        </message>
+        <message>
+            <source>None</source>
+            <translation>無</translation>
+        </message>
+        <message>
+            <source>Small</source>
+            <translation>小</translation>
+        </message>
+        <message>
+            <source>Large</source>
+            <translation>大</translation>
+        </message>
+        <message>
+            <source>Enable transparent effects when moving windows</source>
+            <translation>視窗移動時啟用透明特效</translation>
+        </message>
+        <message>
+            <source>Window Minimize Effect</source>
+            <translation>最小化時效果</translation>
+        </message>
+        <message>
+            <source>Scale</source>
+            <translation>縮放</translation>
+        </message>
+        <message>
+            <source>Magic Lamp</source>
+            <translation>魔燈</translation>
+        </message>
+        <message>
+            <source>Opacity</source>
+            <translation>不透明度調節</translation>
+        </message>
+        <message>
+            <source>Low</source>
+            <translation>低</translation>
+        </message>
+        <message>
+            <source>High</source>
+            <translation>高</translation>
+        </message>
+        <message>
+            <source>Scroll Bars</source>
+            <translation>捲軸</translation>
+        </message>
+        <message>
+            <source>Show on scrolling</source>
+            <translation>滾動時顯示</translation>
+        </message>
+        <message>
+            <source>Keep shown</source>
+            <translation>一直顯示</translation>
+        </message>
+        <message>
+            <source>Compact Display</source>
+            <translation>緊湊模式</translation>
+        </message>
+        <message>
+            <source>If enabled, more content is displayed in the window.</source>
+            <translation>開啟後，視窗將顯示更多內容</translation>
+        </message>
+        <message>
+            <source>Title Bar Height</source>
+            <translation>標題欄高度</translation>
+        </message>
+        <message>
+            <source>Only suitable for application window title bars drawn by the window manager.</source>
+            <translation>僅適用於視窗管理器繪製的應用標題欄</translation>
+        </message>
+        <message>
+            <source>Extremely small</source>
+            <translation>極小</translation>
+        </message>
+        <message>
+            <source>Medium</source>
+            <translation>中</translation>
+            <comment>describe size of window rounded corners</comment>
+        </message>
+        <message>
+            <source>Medium</source>
+            <translation>中</translation>
+            <comment>describe height of window title bar</comment>
+        </message>
+    </context>
+    <context>
+        <name>accounts</name>
+        <message>
+            <source>Account</source>
+            <translation>帳戶</translation>
+        </message>
+        <message>
+            <source>Account manager</source>
+            <translation>帳戶管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>accountsMain</name>
+        <message>
+            <source>Other accounts</source>
+            <translation>其他帳戶</translation>
+        </message>
+    </context>
+    <context>
+        <name>authentication</name>
+        <message>
+            <source>Biometric Authentication</source>
+            <translation>生物認證</translation>
+        </message>
+    </context>
+    <context>
+        <name>authenticationMain</name>
+        <message>
+            <source>Biometric Authentication</source>
+            <translation>生物認證</translation>
+        </message>
+        <message>
+            <source>Face</source>
+            <translation>人臉</translation>
+        </message>
+        <message>
+            <source>Up to 5 facial data can be entered</source>
+            <translation>最多可錄入5個人臉資料</translation>
+        </message>
+        <message>
+            <source>Fingerprint</source>
+            <translation>指紋</translation>
+        </message>
+        <message>
+            <source>Identifying user identity through scanning fingerprints</source>
+            <translation>通過對指紋的掃描進行使用者身份的識別</translation>
+        </message>
+        <message>
+            <source>Iris</source>
+            <translation>虹膜</translation>
+        </message>
+        <message>
+            <source>Identity recognition through iris scanning</source>
+            <translation>通過掃描虹膜進行身份識別</translation>
+        </message>
+        <message>
+            <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
+            <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字元</translation>
+        </message>
+        <message>
+            <source>Use letters, numbers and underscores only</source>
+            <translation>只能由字母、數字、中文、下劃線組成</translation>
+        </message>
+        <message>
+            <source>No more than 15 characters</source>
+            <translation>不得超過15個字元</translation>
+        </message>
+        <message>
+            <source>Add a new</source>
+            <translation>新增新的</translation>
+        </message>
+        <message>
+            <source>This name already exists</source>
+            <translation>該名稱已存在</translation>
+        </message>
+    </context>
+    <context>
+        <name>blueTooth</name>
+        <message>
+            <source>bluetooth</source>
+            <translation>藍牙</translation>
+        </message>
+        <message>
+            <source>Bluetooth settings, devices</source>
+            <translation>藍牙設定、裝置管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>commonInfoMain</name>
+        <message>
+            <source>Boot Menu</source>
+            <translation>啟動菜單</translation>
+        </message>
+        <message>
+            <source>Manage your boot menu</source>
+            <translation>管理您的開機啟動菜單</translation>
+        </message>
+        <message>
+            <source>Developer root permission management</source>
+            <translation>開發者Root許可權管理</translation>
+        </message>
+        <message>
+            <source>Developer Options</source>
+            <translation>開發者選項</translation>
+        </message>
+    </context>
+    <context>
+        <name>datetime</name>
+        <message>
+            <source>Time and date</source>
+            <translation>時間和日期</translation>
+        </message>
+        <message>
+            <source>Time and date, time zone settings</source>
+            <translation>時間日期、時區設定</translation>
+        </message>
+        <message>
+            <source>Language and region</source>
+            <translation>語言和區域</translation>
+        </message>
+        <message>
+            <source>System language, region format</source>
+            <translation>系統語言、區域格式</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::AccountsController</name>
+        <message>
+            <source>Username must be between 3 and 32 characters</source>
+            <translation>使用者名稱長度必須介於 3 到 32 個字元之間</translation>
+        </message>
+        <message>
+            <source>The first character must be a letter or number</source>
+            <translation>必須字母或者數字開頭</translation>
+        </message>
+        <message>
+            <source>Your username should not only have numbers</source>
+            <translation>使用者名稱不能僅僅是數字</translation>
+        </message>
+        <message>
+            <source>The username has been used by other user accounts</source>
+            <translation>使用者名稱和其他使用者名稱重複</translation>
+        </message>
+        <message>
+            <source>The full name is too long</source>
+            <translation>全名太長了</translation>
+        </message>
+        <message>
+            <source>The full name has been used by other user accounts</source>
+            <translation>全名和其他使用者名稱重複</translation>
+        </message>
+        <message>
+            <source>Wrong password</source>
+            <translation>密碼錯誤</translation>
+        </message>
+        <message>
+            <source>Standard User</source>
+            <translation>標準使用者</translation>
+        </message>
+        <message>
+            <source>Administrator</source>
+            <translation>管理員</translation>
+        </message>
+        <message>
+            <source>Customized</source>
+            <translation>自定義</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::AccountsWorker</name>
+        <message>
+            <source>Your host was removed from the domain server successfully</source>
+            <translation>您的主機成功退出了域伺服器</translation>
+        </message>
+        <message>
+            <source>Your host joins the domain server successfully</source>
+            <translation>您的主機成功加入了域伺服器</translation>
+        </message>
+        <message>
+            <source>Your host failed to leave the domain server</source>
+            <translation>您的主機退出域伺服器失敗</translation>
+        </message>
+        <message>
+            <source>Your host failed to join the domain server</source>
+            <translation>您的主機加入域伺服器失敗</translation>
+        </message>
+        <message>
+            <source>AD domain settings</source>
+            <translation>AD域設定</translation>
+        </message>
+        <message>
+            <source>Password not match</source>
+            <translation>密碼不一致</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::AvatarTypesModel</name>
+        <message>
+            <source>Dimensional</source>
+            <translation>立體風格</translation>
+        </message>
+        <message>
+            <source>Flat</source>
+            <translation>平面風格</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::BiometricAuthController</name>
+        <message>
+            <source>Use your face to unlock the device and make settings later</source>
+            <translation>使用人臉資料解鎖您的裝置，之後還可進行更多設定</translation>
+        </message>
+        <message>
+            <source>Faceprint</source>
+            <translation>麵紋</translation>
+        </message>
+        <message>
+            <source>Place your finger</source>
+            <translation>放置手指</translation>
+        </message>
+        <message>
+            <source>Place your finger firmly on the sensor until you're asked to lift it</source>
+            <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
+        </message>
+        <message>
+            <source>Lift your finger</source>
+            <translation>擡起手指</translation>
+        </message>
+        <message>
+            <source>Lift your finger and place it on the sensor again</source>
+            <translation>請擡起手指，再次按壓</translation>
+        </message>
+        <message>
+            <source>Scan the edges of your fingerprint</source>
+            <translation>錄入邊緣指紋</translation>
+        </message>
+        <message>
+            <source>Adjust the position to scan the edges of your fingerprint</source>
+            <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
+        </message>
+        <message>
+            <source>Lift your finger and do that again</source>
+            <translation>請擡起手指，再次按壓</translation>
+        </message>
+        <message>
+            <source>Fingerprint added</source>
+            <translation>成功新增指紋</translation>
+        </message>
+        <message>
+            <source>Scan Suspended</source>
+            <translation>錄入中斷</translation>
+        </message>
+        <message>
+            <source>Place the edges of your fingerprint on the sensor</source>
+            <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
+        </message>
+        <message>
+            <source>Iris</source>
+            <translation>虹膜</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::KeyboardController</name>
+        <message>
+            <source>This shortcut conflicts with [%1]</source>
+            <translation>此快捷鍵與[%1]衝突</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::PwqualityManager</name>
+        <message>
+            <source>Password cannot be empty</source>
+            <translation>密碼不能為空</translation>
+        </message>
+        <message>
+            <source>Password must have at least %1 characters</source>
+            <translation>密碼長度不能少於%1個字元</translation>
+        </message>
+        <message>
+            <source>Password must be no more than %1 characters</source>
+            <translation>密碼長度不能超過%1個字元</translation>
+        </message>
+        <message>
+            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
+        </message>
+        <message>
+            <source>No more than %1 palindrome characters please</source>
+            <translation>迴文字元長度不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 monotonic characters please</source>
+            <translation>單調性字元不超過%1位</translation>
+        </message>
+        <message>
+            <source>No more than %1 repeating characters please</source>
+            <translation>重複字元不超過%1位</translation>
+        </message>
+        <message>
+            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
+            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
+        </message>
+        <message>
+            <source>Password must not contain more than 4 palindrome characters</source>
+            <translation>密碼不得含有連續4個以上的迴文字元</translation>
+        </message>
+        <message>
+            <source>Do not use common words and combinations as password</source>
+            <translation>密碼不能是常見單詞及組合</translation>
+        </message>
+        <message>
+            <source>Create a strong password please</source>
+            <translation>密碼過於簡單，請增加密碼複雜度</translation>
+        </message>
+        <message>
+            <source>It does not meet password rules</source>
+            <translation>密碼不符合安全要求</translation>
+        </message>
+    </context>
+    <context>
+        <name>dccV25::ShortcutModel</name>
+        <message>
+            <source>System</source>
+            <translation>系統</translation>
+        </message>
+        <message>
+            <source>Window</source>
+            <translation>視窗</translation>
+        </message>
+        <message>
+            <source>Workspace</source>
+            <translation>工作區</translation>
+        </message>
+        <message>
+            <source>AssistiveTools</source>
+            <translation>輔助功能</translation>
+        </message>
+        <message>
+            <source>Custom</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>None</source>
+            <translation>無</translation>
+        </message>
+    </context>
+    <context>
+        <name>deepinid</name>
+        <message>
+            <source>deepin ID</source>
+            <translation>deepin ID</translation>
+        </message>
+        <message>
+            <source>UOS ID</source>
+            <translation>UOS ID</translation>
+        </message>
+        <message>
+            <source>Cloud services</source>
+            <translation>雲服務</translation>
+        </message>
+    </context>
+    <context>
+        <name>defaultapp</name>
+        <message>
+            <source>Default App</source>
+            <translation>預設程式</translation>
+        </message>
+        <message>
+            <source>Set the default application for opening various types of files</source>
+            <translation>設定打開各類檔案的預設程式</translation>
+        </message>
+    </context>
+    <context>
+        <name>defaultappMain</name>
+        <message>
+            <source>Webpage</source>
+            <translation>網頁</translation>
+        </message>
+        <message>
+            <source>Mail</source>
+            <translation>郵件</translation>
+        </message>
+        <message>
+            <source>Text</source>
+            <translation>文字</translation>
+        </message>
+        <message>
+            <source>Music</source>
+            <translation>音樂</translation>
+        </message>
+        <message>
+            <source>Video</source>
+            <translation>影片</translation>
+        </message>
+        <message>
+            <source>Picture</source>
+            <translation>圖片</translation>
+        </message>
+        <message>
+            <source>Terminal</source>
+            <translation>終端</translation>
+        </message>
+    </context>
+    <context>
+        <name>device</name>
+        <message>
+            <source>Device</source>
+            <translation>裝置</translation>
+        </message>
+    </context>
+    <context>
+        <name>display</name>
+        <message>
+            <source>Display</source>
+            <translation>顯示</translation>
+        </message>
+        <message>
+            <source>Brightness,resolution,scaling</source>
+            <translation>亮度、解析度、縮放</translation>
+        </message>
+    </context>
+    <context>
+        <name>displayMain</name>
+        <message>
+            <source>100%</source>
+            <translation>100%</translation>
+        </message>
+        <message>
+            <source>125%</source>
+            <translation>125%</translation>
+        </message>
+        <message>
+            <source>150%</source>
+            <translation>150%</translation>
+        </message>
+        <message>
+            <source>175%</source>
+            <translation>175%</translation>
+        </message>
+        <message>
+            <source>200%</source>
+            <translation>200%</translation>
+        </message>
+        <message>
+            <source>225%</source>
+            <translation>225%</translation>
+        </message>
+        <message>
+            <source>250%</source>
+            <translation>250%</translation>
+        </message>
+        <message>
+            <source>275%</source>
+            <translation>275%</translation>
+        </message>
+        <message>
+            <source>300%</source>
+            <translation>300%</translation>
+        </message>
+        <message>
+            <source>Duplicate</source>
+            <translation>複製</translation>
+        </message>
+        <message>
+            <source>Extend</source>
+            <translation>擴充套件</translation>
+        </message>
+        <message>
+            <source>Default</source>
+            <translation>預設</translation>
+        </message>
+        <message>
+            <source>Fit</source>
+            <translation>適應</translation>
+        </message>
+        <message>
+            <source>Stretch</source>
+            <translation>拉伸</translation>
+        </message>
+        <message>
+            <source>Center</source>
+            <translation>居中</translation>
+        </message>
+        <message>
+            <source>Only on %1</source>
+            <translation>僅%1屏</translation>
+        </message>
+        <message>
+            <source>(Recommended)</source>
+            <translation>（推薦）</translation>
+        </message>
+        <message>
+            <source>Hz</source>
+            <translation>赫茲</translation>
+        </message>
+        <message>
+            <source>Multiple Displays Settings</source>
+            <translation>多屏設定</translation>
+        </message>
+        <message>
+            <source>Identify</source>
+            <translation>識別</translation>
+        </message>
+        <message>
+            <source>Screen rearrangement will take effect in %1s after changes</source>
+            <translation>螢幕拼接將在修改完成%1s後生效</translation>
+        </message>
+        <message>
+            <source>Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Main Screen</source>
+            <translation>主螢幕</translation>
+        </message>
+        <message>
+            <source>Display And Layout</source>
+            <translation>顯示和佈局</translation>
+        </message>
+        <message>
+            <source>Brightness</source>
+            <translation>亮度</translation>
+        </message>
+        <message>
+            <source>Resolution</source>
+            <translation>解析度</translation>
+        </message>
+        <message>
+            <source>Resize Desktop</source>
+            <translation>桌面顯示</translation>
+        </message>
+        <message>
+            <source>Refresh Rate</source>
+            <translation>重新整理率</translation>
+        </message>
+        <message>
+            <source>Rotation</source>
+            <translation>方向</translation>
+        </message>
+        <message>
+            <source>Standard</source>
+            <translation>標準</translation>
+        </message>
+        <message>
+            <source>90°</source>
+            <translation>90度</translation>
+        </message>
+        <message>
+            <source>180°</source>
+            <translation>180度</translation>
+        </message>
+        <message>
+            <source>270°</source>
+            <translation>270度</translation>
+        </message>
+        <message>
+            <source>Display Scaling</source>
+            <translation>縮放</translation>
+        </message>
+        <message>
+            <source>The monitor only supports 100% display scaling</source>
+            <translation>當前螢幕僅支援1倍縮放</translation>
+        </message>
+        <message>
+            <source>Eye Comfort</source>
+            <translation>護眼模式</translation>
+        </message>
+        <message>
+            <source>Enable eye comfort</source>
+            <translation>開啟護眼模式</translation>
+        </message>
+        <message>
+            <source>Adjust screen display to warmer colors, reducing screen blue light</source>
+            <translation>調整螢幕顯示較暖的顏色，減少螢幕藍光</translation>
+        </message>
+        <message>
+            <source>Time</source>
+            <translation>時間</translation>
+        </message>
+        <message>
+            <source>All day</source>
+            <translation>全天</translation>
+        </message>
+        <message>
+            <source>Sunset to Sunrise</source>
+            <translation>日落到日出</translation>
+        </message>
+        <message>
+            <source>Custom Time</source>
+            <translation>自定義</translation>
+        </message>
+        <message>
+            <source>from</source>
+            <translation>從</translation>
+        </message>
+        <message>
+            <source>to</source>
+            <translation>至</translation>
+        </message>
+        <message>
+            <source>Color Temperature</source>
+            <translation>色溫</translation>
+        </message>
+    </context>
+    <context>
+        <name>dock</name>
+        <message>
+            <source>Desktop and taskbar</source>
+            <translation>桌面和工作列</translation>
+        </message>
+        <message>
+            <source>Desktop organization, taskbar mode, plugin area settings</source>
+            <translation>桌面整理、工作列模式、外掛區域設定</translation>
+        </message>
+    </context>
+    <context>
+        <name>keyboard</name>
+        <message>
+            <source>Keyboard</source>
+            <translation>鍵盤</translation>
+        </message>
+        <message>
+            <source>General Settings, keyboard layout, input method, shortcuts</source>
+            <translation>通用設定、鍵盤佈局、輸入法、快捷鍵</translation>
+        </message>
+    </context>
+    <context>
+        <name>keyboardMain</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Keyboard layout</source>
+            <translation>鍵盤佈局</translation>
+        </message>
+        <message>
+            <source>Set system default keyboard layout</source>
+            <translation>設定系統預設鍵盤佈局</translation>
+        </message>
+    </context>
+    <context>
+        <name>main</name>
+        <message>
+            <source>Dock</source>
+            <translation>工作列</translation>
+        </message>
+        <message>
+            <source>Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Classic Mode</source>
+            <translation>經典模式</translation>
+        </message>
+        <message>
+            <source>Centered Mode</source>
+            <translation>居中模式</translation>
+        </message>
+        <message>
+            <source>Dock size</source>
+            <translation>工作列大小</translation>
+        </message>
+        <message>
+            <source>Small</source>
+            <translation>小</translation>
+        </message>
+        <message>
+            <source>Large</source>
+            <translation>大</translation>
+        </message>
+        <message>
+            <source>Position on the screen</source>
+            <translation>螢幕中的位置</translation>
+        </message>
+        <message>
+            <source>Top</source>
+            <translation>上</translation>
+        </message>
+        <message>
+            <source>Bottom</source>
+            <translation>下</translation>
+        </message>
+        <message>
+            <source>Left</source>
+            <translation>左</translation>
+        </message>
+        <message>
+            <source>Right</source>
+            <translation>右</translation>
+        </message>
+        <message>
+            <source>Status</source>
+            <translation>狀態</translation>
+        </message>
+        <message>
+            <source>Keep shown</source>
+            <translation>一直顯示</translation>
+        </message>
+        <message>
+            <source>Keep hidden</source>
+            <translation>一直隱藏</translation>
+        </message>
+        <message>
+            <source>Smart hide</source>
+            <translation>智慧隱藏</translation>
+        </message>
+        <message>
+            <source>Multiple Displays</source>
+            <translation>多屏顯示</translation>
+        </message>
+        <message>
+            <source>Set the position of the taskbar on the screen</source>
+            <translation>設定工作列在螢幕中的位置</translation>
+        </message>
+        <message>
+            <source>Only on main</source>
+            <translation>僅主屏顯示</translation>
+        </message>
+        <message>
+            <source>On screen where the cursor is</source>
+            <translation>跟隨滑鼠位置顯示</translation>
+        </message>
+        <message>
+            <source>Plugin Area</source>
+            <translation>外掛區域</translation>
+        </message>
+        <message>
+            <source>Select which icons appear in the Dock</source>
+            <translation>選擇顯示在工作列外掛區域的圖示</translation>
+        </message>
+    </context>
+    <context>
+        <name>mouse</name>
+        <message>
+            <source>Mouse and Touchpad</source>
+            <translation>滑鼠與觸控板</translation>
+        </message>
+        <message>
+            <source>Common、Mouse、Touchpad</source>
+            <translation>通用、滑鼠、觸控板</translation>
+        </message>
+    </context>
+    <context>
+        <name>mouseMain</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Mouse</source>
+            <translation>滑鼠</translation>
+        </message>
+        <message>
+            <source>Touchpad</source>
+            <translation>觸控板</translation>
+        </message>
+    </context>
+    <context>
+        <name>notification</name>
+        <message>
+            <source>DND mode, app notifications</source>
+            <translation>勿擾模式、應用通知</translation>
+        </message>
+        <message>
+            <source>Notification</source>
+            <translation>通知</translation>
+        </message>
+    </context>
+    <context>
+        <name>notificationMain</name>
+        <message>
+            <source>Do Not Disturb Settings</source>
+            <translation>勿擾設定</translation>
+        </message>
+        <message>
+            <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
+            <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心檢視所有消息。</translation>
+        </message>
+        <message>
+            <source>Enable Do Not Disturb</source>
+            <translation>啟用勿擾模式</translation>
+        </message>
+        <message>
+            <source>When the screen is locked</source>
+            <translation>在螢幕鎖屏時</translation>
+        </message>
+        <message>
+            <source>Number of notifications shown on the desktop</source>
+            <translation>通知橫幅展示數量</translation>
+        </message>
+        <message>
+            <source>App Notifications</source>
+            <translation>應用通知</translation>
+        </message>
+        <message>
+            <source>Allow Notifications</source>
+            <translation>允許通知</translation>
+        </message>
+        <message>
+            <source>Display notification on desktop or show unread messages in the notification center</source>
+            <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
+        </message>
+        <message>
+            <source>Desktop</source>
+            <translation>桌面</translation>
+        </message>
+        <message>
+            <source>Lock Screen</source>
+            <translation>鎖屏</translation>
+        </message>
+        <message>
+            <source>Notification Center</source>
+            <translation>通知中心</translation>
+        </message>
+        <message>
+            <source>Show message preview</source>
+            <translation>顯示消息預覽</translation>
+        </message>
+        <message>
+            <source>Play a sound</source>
+            <translation>通知時提示聲音</translation>
+        </message>
+    </context>
+    <context>
+        <name>personalization</name>
+        <message>
+            <source>Personalization</source>
+            <translation>個性化</translation>
+        </message>
+    </context>
+    <context>
+        <name>personalizationMain</name>
+        <message>
+            <source>Theme</source>
+            <translation>主題</translation>
+        </message>
+        <message>
+            <source>Appearance</source>
+            <translation>外觀</translation>
+        </message>
+        <message>
+            <source>Window effect</source>
+            <translation>視窗效果</translation>
+        </message>
+        <message>
+            <source>Personalize your wallpaper and screensaver</source>
+            <translation>個性化您的壁紙和屏保</translation>
+        </message>
+        <message>
+            <source>Screensaver</source>
+            <translation>螢幕保護</translation>
+        </message>
+        <message>
+            <source>Colors and icons</source>
+            <translation>顏色和圖示</translation>
+        </message>
+        <message>
+            <source>Adjust accent color and theme icons</source>
+            <translation>調整活動色和主題圖示</translation>
+        </message>
+        <message>
+            <source>Font and font size</source>
+            <translation>字型和字號</translation>
+        </message>
+        <message>
+            <source>Change system font and size</source>
+            <translation>修改系統字型與字號</translation>
+        </message>
+        <message>
+            <source>Wallpaper</source>
+            <translation>壁紙</translation>
+        </message>
+        <message>
+            <source>Select light, dark or automatic theme appearance</source>
+            <translation>選擇淺色、深色或自動切換主題外觀</translation>
+        </message>
+        <message>
+            <source>Interface and effects, rounded corners</source>
+            <translation>介面和效果、視窗圓角</translation>
+        </message>
+    </context>
+    <context>
+        <name>power</name>
+        <message>
+            <source>Power saving settings, screen and suspend</source>
+            <translation>節能設定、螢幕和待機管理</translation>
+        </message>
+        <message>
+            <source>Power</source>
+            <translation>電源管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>powerMain</name>
+        <message>
+            <source>General</source>
+            <translation>通用</translation>
+        </message>
+        <message>
+            <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
+            <translation>效能模式、節能設定、喚醒設定、關機設定</translation>
+        </message>
+        <message>
+            <source>Plugged In</source>
+            <translation>使用電源</translation>
+        </message>
+        <message>
+            <source>Screen and suspend</source>
+            <translation>螢幕和待機管理</translation>
+        </message>
+        <message>
+            <source>On Battery</source>
+            <translation>使用電池</translation>
+        </message>
+        <message>
+            <source>screen and suspend, low battery, battery management</source>
+            <translation>螢幕和待機管理、低電量管理、電池管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>privacy</name>
+        <message>
+            <source>Privacy and Security</source>
+            <translation>隱私和安全</translation>
+        </message>
+        <message>
+            <source>Camera, folder permissions</source>
+            <translation>攝像頭、資料夾許可權</translation>
+        </message>
+    </context>
+    <context>
+        <name>privacyMain</name>
+        <message>
+            <source>Camera</source>
+            <translation>攝像頭</translation>
+        </message>
+        <message>
+            <source>Choose whether the application has access to the camera</source>
+            <translation>選擇應用是否有攝像頭的訪問許可權</translation>
+        </message>
+        <message>
+            <source>Files and Folders</source>
+            <translation>檔案和資料夾</translation>
+        </message>
+        <message>
+            <source>Choose whether the application has access to files and folders</source>
+            <translation>選擇應用是否有檔案和資料夾的訪問許可權</translation>
+        </message>
+    </context>
+    <context>
+        <name>sound</name>
+        <message>
+            <source>Sound</source>
+            <translation>聲音</translation>
+        </message>
+        <message>
+            <source>Output, input, sound effects, devices</source>
+            <translation>輸入、輸出、系統音效、裝置管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>soundMain</name>
+        <message>
+            <source>Settings</source>
+            <translation>設定</translation>
+        </message>
+        <message>
+            <source>Sound Effects</source>
+            <translation>系統音效</translation>
+        </message>
+        <message>
+            <source>Enable/disable sound effects</source>
+            <translation>開啟/關閉系統音效</translation>
+        </message>
+        <message>
+            <source>Enable/disable audio devices</source>
+            <translation>啟用/停用音訊裝置</translation>
+        </message>
+        <message>
+            <source>Devices</source>
+            <translation>裝置管理</translation>
+        </message>
+    </context>
+    <context>
+        <name>system</name>
+        <message>
+            <source>Common settings</source>
+            <translation>常用設定</translation>
+        </message>
+        <message>
+            <source>System</source>
+            <translation>系統</translation>
+        </message>
+    </context>
+    <context>
+        <name>systemInfo</name>
+        <message>
+            <source>Auxiliary Information</source>
+            <translation>輔助資訊</translation>
+        </message>
+    </context>
+    <context>
+        <name>systemInfoMain</name>
+        <message>
+            <source>About This PC</source>
+            <translation>關於本機</translation>
+        </message>
+        <message>
+            <source>System version, device information</source>
+            <translation>系統版本、裝置資訊</translation>
+        </message>
+        <message>
+            <source>View the notice of open source software</source>
+            <translation>檢視開源軟體宣告</translation>
+        </message>
+        <message>
+            <source>User Experience Program</source>
+            <translation>使用者體驗計劃</translation>
+        </message>
+        <message>
+            <source>Join the user experience program to help improve the product</source>
+            <translation>加入使用者體驗計劃，幫助改進產品</translation>
+        </message>
+        <message>
+            <source>End User License Agreement</source>
+            <translation>使用者許可協議</translation>
+        </message>
+        <message>
+            <source>View the end  user license agreement</source>
+            <translation>檢視終端使用者許可協議</translation>
+        </message>
+        <message>
+            <source>Privacy Policy</source>
+            <translation>隱私政策</translation>
+        </message>
+        <message>
+            <source>View information about privacy policy</source>
+            <translation>檢視隱私政策相關資訊</translation>
+        </message>
+        <message>
+            <source>Open Source Software Notice</source>
+            <translation>開源軟體宣告</translation>
+        </message>
+    </context>
+    <context>
+        <name>touchscreen</name>
+        <message>
+            <source>Touchscreen</source>
+            <translation>觸控屏</translation>
+        </message>
+        <message>
+            <source>Configuring Touchscreen</source>
+            <translation>觸控屏設定</translation>
+        </message>
+    </context>
+    <context>
+        <name>touchscreenMain</name>
+        <message>
+            <source>Common</source>
+            <translation>通用</translation>
+        </message>
+    </context>
+    <context>
+        <name>wacom</name>
+        <message>
+            <source>wacom</source>
+            <translation>數位板</translation>
+        </message>
+        <message>
+            <source>Configuring wacom</source>
+            <translation>數位板選項設定</translation>
+        </message>
+    </context>
+    <context>
+        <name>wacomMain</name>
+        <message>
+            <source>wacom</source>
+            <translation>數位板</translation>
+        </message>
+        <message>
+            <source>Wacom Mode</source>
+            <translation>模式</translation>
+        </message>
+        <message>
+            <source>Pen Mode</source>
+            <translation>筆模式</translation>
+        </message>
+        <message>
+            <source>Mouse Mode</source>
+            <translation>滑鼠模式</translation>
+        </message>
+        <message>
+            <source>Pressure Sensitivity</source>
+            <translation>壓感</translation>
+        </message>
+        <message>
+            <source>Light</source>
+            <translation>輕</translation>
+        </message>
+    </context>
 </TS>


### PR DESCRIPTION
波兰语中,"Medium"(中)会根据上下文翻译成不同的文案,而当前我们未提供相应描述来对不同的场景加以区分。

另外，更新了 `.tx/config` 配置，并更新了繁体中文文案。

## Summary by Sourcery

Disambiguate the translation of "Medium" by adding context comments for window rounded corners and title bar height, refresh Traditional Chinese translations accordingly, and update the .tx/config translation settings.

Enhancements:
- Add context comments to differentiate two uses of "Medium" translations
- Update Traditional Chinese (zh_HK) translation file formatting and copy
- Refresh .tx/config settings for translation management

Build:
- Update .tx/config translation configuration