### PR TITLE
fix: Add a user group error message

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -469,6 +469,12 @@ bool AccountsController::groupEditAble(const QString &id, const QString &name) c
     return true;
 }
 
+bool AccountsController::groupExists(const QString &name) const
+{
+    QStringList existingGroups = allGroups();
+    return existingGroups.contains(name);
+}
+
 void AccountsController::createGroup(const QString &name)
 {
     m_worker->createGroup(name, 0, false);

--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -62,6 +62,7 @@ public slots:
     bool groupContains(const QString &id, const QString &name) const;
     bool groupEnabled(const QString &id, const QString &name) const;
     bool groupEditAble(const QString &id, const QString &name) const;
+    bool groupExists(const QString &name) const;
     void createGroup(const QString &name);
     void deleteGroup(const QString &name);
     void modifyGroup(const QString &oldName, const QString &newName);

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">اسم المستخدم طويل جدًا</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">اسم المستخدم الكاملtoo long</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Пълното име е прекалено дълго</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">মোট নাম খুব দীর্ঘ</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">El nom complet és massa llarg.</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Celé jméno je příliš dlouhé</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Det fulde navn er for langt</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Der vollständige Name ist zu lang</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Το πλήρες όνομα είναι πολύ μεγάλο</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">The full name is too long</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">The full name is too long</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">El nombre completo es muy largo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Täielik nimi on liiga pikk</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Nimesi on liian pitkä</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">El nombre completo es demasiado largo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">O nome completo é moi lonxe</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">שם מלא הוא מדי ארוך</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Puno ime je predugo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">A teljes nev túl hosszú</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Nama lengkap terlalu panjang</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">フルネームが長すぎます</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">სრული სახელი ძალიან გრძელია</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Толық аты-жөні толған</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">전체 이름이 너무 길�습니다</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Vardas yra per ilgas</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Бүтэн нэр хэтэрхий урт байна</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Nama penuh terlalu panjang</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">ਪੂਰਾ ਨਾਂ ਬਹੁਤ ਲੰਮਾ ਹੈ</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Imię i nazwisko jest za długie</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">O nome completo é muito comprido</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">O nome completo é muito longo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Numele complet este prea lung</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Имя слишком длинное</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">සම්පූර්ණ නම දිග වැඩිය</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Celé meno je príliš dlhé</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Ime je preprosto dolgo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Emri i plotë është shumë i gjatë</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Пуно име је предугачко</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Komplettera namnet är för långt</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">ชื่อจริงยาวเกินไป</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Tam isim çok uzun</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">تولۇق ئىسمى بەك ئۇزۇن</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Ім&apos;я повністю є надто довгим</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Tên đầy đủ quá dài</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation>名称过长</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation>组名不允许超出32个字符</translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation>组名不能使用纯数字</translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation>仅使用字母、数字、下划线和破折号，并且必需以字母开头</translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation>组名与其他组名重复</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">全名太長了</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">全名太長了</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>


### PR DESCRIPTION
Add a user group error message

Log: Add a user group error message
pms: BUG-292935

## Summary by Sourcery

Enforce and surface client-side validation errors for user group names in account settings.

Enhancements:
- Add a groupExists API in AccountsController to detect duplicate group names.
- Implement client-side validation in AccountSettings.qml for maximum length, numeric-only, and allowed character rules.
- Display localized error messages and play system sounds when validation fails, restoring the last valid input.
- Adjust QML layout (clip and z-index) to ensure alerts appear correctly above the input field.