### PR TITLE
fix: improve caps lock and num lock toggle functionality

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -125,9 +125,6 @@ bool KeyboardController::numLock() const
 
 void KeyboardController::setNumLock(bool newNumLock)
 {
-    if (numLock() == newNumLock)
-        return;
-
     m_worker->setNumLock(newNumLock);
 }
 
@@ -138,9 +135,6 @@ bool KeyboardController::capsLock() const
 
 void KeyboardController::setCapsLock(bool newCapsLock)
 {
-    if (capsLock() == newCapsLock)
-        return;
-
     m_worker->setCapsLock(newCapsLock);
 }
 

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -78,14 +78,16 @@ void KeyboardDBusProxy::onLangSelectorStartServiceProcessFinished(QDBusPendingCa
 }
 
 //Keyboard
-bool KeyboardDBusProxy::capslockToggle()
+int KeyboardDBusProxy::capslockToggle()
 {
-    return qvariant_cast<bool>(m_dBusKeyboardInter->property("CapslockToggle"));
+    return QDBusPendingReply<int>(m_dBusKeybingdingInter->asyncCall(QStringLiteral("GetCapsLockState")));
 }
 
-void KeyboardDBusProxy::setCapslockToggle(bool value)
+void KeyboardDBusProxy::setCapslockToggle(int value)
 {
-    m_dBusKeyboardInter->setProperty("CapslockToggle", QVariant::fromValue(value));
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(value);
+    m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SetCapsLockState"), argumentList);
 }
 
 QString KeyboardDBusProxy::currentLayout()

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -72,9 +72,9 @@ public:
     explicit KeyboardDBusProxy(QObject *parent = nullptr);
 
     //Keyboard
-    Q_PROPERTY(bool CapslockToggle READ capslockToggle WRITE setCapslockToggle NOTIFY CapslockToggleChanged)
-    bool capslockToggle();
-    void setCapslockToggle(bool value);
+    Q_PROPERTY(int CapslockToggle READ capslockToggle WRITE setCapslockToggle NOTIFY CapslockToggleChanged)
+    int capslockToggle();
+    void setCapslockToggle(int value);
 
     Q_PROPERTY(QString CurrentLayout READ currentLayout WRITE setCurrentLayout NOTIFY CurrentLayoutChanged)
     QString currentLayout();


### PR DESCRIPTION
- Changed capslock API from bool to int type in KeyboardDBusProxy
- Updated to use KeybindingInter instead of KeyboardInter
- Removed redundant condition checks in controller setters for both caps lock and num lock

Log: improve caps lock and num lock toggle functionality
pms: BUG-303365

## Summary by Sourcery

Improve caps lock and num lock toggle functionality by switching caps lock state API from bool to int, updating DBus calls to use the keybinding interface, and removing redundant conditional guards in the controller setters.

Bug Fixes:
- Use correct DBus keybinding interface for caps lock state retrieval and setting to fix toggle behavior

Enhancements:
- Change CapslockToggle property and methods from bool to int to align with underlying API
- Remove unnecessary state-check conditions in setNumLock and setCapsLock methods to streamline toggling