### PR TITLE
fix: Add a user group error message

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -488,6 +488,12 @@ bool AccountsController::groupEditAble(const QString &id, const QString &name) c
     return true;
 }
 
+bool AccountsController::groupExists(const QString &name) const
+{
+    QStringList existingGroups = allGroups();
+    return existingGroups.contains(name);
+}
+
 void AccountsController::createGroup(const QString &name)
 {
     m_worker->createGroup(name, 0, false);

--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -65,6 +65,7 @@ public slots:
     bool groupContains(const QString &id, const QString &name) const;
     bool groupEnabled(const QString &id, const QString &name) const;
     bool groupEditAble(const QString &id, const QString &name) const;
+    bool groupExists(const QString &name) const;
     void createGroup(const QString &name);
     void deleteGroup(const QString &name);
     void modifyGroup(const QString &oldName, const QString &newName);

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -626,6 +626,7 @@ DccObject {
             currentIndex: -1
             activeFocusOnTab: false
             keyNavigationEnabled: false
+            clip: false
             anchors {
                 left: parent ? parent.left : undefined
                 right: parent ? parent.right : undefined
@@ -680,6 +681,8 @@ DccObject {
                 implicitHeight: 50
                 checkable: false
                 enabled: model.groupEnabled
+                clip: false
+                z: editLabel.showAlert ? 100 : 1
                 background: DccItemBackground {
                     backgroundType: DccObject.Normal
                     separatorVisible: true
@@ -692,38 +695,103 @@ DccObject {
                 }
 
                 contentItem: RowLayout {
-                    EditActionLabel {
-                        id: editLabel
-                        property bool editAble: model.groupEditAble
-                        text: model.display
-                        completeText: model.display
-                        rightPadding: editButton.width + 10
-                        validator: RegularExpressionValidator {
-                            // 仅使用字母、数字、下划线或短横线，并且以字母开头
-                            regularExpression: /[a-zA-Z][a-zA-Z0-9-_]{0,31}$/
-                        }
+                    Item {
+                        id: editContainer
+                        Layout.fillWidth: !editLabel.readOnly
                         implicitHeight: 40
-                        implicitWidth: Math.min(metrics.advanceWidth(completeText) + editButton.width + 20,
+                        implicitWidth: Math.min(editLabel.metrics.advanceWidth(editLabel.completeText) + editButton.width + 20,
                                         groupview.width - editButton.width - 30)
-                        Layout.fillWidth: !readOnly
-                        placeholderText: qsTr("Group name")
-                        horizontalAlignment: TextInput.AlignLeft | Qt.AlignVCenter
-                        editBtn.visible: readOnly && editAble
-                                         && !groupSettings.isEditing
-                        readOnly: model.display.length > 0
-                        background: null
-                        onFinished: function () {
-                            if (text.length < 1) {
-                                text = model.display
+                        
+                        EditActionLabel {
+                            id: editLabel
+                            property bool editAble: model.groupEditAble
+                            property string lastValidText: ""
+                            property bool isRestoring: false
+                            anchors.fill: parent
+                            text: model.display
+                            completeText: model.display
+                            rightPadding: editButton.width + 10
+                            placeholderText: qsTr("Group name")
+                            horizontalAlignment: TextInput.AlignLeft | Qt.AlignVCenter
+                            editBtn.visible: readOnly && editAble
+                                             && !groupSettings.isEditing
+                            readOnly: model.display.length > 0
+                        
+                        onReadOnlyChanged: {
+                            if (!readOnly) {
+                                lastValidText = model.display
+                            }
+                        }
+                        
+                        onTextChanged: {
+                            if (isRestoring) {
+                                isRestoring = false
                                 return
                             }
+                            
+                            if (showAlert)
+                                showAlert = false
+                            
+                            var isNewGroup = (model.display.length === 0)
+                            
+                            if (text.length > 32) {
+                                showAlert = true
+                                alertText = qsTr("Group names should be no more than 32 characters")
+                                dccData.playSystemSound(14)
+                                isRestoring = true
+                                text = lastValidText
+                                return
+                            }
+                            
+                            if (isNewGroup) {
+                                var numbersOnlyRegex = /^[0-9]+$/
+                                if (text.length > 0 && numbersOnlyRegex.test(text)) {
+                                    showAlert = true
+                                    alertText = qsTr("Group names cannot only have numbers")
+                                    dccData.playSystemSound(14)
+                                    isRestoring = true
+                                    text = lastValidText
+                                    return
+                                }
+                                
+                                var validFormatRegex = /^[a-zA-Z][a-zA-Z0-9-_]*$/
+                                if (text.length > 0 && !validFormatRegex.test(text)) {
+                                    showAlert = true
+                                    alertText = qsTr("Use letters,numbers,underscores and dashes only, and must start with a letter")
+                                    dccData.playSystemSound(14)
+                                    isRestoring = true
+                                    text = lastValidText
+                                    return
+                                }
+                            }
+                            
+                            lastValidText = text
+                        }
+                        
+                        onFinished: function () {
+                            if (text.length < 1) {
+                                if (model.display.length < 1) {
+                                    dccData.requestClearEmptyGroup(settings.userId)
+                                } else {
+                                    text = model.display
+                                }
+                                return
+                            }
+                            
+                            if (dccData.groupExists(text) && text !== model.display) {
+                                showAlert = true
+                                alertText = qsTr("The group name has been used")
+                                readOnly = false
+                                return
+                            }
+                            
                             if (model.display.length < 1)
                                 dccData.createGroup(text)
                             else
                                 dccData.modifyGroup(model.display, text)
                         }
                         onFocusChanged: {
-                            if (focus || text.length > 0 || editLabel.readonly)
+                            if (focus || text.length > 0 || editLabel.readOnly)
                                 return
 
                             if (model.display.length < 1) {
@@ -734,6 +802,8 @@ DccObject {
                             text = model.display
                         }
                         Component.onCompleted: {
+                            lastValidText = model.display
+                            
                             if (editLabel.readOnly)
                                 return
 
@@ -741,6 +811,7 @@ DccObject {
                                 editLabel.focus = true
                             })
                         }
+                    }
                     }
 
                     ActionButton {

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">اسم المستخدم طويل جدًا</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">اسم المستخدم الكاملtoo long</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Пълното име е прекалено дълго</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">মোট নাম খুব দীর্ঘ</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3037,12 +3053,12 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">মধ্যরেখা</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">মধ্যরেখা</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation>El nom complet és massa llarg.</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Celé jméno je příliš dlouhé</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Det fulde navn er for langt</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Der vollständige Name ist zu lang</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Το πλήρες όνομα είναι πολύ μεγάλο</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">The full name is too long</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">The full name is too long</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">El nombre completo es muy largo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3022,12 +3038,12 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Medio</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Medio</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Täielik nimi on liiga pikk</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3014,12 +3030,12 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mõistlik</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Mõistlik</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Nimesi on liian pitkä</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">El nombre completo es demasiado largo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">O nome completo é moi lonxe</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3036,12 +3052,12 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Medio</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Medio</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">שם מלא הוא מדי ארוך</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Puno ime je predugo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">A teljes nev túl hosszú</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Nama lengkap terlalu panjang</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">フルネームが長すぎます</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">სრული სახელი ძალიან გრძელია</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Толық аты-жөні толған</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3007,12 +3023,12 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Мындай</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Мындай</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">전체 이름이 너무 길�습니다</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Vardas yra per ilgas</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Бүтэн нэр хэтэрхий урт байна</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Nama penuh terlalu panjang</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">ਪੂਰਾ ਨਾਂ ਬਹੁਤ ਲੰਮਾ ਹੈ</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation>Imię i nazwisko jest za długie</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">O nome completo é muito comprido</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">O nome completo é muito longo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Numele complet este prea lung</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Имя слишком длинное</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">සම්පූර්ණ නම දිග වැඩිය</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Celé meno je príliš dlhé</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Ime je preprosto dolgo</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3010,12 +3026,12 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Srednji</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Srednji</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Emri i plotë është shumë i gjatë</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Пуно име је предугачко</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Komplettera namnet är för långt</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">ชื่อจริงยาวเกินไป</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Tam isim çok uzun</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">تولۇق ئىسمى بەك ئۇزۇن</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Ім&apos;я повністю є надто довгим</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation type="unfinished">Tên đầy đủ quá dài</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>
@@ -3033,12 +3049,12 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Medium</source>
         <comment>describe size of window rounded corners</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Trung bình中</translation>
     </message>
     <message>
         <source>Medium</source>
         <comment>describe height of window title bar</comment>
-        <translation type="unfinished"></translation>
+        <translation type="unfinished">Trung bình中</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -83,6 +83,22 @@
         <source>The full name is too long</source>
         <translation>名称过长</translation>
     </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation>组名不允许超出32个字符</translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation>组名不能使用纯数字</translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation>仅使用字母、数字、下划线和破折号，并且必需以字母开头</translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation>组名与其他组名重复</translation>
+    </message>
 </context>
 <context>
     <name>AddFaceinfoDialog</name>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -1,133 +1,149 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="zh_HK" version="2.1">
-    <context>
-        <name>AccountSettings</name>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Add new user</source>
-            <translation>添加新用户</translation>
-        </message>
-        <message>
-            <source>Set fullname</source>
-            <translation>設置全名</translation>
-        </message>
-        <message>
-            <source>Login settings</source>
-            <translation>登錄設置</translation>
-        </message>
-        <message>
-            <source>Login Settings</source>
-            <translation>登錄設置</translation>
-        </message>
-        <message>
-            <source>Login without password</source>
-            <translation>免密登錄</translation>
-        </message>
-        <message>
-            <source>Delete current account</source>
-            <translation>刪除當前賬户</translation>
-        </message>
-        <message>
-            <source>Group setting</source>
-            <translation>用户組設置</translation>
-        </message>
-        <message>
-            <source>Account groups</source>
-            <translation>用户組</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>Group name</source>
-            <translation>用户組名稱</translation>
-        </message>
-        <message>
-            <source>Add group</source>
-            <translation>添加用户組</translation>
-        </message>
-        <message>
-            <source>Auto login, login without password</source>
-            <translation>自動登錄, 免密登錄</translation>
-        </message>
-        <message>
-            <source>Auto login</source>
-            <translation>自動登錄</translation>
-        </message>
-        <message>
-            <source>Account Information</source>
-            <translation>賬户信息</translation>
-        </message>
-        <message>
-            <source>Account name, account fullname, account type</source>
-            <translation>賬户名，全名，賬户類型</translation>
-        </message>
-        <message>
-            <source>Account name</source>
-            <translation>賬户名</translation>
-        </message>
-        <message>
-            <source>Account fullname</source>
-            <translation>賬户全名</translation>
-        </message>
-        <message>
-            <source>Account type</source>
-            <translation>賬户類型</translation>
-        </message>
-        <message>
-            <source>The full name is too long</source>
-            <translation>名稱過長</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddFaceinfoDialog</name>
-        <message>
-            <source>Enroll Face</source>
-            <translation>添加人臉數據</translation>
-        </message>
-        <message>
-            <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
-            <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
-        </message>
-        <message>
-            <source>I have read and agree to the</source>
-            <translation>我已閲讀並同意</translation>
-        </message>
-        <message>
-            <source>Disclaimer</source>
-            <translation>《用户免責聲明》</translation>
-        </message>
-        <message>
-            <source>Next</source>
-            <translation>下一步</translation>
-        </message>
-        <message>
-            <source>Face enrolled</source>
-            <translation>人臉錄入完成</translation>
-        </message>
-        <message>
-            <source>Failed to enroll your face</source>
-            <translation>人臉錄入失敗</translation>
-        </message>
-        <message>
-            <source>Done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Retry Enroll</source>
-            <translation>重新錄入</translation>
-        </message>
-        <message>
-            <source>Before using face recognition, please note that: 
+<TS version="2.1" language="zh_HK">
+<context>
+    <name>AccountSettings</name>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Add new user</source>
+        <translation>添加新用户</translation>
+    </message>
+    <message>
+        <source>Set fullname</source>
+        <translation>設置全名</translation>
+    </message>
+    <message>
+        <source>Login settings</source>
+        <translation>登錄設置</translation>
+    </message>
+    <message>
+        <source>Login Settings</source>
+        <translation>登錄設置</translation>
+    </message>
+    <message>
+        <source>Login without password</source>
+        <translation>免密登錄</translation>
+    </message>
+    <message>
+        <source>Delete current account</source>
+        <translation>刪除當前賬户</translation>
+    </message>
+    <message>
+        <source>Group setting</source>
+        <translation>用户組設置</translation>
+    </message>
+    <message>
+        <source>Account groups</source>
+        <translation>用户組</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>Group name</source>
+        <translation>用户組名稱</translation>
+    </message>
+    <message>
+        <source>Add group</source>
+        <translation>添加用户組</translation>
+    </message>
+    <message>
+        <source>Auto login, login without password</source>
+        <translation>自動登錄, 免密登錄</translation>
+    </message>
+    <message>
+        <source>Auto login</source>
+        <translation>自動登錄</translation>
+    </message>
+    <message>
+        <source>Account Information</source>
+        <translation>賬户信息</translation>
+    </message>
+    <message>
+        <source>Account name, account fullname, account type</source>
+        <translation>賬户名，全名，賬户類型</translation>
+    </message>
+    <message>
+        <source>Account name</source>
+        <translation>賬户名</translation>
+    </message>
+    <message>
+        <source>Account fullname</source>
+        <translation>賬户全名</translation>
+    </message>
+    <message>
+        <source>Account type</source>
+        <translation>賬户類型</translation>
+    </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation>名稱過長</translation>
+    </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AddFaceinfoDialog</name>
+    <message>
+        <source>Enroll Face</source>
+        <translation>添加人臉數據</translation>
+    </message>
+    <message>
+        <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
+        <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
+    </message>
+    <message>
+        <source>I have read and agree to the</source>
+        <translation>我已閲讀並同意</translation>
+    </message>
+    <message>
+        <source>Disclaimer</source>
+        <translation>《用户免責聲明》</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>下一步</translation>
+    </message>
+    <message>
+        <source>Face enrolled</source>
+        <translation>人臉錄入完成</translation>
+    </message>
+    <message>
+        <source>Failed to enroll your face</source>
+        <translation>人臉錄入失敗</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Retry Enroll</source>
+        <translation>重新錄入</translation>
+    </message>
+    <message>
+        <source>Before using face recognition, please note that: 
 1. Your device may be unlocked by people or objects that look or appear similar to you.
 2. Face recognition is less secure than digital passwords and mixed passwords.
 3. The success rate of unlocking your device through face recognition will be reduced in a low-light, high-light, back-light, large angle scenario and other scenarios.
@@ -138,7 +154,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-            <translation>在使用人臉識別功能前，請注意以下事項：
+        <translation>在使用人臉識別功能前，請注意以下事項：
 1.您的設備可能會被容貌、外形與您相近的人或物品解鎖。
 2.人臉識別的安全性低於數字密碼、混合密碼。
 3.在暗光、強光、逆光或角度過大等場景下，人臉識別的解鎖成功率會有所降低。
@@ -149,3983 +165,3983 @@ In order to better use of face recognition, please pay attention to the followin
 1.請保證光線充足，避免陽光直射並避免其他人出現在錄入的畫面中。
 2.請注意錄入數據時的面部狀態，避免衣帽、頭髮、墨鏡、口罩、濃妝等遮擋面部信息。
 3.請避免仰頭、低頭、閉眼或僅露出側臉的情況，確保臉部正面清晰完整的出現在提示框內。</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddFingerDialog</name>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>Enroll Finger</source>
-            <translation>添加指紋數據</translation>
-        </message>
-        <message>
-            <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-            <translation>將要錄入的手指放入指紋錄入器裏面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
-        </message>
-        <message>
-            <source>I have read and agree to the</source>
-            <translation>我已閲讀並同意</translation>
-        </message>
-        <message>
-            <source>Disclaimer</source>
-            <translation>《用户免責聲明》</translation>
-        </message>
-        <message>
-            <source>Next</source>
-            <translation>下一步</translation>
-        </message>
-        <message>
-            <source>Retry Enroll</source>
-            <translation>重新錄入</translation>
-        </message>
-        <message>
-            <source>"Biometric authentication" is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through "biometric authentication", the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
+    </message>
+</context>
+<context>
+    <name>AddFingerDialog</name>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>Enroll Finger</source>
+        <translation>添加指紋數據</translation>
+    </message>
+    <message>
+        <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
+        <translation>將要錄入的手指放入指紋錄入器裏面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
+    </message>
+    <message>
+        <source>I have read and agree to the</source>
+        <translation>我已閲讀並同意</translation>
+    </message>
+    <message>
+        <source>Disclaimer</source>
+        <translation>《用户免責聲明》</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>下一步</translation>
+    </message>
+    <message>
+        <source>Retry Enroll</source>
+        <translation>重新錄入</translation>
+    </message>
+    <message>
+        <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
-UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through "Service and Support" in the UOS.</source>
-            <translation>「生物認證」是統信軟件技術有限公司提供的一種對用户進行身份認證的功能。通過「生物認證」，將採集的生物識別數據與存儲在設備本地的生物識別數據進行比對，並根據比對結果來驗證用户身份。
+UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
+        <translation>「生物認證」是統信軟件技術有限公司提供的一種對用户進行身份認證的功能。通過「生物認證」，將採集的生物識別數據與存儲在設備本地的生物識別數據進行比對，並根據比對結果來驗證用户身份。
         請您注意，統信軟件不會收集或訪問您的生物識別信息，此類信息將會存儲在您的本地設備中。請您僅在您的個人設備中開啓生物認證功能，並使用您本人的生物識別信息進行相關操作，並及時在該設備上禁用或清除他人的生物識別信息，否則由此給您帶來的風險將由您承擔。
         統信軟件致力於研究與提高生物認證功能的安全性、精確性、與穩定性，但是，受限於環境、設備、技術等因素和風險控制等原因，我們暫時無法保證您一定能通過生物認證，請您不要將生物認證作為登錄統信作業系統的唯一途徑。若您在使用生物認證時有任何問題或建議的，可以通過系統內的「服務與支持」進行反饋。</translation>
-        </message>
-    </context>
-    <context>
-        <name>AutoLoginWarningDialog</name>
-        <message>
-            <source>"Auto Login" can be enabled for only one account, please disable it for the account "%1" first</source>
-            <translation>只允許一個賬户開啓自動登錄，請先關閉%1賬户的自動登錄，再進行操作</translation>
-        </message>
-        <message>
-            <source>Ok</source>
-            <translation>確 定</translation>
-        </message>
-    </context>
-    <context>
-        <name>AvatarSettingsDialog</name>
-        <message>
-            <source>Images</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Human</source>
-            <translation>人物</translation>
-        </message>
-        <message>
-            <source>Animal</source>
-            <translation>動物</translation>
-        </message>
-        <message>
-            <source>Scenery</source>
-            <translation>靜物</translation>
-        </message>
-        <message>
-            <source>Illustration</source>
-            <translation>創意插圖</translation>
-        </message>
-        <message>
-            <source>Emoji</source>
-            <translation>表情符號</translation>
-        </message>
-        <message>
-            <source>custom</source>
-            <translation>自定義圖片</translation>
-        </message>
-        <message>
-            <source>Cartoon style</source>
-            <translation>Q版風格</translation>
-        </message>
-        <message>
-            <source>Dimensional style</source>
-            <translation>立體風格</translation>
-        </message>
-        <message>
-            <source>Flat style</source>
-            <translation>平面風格</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>保存</translation>
-        </message>
-    </context>
-    <context>
-        <name>BatteryPage</name>
-        <message>
-            <source>Screen and Suspend</source>
-            <translation>屏幕和待機</translation>
-        </message>
-        <message>
-            <source>Turn off the monitor after</source>
-            <translation>關閉顯示器</translation>
-        </message>
-        <message>
-            <source>Lock screen after</source>
-            <translation>自動鎖屏</translation>
-        </message>
-        <message>
-            <source>Computer suspends after</source>
-            <translation>進入待機</translation>
-        </message>
-        <message>
-            <source>When the lid is closed</source>
-            <translation>筆記本合蓋時</translation>
-        </message>
-        <message>
-            <source>When the power button is pressed</source>
-            <translation>按電源按鈕時</translation>
-        </message>
-        <message>
-            <source>Low Battery</source>
-            <translation>低電量管理</translation>
-        </message>
-        <message>
-            <source>Low battery notification</source>
-            <translation>低電量提醒</translation>
-        </message>
-        <message>
-            <source>Auto suspend</source>
-            <translation>自動待機</translation>
-        </message>
-        <message>
-            <source>Auto Hibernate</source>
-            <translation>自動休眠</translation>
-        </message>
-        <message>
-            <source>Low battery threshold</source>
-            <translation>低電量閾值</translation>
-        </message>
-        <message>
-            <source>Battery Management</source>
-            <translation>電池管理</translation>
-        </message>
-        <message>
-            <source>Display remaining using and charging time</source>
-            <translation>顯示剩餘使用時間及剩餘充電時間</translation>
-        </message>
-        <message>
-            <source>Maximum capacity</source>
-            <translation>最大容量</translation>
-        </message>
-        <message>
-            <source>Low battery level</source>
-            <translation>低電量時</translation>
-        </message>
-        <message>
-            <source>Disable</source>
-            <translation>從不</translation>
-        </message>
-    </context>
-    <context>
-        <name>BlueToothAdaptersModel</name>
-        <message>
-            <source>Bluetooth is turned off, and the name is displayed as "%1"</source>
-            <translation>藍牙已關閉，名稱顯示為"%1"</translation>
-        </message>
-        <message>
-            <source>Bluetooth is turned on, and the name is displayed as "%1"</source>
-            <translation>藍牙已打開，名稱顯示為 "%1"</translation>
-        </message>
-    </context>
-    <context>
-        <name>BlueToothDeviceListView</name>
-        <message>
-            <source>Disconnect</source>
-            <translation>斷開連接</translation>
-        </message>
-        <message>
-            <source>Connect</source>
-            <translation>連接</translation>
-        </message>
-        <message>
-            <source>Send Files</source>
-            <translation>發送文件</translation>
-        </message>
-        <message>
-            <source>Rename</source>
-            <translation>重命名</translation>
-        </message>
-        <message>
-            <source>Remove Device</source>
-            <translation>移除設備</translation>
-        </message>
-        <message>
-            <source>Select file</source>
-            <translation>選擇文件</translation>
-        </message>
-    </context>
-    <context>
-        <name>BluetoothCtl</name>
-        <message>
-            <source>Edit</source>
-            <translation>修改</translation>
-        </message>
-        <message>
-            <source>Allow other Bluetooth devices to find this device</source>
-            <translation>允許其他藍牙設備找到該設備</translation>
-        </message>
-        <message>
-            <source>To use the Bluetooth function, please turn off</source>
-            <translation>如需使用藍牙功能，請關閉</translation>
-        </message>
-        <message>
-            <source>Airplane Mode</source>
-            <translation>飛行模式</translation>
-        </message>
-        <message>
-            <source>Bluetooth name cannot exceed 64 characters</source>
-            <translation>藍牙名稱不能超過64個字符</translation>
-        </message>
-    </context>
-    <context>
-        <name>BluetoothDeviceModel</name>
-        <message>
-            <source>Connected</source>
-            <translation>已連接</translation>
-        </message>
-        <message>
-            <source>Not connected</source>
-            <translation>未連接</translation>
-        </message>
-    </context>
-    <context>
-        <name>BootPage</name>
-        <message>
-            <source>Startup Settings</source>
-            <translation>啓動設置</translation>
-        </message>
-        <message>
-            <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-            <translation>您可以點擊菜單改變默認啓動項，也可以拖拽圖片到窗口改變背景圖片.</translation>
-        </message>
-        <message>
-            <source>grub start delay</source>
-            <translation>啓動延時</translation>
-        </message>
-        <message>
-            <source>theme</source>
-            <translation>主題</translation>
-        </message>
-        <message>
-            <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-            <translation>開啓主題後您可以在開機時看到主題背景</translation>
-        </message>
-        <message>
-            <source>Boot menu verification</source>
-            <translation>啓動菜單驗證</translation>
-        </message>
-        <message>
-            <source>After opening, entering the menu editing requires a password.</source>
-            <translation>開啓後進入啓動菜單編輯需要密碼.</translation>
-        </message>
-        <message>
-            <source>Change Password</source>
-            <translation>修改密碼</translation>
-        </message>
-        <message>
-            <source>Change boot menu verification password</source>
-            <translation>修改啓動菜單驗證密碼</translation>
-        </message>
-        <message>
-            <source>Set the boot menu authentication password</source>
-            <translation>設置啓動菜單驗證密碼</translation>
-        </message>
-        <message>
-            <source>User Name :</source>
-            <translation>用户名：</translation>
-        </message>
-        <message>
-            <source>root</source>
-            <translation>root</translation>
-        </message>
-        <message>
-            <source>New Password :</source>
-            <translation>新密碼：</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Passwords do not match</source>
-            <translation>密碼不一致</translation>
-        </message>
-        <message>
-            <source>Repeat password:</source>
-            <translation>確認密碼：</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Sure</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <source>Start animation</source>
-            <translation>啓動動畫</translation>
-        </message>
-        <message>
-            <source>Adjust the size of the logo animation on the system startup interface</source>
-            <translation>調整系統啓動界面的logo動畫尺寸大小</translation>
-        </message>
-    </context>
-    <context>
-        <name>Camera</name>
-        <message>
-            <source>Allow below apps to access your camera:</source>
-            <translation>允許下面的應用訪問您的攝像頭</translation>
-        </message>
-    </context>
-    <context>
-        <name>CharaMangerModel</name>
-        <message>
-            <source>Fingerprint1</source>
-            <translation>指紋1</translation>
-        </message>
-        <message>
-            <source>Fingerprint2</source>
-            <translation>指紋2</translation>
-        </message>
-        <message>
-            <source>Fingerprint3</source>
-            <translation>指紋3</translation>
-        </message>
-        <message>
-            <source>Fingerprint4</source>
-            <translation>指紋4</translation>
-        </message>
-        <message>
-            <source>Fingerprint5</source>
-            <translation>指紋5</translation>
-        </message>
-        <message>
-            <source>Fingerprint6</source>
-            <translation>指紋6</translation>
-        </message>
-        <message>
-            <source>Fingerprint7</source>
-            <translation>指紋7</translation>
-        </message>
-        <message>
-            <source>Fingerprint8</source>
-            <translation>指紋8</translation>
-        </message>
-        <message>
-            <source>Fingerprint9</source>
-            <translation>指紋9</translation>
-        </message>
-        <message>
-            <source>Fingerprint10</source>
-            <translation>指紋10</translation>
-        </message>
-        <message>
-            <source>Scan failed</source>
-            <translation>指紋錄入失敗</translation>
-        </message>
-        <message>
-            <source>The fingerprint already exists</source>
-            <translation>指紋已存在</translation>
-        </message>
-        <message>
-            <source>Please scan other fingers</source>
-            <translation>請使用其他手指錄入</translation>
-        </message>
-        <message>
-            <source>Unknown error</source>
-            <translation>未知錯誤</translation>
-        </message>
-        <message>
-            <source>Scan suspended</source>
-            <translation>指紋錄入被中斷</translation>
-        </message>
-        <message>
-            <source>Cannot recognize</source>
-            <translation>無法識別</translation>
-        </message>
-        <message>
-            <source>Moved too fast</source>
-            <translation>接觸時間短</translation>
-        </message>
-        <message>
-            <source>Finger moved too fast, please do not lift until prompted</source>
-            <translation>接觸時間短，驗證時請勿移動手指</translation>
-        </message>
-        <message>
-            <source>Unclear fingerprint</source>
-            <translation>圖像模糊</translation>
-        </message>
-        <message>
-            <source>Clean your finger or adjust the finger position, and try again</source>
-            <translation>請清潔手指或調整觸摸位置，再次按壓指紋識別器</translation>
-        </message>
-        <message>
-            <source>Already scanned</source>
-            <translation>圖像重複</translation>
-        </message>
-        <message>
-            <source>Adjust the finger position to scan your fingerprint fully</source>
-            <translation>請調整手指按壓區域以錄入更多指紋</translation>
-        </message>
-        <message>
-            <source>Finger moved too fast. Please do not lift until prompted</source>
-            <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
-        </message>
-        <message>
-            <source>Lift your finger and place it on the sensor again</source>
-            <translation>請擡起手指，再次按壓</translation>
-        </message>
-        <message>
-            <source>Position your face inside the frame</source>
-            <translation>請確保您的面部全部顯示在識別區域內</translation>
-        </message>
-        <message>
-            <source>Face enrolled</source>
-            <translation>人臉錄入完成</translation>
-        </message>
-        <message>
-            <source>Position a human face please</source>
-            <translation>請使用人類面容</translation>
-        </message>
-        <message>
-            <source>Keep away from the camera</source>
-            <translation>請遠離鏡頭</translation>
-        </message>
-        <message>
-            <source>Get closer to the camera</source>
-            <translation>請靠近鏡頭</translation>
-        </message>
-        <message>
-            <source>Do not position multiple faces inside the frame</source>
-            <translation>請不要多人入鏡</translation>
-        </message>
-        <message>
-            <source>Make sure the camera lens is clean</source>
-            <translation>請確保鏡頭清潔</translation>
-        </message>
-        <message>
-            <source>Do not enroll in dark, bright or backlit environments</source>
-            <translation>請避免在暗光、強光、逆光環境下操作</translation>
-        </message>
-        <message>
-            <source>Keep your face uncovered</source>
-            <translation>請保持面部無遮擋</translation>
-        </message>
-        <message>
-            <source>Scan timed out</source>
-            <translation>錄入超時</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Camera occupied!</source>
-            <translation>攝像頭被佔用！</translation>
-        </message>
-    </context>
-    <context>
-        <name>ColorAndIcons</name>
-        <message>
-            <source>Accent Color</source>
-            <translation>活動用色</translation>
-        </message>
-        <message>
-            <source>Icon Settings</source>
-            <translation>圖標設置</translation>
-        </message>
-        <message>
-            <source>Icon Theme</source>
-            <translation>圖標主題</translation>
-        </message>
-        <message>
-            <source>Customize your theme icon</source>
-            <translation>自定義您的主題圖標</translation>
-        </message>
-        <message>
-            <source>Cursor Theme</source>
-            <translation>光標主題</translation>
-        </message>
-        <message>
-            <source>Customize your theme cursor</source>
-            <translation>自定義您的主題光標</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComfirmDeleteDialog</name>
-        <message>
-            <source>Are you sure you want to delete this account?</source>
-            <translation>您確定要刪除此賬户嗎？</translation>
-        </message>
-        <message>
-            <source>Delete account directory</source>
-            <translation>刪除賬户目錄</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComfirmSafePage</name>
-        <message>
-            <source>Go to settings</source>
-            <translation>去設置</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-    </context>
-    <context>
-        <name>Common</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Repeat delay</source>
-            <translation>重複延遲</translation>
-        </message>
-        <message>
-            <source>Short</source>
-            <translation>短</translation>
-        </message>
-        <message>
-            <source>Long</source>
-            <translation>長</translation>
-        </message>
-        <message>
-            <source>Repeat rate</source>
-            <translation>重複速度</translation>
-        </message>
-        <message>
-            <source>Slow</source>
-            <translation>慢</translation>
-        </message>
-        <message>
-            <source>Fast</source>
-            <translation>快</translation>
-        </message>
-        <message>
-            <source>Numeric Keypad</source>
-            <translation>啓用數字鍵盤</translation>
-        </message>
-        <message>
-            <source>test here</source>
-            <translation>請在此輸入測試</translation>
-        </message>
-        <message>
-            <source>Caps lock prompt</source>
-            <translation>大寫鎖定提示</translation>
-        </message>
-        <message>
-            <source>Scroll Speed</source>
-            <translation>滾動速度</translation>
-        </message>
-        <message>
-            <source>Double Click Speed</source>
-            <translation>雙擊速度</translation>
-        </message>
-        <message>
-            <source>Double Click Test</source>
-            <translation>雙擊測試</translation>
-        </message>
-        <message>
-            <source>Left Hand Mode</source>
-            <translation>左手模式</translation>
-        </message>
-        <message>
-            <source>Enable Keyboard</source>
-            <translation>鍵盤</translation>
-        </message>
-    </context>
-    <context>
-        <name>CommonInfoWork</name>
-        <message>
-            <source>Large size</source>
-            <translation>大尺寸</translation>
-        </message>
-        <message>
-            <source>Small size</source>
-            <translation>小尺寸</translation>
-        </message>
-        <message>
-            <source>Failed to get root access</source>
-            <translation>進入開發者模式失敗</translation>
-        </message>
-        <message>
-            <source>Please sign in to your Union ID first</source>
-            <translation>請先登錄Union ID</translation>
-        </message>
-        <message>
-            <source>Cannot read your PC information</source>
-            <translation>無法獲取硬件信息</translation>
-        </message>
-        <message>
-            <source>No network connection</source>
-            <translation>無網絡連接</translation>
-        </message>
-        <message>
-            <source>Certificate loading failed, unable to get root access</source>
-            <translation>證書加載失敗，無法進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Signature verification failed, unable to get root access</source>
-            <translation>簽名驗證失敗，無法進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Agree and Join User Experience Program</source>
-            <translation>同意並加入用户體驗計劃</translation>
-        </message>
-        <message>
-            <source>The Disclaimer of Developer Mode</source>
-            <translation>開發者模式免責聲明</translation>
-        </message>
-        <message>
-            <source>Agree and Request Root Access</source>
-            <translation>同意並進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Start setting the new boot animation, please wait for a minute</source>
-            <translation>開始設置啓動新動畫，請稍等一會兒</translation>
-        </message>
-        <message>
-            <source>Setting new boot animation finished</source>
-            <translation>新的啓動動畫設置完成</translation>
-        </message>
-        <message>
-            <source>The settings will be applied after rebooting the system</source>
-            <translation>新的設置會在重啓系統後生效</translation>
-        </message>
-    </context>
-    <context>
-        <name>ConfirmManager</name>
-        <message>
-            <source>Password must contain numbers and letters</source>
-            <translation>密碼必須包含數字和字母</translation>
-        </message>
-        <message>
-            <source>Password must be between 8 and 64 characters</source>
-            <translation>密碼長度必須為8~64個字符</translation>
-        </message>
-    </context>
-    <context>
-        <name>CreateAccountDialog</name>
-        <message>
-            <source>Create a new account</source>
-            <translation>創建新用户</translation>
-        </message>
-        <message>
-            <source>Account type</source>
-            <translation>賬户類型</translation>
-        </message>
-        <message>
-            <source>UserName</source>
-            <translation>用户名</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>FullName</source>
-            <translation>全名</translation>
-        </message>
-        <message>
-            <source>Optional</source>
-            <translation>選填</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Create account</source>
-            <translation>創建用户</translation>
-        </message>
-    </context>
-    <context>
-        <name>CustomAvatarEmpatyArea</name>
-        <message>
-            <source>You haven't uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-            <translation>您還沒有上傳過頭像，可點擊或拖拽上傳圖片</translation>
-        </message>
-    </context>
-    <context>
-        <name>DCC_NAMESPACE::SystemInfoModel</name>
-        <message>
-            <source>available</source>
-            <translation>可用</translation>
-        </message>
-    </context>
-    <context>
-        <name>DCC_NAMESPACE::SystemInfoWork</name>
-        <message>
-            <source>https://www.deepin.org/en/agreement/privacy/</source>
-            <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
-        </message>
-        <message>
-            <source>https://www.uniontech.com/agreement/privacy-en</source>
-            <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
-        </message>
-        <message>
-            <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href="%1"&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href="%1"&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;統信軟件非常重視您的私隱。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及存儲您的信息的私隱政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href="%1"&gt;點擊此處&lt;/a&gt;查看我們最新的私隱政策和/或通過訪問 &lt;a href="%1"&gt;%1&lt;/a&gt;在線查看。請您務必認真閲讀、充分理解我們針對客户私隱的做法，如果有任何疑問，請聯繫我們：support@uniontech.com。&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <source>https://www.uniontech.com/agreement/experience-en</source>
-            <translation>https://www.uniontech.com/agreement/experience-cn</translation>
-        </message>
-        <message>
-            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href="%1"&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-            <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。詳細説明請參照Deepin私隱政策 (&lt;a href="%1"&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href="%1"&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。瞭解用户體驗計劃，請訪問：&lt;a href="%1"&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <source>Agree and Join User Experience Program</source>
-            <translation>同意並加入用户體驗計劃</translation>
-        </message>
-    </context>
-    <context>
-        <name>DateTimeSettingDialog</name>
-        <message>
-            <source>Date and time setting</source>
-            <translation>日期和時間設置</translation>
-        </message>
-        <message>
-            <source>Date</source>
-            <translation>日期</translation>
-        </message>
-        <message>
-            <source>Year</source>
-            <translation>年</translation>
-        </message>
-        <message>
-            <source>Month</source>
-            <translation>月</translation>
-        </message>
-        <message>
-            <source>Day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-    </context>
-    <context>
-        <name>DatetimeModel</name>
-        <message>
-            <source>Tomorrow</source>
-            <translation>明天</translation>
-        </message>
-        <message>
-            <source>Yesterday</source>
-            <translation>昨天</translation>
-        </message>
-        <message>
-            <source>Today</source>
-            <translation>今天</translation>
-        </message>
-        <message>
-            <source>%1 hours earlier than local</source>
-            <translation>比本地早了 %1 小時</translation>
-        </message>
-        <message>
-            <source>%1 hours later than local</source>
-            <translation>比本地晚了 %1 小時</translation>
-        </message>
-        <message>
-            <source>Space</source>
-            <translation>空格</translation>
-        </message>
-        <message>
-            <source>Week</source>
-            <translation>星期/周</translation>
-        </message>
-        <message>
-            <source>First day of week</source>
-            <translation>一週首日</translation>
-        </message>
-        <message>
-            <source>Short date</source>
-            <translation>短日期</translation>
-        </message>
-        <message>
-            <source>Long date</source>
-            <translation>長日期</translation>
-        </message>
-        <message>
-            <source>Short time</source>
-            <translation>短時間</translation>
-        </message>
-        <message>
-            <source>Long time</source>
-            <translation>長時間</translation>
-        </message>
-        <message>
-            <source>Currency symbol</source>
-            <translation>貨幣符號</translation>
-        </message>
-        <message>
-            <source>Positive currency</source>
-            <translation>貨幣正數</translation>
-        </message>
-        <message>
-            <source>Negative currency</source>
-            <translation>貨幣負數</translation>
-        </message>
-        <message>
-            <source>Decimal symbol</source>
-            <translation>小數點</translation>
-        </message>
-        <message>
-            <source>Digit grouping symbol</source>
-            <translation>分隔符</translation>
-        </message>
-        <message>
-            <source>Digit grouping</source>
-            <translation>數字分組</translation>
-        </message>
-        <message>
-            <source>Page size</source>
-            <translation>紙張</translation>
-        </message>
-    </context>
-    <context>
-        <name>DatetimeWorker</name>
-        <message>
-            <source>Authentication is required to change NTP server</source>
-            <translation>修改 NTP 地址需要認證</translation>
-        </message>
-    </context>
-    <context>
-        <name>DccColorDialog</name>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>保存</translation>
-        </message>
-    </context>
-    <context>
-        <name>DccWindow</name>
-        <message>
-            <source>Control Center provides the options for system settings.</source>
-            <translation>控制中心提供作業系統的所有設置選項。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDAccountSecurity</name>
-        <message>
-            <source>Bind WeChat</source>
-            <translation>綁定微信</translation>
-        </message>
-        <message>
-            <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-            <translation>通過綁定微信，您可以安全快速地登錄您的%1 ID和本地賬户</translation>
-        </message>
-        <message>
-            <source>Unlinked</source>
-            <translation>未綁定</translation>
-        </message>
-        <message>
-            <source>Unbinding</source>
-            <translation>解綁</translation>
-        </message>
-        <message>
-            <source>Link</source>
-            <translation>去綁定</translation>
-        </message>
-        <message>
-            <source>Are you sure you want to unbind WeChat?</source>
-            <translation>您確定要解綁微信嗎？</translation>
-        </message>
-        <message>
-            <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-            <translation>解綁微信後，您將無法使用微信掃碼登錄%1 ID、微信掃碼登錄本地賬户</translation>
-        </message>
-        <message>
-            <source>Let me think it over</source>
-            <translation>我再想想</translation>
-        </message>
-        <message>
-            <source>Local Account Binding</source>
-            <translation>綁定本地賬户</translation>
-        </message>
-        <message>
-            <source>After binding your local account, you can use the following functions:</source>
-            <translation>綁定本地賬户後，您可以使用如下功能：</translation>
-        </message>
-        <message>
-            <source>WeChat Scan Code Login System</source>
-            <translation>微信掃碼登錄系統</translation>
-        </message>
-        <message>
-            <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-            <translation>使用%1 ID綁定的微信，掃碼登錄本地賬户</translation>
-        </message>
-        <message>
-            <source>Reset password via %1 ID</source>
-            <translation>通過%1 ID重置密碼</translation>
-        </message>
-        <message>
-            <source>Reset your local password via %1 ID in case you forget it.</source>
-            <translation>在您忘記本地賬户密碼時，通過%1 ID重置密碼</translation>
-        </message>
-        <message>
-            <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-            <translation>如需使用上述功能，請前往控制中心-賬户，開啓相應選項</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDInterface</name>
-        <message>
-            <source>deepin</source>
-            <translation>deepin</translation>
-        </message>
-        <message>
-            <source>UOS</source>
-            <translation>UOS</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDLogin</name>
-        <message>
-            <source>Cloud Sync</source>
-            <translation>雲同步</translation>
-        </message>
-        <message>
-            <source>Manage your %1 ID and sync your personal data across devices.
+    </message>
+</context>
+<context>
+    <name>AutoLoginWarningDialog</name>
+    <message>
+        <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
+        <translation>只允許一個賬户開啓自動登錄，請先關閉%1賬户的自動登錄，再進行操作</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>確 定</translation>
+    </message>
+</context>
+<context>
+    <name>AvatarSettingsDialog</name>
+    <message>
+        <source>Images</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Human</source>
+        <translation>人物</translation>
+    </message>
+    <message>
+        <source>Animal</source>
+        <translation>動物</translation>
+    </message>
+    <message>
+        <source>Scenery</source>
+        <translation>靜物</translation>
+    </message>
+    <message>
+        <source>Illustration</source>
+        <translation>創意插圖</translation>
+    </message>
+    <message>
+        <source>Emoji</source>
+        <translation>表情符號</translation>
+    </message>
+    <message>
+        <source>custom</source>
+        <translation>自定義圖片</translation>
+    </message>
+    <message>
+        <source>Cartoon style</source>
+        <translation>Q版風格</translation>
+    </message>
+    <message>
+        <source>Dimensional style</source>
+        <translation>立體風格</translation>
+    </message>
+    <message>
+        <source>Flat style</source>
+        <translation>平面風格</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+</context>
+<context>
+    <name>BatteryPage</name>
+    <message>
+        <source>Screen and Suspend</source>
+        <translation>屏幕和待機</translation>
+    </message>
+    <message>
+        <source>Turn off the monitor after</source>
+        <translation>關閉顯示器</translation>
+    </message>
+    <message>
+        <source>Lock screen after</source>
+        <translation>自動鎖屏</translation>
+    </message>
+    <message>
+        <source>Computer suspends after</source>
+        <translation>進入待機</translation>
+    </message>
+    <message>
+        <source>When the lid is closed</source>
+        <translation>筆記本合蓋時</translation>
+    </message>
+    <message>
+        <source>When the power button is pressed</source>
+        <translation>按電源按鈕時</translation>
+    </message>
+    <message>
+        <source>Low Battery</source>
+        <translation>低電量管理</translation>
+    </message>
+    <message>
+        <source>Low battery notification</source>
+        <translation>低電量提醒</translation>
+    </message>
+    <message>
+        <source>Auto suspend</source>
+        <translation>自動待機</translation>
+    </message>
+    <message>
+        <source>Auto Hibernate</source>
+        <translation>自動休眠</translation>
+    </message>
+    <message>
+        <source>Low battery threshold</source>
+        <translation>低電量閾值</translation>
+    </message>
+    <message>
+        <source>Battery Management</source>
+        <translation>電池管理</translation>
+    </message>
+    <message>
+        <source>Display remaining using and charging time</source>
+        <translation>顯示剩餘使用時間及剩餘充電時間</translation>
+    </message>
+    <message>
+        <source>Maximum capacity</source>
+        <translation>最大容量</translation>
+    </message>
+    <message>
+        <source>Low battery level</source>
+        <translation>低電量時</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>從不</translation>
+    </message>
+</context>
+<context>
+    <name>BlueToothAdaptersModel</name>
+    <message>
+        <source>Bluetooth is turned off, and the name is displayed as &quot;%1&quot;</source>
+        <translation>藍牙已關閉，名稱顯示為&quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Bluetooth is turned on, and the name is displayed as &quot;%1&quot;</source>
+        <translation>藍牙已打開，名稱顯示為 &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>BlueToothDeviceListView</name>
+    <message>
+        <source>Disconnect</source>
+        <translation>斷開連接</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation>連接</translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <translation>發送文件</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>重命名</translation>
+    </message>
+    <message>
+        <source>Remove Device</source>
+        <translation>移除設備</translation>
+    </message>
+    <message>
+        <source>Select file</source>
+        <translation>選擇文件</translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothCtl</name>
+    <message>
+        <source>Edit</source>
+        <translation>修改</translation>
+    </message>
+    <message>
+        <source>Allow other Bluetooth devices to find this device</source>
+        <translation>允許其他藍牙設備找到該設備</translation>
+    </message>
+    <message>
+        <source>To use the Bluetooth function, please turn off</source>
+        <translation>如需使用藍牙功能，請關閉</translation>
+    </message>
+    <message>
+        <source>Airplane Mode</source>
+        <translation>飛行模式</translation>
+    </message>
+    <message>
+        <source>Bluetooth name cannot exceed 64 characters</source>
+        <translation>藍牙名稱不能超過64個字符</translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothDeviceModel</name>
+    <message>
+        <source>Connected</source>
+        <translation>已連接</translation>
+    </message>
+    <message>
+        <source>Not connected</source>
+        <translation>未連接</translation>
+    </message>
+</context>
+<context>
+    <name>BootPage</name>
+    <message>
+        <source>Startup Settings</source>
+        <translation>啓動設置</translation>
+    </message>
+    <message>
+        <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
+        <translation>您可以點擊菜單改變默認啓動項，也可以拖拽圖片到窗口改變背景圖片.</translation>
+    </message>
+    <message>
+        <source>grub start delay</source>
+        <translation>啓動延時</translation>
+    </message>
+    <message>
+        <source>theme</source>
+        <translation>主題</translation>
+    </message>
+    <message>
+        <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
+        <translation>開啓主題後您可以在開機時看到主題背景</translation>
+    </message>
+    <message>
+        <source>Boot menu verification</source>
+        <translation>啓動菜單驗證</translation>
+    </message>
+    <message>
+        <source>After opening, entering the menu editing requires a password.</source>
+        <translation>開啓後進入啓動菜單編輯需要密碼.</translation>
+    </message>
+    <message>
+        <source>Change Password</source>
+        <translation>修改密碼</translation>
+    </message>
+    <message>
+        <source>Change boot menu verification password</source>
+        <translation>修改啓動菜單驗證密碼</translation>
+    </message>
+    <message>
+        <source>Set the boot menu authentication password</source>
+        <translation>設置啓動菜單驗證密碼</translation>
+    </message>
+    <message>
+        <source>User Name :</source>
+        <translation>用户名：</translation>
+    </message>
+    <message>
+        <source>root</source>
+        <translation>root</translation>
+    </message>
+    <message>
+        <source>New Password :</source>
+        <translation>新密碼：</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Passwords do not match</source>
+        <translation>密碼不一致</translation>
+    </message>
+    <message>
+        <source>Repeat password:</source>
+        <translation>確認密碼：</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Sure</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>Start animation</source>
+        <translation>啓動動畫</translation>
+    </message>
+    <message>
+        <source>Adjust the size of the logo animation on the system startup interface</source>
+        <translation>調整系統啓動界面的logo動畫尺寸大小</translation>
+    </message>
+</context>
+<context>
+    <name>Camera</name>
+    <message>
+        <source>Allow below apps to access your camera:</source>
+        <translation>允許下面的應用訪問您的攝像頭</translation>
+    </message>
+</context>
+<context>
+    <name>CharaMangerModel</name>
+    <message>
+        <source>Fingerprint1</source>
+        <translation>指紋1</translation>
+    </message>
+    <message>
+        <source>Fingerprint2</source>
+        <translation>指紋2</translation>
+    </message>
+    <message>
+        <source>Fingerprint3</source>
+        <translation>指紋3</translation>
+    </message>
+    <message>
+        <source>Fingerprint4</source>
+        <translation>指紋4</translation>
+    </message>
+    <message>
+        <source>Fingerprint5</source>
+        <translation>指紋5</translation>
+    </message>
+    <message>
+        <source>Fingerprint6</source>
+        <translation>指紋6</translation>
+    </message>
+    <message>
+        <source>Fingerprint7</source>
+        <translation>指紋7</translation>
+    </message>
+    <message>
+        <source>Fingerprint8</source>
+        <translation>指紋8</translation>
+    </message>
+    <message>
+        <source>Fingerprint9</source>
+        <translation>指紋9</translation>
+    </message>
+    <message>
+        <source>Fingerprint10</source>
+        <translation>指紋10</translation>
+    </message>
+    <message>
+        <source>Scan failed</source>
+        <translation>指紋錄入失敗</translation>
+    </message>
+    <message>
+        <source>The fingerprint already exists</source>
+        <translation>指紋已存在</translation>
+    </message>
+    <message>
+        <source>Please scan other fingers</source>
+        <translation>請使用其他手指錄入</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation>未知錯誤</translation>
+    </message>
+    <message>
+        <source>Scan suspended</source>
+        <translation>指紋錄入被中斷</translation>
+    </message>
+    <message>
+        <source>Cannot recognize</source>
+        <translation>無法識別</translation>
+    </message>
+    <message>
+        <source>Moved too fast</source>
+        <translation>接觸時間短</translation>
+    </message>
+    <message>
+        <source>Finger moved too fast, please do not lift until prompted</source>
+        <translation>接觸時間短，驗證時請勿移動手指</translation>
+    </message>
+    <message>
+        <source>Unclear fingerprint</source>
+        <translation>圖像模糊</translation>
+    </message>
+    <message>
+        <source>Clean your finger or adjust the finger position, and try again</source>
+        <translation>請清潔手指或調整觸摸位置，再次按壓指紋識別器</translation>
+    </message>
+    <message>
+        <source>Already scanned</source>
+        <translation>圖像重複</translation>
+    </message>
+    <message>
+        <source>Adjust the finger position to scan your fingerprint fully</source>
+        <translation>請調整手指按壓區域以錄入更多指紋</translation>
+    </message>
+    <message>
+        <source>Finger moved too fast. Please do not lift until prompted</source>
+        <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
+    </message>
+    <message>
+        <source>Lift your finger and place it on the sensor again</source>
+        <translation>請擡起手指，再次按壓</translation>
+    </message>
+    <message>
+        <source>Position your face inside the frame</source>
+        <translation>請確保您的面部全部顯示在識別區域內</translation>
+    </message>
+    <message>
+        <source>Face enrolled</source>
+        <translation>人臉錄入完成</translation>
+    </message>
+    <message>
+        <source>Position a human face please</source>
+        <translation>請使用人類面容</translation>
+    </message>
+    <message>
+        <source>Keep away from the camera</source>
+        <translation>請遠離鏡頭</translation>
+    </message>
+    <message>
+        <source>Get closer to the camera</source>
+        <translation>請靠近鏡頭</translation>
+    </message>
+    <message>
+        <source>Do not position multiple faces inside the frame</source>
+        <translation>請不要多人入鏡</translation>
+    </message>
+    <message>
+        <source>Make sure the camera lens is clean</source>
+        <translation>請確保鏡頭清潔</translation>
+    </message>
+    <message>
+        <source>Do not enroll in dark, bright or backlit environments</source>
+        <translation>請避免在暗光、強光、逆光環境下操作</translation>
+    </message>
+    <message>
+        <source>Keep your face uncovered</source>
+        <translation>請保持面部無遮擋</translation>
+    </message>
+    <message>
+        <source>Scan timed out</source>
+        <translation>錄入超時</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Camera occupied!</source>
+        <translation>攝像頭被佔用！</translation>
+    </message>
+</context>
+<context>
+    <name>ColorAndIcons</name>
+    <message>
+        <source>Accent Color</source>
+        <translation>活動用色</translation>
+    </message>
+    <message>
+        <source>Icon Settings</source>
+        <translation>圖標設置</translation>
+    </message>
+    <message>
+        <source>Icon Theme</source>
+        <translation>圖標主題</translation>
+    </message>
+    <message>
+        <source>Customize your theme icon</source>
+        <translation>自定義您的主題圖標</translation>
+    </message>
+    <message>
+        <source>Cursor Theme</source>
+        <translation>光標主題</translation>
+    </message>
+    <message>
+        <source>Customize your theme cursor</source>
+        <translation>自定義您的主題光標</translation>
+    </message>
+</context>
+<context>
+    <name>ComfirmDeleteDialog</name>
+    <message>
+        <source>Are you sure you want to delete this account?</source>
+        <translation>您確定要刪除此賬户嗎？</translation>
+    </message>
+    <message>
+        <source>Delete account directory</source>
+        <translation>刪除賬户目錄</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+</context>
+<context>
+    <name>ComfirmSafePage</name>
+    <message>
+        <source>Go to settings</source>
+        <translation>去設置</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>Common</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Repeat delay</source>
+        <translation>重複延遲</translation>
+    </message>
+    <message>
+        <source>Short</source>
+        <translation>短</translation>
+    </message>
+    <message>
+        <source>Long</source>
+        <translation>長</translation>
+    </message>
+    <message>
+        <source>Repeat rate</source>
+        <translation>重複速度</translation>
+    </message>
+    <message>
+        <source>Slow</source>
+        <translation>慢</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation>快</translation>
+    </message>
+    <message>
+        <source>Numeric Keypad</source>
+        <translation>啓用數字鍵盤</translation>
+    </message>
+    <message>
+        <source>test here</source>
+        <translation>請在此輸入測試</translation>
+    </message>
+    <message>
+        <source>Caps lock prompt</source>
+        <translation>大寫鎖定提示</translation>
+    </message>
+    <message>
+        <source>Scroll Speed</source>
+        <translation>滾動速度</translation>
+    </message>
+    <message>
+        <source>Double Click Speed</source>
+        <translation>雙擊速度</translation>
+    </message>
+    <message>
+        <source>Double Click Test</source>
+        <translation>雙擊測試</translation>
+    </message>
+    <message>
+        <source>Left Hand Mode</source>
+        <translation>左手模式</translation>
+    </message>
+    <message>
+        <source>Enable Keyboard</source>
+        <translation>鍵盤</translation>
+    </message>
+</context>
+<context>
+    <name>CommonInfoWork</name>
+    <message>
+        <source>Large size</source>
+        <translation>大尺寸</translation>
+    </message>
+    <message>
+        <source>Small size</source>
+        <translation>小尺寸</translation>
+    </message>
+    <message>
+        <source>Failed to get root access</source>
+        <translation>進入開發者模式失敗</translation>
+    </message>
+    <message>
+        <source>Please sign in to your Union ID first</source>
+        <translation>請先登錄Union ID</translation>
+    </message>
+    <message>
+        <source>Cannot read your PC information</source>
+        <translation>無法獲取硬件信息</translation>
+    </message>
+    <message>
+        <source>No network connection</source>
+        <translation>無網絡連接</translation>
+    </message>
+    <message>
+        <source>Certificate loading failed, unable to get root access</source>
+        <translation>證書加載失敗，無法進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Signature verification failed, unable to get root access</source>
+        <translation>簽名驗證失敗，無法進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Agree and Join User Experience Program</source>
+        <translation>同意並加入用户體驗計劃</translation>
+    </message>
+    <message>
+        <source>The Disclaimer of Developer Mode</source>
+        <translation>開發者模式免責聲明</translation>
+    </message>
+    <message>
+        <source>Agree and Request Root Access</source>
+        <translation>同意並進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Start setting the new boot animation, please wait for a minute</source>
+        <translation>開始設置啓動新動畫，請稍等一會兒</translation>
+    </message>
+    <message>
+        <source>Setting new boot animation finished</source>
+        <translation>新的啓動動畫設置完成</translation>
+    </message>
+    <message>
+        <source>The settings will be applied after rebooting the system</source>
+        <translation>新的設置會在重啓系統後生效</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmManager</name>
+    <message>
+        <source>Password must contain numbers and letters</source>
+        <translation>密碼必須包含數字和字母</translation>
+    </message>
+    <message>
+        <source>Password must be between 8 and 64 characters</source>
+        <translation>密碼長度必須為8~64個字符</translation>
+    </message>
+</context>
+<context>
+    <name>CreateAccountDialog</name>
+    <message>
+        <source>Create a new account</source>
+        <translation>創建新用户</translation>
+    </message>
+    <message>
+        <source>Account type</source>
+        <translation>賬户類型</translation>
+    </message>
+    <message>
+        <source>UserName</source>
+        <translation>用户名</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>FullName</source>
+        <translation>全名</translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation>選填</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Create account</source>
+        <translation>創建用户</translation>
+    </message>
+</context>
+<context>
+    <name>CustomAvatarEmpatyArea</name>
+    <message>
+        <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
+        <translation>您還沒有上傳過頭像，可點擊或拖拽上傳圖片</translation>
+    </message>
+</context>
+<context>
+    <name>DCC_NAMESPACE::SystemInfoModel</name>
+    <message>
+        <source>available</source>
+        <translation>可用</translation>
+    </message>
+</context>
+<context>
+    <name>DCC_NAMESPACE::SystemInfoWork</name>
+    <message>
+        <source>https://www.deepin.org/en/agreement/privacy/</source>
+        <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
+    </message>
+    <message>
+        <source>https://www.uniontech.com/agreement/privacy-en</source>
+        <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;統信軟件非常重視您的私隱。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及存儲您的信息的私隱政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href=&quot;%1&quot;&gt;點擊此處&lt;/a&gt;查看我們最新的私隱政策和/或通過訪問 &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;在線查看。請您務必認真閲讀、充分理解我們針對客户私隱的做法，如果有任何疑問，請聯繫我們：support@uniontech.com。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>https://www.uniontech.com/agreement/experience-en</source>
+        <translation>https://www.uniontech.com/agreement/experience-cn</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
+        <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。詳細説明請參照Deepin私隱政策 (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;開啓用户體驗計劃視為您授權我們收集和使用您的設備及系統信息，以及應用軟件信息，您可以關閉用户體驗計劃以拒絕我們對前述信息的收集和使用。瞭解用户體驗計劃，請訪問：&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Agree and Join User Experience Program</source>
+        <translation>同意並加入用户體驗計劃</translation>
+    </message>
+</context>
+<context>
+    <name>DateTimeSettingDialog</name>
+    <message>
+        <source>Date and time setting</source>
+        <translation>日期和時間設置</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>日期</translation>
+    </message>
+    <message>
+        <source>Year</source>
+        <translation>年</translation>
+    </message>
+    <message>
+        <source>Month</source>
+        <translation>月</translation>
+    </message>
+    <message>
+        <source>Day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+</context>
+<context>
+    <name>DatetimeModel</name>
+    <message>
+        <source>Tomorrow</source>
+        <translation>明天</translation>
+    </message>
+    <message>
+        <source>Yesterday</source>
+        <translation>昨天</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation>今天</translation>
+    </message>
+    <message>
+        <source>%1 hours earlier than local</source>
+        <translation>比本地早了 %1 小時</translation>
+    </message>
+    <message>
+        <source>%1 hours later than local</source>
+        <translation>比本地晚了 %1 小時</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation>空格</translation>
+    </message>
+    <message>
+        <source>Week</source>
+        <translation>星期/周</translation>
+    </message>
+    <message>
+        <source>First day of week</source>
+        <translation>一週首日</translation>
+    </message>
+    <message>
+        <source>Short date</source>
+        <translation>短日期</translation>
+    </message>
+    <message>
+        <source>Long date</source>
+        <translation>長日期</translation>
+    </message>
+    <message>
+        <source>Short time</source>
+        <translation>短時間</translation>
+    </message>
+    <message>
+        <source>Long time</source>
+        <translation>長時間</translation>
+    </message>
+    <message>
+        <source>Currency symbol</source>
+        <translation>貨幣符號</translation>
+    </message>
+    <message>
+        <source>Positive currency</source>
+        <translation>貨幣正數</translation>
+    </message>
+    <message>
+        <source>Negative currency</source>
+        <translation>貨幣負數</translation>
+    </message>
+    <message>
+        <source>Decimal symbol</source>
+        <translation>小數點</translation>
+    </message>
+    <message>
+        <source>Digit grouping symbol</source>
+        <translation>分隔符</translation>
+    </message>
+    <message>
+        <source>Digit grouping</source>
+        <translation>數字分組</translation>
+    </message>
+    <message>
+        <source>Page size</source>
+        <translation>紙張</translation>
+    </message>
+</context>
+<context>
+    <name>DatetimeWorker</name>
+    <message>
+        <source>Authentication is required to change NTP server</source>
+        <translation>修改 NTP 地址需要認證</translation>
+    </message>
+</context>
+<context>
+    <name>DccColorDialog</name>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+</context>
+<context>
+    <name>DccWindow</name>
+    <message>
+        <source>Control Center provides the options for system settings.</source>
+        <translation>控制中心提供作業系統的所有設置選項。</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDAccountSecurity</name>
+    <message>
+        <source>Bind WeChat</source>
+        <translation>綁定微信</translation>
+    </message>
+    <message>
+        <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
+        <translation>通過綁定微信，您可以安全快速地登錄您的%1 ID和本地賬户</translation>
+    </message>
+    <message>
+        <source>Unlinked</source>
+        <translation>未綁定</translation>
+    </message>
+    <message>
+        <source>Unbinding</source>
+        <translation>解綁</translation>
+    </message>
+    <message>
+        <source>Link</source>
+        <translation>去綁定</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to unbind WeChat?</source>
+        <translation>您確定要解綁微信嗎？</translation>
+    </message>
+    <message>
+        <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
+        <translation>解綁微信後，您將無法使用微信掃碼登錄%1 ID、微信掃碼登錄本地賬户</translation>
+    </message>
+    <message>
+        <source>Let me think it over</source>
+        <translation>我再想想</translation>
+    </message>
+    <message>
+        <source>Local Account Binding</source>
+        <translation>綁定本地賬户</translation>
+    </message>
+    <message>
+        <source>After binding your local account, you can use the following functions:</source>
+        <translation>綁定本地賬户後，您可以使用如下功能：</translation>
+    </message>
+    <message>
+        <source>WeChat Scan Code Login System</source>
+        <translation>微信掃碼登錄系統</translation>
+    </message>
+    <message>
+        <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
+        <translation>使用%1 ID綁定的微信，掃碼登錄本地賬户</translation>
+    </message>
+    <message>
+        <source>Reset password via %1 ID</source>
+        <translation>通過%1 ID重置密碼</translation>
+    </message>
+    <message>
+        <source>Reset your local password via %1 ID in case you forget it.</source>
+        <translation>在您忘記本地賬户密碼時，通過%1 ID重置密碼</translation>
+    </message>
+    <message>
+        <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
+        <translation>如需使用上述功能，請前往控制中心-賬户，開啓相應選項</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDInterface</name>
+    <message>
+        <source>deepin</source>
+        <translation>deepin</translation>
+    </message>
+    <message>
+        <source>UOS</source>
+        <translation>UOS</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDLogin</name>
+    <message>
+        <source>Cloud Sync</source>
+        <translation>雲同步</translation>
+    </message>
+    <message>
+        <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-            <translation>管理您的%1 ID，將您的個人數據在不同設備之間同步。
+        <translation>管理您的%1 ID，將您的個人數據在不同設備之間同步。
 登錄%1 ID以獲取瀏覽器、應用商店、服務與支持等眾多應用的個性功能和服務。</translation>
-        </message>
-        <message>
-            <source>Sign In to %1 ID</source>
-            <translation>登錄%1 ID</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDSyncService</name>
-        <message>
-            <source>Auto Sync</source>
-            <translation>自動同步</translation>
-        </message>
-        <message>
-            <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-            <translation>將您的系統設置和個人信息安全地存儲在雲端，並在您不同的設備上保持同步</translation>
-        </message>
-        <message>
-            <source>System Settings</source>
-            <translation>系統設置</translation>
-        </message>
-        <message>
-            <source>Last sync time: %1</source>
-            <translation>最近同步時間：%1</translation>
-        </message>
-        <message>
-            <source>Clear cloud data</source>
-            <translation>清除雲端數據</translation>
-        </message>
-        <message>
-            <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-            <translation>確定要清除您保存在雲端的系統設置和個人數據嗎？</translation>
-        </message>
-        <message>
-            <source>Once the data is cleared, it cannot be recovered!</source>
-            <translation>數據清除後將無法恢復！</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Clear</source>
-            <translation>清除</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDUserInfo</name>
-        <message>
-            <source>Synchronization Service</source>
-            <translation>同步服務</translation>
-        </message>
-        <message>
-            <source>Account and Security</source>
-            <translation>賬户與安全</translation>
-        </message>
-        <message>
-            <source>Sign out</source>
-            <translation>退出登錄</translation>
-        </message>
-        <message>
-            <source>Go to web settings</source>
-            <translation>前往網頁設置</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinWorker</name>
-        <message>
-            <source>encrypt password failed</source>
-            <translation>加密密碼失敗</translation>
-        </message>
-        <message>
-            <source>Wrong password, %1 chances left</source>
-            <translation>密碼錯誤，您還可以嘗試%1次</translation>
-        </message>
-        <message>
-            <source>The login error has reached the limit today. You can reset the password and try again.</source>
-            <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
-        </message>
-        <message>
-            <source>Operation Successful</source>
-            <translation>操作成功</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinidModel</name>
-        <message>
-            <source>Mainland China</source>
-            <translation>中國大陸</translation>
-        </message>
-        <message>
-            <source>Other regions</source>
-            <translation>其他地區</translation>
-        </message>
-        <message>
-            <source>The feature is not available at present, please activate your system first</source>
-            <translation>當前系統未激活，暫無法使用該功能</translation>
-        </message>
-        <message>
-            <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-            <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DetailItem</name>
-        <message>
-            <source>Please choose the default program to open '%1'</source>
-            <translation>選擇打開「%1」的默認程序</translation>
-        </message>
-        <message>
-            <source>add</source>
-            <translation>添加</translation>
-        </message>
-        <message>
-            <source>Open Desktop file</source>
-            <translation>打開Desktop文件</translation>
-        </message>
-        <message>
-            <source>Apps (*.desktop)</source>
-            <translation>應用程式(*.desktop)</translation>
-        </message>
-        <message>
-            <source>All files (*)</source>
-            <translation>所有文件(*)</translation>
-        </message>
-    </context>
-    <context>
-        <name>DevelopModePage</name>
-        <message>
-            <source>Root Access</source>
-            <translation>開發者模式</translation>
-        </message>
-        <message>
-            <source>Request Root Access</source>
-            <translation>進入開發者模式</translation>
-        </message>
-        <message>
-            <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-            <translation>可獲得root使用權限，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
-        </message>
-        <message>
-            <source>Allowed</source>
-            <translation>已進入</translation>
-        </message>
-        <message>
-            <source>Enter</source>
-            <translation>進入</translation>
-        </message>
-        <message>
-            <source>Online</source>
-            <translation>在線激活</translation>
-        </message>
-        <message>
-            <source>Login UOS ID</source>
-            <translation>登錄UOS ID</translation>
-        </message>
-        <message>
-            <source>Offline</source>
-            <translation>離線激活</translation>
-        </message>
-        <message>
-            <source>Import Certificate</source>
-            <translation>導入證書</translation>
-        </message>
-        <message>
-            <source>Select file</source>
-            <translation>選擇文件</translation>
-        </message>
-        <message>
-            <source>Your UOS ID has been logged in, click to enter developer mode</source>
-            <translation>您的UOS ID已登錄，點擊進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Please sign in to your UOS ID first and continue</source>
-            <translation>進入開發者模式需要登錄UOS ID</translation>
-        </message>
-        <message>
-            <source>1.Export PC Info</source>
-            <translation>1.導出機器信息</translation>
-        </message>
-        <message>
-            <source>Export</source>
-            <translation>導出</translation>
-        </message>
-        <message>
-            <source>2.please go to &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-            <translation>2.前往 &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
-        </message>
-        <message>
-            <source>3.Import Certificate</source>
-            <translation>3.導入證書</translation>
-        </message>
-        <message>
-            <source>To install and run unsigned apps, please go to &lt;a href="Security Center"&gt;Security Center&lt;/a&gt; to change the settings.</source>
-            <translation>如需安裝非應用商店來源的應用，前往 &lt;a href="Security Center"&gt;安全中心&lt;/a&gt; 進行設置。</translation>
-        </message>
-        <message>
-            <source>Development and debugging options</source>
-            <translation>開發調試選項</translation>
-        </message>
-        <message>
-            <source>System logging level</source>
-            <translation>系統日誌記錄級別</translation>
-        </message>
-        <message>
-            <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-            <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多存儲空間.</translation>
-        </message>
-        <message>
-            <source>Off</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <source>Debug</source>
-            <translation>調試</translation>
-        </message>
-        <message>
-            <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-            <translation>更改選項處理可能需要一分鐘，收到設置成功提示後，請重啓設備方可生效。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DisclaimerControl</name>
-        <message>
-            <source>Disclaimer</source>
-            <translation>《用户免責聲明》</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Agree</source>
-            <translation>同意</translation>
-        </message>
-    </context>
-    <context>
-        <name>FileAndFolder</name>
-        <message>
-            <source>Allow below apps to access these files and folders:</source>
-            <translation>允許下面的應用訪問您的文件和文件夾</translation>
-        </message>
-        <message>
-            <source>Documents</source>
-            <translation>文檔</translation>
-        </message>
-        <message>
-            <source>Desktop</source>
-            <translation>桌面</translation>
-        </message>
-        <message>
-            <source>Pictures</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Videos</source>
-            <translation>視頻</translation>
-        </message>
-        <message>
-            <source>Music</source>
-            <translation>音樂</translation>
-        </message>
-        <message>
-            <source>Downloads</source>
-            <translation>下載</translation>
-        </message>
-        <message>
-            <source>folder</source>
-            <translation>文件夾</translation>
-        </message>
-    </context>
-    <context>
-        <name>FontSizePage</name>
-        <message>
-            <source>Size</source>
-            <translation>字號</translation>
-        </message>
-        <message>
-            <source>Standard Font</source>
-            <translation>標準字體</translation>
-        </message>
-        <message>
-            <source>Monospaced Font</source>
-            <translation>等寬字體</translation>
-        </message>
-    </context>
-    <context>
-        <name>GeneralPage</name>
-        <message>
-            <source>Power Plans</source>
-            <translation>性能模式</translation>
-        </message>
-        <message>
-            <source>Power Saving Settings</source>
-            <translation>節能設置</translation>
-        </message>
-        <message>
-            <source>Auto power saving on low battery</source>
-            <translation>低電量時自動開啓節能模式</translation>
-        </message>
-        <message>
-            <source>Low battery threshold</source>
-            <translation>低電量閾值</translation>
-        </message>
-        <message>
-            <source>Auto power saving on battery</source>
-            <translation>使用電池時自動開啓節能模式</translation>
-        </message>
-        <message>
-            <source>Wakeup Settings</source>
-            <translation>喚醒設置</translation>
-        </message>
-        <message>
-            <source>Password is required to wake up the computer</source>
-            <translation>待機恢復時需要密碼</translation>
-        </message>
-        <message>
-            <source>Password is required to wake up the monitor</source>
-            <translation>喚醒顯示器時需要密碼</translation>
-        </message>
-        <message>
-            <source>Shutdown Settings</source>
-            <translation>關機設置</translation>
-        </message>
-        <message>
-            <source>Scheduled Shutdown</source>
-            <translation>定時關機</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <source>Repeat</source>
-            <translation>重複</translation>
-        </message>
-        <message>
-            <source>Once</source>
-            <translation>一次</translation>
-        </message>
-        <message>
-            <source>Every day</source>
-            <translation>每天</translation>
-        </message>
-        <message>
-            <source>Working days</source>
-            <translation>工作日</translation>
-        </message>
-        <message>
-            <source>Custom Time</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>Decrease screen brightness on power saver</source>
-            <translation>節能模式時降低屏幕亮度</translation>
-        </message>
-    </context>
-    <context>
-        <name>GestureModel</name>
-        <message>
-            <source>Three-finger</source>
-            <translation>三指</translation>
-        </message>
-        <message>
-            <source>Four-finger</source>
-            <translation>四指</translation>
-        </message>
-        <message>
-            <source>Up</source>
-            <translation>向上</translation>
-        </message>
-        <message>
-            <source>Down</source>
-            <translation>向下</translation>
-        </message>
-        <message>
-            <source>Left</source>
-            <translation>向左</translation>
-        </message>
-        <message>
-            <source>Right</source>
-            <translation>向右</translation>
-        </message>
-        <message>
-            <source>tap</source>
-            <translation>點擊</translation>
-        </message>
-    </context>
-    <context>
-        <name>HomePage</name>
-        <message>
-            <source>,</source>
-            <translation>、</translation>
-        </message>
-        <message>
-            <source>...</source>
-            <translation>等</translation>
-        </message>
-    </context>
-    <context>
-        <name>InterfaceEffectListview</name>
-        <message>
-            <source>Optimal Performance</source>
-            <translation>最佳性能</translation>
-        </message>
-        <message>
-            <source>Balance</source>
-            <translation>均衡</translation>
-        </message>
-        <message>
-            <source>Best Visuals</source>
-            <translation>最佳視覺</translation>
-        </message>
-        <message>
-            <source>Disable all interface and window effects for efficient system performance.</source>
-            <translation>關閉所有界面和窗口特效，保障系統高效運行</translation>
-        </message>
-        <message>
-            <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-            <translation>限制部分窗口特效，保障出色的視覺效果，同時維持系統流暢運行</translation>
-        </message>
-        <message>
-            <source>Enable all interface and window effects for the best visual experience.</source>
-            <translation>啓用所有界面和窗口特效，體驗最佳視覺效果</translation>
-        </message>
-    </context>
-    <context>
-        <name>KeyboardLayout</name>
-        <message>
-            <source>Keyboard layout</source>
-            <translation>鍵盤佈局</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Add the corresponding input method in &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-            <translation>如需添加或切換鍵盤佈局，請同時在 &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt; 輸入法管理 &lt;/a&gt;  中添加對應的輸入法以確保生效</translation>
-        </message>
-        <message>
-            <source>Add new keyboard layout...</source>
-            <translation>添加鍵盤佈局...</translation>
-        </message>
-    </context>
-    <context>
-        <name>LangAndFormat</name>
-        <message>
-            <source>Language</source>
-            <translation>語言</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Other languages</source>
-            <translation>其他語言</translation>
-        </message>
-        <message>
-            <source>add</source>
-            <translation>添加</translation>
-        </message>
-        <message>
-            <source>Region</source>
-            <translation>區域</translation>
-        </message>
-        <message>
-            <source>Area</source>
-            <translation>地區</translation>
-        </message>
-        <message>
-            <source>Operating system and applications may provide you with local content based on your country and region</source>
-            <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
-        </message>
-        <message>
-            <source>Region and format</source>
-            <translation>區域格式</translation>
-        </message>
-        <message>
-            <source>Operating system and applications may set date and time formats based on regional formats</source>
-            <translation>作業系統和某些應用會根據區域格式設置日期和時間格式</translation>
-        </message>
-    </context>
-    <context>
-        <name>LangsChooserDialog</name>
-        <message>
-            <source>Add language</source>
-            <translation>添加語言</translation>
-        </message>
-        <message>
-            <source>Search</source>
-            <translation>搜索</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Add</source>
-            <translation>添加</translation>
-        </message>
-    </context>
-    <context>
-        <name>LayoutsChooser</name>
-        <message>
-            <source>Add language</source>
-            <translation>添加語言</translation>
-        </message>
-        <message>
-            <source>Search</source>
-            <translation>搜索</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Add</source>
-            <translation>添加</translation>
-        </message>
-    </context>
-    <context>
-        <name>LoginMethod</name>
-        <message>
-            <source>Login method</source>
-            <translation>登錄方式</translation>
-        </message>
-        <message>
-            <source>Password, wechat, biometric authentication, security key</source>
-            <translation>密碼，微信掃碼，生物認證，安全密鑰</translation>
-        </message>
-        <message>
-            <source>Password</source>
-            <translation>密碼</translation>
-        </message>
-        <message>
-            <source>Modify password</source>
-            <translation>修改密碼</translation>
-        </message>
-        <message>
-            <source>Validity days</source>
-            <translation>有效天數</translation>
-        </message>
-        <message>
-            <source>Always</source>
-            <translation>長期有效</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogoModule</name>
-        <message>
-            <source>Copyright© 2011-%1 Deepin Community</source>
-            <translation>Copyright © 2011-%1 深度社區</translation>
-        </message>
-        <message>
-            <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
-            <translation>Copyright © 2019-%1 統信軟件技術有限公司</translation>
-        </message>
-    </context>
-    <context>
-        <name>MicrophonePage</name>
-        <message>
-            <source>Automatic Noise Suppression</source>
-            <translation>噪音抑制</translation>
-        </message>
-        <message>
-            <source>Input Volume</source>
-            <translation>輸入音量</translation>
-        </message>
-        <message>
-            <source>Input Level</source>
-            <translation>反饋音量</translation>
-        </message>
-        <message>
-            <source>Input</source>
-            <translation>輸入</translation>
-        </message>
-        <message>
-            <source>No input device for sound found</source>
-            <translation>沒有找到聲音輸入設備</translation>
-        </message>
-        <message>
-            <source>Input Devices</source>
-            <translation>輸入設備</translation>
-        </message>
-    </context>
-    <context>
-        <name>Mouse</name>
-        <message>
-            <source>Mouse</source>
-            <translation>鼠標</translation>
-        </message>
-        <message>
-            <source>Pointer Speed</source>
-            <translation>指針速度</translation>
-        </message>
-        <message>
-            <source>Slow</source>
-            <translation>慢</translation>
-        </message>
-        <message>
-            <source>Fast</source>
-            <translation>快</translation>
-        </message>
-        <message>
-            <source>Pointer Size</source>
-            <translation>指針大小</translation>
-        </message>
-        <message>
-            <source>Short</source>
-            <translation>短</translation>
-        </message>
-        <message>
-            <source>Long</source>
-            <translation>長</translation>
-        </message>
-        <message>
-            <source>Mouse Acceleration</source>
-            <translation>鼠標加速</translation>
-        </message>
-        <message>
-            <source>Disable touchpad when a mouse is connected</source>
-            <translation>插入鼠標時禁用觸摸板</translation>
-        </message>
-        <message>
-            <source>Natural Scrolling</source>
-            <translation>自然滾動</translation>
-        </message>
-    </context>
-    <context>
-        <name>MyDevice</name>
-        <message>
-            <source>My Devices</source>
-            <translation>我的設備</translation>
-        </message>
-    </context>
-    <context>
-        <name>NativeInfoPage</name>
-        <message>
-            <source>UOS</source>
-            <translation>UOS</translation>
-        </message>
-        <message>
-            <source>Computer name</source>
-            <translation>計算機名</translation>
-        </message>
-        <message>
-            <source>It cannot start or end with dashes</source>
-            <translation>計算機名不能以 - 開頭結尾</translation>
-        </message>
-        <message>
-            <source>OS Name</source>
-            <translation>產品名稱</translation>
-        </message>
-        <message>
-            <source>Version</source>
-            <translation>版本號</translation>
-        </message>
-        <message>
-            <source>Edition</source>
-            <translation>版本</translation>
-        </message>
-        <message>
-            <source>Type</source>
-            <translation>類型</translation>
-        </message>
-        <message>
-            <source>bit</source>
-            <translation>位</translation>
-        </message>
-        <message>
-            <source>Authorization</source>
-            <translation>版本授權</translation>
-        </message>
-        <message>
-            <source>System installation time</source>
-            <translation>系統安裝日期</translation>
-        </message>
-        <message>
-            <source>Kernel</source>
-            <translation>內核版本</translation>
-        </message>
-        <message>
-            <source>Graphics Platform</source>
-            <translation>圖形平台</translation>
-        </message>
-        <message>
-            <source>Processor</source>
-            <translation>處理器</translation>
-        </message>
-        <message>
-            <source>Memory</source>
-            <translation>內存</translation>
-        </message>
-        <message>
-            <source>1~63 characters please</source>
-            <translation>計算機名長度必須介於1到63個字符之間</translation>
-        </message>
-    </context>
-    <context>
-        <name>OtherDevice</name>
-        <message>
-            <source>Other Devices</source>
-            <translation>其他設備</translation>
-        </message>
-        <message>
-            <source>Show Bluetooth devices without names</source>
-            <translation>顯示沒有名稱的藍牙設備</translation>
-        </message>
-    </context>
-    <context>
-        <name>PasswordLayout</name>
-        <message>
-            <source>Current password</source>
-            <translation>當前密碼</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>Weak</source>
-            <translation>強度低</translation>
-        </message>
-        <message>
-            <source>Medium</source>
-            <translation>強度中</translation>
-        </message>
-        <message>
-            <source>Strong</source>
-            <translation>強度高</translation>
-        </message>
-        <message>
-            <source>Password</source>
-            <translation>密碼</translation>
-        </message>
-        <message>
-            <source>Repeat Password</source>
-            <translation>重複密碼</translation>
-        </message>
-        <message>
-            <source>Password hint</source>
-            <translation>密碼提示</translation>
-        </message>
-        <message>
-            <source>Optional</source>
-            <translation>選填</translation>
-        </message>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Passwords do not match</source>
-            <translation>密碼不一致</translation>
-        </message>
-        <message>
-            <source>New password should differ from the current one</source>
-            <translation>新密碼和舊密碼不能相同</translation>
-        </message>
-        <message>
-            <source>The hint is visible to all users. Do not include the password here.</source>
-            <translation>密碼提示對所有人可見，切勿包含具體密碼信息</translation>
-        </message>
-    </context>
-    <context>
-        <name>PasswordModifyDialog</name>
-        <message>
-            <source>Modify password</source>
-            <translation>修改密碼</translation>
-        </message>
-        <message>
-            <source>Reset password</source>
-            <translation>重置密碼</translation>
-        </message>
-        <message>
-            <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-            <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
-        </message>
-        <message>
-            <source>Resetting the password will clear the data stored in the keyring.</source>
-            <translation>重設密碼將會清除密鑰環內已存儲的數據</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-    </context>
-    <context>
-        <name>PersonalizationInterface</name>
-        <message>
-            <source>Light</source>
-            <translation>淺色</translation>
-        </message>
-        <message>
-            <source>Auto</source>
-            <translation>自動</translation>
-        </message>
-        <message>
-            <source>Dark</source>
-            <translation>深色</translation>
-        </message>
-    </context>
-    <context>
-        <name>PersonalizationWorker</name>
-        <message>
-            <source>Custom</source>
-            <translation>自定義</translation>
-        </message>
-    </context>
-    <context>
-        <name>PluginArea</name>
-        <message>
-            <source>Plugin Area</source>
-            <translation>插件區域</translation>
-        </message>
-        <message>
-            <source>Select which icons appear in the Dock</source>
-            <translation>選擇顯示在任務欄插件區域的圖標</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerOperatorModel</name>
-        <message>
-            <source>Shut down</source>
-            <translation>關機</translation>
-        </message>
-        <message>
-            <source>Suspend</source>
-            <translation>待機</translation>
-        </message>
-        <message>
-            <source>Hibernate</source>
-            <translation>休眠</translation>
-        </message>
-        <message>
-            <source>Turn off the monitor</source>
-            <translation>關閉顯示器</translation>
-        </message>
-        <message>
-            <source>Show the shutdown Interface</source>
-            <translation>進入關機界面</translation>
-        </message>
-        <message>
-            <source>Do nothing</source>
-            <translation>無任何操作</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerPage</name>
-        <message>
-            <source>Screen and Suspend</source>
-            <translation>屏幕和待機</translation>
-        </message>
-        <message>
-            <source>Turn off the monitor after</source>
-            <translation>關閉顯示器</translation>
-        </message>
-        <message>
-            <source>Lock screen after</source>
-            <translation>自動鎖屏</translation>
-        </message>
-        <message>
-            <source>Computer suspends after</source>
-            <translation>進入待機</translation>
-        </message>
-        <message>
-            <source>When the lid is closed</source>
-            <translation>筆記本合蓋時</translation>
-        </message>
-        <message>
-            <source>When the power button is pressed</source>
-            <translation>按電源按鈕時</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerPlansListview</name>
-        <message>
-            <source>High Performance</source>
-            <translation>高性能模式</translation>
-        </message>
-        <message>
-            <source>Balance Performance</source>
-            <translation>性能模式</translation>
-        </message>
-        <message>
-            <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-            <translation>根據負載情況積極調整運行頻率</translation>
-        </message>
-        <message>
-            <source>Balanced</source>
-            <translation>平衡模式</translation>
-        </message>
-        <message>
-            <source>Power Saver</source>
-            <translation>節能模式</translation>
-        </message>
-        <message>
-            <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-            <translation>性能優先，會顯著提升功耗和發熱</translation>
-        </message>
-        <message>
-            <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-            <translation>兼顧性能和續航，根據使用情況自動調節</translation>
-        </message>
-        <message>
-            <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-            <translation>續航優先，系統會犧牲一些性能表現來降低功耗</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerWorker</name>
-        <message>
-            <source>Minutes</source>
-            <translation>分鐘</translation>
-        </message>
-        <message>
-            <source>Hour</source>
-            <translation>小時</translation>
-        </message>
-        <message>
-            <source>Never</source>
-            <translation>從不</translation>
-        </message>
-    </context>
-    <context>
-        <name>PrivacyPolicyPage</name>
-        <message>
-            <source>Privacy Policy</source>
-            <translation>私隱政策</translation>
-        </message>
-        <message>
-            <source>Copy Link Address</source>
-            <translation>複製連結地址</translation>
-        </message>
-    </context>
-    <context>
-        <name>PwqualityManager</name>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Password must have at least %1 characters</source>
-            <translation>密碼長度不能少於%1個字符</translation>
-        </message>
-        <message>
-            <source>Password must be no more than %1 characters</source>
-            <translation>密碼長度不能超過%1個字符</translation>
-        </message>
-        <message>
-            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
-        </message>
-        <message>
-            <source>No more than %1 palindrome characters please</source>
-            <translation>迴文字符長度不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 monotonic characters please</source>
-            <translation>單調性字符不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 repeating characters please</source>
-            <translation>重複字符不超過%1位</translation>
-        </message>
-        <message>
-            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
-        </message>
-        <message>
-            <source>Password must not contain more than 4 palindrome characters</source>
-            <translation>密碼不得含有連續4個以上的迴文字符</translation>
-        </message>
-        <message>
-            <source>Do not use common words and combinations as password</source>
-            <translation>密碼不能是常見單詞及組合</translation>
-        </message>
-        <message>
-            <source>Create a strong password please</source>
-            <translation>密碼過於簡單，請增加密碼複雜度</translation>
-        </message>
-        <message>
-            <source>It does not meet password rules</source>
-            <translation>密碼不符合安全要求</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <source>Control Center</source>
-            <translation>控制中心</translation>
-        </message>
-        <message>
-            <source>Activated</source>
-            <translation>已激活</translation>
-        </message>
-        <message>
-            <source>View</source>
-            <translation>查看</translation>
-        </message>
-        <message>
-            <source>To be activated</source>
-            <translation>待激活</translation>
-        </message>
-        <message>
-            <source>Activate</source>
-            <translation>激活</translation>
-        </message>
-        <message>
-            <source>Expired</source>
-            <translation>已過期</translation>
-        </message>
-        <message>
-            <source>In trial period</source>
-            <translation>試用期</translation>
-        </message>
-        <message>
-            <source>Trial expired</source>
-            <translation>試用期過期</translation>
-        </message>
-        <message>
-            <source>dde-control-center</source>
-            <translation>控制中心</translation>
-        </message>
-        <message>
-            <source>Touch Screen Settings</source>
-            <translation>觸控屏設置</translation>
-        </message>
-        <message>
-            <source>The settings of touch screen changed</source>
-            <translation>已變更觸控屏設置</translation>
-        </message>
-        <message>
-            <source>This system wallpaper is locked. Please contact your admin.</source>
-            <translation>當前系統壁紙已被鎖定，請聯繫管理員</translation>
-        </message>
-    </context>
-    <context>
-        <name>RegionFormatDialog</name>
-        <message>
-            <source>Regions and formats</source>
-            <translation>區域和格式</translation>
-        </message>
-        <message>
-            <source>Search</source>
-            <translation>搜索</translation>
-        </message>
-        <message>
-            <source>Default formats</source>
-            <translation>默認格式</translation>
-        </message>
-        <message>
-            <source>First day of week</source>
-            <translation>一週第一天</translation>
-        </message>
-        <message>
-            <source>Short date</source>
-            <translation>短日期</translation>
-        </message>
-        <message>
-            <source>Long date</source>
-            <translation>長日期</translation>
-        </message>
-        <message>
-            <source>Short time</source>
-            <translation>短時間</translation>
-        </message>
-        <message>
-            <source>Long time</source>
-            <translation>長時間</translation>
-        </message>
-        <message>
-            <source>Currency symbol</source>
-            <translation>貨幣符號</translation>
-        </message>
-        <message>
-            <source>Digit</source>
-            <translation>數字</translation>
-        </message>
-        <message>
-            <source>Paper size</source>
-            <translation>紙張</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>保存</translation>
-        </message>
-    </context>
-    <context>
-        <name>RegionsChooserWindow</name>
-        <message>
-            <source>Search</source>
-            <translation>搜索</translation>
-        </message>
-    </context>
-    <context>
-        <name>RegisterDialog</name>
-        <message>
-            <source>Set a Password</source>
-            <translation>設置密碼</translation>
-        </message>
-        <message>
-            <source>8-64 characters</source>
-            <translation>請輸入8-64位密碼</translation>
-        </message>
-        <message>
-            <source>Repeat the password</source>
-            <translation>請再次輸入密碼</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Confirm</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <source>Passwords don't match</source>
-            <translation>兩次密碼輸入不一致</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScheduledShutdownDialog</name>
-        <message>
-            <source>Customize repetition time</source>
-            <translation>自定義重複時間</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>保存</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScreenSaverPage</name>
-        <message>
-            <source>Screensaver</source>
-            <translation>屏幕保護</translation>
-        </message>
-        <message>
-            <source>preview</source>
-            <translation>全屏預覽</translation>
-        </message>
-        <message>
-            <source>Personalized screensaver</source>
-            <translation>個性化屏保</translation>
-        </message>
-        <message>
-            <source>setting</source>
-            <translation>設置</translation>
-        </message>
-        <message>
-            <source>idle time</source>
-            <translation>閒置時間</translation>
-        </message>
-        <message>
-            <source>1 minute</source>
-            <translation>1分鐘</translation>
-        </message>
-        <message>
-            <source>5 minute</source>
-            <translation>5分鐘</translation>
-        </message>
-        <message>
-            <source>10 minute</source>
-            <translation>10分鐘</translation>
-        </message>
-        <message>
-            <source>15 minute</source>
-            <translation>15分鐘</translation>
-        </message>
-        <message>
-            <source>30 minute</source>
-            <translation>30分鐘</translation>
-        </message>
-        <message>
-            <source>1 hour</source>
-            <translation>1小時</translation>
-        </message>
-        <message>
-            <source>never</source>
-            <translation>從不</translation>
-        </message>
-        <message>
-            <source>Password required for recovery</source>
-            <translation>恢復時需要密碼</translation>
-        </message>
-        <message>
-            <source>Picture slideshow screensaver</source>
-            <translation>圖片輪播屏保</translation>
-        </message>
-        <message>
-            <source>System screensaver</source>
-            <translation>系統屏保</translation>
-        </message>
-    </context>
-    <context>
-        <name>SearchableListViewPopup</name>
-        <message>
-            <source>Search</source>
-            <translation>搜索</translation>
-        </message>
-        <message>
-            <source>No search results</source>
-            <translation>無搜索結果</translation>
-        </message>
-    </context>
-    <context>
-        <name>ShortcutSettingDialog</name>
-        <message>
-            <source>Add custom shortcut</source>
-            <translation>添加自定義快捷鍵</translation>
-        </message>
-        <message>
-            <source>Name:</source>
-            <translation>名稱：</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>Command:</source>
-            <translation>命令：</translation>
-        </message>
-        <message>
-            <source>Shortcut</source>
-            <translation>快捷鍵</translation>
-        </message>
-        <message>
-            <source>None</source>
-            <translation>無</translation>
-        </message>
-        <message>
-            <source>Please enter a new shortcut</source>
-            <translation>請輸入新的快捷鍵</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Add</source>
-            <translation>添加</translation>
-        </message>
-        <message>
-            <source>Click Add to replace</source>
-            <translation>點擊添加替換</translation>
-        </message>
-    </context>
-    <context>
-        <name>Shortcuts</name>
-        <message>
-            <source>Shortcuts</source>
-            <translation>快捷鍵</translation>
-        </message>
-        <message>
-            <source>System shortcut, custom shortcut</source>
-            <translation>系統快捷鍵、自定義快捷鍵</translation>
-        </message>
-        <message>
-            <source>Search shortcuts</source>
-            <translation>搜索快捷鍵</translation>
-        </message>
-        <message>
-            <source>Custom</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Please enter a new shortcut</source>
-            <translation>請輸入新的快捷鍵</translation>
-        </message>
-        <message>
-            <source>Click</source>
-            <translation>點擊</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>or</source>
-            <translation>或</translation>
-        </message>
-        <message>
-            <source>Replace</source>
-            <translation>替換</translation>
-        </message>
-        <message>
-            <source>Restore default</source>
-            <translation>恢復默認</translation>
-        </message>
-        <message>
-            <source>Add custom shortcut</source>
-            <translation>添加快捷鍵</translation>
-        </message>
-    </context>
-    <context>
-        <name>SoundDevicemanagesPage</name>
-        <message>
-            <source>Output Devices</source>
-            <translation>輸出設備</translation>
-        </message>
-        <message>
-            <source>Select whether to enable the devices</source>
-            <translation>選擇是否啓用設備</translation>
-        </message>
-        <message>
-            <source>Input Devices</source>
-            <translation>輸入設備</translation>
-        </message>
-    </context>
-    <context>
-        <name>SoundEffectsPage</name>
-        <message>
-            <source>Sound Effects</source>
-            <translation>系統音效</translation>
-        </message>
-    </context>
-    <context>
-        <name>SoundModel</name>
-        <message>
-            <source>Boot up</source>
-            <translation>開機</translation>
-        </message>
-        <message>
-            <source>Shut down</source>
-            <translation>關機</translation>
-        </message>
-        <message>
-            <source>Log out</source>
-            <translation>註銷</translation>
-        </message>
-        <message>
-            <source>Wake up</source>
-            <translation>喚醒</translation>
-        </message>
-        <message>
-            <source>Volume +/-</source>
-            <translation>音量調節</translation>
-        </message>
-        <message>
-            <source>Notification</source>
-            <translation>通知</translation>
-        </message>
-        <message>
-            <source>Low battery</source>
-            <translation>電量不足</translation>
-        </message>
-        <message>
-            <source>Send icon in Launcher to Desktop</source>
-            <translation>從啓動器發送圖標到桌面</translation>
-        </message>
-        <message>
-            <source>Empty Trash</source>
-            <translation>清空回收站</translation>
-        </message>
-        <message>
-            <source>Plug in</source>
-            <translation>電源接入</translation>
-        </message>
-        <message>
-            <source>Plug out</source>
-            <translation>電源拔出</translation>
-        </message>
-        <message>
-            <source>Removable device connected</source>
-            <translation>流動裝置接入</translation>
-        </message>
-        <message>
-            <source>Removable device removed</source>
-            <translation>流動裝置拔出</translation>
-        </message>
-        <message>
-            <source>Error</source>
-            <translation>錯誤提示</translation>
-        </message>
-    </context>
-    <context>
-        <name>SpeakerPage</name>
-        <message>
-            <source>Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Output Volume</source>
-            <translation>輸出音量</translation>
-        </message>
-        <message>
-            <source>Volume Boost</source>
-            <translation>音量增強</translation>
-        </message>
-        <message>
-            <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
-            <translation>音量大於100%時可能會導致音效失真，同時損害您的音頻輸出設備</translation>
-        </message>
-        <message>
-            <source>Left</source>
-            <translation>左</translation>
-        </message>
-        <message>
-            <source>Right</source>
-            <translation>右</translation>
-        </message>
-        <message>
-            <source>Output</source>
-            <translation>輸出</translation>
-        </message>
-        <message>
-            <source>No output device for sound found</source>
-            <translation>沒有找到聲音輸出設備</translation>
-        </message>
-        <message>
-            <source>Left Right Balance</source>
-            <translation>左右平衡</translation>
-        </message>
-        <message>
-            <source>Mono audio</source>
-            <translation>單聲道音頻</translation>
-        </message>
-        <message>
-            <source>Merge left and right channels into a single channel</source>
-            <translation>將左聲道和右聲道合併成一個聲道</translation>
-        </message>
-        <message>
-            <source>Auto pause</source>
-            <translation>插拔管理</translation>
-        </message>
-        <message>
-            <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-            <translation>外設插拔時音頻輸出是否自動暫停</translation>
-        </message>
-        <message>
-            <source>Output Devices</source>
-            <translation>輸出設備</translation>
-        </message>
-    </context>
-    <context>
-        <name>SyncInfoListModel</name>
-        <message>
-            <source>Sound</source>
-            <translation>聲音</translation>
-        </message>
-        <message>
-            <source>Power</source>
-            <translation>電源</translation>
-        </message>
-        <message>
-            <source>Mouse</source>
-            <translation>鼠標</translation>
-        </message>
-        <message>
-            <source>Update</source>
-            <translation>更新</translation>
-        </message>
-        <message>
-            <source>Screensaver</source>
-            <translation>屏幕保護</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThemeSelectView</name>
-        <message>
-            <source>More Wallpapers</source>
-            <translation>下載更多</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeAndDate</name>
-        <message>
-            <source>Auto sync time</source>
-            <translation>自動同步配置</translation>
-        </message>
-        <message>
-            <source>Ntp server</source>
-            <translation>伺服器</translation>
-        </message>
-        <message>
-            <source>System date and time</source>
-            <translation>系統日期和時間</translation>
-        </message>
-        <message>
-            <source>Customize</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>Settings</source>
-            <translation>設置</translation>
-        </message>
-        <message>
-            <source>Server address</source>
-            <translation>伺服器地址</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>The ntp server address cannot be empty</source>
-            <translation>NTP 服務地址不能為空</translation>
-        </message>
-        <message>
-            <source>Use 24-hour format</source>
-            <translation>24小時制</translation>
-        </message>
-        <message>
-            <source>system time zone</source>
-            <translation>系統時區</translation>
-        </message>
-        <message>
-            <source>Timezone list</source>
-            <translation>時區列表</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeRange</name>
-        <message>
-            <source>from</source>
-            <translation>從</translation>
-        </message>
-        <message>
-            <source>to</source>
-            <translation>至</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeoutDialog</name>
-        <message>
-            <source>Save the display settings?</source>
-            <translation>是否要保存顯示設置？</translation>
-        </message>
-        <message>
-            <source>Settings will be reverted in %1s.</source>
-            <translation>如無任何操作將在%1秒後還原。</translation>
-        </message>
-        <message>
-            <source>Revert</source>
-            <translation>還原</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>保存</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimezoneDialog</name>
-        <message>
-            <source>Add time zone</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Determine the time zone based on the current location</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Time zone:</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Nearest City:</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>保存</translation>
-        </message>
-    </context>
-    <context>
-        <name>TouchScreen</name>
-        <message>
-            <source>TouchScreen</source>
-            <translation>觸控屏</translation>
-        </message>
-        <message>
-            <source>Set up here when connecting the touch screen</source>
-            <translation>連接觸摸屏時在此處設置</translation>
-        </message>
-    </context>
-    <context>
-        <name>Touchpad</name>
-        <message>
-            <source>Basic Settings</source>
-            <translation>基礎設置</translation>
-        </message>
-        <message>
-            <source>Touchpad</source>
-            <translation>觸控板</translation>
-        </message>
-        <message>
-            <source>Pointer Speed</source>
-            <translation>指針速度</translation>
-        </message>
-        <message>
-            <source>Slow</source>
-            <translation>慢</translation>
-        </message>
-        <message>
-            <source>Fast</source>
-            <translation>快</translation>
-        </message>
-        <message>
-            <source>Disable touchpad during input</source>
-            <translation>輸入時禁用觸摸板</translation>
-        </message>
-        <message>
-            <source>Tap to Click</source>
-            <translation>輕觸以點擊</translation>
-        </message>
-        <message>
-            <source>Natural Scrolling</source>
-            <translation>自然滾動</translation>
-        </message>
-        <message>
-            <source>Gesture</source>
-            <translation>手勢</translation>
-        </message>
-        <message>
-            <source>Three-finger gestures</source>
-            <translation>三指手勢</translation>
-        </message>
-        <message>
-            <source>Four-finger gestures</source>
-            <translation>四指手勢</translation>
-        </message>
-    </context>
-    <context>
-        <name>UserExperienceProgramPage</name>
-        <message>
-            <source>Join User Experience Program</source>
-            <translation>加入用户體驗計劃</translation>
-        </message>
-        <message>
-            <source>Copy Link Address</source>
-            <translation>複製連結地址</translation>
-        </message>
-    </context>
-    <context>
-        <name>VerifyDialog</name>
-        <message>
-            <source>Security Verification</source>
-            <translation>安全驗證</translation>
-        </message>
-        <message>
-            <source>The action is sensitive, please enter the login password first</source>
-            <translation>您正在進行敏感操作，請進行登錄密碼認證</translation>
-        </message>
-        <message>
-            <source>8-64 characters</source>
-            <translation>請輸入8-64位密碼</translation>
-        </message>
-        <message>
-            <source>Forgot Password?</source>
-            <translation>忘記密碼？</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Confirm</source>
-            <translation>確定</translation>
-        </message>
-    </context>
-    <context>
-        <name>WallpaperPage</name>
-        <message>
-            <source>wallpaper</source>
-            <translation>壁紙</translation>
-        </message>
-        <message>
-            <source>Window rounded corners</source>
-            <translation>窗口圓角</translation>
-        </message>
-        <message>
-            <source>My pictures</source>
-            <translation>我的圖片</translation>
-        </message>
-        <message>
-            <source>System Wallpaper</source>
-            <translation>系統壁紙</translation>
-        </message>
-        <message>
-            <source>Solid color wallpaper</source>
-            <translation>純色壁紙</translation>
-        </message>
-        <message>
-            <source>Customizable wallpapers</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>fill style</source>
-            <translation>填充方式</translation>
-        </message>
-        <message>
-            <source>Automatic wallpaper change</source>
-            <translation>自動切換壁紙</translation>
-        </message>
-        <message>
-            <source>never</source>
-            <translation>從不</translation>
-        </message>
-        <message>
-            <source>30 second</source>
-            <translation>30秒</translation>
-        </message>
-        <message>
-            <source>1 minute</source>
-            <translation>1分鐘</translation>
-        </message>
-        <message>
-            <source>5 minute</source>
-            <translation>5分鐘</translation>
-        </message>
-        <message>
-            <source>10 minute</source>
-            <translation>10分鐘</translation>
-        </message>
-        <message>
-            <source>15 minute</source>
-            <translation>15分鐘</translation>
-        </message>
-        <message>
-            <source>30 minute</source>
-            <translation>30分鐘</translation>
-        </message>
-        <message>
-            <source>login</source>
-            <translation>登錄時</translation>
-        </message>
-        <message>
-            <source>wake up</source>
-            <translation>喚醒時</translation>
-        </message>
-        <message>
-            <source>System Wallapers</source>
-            <translation>系統壁紙</translation>
-        </message>
-        <message>
-            <source>Live Wallpaper</source>
-            <translation>動態壁紙</translation>
-        </message>
-        <message>
-            <source>1 hour</source>
-            <translation>1小時</translation>
-        </message>
-    </context>
-    <context>
-        <name>WallpaperSelectView</name>
-        <message>
-            <source>unfold</source>
-            <translation>收起</translation>
-        </message>
-        <message>
-            <source>show all</source>
-            <translation>顯示全部</translation>
-        </message>
-        <message>
-            <source>items</source>
-            <translation>張</translation>
-        </message>
-        <message>
-            <source>Set lock screen</source>
-            <translation>設置鎖屏</translation>
-        </message>
-        <message>
-            <source>Set desktop</source>
-            <translation>設置桌面</translation>
-        </message>
-    </context>
-    <context>
-        <name>WindowEffectPage</name>
-        <message>
-            <source>Interface and Effects</source>
-            <translation>界面效果</translation>
-        </message>
-        <message>
-            <source>Window Settings</source>
-            <translation>窗口設置</translation>
-        </message>
-        <message>
-            <source>Window rounded corners</source>
-            <translation>窗口圓角</translation>
-        </message>
-        <message>
-            <source>None</source>
-            <translation>無</translation>
-        </message>
-        <message>
-            <source>Small</source>
-            <translation>小</translation>
-        </message>
-        <message>
-            <source>Large</source>
-            <translation>大</translation>
-        </message>
-        <message>
-            <source>Enable transparent effects when moving windows</source>
-            <translation>窗口移動時啓用透明特效</translation>
-        </message>
-        <message>
-            <source>Window Minimize Effect</source>
-            <translation>最小化時效果</translation>
-        </message>
-        <message>
-            <source>Scale</source>
-            <translation>縮放</translation>
-        </message>
-        <message>
-            <source>Magic Lamp</source>
-            <translation>魔燈</translation>
-        </message>
-        <message>
-            <source>Opacity</source>
-            <translation>不透明度調節</translation>
-        </message>
-        <message>
-            <source>Low</source>
-            <translation>低</translation>
-        </message>
-        <message>
-            <source>High</source>
-            <translation>高</translation>
-        </message>
-        <message>
-            <source>Scroll Bars</source>
-            <translation>滾動條</translation>
-        </message>
-        <message>
-            <source>Show on scrolling</source>
-            <translation>滾動時顯示</translation>
-        </message>
-        <message>
-            <source>Keep shown</source>
-            <translation>一直顯示</translation>
-        </message>
-        <message>
-            <source>Compact Display</source>
-            <translation>緊湊模式</translation>
-        </message>
-        <message>
-            <source>If enabled, more content is displayed in the window.</source>
-            <translation>開啓後，窗口將顯示更多內容</translation>
-        </message>
-        <message>
-            <source>Title Bar Height</source>
-            <translation>標題欄高度</translation>
-        </message>
-        <message>
-            <source>Only suitable for application window title bars drawn by the window manager.</source>
-            <translation>僅適用於窗口管理器繪製的應用標題欄</translation>
-        </message>
-        <message>
-            <source>Extremely small</source>
-            <translation>極小</translation>
-        </message>
-        <message>
-            <source>Medium</source>
-            <translation>中</translation>
-            <comment>describe size of window rounded corners</comment>
-        </message>
-        <message>
-            <source>Medium</source>
-            <translation>中</translation>
-            <comment>describe height of window title bar</comment>
-        </message>
-    </context>
-    <context>
-        <name>accounts</name>
-        <message>
-            <source>Account</source>
-            <translation>賬户</translation>
-        </message>
-        <message>
-            <source>Account manager</source>
-            <translation>賬户管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>accountsMain</name>
-        <message>
-            <source>Other accounts</source>
-            <translation>其他賬户</translation>
-        </message>
-    </context>
-    <context>
-        <name>authentication</name>
-        <message>
-            <source>Biometric Authentication</source>
-            <translation>生物認證</translation>
-        </message>
-    </context>
-    <context>
-        <name>authenticationMain</name>
-        <message>
-            <source>Biometric Authentication</source>
-            <translation>生物認證</translation>
-        </message>
-        <message>
-            <source>Face</source>
-            <translation>人臉</translation>
-        </message>
-        <message>
-            <source>Up to 5 facial data can be entered</source>
-            <translation>最多可錄入5個人臉數據</translation>
-        </message>
-        <message>
-            <source>Fingerprint</source>
-            <translation>指紋</translation>
-        </message>
-        <message>
-            <source>Identifying user identity through scanning fingerprints</source>
-            <translation>通過對指紋的掃描進行用户身份的識別</translation>
-        </message>
-        <message>
-            <source>Iris</source>
-            <translation>虹膜</translation>
-        </message>
-        <message>
-            <source>Identity recognition through iris scanning</source>
-            <translation>通過掃描虹膜進行身份識別</translation>
-        </message>
-        <message>
-            <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-            <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字符</translation>
-        </message>
-        <message>
-            <source>Use letters, numbers and underscores only</source>
-            <translation>只能由字母、數字、中文、下劃線組成</translation>
-        </message>
-        <message>
-            <source>No more than 15 characters</source>
-            <translation>不得超過15個字符</translation>
-        </message>
-        <message>
-            <source>Add a new</source>
-            <translation>添加新的</translation>
-        </message>
-        <message>
-            <source>This name already exists</source>
-            <translation>該名稱已存在</translation>
-        </message>
-    </context>
-    <context>
-        <name>blueTooth</name>
-        <message>
-            <source>bluetooth</source>
-            <translation>藍牙</translation>
-        </message>
-        <message>
-            <source>Bluetooth settings, devices</source>
-            <translation>藍牙設置、設備管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>commonInfoMain</name>
-        <message>
-            <source>Boot Menu</source>
-            <translation>啓動菜單</translation>
-        </message>
-        <message>
-            <source>Manage your boot menu</source>
-            <translation>管理您的開機啓動菜單</translation>
-        </message>
-        <message>
-            <source>Developer root permission management</source>
-            <translation>開發者Root權限管理</translation>
-        </message>
-        <message>
-            <source>Developer Options</source>
-            <translation>開發者選項</translation>
-        </message>
-    </context>
-    <context>
-        <name>datetime</name>
-        <message>
-            <source>Time and date</source>
-            <translation>時間和日期</translation>
-        </message>
-        <message>
-            <source>Time and date, time zone settings</source>
-            <translation>時間日期、時區設置</translation>
-        </message>
-        <message>
-            <source>Language and region</source>
-            <translation>語言和區域</translation>
-        </message>
-        <message>
-            <source>System language, region format</source>
-            <translation>系統語言、區域格式</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::AccountsController</name>
-        <message>
-            <source>Username must be between 3 and 32 characters</source>
-            <translation>用户名長度必須介於 3 到 32 個字符之間</translation>
-        </message>
-        <message>
-            <source>The first character must be a letter or number</source>
-            <translation>必須字母或者數字開頭</translation>
-        </message>
-        <message>
-            <source>Your username should not only have numbers</source>
-            <translation>用户名不能僅僅是數字</translation>
-        </message>
-        <message>
-            <source>The username has been used by other user accounts</source>
-            <translation>用户名和其他用户名重複</translation>
-        </message>
-        <message>
-            <source>The full name is too long</source>
-            <translation>全名太長了</translation>
-        </message>
-        <message>
-            <source>The full name has been used by other user accounts</source>
-            <translation>全名和其他用户名重複</translation>
-        </message>
-        <message>
-            <source>Wrong password</source>
-            <translation>密碼錯誤</translation>
-        </message>
-        <message>
-            <source>Standard User</source>
-            <translation>標準用户</translation>
-        </message>
-        <message>
-            <source>Administrator</source>
-            <translation>管理員</translation>
-        </message>
-        <message>
-            <source>Customized</source>
-            <translation>自定義</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::AccountsWorker</name>
-        <message>
-            <source>Your host was removed from the domain server successfully</source>
-            <translation>您的主機成功退出了域伺服器</translation>
-        </message>
-        <message>
-            <source>Your host joins the domain server successfully</source>
-            <translation>您的主機成功加入了域伺服器</translation>
-        </message>
-        <message>
-            <source>Your host failed to leave the domain server</source>
-            <translation>您的主機退出域伺服器失敗</translation>
-        </message>
-        <message>
-            <source>Your host failed to join the domain server</source>
-            <translation>您的主機加入域伺服器失敗</translation>
-        </message>
-        <message>
-            <source>AD domain settings</source>
-            <translation>AD域設置</translation>
-        </message>
-        <message>
-            <source>Password not match</source>
-            <translation>密碼不一致</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::AvatarTypesModel</name>
-        <message>
-            <source>Dimensional</source>
-            <translation>立體風格</translation>
-        </message>
-        <message>
-            <source>Flat</source>
-            <translation>平面風格</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::BiometricAuthController</name>
-        <message>
-            <source>Use your face to unlock the device and make settings later</source>
-            <translation>使用人臉數據解鎖您的設備，之後還可進行更多設置</translation>
-        </message>
-        <message>
-            <source>Faceprint</source>
-            <translation>面紋</translation>
-        </message>
-        <message>
-            <source>Place your finger</source>
-            <translation>放置手指</translation>
-        </message>
-        <message>
-            <source>Place your finger firmly on the sensor until you're asked to lift it</source>
-            <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
-        </message>
-        <message>
-            <source>Lift your finger</source>
-            <translation>擡起手指</translation>
-        </message>
-        <message>
-            <source>Lift your finger and place it on the sensor again</source>
-            <translation>請擡起手指，再次按壓</translation>
-        </message>
-        <message>
-            <source>Scan the edges of your fingerprint</source>
-            <translation>錄入邊緣指紋</translation>
-        </message>
-        <message>
-            <source>Adjust the position to scan the edges of your fingerprint</source>
-            <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
-        </message>
-        <message>
-            <source>Lift your finger and do that again</source>
-            <translation>請擡起手指，再次按壓</translation>
-        </message>
-        <message>
-            <source>Fingerprint added</source>
-            <translation>成功添加指紋</translation>
-        </message>
-        <message>
-            <source>Scan Suspended</source>
-            <translation>錄入中斷</translation>
-        </message>
-        <message>
-            <source>Place the edges of your fingerprint on the sensor</source>
-            <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
-        </message>
-        <message>
-            <source>Iris</source>
-            <translation>虹膜</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::KeyboardController</name>
-        <message>
-            <source>This shortcut conflicts with [%1]</source>
-            <translation>此快捷鍵與[%1]衝突</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::PwqualityManager</name>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Password must have at least %1 characters</source>
-            <translation>密碼長度不能少於%1個字符</translation>
-        </message>
-        <message>
-            <source>Password must be no more than %1 characters</source>
-            <translation>密碼長度不能超過%1個字符</translation>
-        </message>
-        <message>
-            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
-        </message>
-        <message>
-            <source>No more than %1 palindrome characters please</source>
-            <translation>迴文字符長度不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 monotonic characters please</source>
-            <translation>單調性字符不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 repeating characters please</source>
-            <translation>重複字符不超過%1位</translation>
-        </message>
-        <message>
-            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
-        </message>
-        <message>
-            <source>Password must not contain more than 4 palindrome characters</source>
-            <translation>密碼不得含有連續4個以上的迴文字符</translation>
-        </message>
-        <message>
-            <source>Do not use common words and combinations as password</source>
-            <translation>密碼不能是常見單詞及組合</translation>
-        </message>
-        <message>
-            <source>Create a strong password please</source>
-            <translation>密碼過於簡單，請增加密碼複雜度</translation>
-        </message>
-        <message>
-            <source>It does not meet password rules</source>
-            <translation>密碼不符合安全要求</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::ShortcutModel</name>
-        <message>
-            <source>System</source>
-            <translation>系統</translation>
-        </message>
-        <message>
-            <source>Window</source>
-            <translation>窗口</translation>
-        </message>
-        <message>
-            <source>Workspace</source>
-            <translation>工作區</translation>
-        </message>
-        <message>
-            <source>AssistiveTools</source>
-            <translation>輔助功能</translation>
-        </message>
-        <message>
-            <source>Custom</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>None</source>
-            <translation>無</translation>
-        </message>
-    </context>
-    <context>
-        <name>deepinid</name>
-        <message>
-            <source>deepin ID</source>
-            <translation>deepin ID</translation>
-        </message>
-        <message>
-            <source>UOS ID</source>
-            <translation>UOS ID</translation>
-        </message>
-        <message>
-            <source>Cloud services</source>
-            <translation>雲服務</translation>
-        </message>
-    </context>
-    <context>
-        <name>defaultapp</name>
-        <message>
-            <source>Default App</source>
-            <translation>默認程序</translation>
-        </message>
-        <message>
-            <source>Set the default application for opening various types of files</source>
-            <translation>設置打開各類文件的默認程序</translation>
-        </message>
-    </context>
-    <context>
-        <name>defaultappMain</name>
-        <message>
-            <source>Webpage</source>
-            <translation>網頁</translation>
-        </message>
-        <message>
-            <source>Mail</source>
-            <translation>郵件</translation>
-        </message>
-        <message>
-            <source>Text</source>
-            <translation>文本</translation>
-        </message>
-        <message>
-            <source>Music</source>
-            <translation>音樂</translation>
-        </message>
-        <message>
-            <source>Video</source>
-            <translation>視頻</translation>
-        </message>
-        <message>
-            <source>Picture</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Terminal</source>
-            <translation>終端</translation>
-        </message>
-    </context>
-    <context>
-        <name>device</name>
-        <message>
-            <source>Device</source>
-            <translation>設備</translation>
-        </message>
-    </context>
-    <context>
-        <name>display</name>
-        <message>
-            <source>Display</source>
-            <translation>顯示</translation>
-        </message>
-        <message>
-            <source>Brightness,resolution,scaling</source>
-            <translation>亮度、解像度、縮放</translation>
-        </message>
-    </context>
-    <context>
-        <name>displayMain</name>
-        <message>
-            <source>100%</source>
-            <translation>100%</translation>
-        </message>
-        <message>
-            <source>125%</source>
-            <translation>125%</translation>
-        </message>
-        <message>
-            <source>150%</source>
-            <translation>150%</translation>
-        </message>
-        <message>
-            <source>175%</source>
-            <translation>175%</translation>
-        </message>
-        <message>
-            <source>200%</source>
-            <translation>200%</translation>
-        </message>
-        <message>
-            <source>225%</source>
-            <translation>225%</translation>
-        </message>
-        <message>
-            <source>250%</source>
-            <translation>250%</translation>
-        </message>
-        <message>
-            <source>275%</source>
-            <translation>275%</translation>
-        </message>
-        <message>
-            <source>300%</source>
-            <translation>300%</translation>
-        </message>
-        <message>
-            <source>Duplicate</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <source>Extend</source>
-            <translation>擴展</translation>
-        </message>
-        <message>
-            <source>Default</source>
-            <translation>默認</translation>
-        </message>
-        <message>
-            <source>Fit</source>
-            <translation>適應</translation>
-        </message>
-        <message>
-            <source>Stretch</source>
-            <translation>拉伸</translation>
-        </message>
-        <message>
-            <source>Center</source>
-            <translation>居中</translation>
-        </message>
-        <message>
-            <source>Only on %1</source>
-            <translation>僅%1屏</translation>
-        </message>
-        <message>
-            <source>(Recommended)</source>
-            <translation>（推薦）</translation>
-        </message>
-        <message>
-            <source>Hz</source>
-            <translation>赫茲</translation>
-        </message>
-        <message>
-            <source>Multiple Displays Settings</source>
-            <translation>多屏設置</translation>
-        </message>
-        <message>
-            <source>Identify</source>
-            <translation>識別</translation>
-        </message>
-        <message>
-            <source>Screen rearrangement will take effect in %1s after changes</source>
-            <translation>屏幕拼接將在修改完成%1s後生效</translation>
-        </message>
-        <message>
-            <source>Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Main Screen</source>
-            <translation>主屏幕</translation>
-        </message>
-        <message>
-            <source>Display And Layout</source>
-            <translation>顯示和佈局</translation>
-        </message>
-        <message>
-            <source>Brightness</source>
-            <translation>亮度</translation>
-        </message>
-        <message>
-            <source>Resolution</source>
-            <translation>解像度</translation>
-        </message>
-        <message>
-            <source>Resize Desktop</source>
-            <translation>桌面顯示</translation>
-        </message>
-        <message>
-            <source>Refresh Rate</source>
-            <translation>刷新率</translation>
-        </message>
-        <message>
-            <source>Rotation</source>
-            <translation>方向</translation>
-        </message>
-        <message>
-            <source>Standard</source>
-            <translation>標準</translation>
-        </message>
-        <message>
-            <source>90°</source>
-            <translation>90度</translation>
-        </message>
-        <message>
-            <source>180°</source>
-            <translation>180度</translation>
-        </message>
-        <message>
-            <source>270°</source>
-            <translation>270度</translation>
-        </message>
-        <message>
-            <source>Display Scaling</source>
-            <translation>縮放</translation>
-        </message>
-        <message>
-            <source>The monitor only supports 100% display scaling</source>
-            <translation>當前屏幕僅支持1倍縮放</translation>
-        </message>
-        <message>
-            <source>Eye Comfort</source>
-            <translation>護眼模式</translation>
-        </message>
-        <message>
-            <source>Enable eye comfort</source>
-            <translation>開啓護眼模式</translation>
-        </message>
-        <message>
-            <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-            <translation>調整屏幕顯示較暖的顏色，減少屏幕藍光</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <source>All day</source>
-            <translation>全天</translation>
-        </message>
-        <message>
-            <source>Sunset to Sunrise</source>
-            <translation>日落到日出</translation>
-        </message>
-        <message>
-            <source>Custom Time</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>from</source>
-            <translation>從</translation>
-        </message>
-        <message>
-            <source>to</source>
-            <translation>至</translation>
-        </message>
-        <message>
-            <source>Color Temperature</source>
-            <translation>色温</translation>
-        </message>
-    </context>
-    <context>
-        <name>dock</name>
-        <message>
-            <source>Desktop and taskbar</source>
-            <translation>桌面和任務欄</translation>
-        </message>
-        <message>
-            <source>Desktop organization, taskbar mode, plugin area settings</source>
-            <translation>桌面整理、任務欄模式、插件區域設置</translation>
-        </message>
-    </context>
-    <context>
-        <name>keyboard</name>
-        <message>
-            <source>Keyboard</source>
-            <translation>鍵盤</translation>
-        </message>
-        <message>
-            <source>General Settings, keyboard layout, input method, shortcuts</source>
-            <translation>通用設置、鍵盤佈局、輸入法、快捷鍵</translation>
-        </message>
-    </context>
-    <context>
-        <name>keyboardMain</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Keyboard layout</source>
-            <translation>鍵盤佈局</translation>
-        </message>
-        <message>
-            <source>Set system default keyboard layout</source>
-            <translation>設置系統默認鍵盤佈局</translation>
-        </message>
-    </context>
-    <context>
-        <name>main</name>
-        <message>
-            <source>Dock</source>
-            <translation>任務欄</translation>
-        </message>
-        <message>
-            <source>Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Classic Mode</source>
-            <translation>經典模式</translation>
-        </message>
-        <message>
-            <source>Centered Mode</source>
-            <translation>居中模式</translation>
-        </message>
-        <message>
-            <source>Dock size</source>
-            <translation>任務欄大小</translation>
-        </message>
-        <message>
-            <source>Small</source>
-            <translation>小</translation>
-        </message>
-        <message>
-            <source>Large</source>
-            <translation>大</translation>
-        </message>
-        <message>
-            <source>Position on the screen</source>
-            <translation>屏幕中的位置</translation>
-        </message>
-        <message>
-            <source>Top</source>
-            <translation>上</translation>
-        </message>
-        <message>
-            <source>Bottom</source>
-            <translation>下</translation>
-        </message>
-        <message>
-            <source>Left</source>
-            <translation>左</translation>
-        </message>
-        <message>
-            <source>Right</source>
-            <translation>右</translation>
-        </message>
-        <message>
-            <source>Status</source>
-            <translation>狀態</translation>
-        </message>
-        <message>
-            <source>Keep shown</source>
-            <translation>一直顯示</translation>
-        </message>
-        <message>
-            <source>Keep hidden</source>
-            <translation>一直隱藏</translation>
-        </message>
-        <message>
-            <source>Smart hide</source>
-            <translation>智能隱藏</translation>
-        </message>
-        <message>
-            <source>Multiple Displays</source>
-            <translation>多屏顯示</translation>
-        </message>
-        <message>
-            <source>Set the position of the taskbar on the screen</source>
-            <translation>設置任務欄在屏幕中的位置</translation>
-        </message>
-        <message>
-            <source>Only on main</source>
-            <translation>僅主屏顯示</translation>
-        </message>
-        <message>
-            <source>On screen where the cursor is</source>
-            <translation>跟隨鼠標位置顯示</translation>
-        </message>
-        <message>
-            <source>Plugin Area</source>
-            <translation>插件區域</translation>
-        </message>
-        <message>
-            <source>Select which icons appear in the Dock</source>
-            <translation>選擇顯示在任務欄插件區域的圖標</translation>
-        </message>
-    </context>
-    <context>
-        <name>mouse</name>
-        <message>
-            <source>Mouse and Touchpad</source>
-            <translation>鼠標與觸控板</translation>
-        </message>
-        <message>
-            <source>Common、Mouse、Touchpad</source>
-            <translation>通用、鼠標、觸控板</translation>
-        </message>
-    </context>
-    <context>
-        <name>mouseMain</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Mouse</source>
-            <translation>鼠標</translation>
-        </message>
-        <message>
-            <source>Touchpad</source>
-            <translation>觸控板</translation>
-        </message>
-    </context>
-    <context>
-        <name>notification</name>
-        <message>
-            <source>DND mode, app notifications</source>
-            <translation>勿擾模式、應用通知</translation>
-        </message>
-        <message>
-            <source>Notification</source>
-            <translation>通知</translation>
-        </message>
-    </context>
-    <context>
-        <name>notificationMain</name>
-        <message>
-            <source>Do Not Disturb Settings</source>
-            <translation>勿擾設置</translation>
-        </message>
-        <message>
-            <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-            <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心查看所有消息。</translation>
-        </message>
-        <message>
-            <source>Enable Do Not Disturb</source>
-            <translation>啓用勿擾模式</translation>
-        </message>
-        <message>
-            <source>When the screen is locked</source>
-            <translation>在屏幕鎖屏時</translation>
-        </message>
-        <message>
-            <source>Number of notifications shown on the desktop</source>
-            <translation>通知橫幅展示數量</translation>
-        </message>
-        <message>
-            <source>App Notifications</source>
-            <translation>應用通知</translation>
-        </message>
-        <message>
-            <source>Allow Notifications</source>
-            <translation>允許通知</translation>
-        </message>
-        <message>
-            <source>Display notification on desktop or show unread messages in the notification center</source>
-            <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
-        </message>
-        <message>
-            <source>Desktop</source>
-            <translation>桌面</translation>
-        </message>
-        <message>
-            <source>Lock Screen</source>
-            <translation>鎖屏</translation>
-        </message>
-        <message>
-            <source>Notification Center</source>
-            <translation>通知中心</translation>
-        </message>
-        <message>
-            <source>Show message preview</source>
-            <translation>顯示消息預覽</translation>
-        </message>
-        <message>
-            <source>Play a sound</source>
-            <translation>通知時提示聲音</translation>
-        </message>
-    </context>
-    <context>
-        <name>personalization</name>
-        <message>
-            <source>Personalization</source>
-            <translation>個性化</translation>
-        </message>
-    </context>
-    <context>
-        <name>personalizationMain</name>
-        <message>
-            <source>Theme</source>
-            <translation>主題</translation>
-        </message>
-        <message>
-            <source>Appearance</source>
-            <translation>外觀</translation>
-        </message>
-        <message>
-            <source>Window effect</source>
-            <translation>窗口效果</translation>
-        </message>
-        <message>
-            <source>Personalize your wallpaper and screensaver</source>
-            <translation>個性化您的壁紙和屏保</translation>
-        </message>
-        <message>
-            <source>Screensaver</source>
-            <translation>屏幕保護</translation>
-        </message>
-        <message>
-            <source>Colors and icons</source>
-            <translation>顏色和圖標</translation>
-        </message>
-        <message>
-            <source>Adjust accent color and theme icons</source>
-            <translation>調整活動色和主題圖標</translation>
-        </message>
-        <message>
-            <source>Font and font size</source>
-            <translation>字體和字號</translation>
-        </message>
-        <message>
-            <source>Change system font and size</source>
-            <translation>修改系統字體與字號</translation>
-        </message>
-        <message>
-            <source>Wallpaper</source>
-            <translation>壁紙</translation>
-        </message>
-        <message>
-            <source>Select light, dark or automatic theme appearance</source>
-            <translation>選擇淺色、深色或自動切換主題外觀</translation>
-        </message>
-        <message>
-            <source>Interface and effects, rounded corners</source>
-            <translation>界面和效果、窗口圓角</translation>
-        </message>
-    </context>
-    <context>
-        <name>power</name>
-        <message>
-            <source>Power saving settings, screen and suspend</source>
-            <translation>節能設置、屏幕和待機管理</translation>
-        </message>
-        <message>
-            <source>Power</source>
-            <translation>電源管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>powerMain</name>
-        <message>
-            <source>General</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-            <translation>性能模式、節能設置、喚醒設置、關機設置</translation>
-        </message>
-        <message>
-            <source>Plugged In</source>
-            <translation>使用電源</translation>
-        </message>
-        <message>
-            <source>Screen and suspend</source>
-            <translation>屏幕和待機管理</translation>
-        </message>
-        <message>
-            <source>On Battery</source>
-            <translation>使用電池</translation>
-        </message>
-        <message>
-            <source>screen and suspend, low battery, battery management</source>
-            <translation>屏幕和待機管理、低電量管理、電池管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>privacy</name>
-        <message>
-            <source>Privacy and Security</source>
-            <translation>私隱和安全</translation>
-        </message>
-        <message>
-            <source>Camera, folder permissions</source>
-            <translation>攝像頭、文件夾權限</translation>
-        </message>
-    </context>
-    <context>
-        <name>privacyMain</name>
-        <message>
-            <source>Camera</source>
-            <translation>攝像頭</translation>
-        </message>
-        <message>
-            <source>Choose whether the application has access to the camera</source>
-            <translation>選擇應用是否有攝像頭的訪問權限</translation>
-        </message>
-        <message>
-            <source>Files and Folders</source>
-            <translation>文件和文件夾</translation>
-        </message>
-        <message>
-            <source>Choose whether the application has access to files and folders</source>
-            <translation>選擇應用是否有文件和文件夾的訪問權限</translation>
-        </message>
-    </context>
-    <context>
-        <name>sound</name>
-        <message>
-            <source>Sound</source>
-            <translation>聲音</translation>
-        </message>
-        <message>
-            <source>Output, input, sound effects, devices</source>
-            <translation>輸入、輸出、系統音效、設備管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>soundMain</name>
-        <message>
-            <source>Settings</source>
-            <translation>設置</translation>
-        </message>
-        <message>
-            <source>Sound Effects</source>
-            <translation>系統音效</translation>
-        </message>
-        <message>
-            <source>Enable/disable sound effects</source>
-            <translation>開啓/關閉系統音效</translation>
-        </message>
-        <message>
-            <source>Enable/disable audio devices</source>
-            <translation>啓用/禁用音頻設備</translation>
-        </message>
-        <message>
-            <source>Devices</source>
-            <translation>設備管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>system</name>
-        <message>
-            <source>Common settings</source>
-            <translation>常用設置</translation>
-        </message>
-        <message>
-            <source>System</source>
-            <translation>系統</translation>
-        </message>
-    </context>
-    <context>
-        <name>systemInfo</name>
-        <message>
-            <source>Auxiliary Information</source>
-            <translation>輔助信息</translation>
-        </message>
-    </context>
-    <context>
-        <name>systemInfoMain</name>
-        <message>
-            <source>About This PC</source>
-            <translation>關於本機</translation>
-        </message>
-        <message>
-            <source>System version, device information</source>
-            <translation>系統版本、設備信息</translation>
-        </message>
-        <message>
-            <source>View the notice of open source software</source>
-            <translation>查看開源軟件聲明</translation>
-        </message>
-        <message>
-            <source>User Experience Program</source>
-            <translation>用户體驗計劃</translation>
-        </message>
-        <message>
-            <source>Join the user experience program to help improve the product</source>
-            <translation>加入用户體驗計劃，幫助改進產品</translation>
-        </message>
-        <message>
-            <source>End User License Agreement</source>
-            <translation>用户許可協議</translation>
-        </message>
-        <message>
-            <source>View the end  user license agreement</source>
-            <translation>查看最終用户許可協議</translation>
-        </message>
-        <message>
-            <source>Privacy Policy</source>
-            <translation>私隱政策</translation>
-        </message>
-        <message>
-            <source>View information about privacy policy</source>
-            <translation>查看私隱政策相關信息</translation>
-        </message>
-        <message>
-            <source>Open Source Software Notice</source>
-            <translation>開源軟件聲明</translation>
-        </message>
-    </context>
-    <context>
-        <name>touchscreen</name>
-        <message>
-            <source>Touchscreen</source>
-            <translation>觸控屏</translation>
-        </message>
-        <message>
-            <source>Configuring Touchscreen</source>
-            <translation>觸控屏設置</translation>
-        </message>
-    </context>
-    <context>
-        <name>touchscreenMain</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-    </context>
-    <context>
-        <name>wacom</name>
-        <message>
-            <source>wacom</source>
-            <translation>數位板</translation>
-        </message>
-        <message>
-            <source>Configuring wacom</source>
-            <translation>數位板選項設置</translation>
-        </message>
-    </context>
-    <context>
-        <name>wacomMain</name>
-        <message>
-            <source>wacom</source>
-            <translation>數位板</translation>
-        </message>
-        <message>
-            <source>Wacom Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Pen Mode</source>
-            <translation>筆模式</translation>
-        </message>
-        <message>
-            <source>Mouse Mode</source>
-            <translation>鼠標模式</translation>
-        </message>
-        <message>
-            <source>Pressure Sensitivity</source>
-            <translation>壓感</translation>
-        </message>
-        <message>
-            <source>Light</source>
-            <translation>輕</translation>
-        </message>
-    </context>
+    </message>
+    <message>
+        <source>Sign In to %1 ID</source>
+        <translation>登錄%1 ID</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDSyncService</name>
+    <message>
+        <source>Auto Sync</source>
+        <translation>自動同步</translation>
+    </message>
+    <message>
+        <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
+        <translation>將您的系統設置和個人信息安全地存儲在雲端，並在您不同的設備上保持同步</translation>
+    </message>
+    <message>
+        <source>System Settings</source>
+        <translation>系統設置</translation>
+    </message>
+    <message>
+        <source>Last sync time: %1</source>
+        <translation>最近同步時間：%1</translation>
+    </message>
+    <message>
+        <source>Clear cloud data</source>
+        <translation>清除雲端數據</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
+        <translation>確定要清除您保存在雲端的系統設置和個人數據嗎？</translation>
+    </message>
+    <message>
+        <source>Once the data is cleared, it cannot be recovered!</source>
+        <translation>數據清除後將無法恢復！</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>清除</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDUserInfo</name>
+    <message>
+        <source>Synchronization Service</source>
+        <translation>同步服務</translation>
+    </message>
+    <message>
+        <source>Account and Security</source>
+        <translation>賬户與安全</translation>
+    </message>
+    <message>
+        <source>Sign out</source>
+        <translation>退出登錄</translation>
+    </message>
+    <message>
+        <source>Go to web settings</source>
+        <translation>前往網頁設置</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinWorker</name>
+    <message>
+        <source>encrypt password failed</source>
+        <translation>加密密碼失敗</translation>
+    </message>
+    <message>
+        <source>Wrong password, %1 chances left</source>
+        <translation>密碼錯誤，您還可以嘗試%1次</translation>
+    </message>
+    <message>
+        <source>The login error has reached the limit today. You can reset the password and try again.</source>
+        <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
+    </message>
+    <message>
+        <source>Operation Successful</source>
+        <translation>操作成功</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinidModel</name>
+    <message>
+        <source>Mainland China</source>
+        <translation>中國大陸</translation>
+    </message>
+    <message>
+        <source>Other regions</source>
+        <translation>其他地區</translation>
+    </message>
+    <message>
+        <source>The feature is not available at present, please activate your system first</source>
+        <translation>當前系統未激活，暫無法使用該功能</translation>
+    </message>
+    <message>
+        <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
+        <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
+    </message>
+</context>
+<context>
+    <name>DetailItem</name>
+    <message>
+        <source>Please choose the default program to open &apos;%1&apos;</source>
+        <translation>選擇打開「%1」的默認程序</translation>
+    </message>
+    <message>
+        <source>add</source>
+        <translation>添加</translation>
+    </message>
+    <message>
+        <source>Open Desktop file</source>
+        <translation>打開Desktop文件</translation>
+    </message>
+    <message>
+        <source>Apps (*.desktop)</source>
+        <translation>應用程式(*.desktop)</translation>
+    </message>
+    <message>
+        <source>All files (*)</source>
+        <translation>所有文件(*)</translation>
+    </message>
+</context>
+<context>
+    <name>DevelopModePage</name>
+    <message>
+        <source>Root Access</source>
+        <translation>開發者模式</translation>
+    </message>
+    <message>
+        <source>Request Root Access</source>
+        <translation>進入開發者模式</translation>
+    </message>
+    <message>
+        <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
+        <translation>可獲得root使用權限，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>已進入</translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation>進入</translation>
+    </message>
+    <message>
+        <source>Online</source>
+        <translation>在線激活</translation>
+    </message>
+    <message>
+        <source>Login UOS ID</source>
+        <translation>登錄UOS ID</translation>
+    </message>
+    <message>
+        <source>Offline</source>
+        <translation>離線激活</translation>
+    </message>
+    <message>
+        <source>Import Certificate</source>
+        <translation>導入證書</translation>
+    </message>
+    <message>
+        <source>Select file</source>
+        <translation>選擇文件</translation>
+    </message>
+    <message>
+        <source>Your UOS ID has been logged in, click to enter developer mode</source>
+        <translation>您的UOS ID已登錄，點擊進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Please sign in to your UOS ID first and continue</source>
+        <translation>進入開發者模式需要登錄UOS ID</translation>
+    </message>
+    <message>
+        <source>1.Export PC Info</source>
+        <translation>1.導出機器信息</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>導出</translation>
+    </message>
+    <message>
+        <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
+        <translation>2.前往 &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
+    </message>
+    <message>
+        <source>3.Import Certificate</source>
+        <translation>3.導入證書</translation>
+    </message>
+    <message>
+        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
+        <translation>如需安裝非應用商店來源的應用，前往 &lt;a href=&quot;Security Center&quot;&gt;安全中心&lt;/a&gt; 進行設置。</translation>
+    </message>
+    <message>
+        <source>Development and debugging options</source>
+        <translation>開發調試選項</translation>
+    </message>
+    <message>
+        <source>System logging level</source>
+        <translation>系統日誌記錄級別</translation>
+    </message>
+    <message>
+        <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
+        <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多存儲空間.</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation>調試</translation>
+    </message>
+    <message>
+        <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
+        <translation>更改選項處理可能需要一分鐘，收到設置成功提示後，請重啓設備方可生效。</translation>
+    </message>
+</context>
+<context>
+    <name>DisclaimerControl</name>
+    <message>
+        <source>Disclaimer</source>
+        <translation>《用户免責聲明》</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Agree</source>
+        <translation>同意</translation>
+    </message>
+</context>
+<context>
+    <name>FileAndFolder</name>
+    <message>
+        <source>Allow below apps to access these files and folders:</source>
+        <translation>允許下面的應用訪問您的文件和文件夾</translation>
+    </message>
+    <message>
+        <source>Documents</source>
+        <translation>文檔</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <translation>桌面</translation>
+    </message>
+    <message>
+        <source>Pictures</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Videos</source>
+        <translation>視頻</translation>
+    </message>
+    <message>
+        <source>Music</source>
+        <translation>音樂</translation>
+    </message>
+    <message>
+        <source>Downloads</source>
+        <translation>下載</translation>
+    </message>
+    <message>
+        <source>folder</source>
+        <translation>文件夾</translation>
+    </message>
+</context>
+<context>
+    <name>FontSizePage</name>
+    <message>
+        <source>Size</source>
+        <translation>字號</translation>
+    </message>
+    <message>
+        <source>Standard Font</source>
+        <translation>標準字體</translation>
+    </message>
+    <message>
+        <source>Monospaced Font</source>
+        <translation>等寬字體</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralPage</name>
+    <message>
+        <source>Power Plans</source>
+        <translation>性能模式</translation>
+    </message>
+    <message>
+        <source>Power Saving Settings</source>
+        <translation>節能設置</translation>
+    </message>
+    <message>
+        <source>Auto power saving on low battery</source>
+        <translation>低電量時自動開啓節能模式</translation>
+    </message>
+    <message>
+        <source>Low battery threshold</source>
+        <translation>低電量閾值</translation>
+    </message>
+    <message>
+        <source>Auto power saving on battery</source>
+        <translation>使用電池時自動開啓節能模式</translation>
+    </message>
+    <message>
+        <source>Wakeup Settings</source>
+        <translation>喚醒設置</translation>
+    </message>
+    <message>
+        <source>Password is required to wake up the computer</source>
+        <translation>待機恢復時需要密碼</translation>
+    </message>
+    <message>
+        <source>Password is required to wake up the monitor</source>
+        <translation>喚醒顯示器時需要密碼</translation>
+    </message>
+    <message>
+        <source>Shutdown Settings</source>
+        <translation>關機設置</translation>
+    </message>
+    <message>
+        <source>Scheduled Shutdown</source>
+        <translation>定時關機</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation>重複</translation>
+    </message>
+    <message>
+        <source>Once</source>
+        <translation>一次</translation>
+    </message>
+    <message>
+        <source>Every day</source>
+        <translation>每天</translation>
+    </message>
+    <message>
+        <source>Working days</source>
+        <translation>工作日</translation>
+    </message>
+    <message>
+        <source>Custom Time</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Decrease screen brightness on power saver</source>
+        <translation>節能模式時降低屏幕亮度</translation>
+    </message>
+</context>
+<context>
+    <name>GestureModel</name>
+    <message>
+        <source>Three-finger</source>
+        <translation>三指</translation>
+    </message>
+    <message>
+        <source>Four-finger</source>
+        <translation>四指</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation>向上</translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation>向下</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>向左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>向右</translation>
+    </message>
+    <message>
+        <source>tap</source>
+        <translation>點擊</translation>
+    </message>
+</context>
+<context>
+    <name>HomePage</name>
+    <message>
+        <source>,</source>
+        <translation>、</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>等</translation>
+    </message>
+</context>
+<context>
+    <name>InterfaceEffectListview</name>
+    <message>
+        <source>Optimal Performance</source>
+        <translation>最佳性能</translation>
+    </message>
+    <message>
+        <source>Balance</source>
+        <translation>均衡</translation>
+    </message>
+    <message>
+        <source>Best Visuals</source>
+        <translation>最佳視覺</translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance.</source>
+        <translation>關閉所有界面和窗口特效，保障系統高效運行</translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
+        <translation>限制部分窗口特效，保障出色的視覺效果，同時維持系統流暢運行</translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience.</source>
+        <translation>啓用所有界面和窗口特效，體驗最佳視覺效果</translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardLayout</name>
+    <message>
+        <source>Keyboard layout</source>
+        <translation>鍵盤佈局</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
+        <translation>如需添加或切換鍵盤佈局，請同時在 &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt; 輸入法管理 &lt;/a&gt;  中添加對應的輸入法以確保生效</translation>
+    </message>
+    <message>
+        <source>Add new keyboard layout...</source>
+        <translation>添加鍵盤佈局...</translation>
+    </message>
+</context>
+<context>
+    <name>LangAndFormat</name>
+    <message>
+        <source>Language</source>
+        <translation>語言</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Other languages</source>
+        <translation>其他語言</translation>
+    </message>
+    <message>
+        <source>add</source>
+        <translation>添加</translation>
+    </message>
+    <message>
+        <source>Region</source>
+        <translation>區域</translation>
+    </message>
+    <message>
+        <source>Area</source>
+        <translation>地區</translation>
+    </message>
+    <message>
+        <source>Operating system and applications may provide you with local content based on your country and region</source>
+        <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
+    </message>
+    <message>
+        <source>Region and format</source>
+        <translation>區域格式</translation>
+    </message>
+    <message>
+        <source>Operating system and applications may set date and time formats based on regional formats</source>
+        <translation>作業系統和某些應用會根據區域格式設置日期和時間格式</translation>
+    </message>
+</context>
+<context>
+    <name>LangsChooserDialog</name>
+    <message>
+        <source>Add language</source>
+        <translation>添加語言</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>添加</translation>
+    </message>
+</context>
+<context>
+    <name>LayoutsChooser</name>
+    <message>
+        <source>Add language</source>
+        <translation>添加語言</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>添加</translation>
+    </message>
+</context>
+<context>
+    <name>LoginMethod</name>
+    <message>
+        <source>Login method</source>
+        <translation>登錄方式</translation>
+    </message>
+    <message>
+        <source>Password, wechat, biometric authentication, security key</source>
+        <translation>密碼，微信掃碼，生物認證，安全密鑰</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>密碼</translation>
+    </message>
+    <message>
+        <source>Modify password</source>
+        <translation>修改密碼</translation>
+    </message>
+    <message>
+        <source>Validity days</source>
+        <translation>有效天數</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>長期有效</translation>
+    </message>
+</context>
+<context>
+    <name>LogoModule</name>
+    <message>
+        <source>Copyright© 2011-%1 Deepin Community</source>
+        <translation>Copyright © 2011-%1 深度社區</translation>
+    </message>
+    <message>
+        <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
+        <translation>Copyright © 2019-%1 統信軟件技術有限公司</translation>
+    </message>
+</context>
+<context>
+    <name>MicrophonePage</name>
+    <message>
+        <source>Automatic Noise Suppression</source>
+        <translation>噪音抑制</translation>
+    </message>
+    <message>
+        <source>Input Volume</source>
+        <translation>輸入音量</translation>
+    </message>
+    <message>
+        <source>Input Level</source>
+        <translation>反饋音量</translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation>輸入</translation>
+    </message>
+    <message>
+        <source>No input device for sound found</source>
+        <translation>沒有找到聲音輸入設備</translation>
+    </message>
+    <message>
+        <source>Input Devices</source>
+        <translation>輸入設備</translation>
+    </message>
+</context>
+<context>
+    <name>Mouse</name>
+    <message>
+        <source>Mouse</source>
+        <translation>鼠標</translation>
+    </message>
+    <message>
+        <source>Pointer Speed</source>
+        <translation>指針速度</translation>
+    </message>
+    <message>
+        <source>Slow</source>
+        <translation>慢</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation>快</translation>
+    </message>
+    <message>
+        <source>Pointer Size</source>
+        <translation>指針大小</translation>
+    </message>
+    <message>
+        <source>Short</source>
+        <translation>短</translation>
+    </message>
+    <message>
+        <source>Long</source>
+        <translation>長</translation>
+    </message>
+    <message>
+        <source>Mouse Acceleration</source>
+        <translation>鼠標加速</translation>
+    </message>
+    <message>
+        <source>Disable touchpad when a mouse is connected</source>
+        <translation>插入鼠標時禁用觸摸板</translation>
+    </message>
+    <message>
+        <source>Natural Scrolling</source>
+        <translation>自然滾動</translation>
+    </message>
+</context>
+<context>
+    <name>MyDevice</name>
+    <message>
+        <source>My Devices</source>
+        <translation>我的設備</translation>
+    </message>
+</context>
+<context>
+    <name>NativeInfoPage</name>
+    <message>
+        <source>UOS</source>
+        <translation>UOS</translation>
+    </message>
+    <message>
+        <source>Computer name</source>
+        <translation>計算機名</translation>
+    </message>
+    <message>
+        <source>It cannot start or end with dashes</source>
+        <translation>計算機名不能以 - 開頭結尾</translation>
+    </message>
+    <message>
+        <source>OS Name</source>
+        <translation>產品名稱</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation>版本號</translation>
+    </message>
+    <message>
+        <source>Edition</source>
+        <translation>版本</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>類型</translation>
+    </message>
+    <message>
+        <source>bit</source>
+        <translation>位</translation>
+    </message>
+    <message>
+        <source>Authorization</source>
+        <translation>版本授權</translation>
+    </message>
+    <message>
+        <source>System installation time</source>
+        <translation>系統安裝日期</translation>
+    </message>
+    <message>
+        <source>Kernel</source>
+        <translation>內核版本</translation>
+    </message>
+    <message>
+        <source>Graphics Platform</source>
+        <translation>圖形平台</translation>
+    </message>
+    <message>
+        <source>Processor</source>
+        <translation>處理器</translation>
+    </message>
+    <message>
+        <source>Memory</source>
+        <translation>內存</translation>
+    </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation>計算機名長度必須介於1到63個字符之間</translation>
+    </message>
+</context>
+<context>
+    <name>OtherDevice</name>
+    <message>
+        <source>Other Devices</source>
+        <translation>其他設備</translation>
+    </message>
+    <message>
+        <source>Show Bluetooth devices without names</source>
+        <translation>顯示沒有名稱的藍牙設備</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordLayout</name>
+    <message>
+        <source>Current password</source>
+        <translation>當前密碼</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation>強度低</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation>強度中</translation>
+    </message>
+    <message>
+        <source>Strong</source>
+        <translation>強度高</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>密碼</translation>
+    </message>
+    <message>
+        <source>Repeat Password</source>
+        <translation>重複密碼</translation>
+    </message>
+    <message>
+        <source>Password hint</source>
+        <translation>密碼提示</translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation>選填</translation>
+    </message>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Passwords do not match</source>
+        <translation>密碼不一致</translation>
+    </message>
+    <message>
+        <source>New password should differ from the current one</source>
+        <translation>新密碼和舊密碼不能相同</translation>
+    </message>
+    <message>
+        <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation>密碼提示對所有人可見，切勿包含具體密碼信息</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordModifyDialog</name>
+    <message>
+        <source>Modify password</source>
+        <translation>修改密碼</translation>
+    </message>
+    <message>
+        <source>Reset password</source>
+        <translation>重置密碼</translation>
+    </message>
+    <message>
+        <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
+        <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
+    </message>
+    <message>
+        <source>Resetting the password will clear the data stored in the keyring.</source>
+        <translation>重設密碼將會清除密鑰環內已存儲的數據</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>PersonalizationInterface</name>
+    <message>
+        <source>Light</source>
+        <translation>淺色</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>自動</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+</context>
+<context>
+    <name>PersonalizationWorker</name>
+    <message>
+        <source>Custom</source>
+        <translation>自定義</translation>
+    </message>
+</context>
+<context>
+    <name>PluginArea</name>
+    <message>
+        <source>Plugin Area</source>
+        <translation>插件區域</translation>
+    </message>
+    <message>
+        <source>Select which icons appear in the Dock</source>
+        <translation>選擇顯示在任務欄插件區域的圖標</translation>
+    </message>
+</context>
+<context>
+    <name>PowerOperatorModel</name>
+    <message>
+        <source>Shut down</source>
+        <translation>關機</translation>
+    </message>
+    <message>
+        <source>Suspend</source>
+        <translation>待機</translation>
+    </message>
+    <message>
+        <source>Hibernate</source>
+        <translation>休眠</translation>
+    </message>
+    <message>
+        <source>Turn off the monitor</source>
+        <translation>關閉顯示器</translation>
+    </message>
+    <message>
+        <source>Show the shutdown Interface</source>
+        <translation>進入關機界面</translation>
+    </message>
+    <message>
+        <source>Do nothing</source>
+        <translation>無任何操作</translation>
+    </message>
+</context>
+<context>
+    <name>PowerPage</name>
+    <message>
+        <source>Screen and Suspend</source>
+        <translation>屏幕和待機</translation>
+    </message>
+    <message>
+        <source>Turn off the monitor after</source>
+        <translation>關閉顯示器</translation>
+    </message>
+    <message>
+        <source>Lock screen after</source>
+        <translation>自動鎖屏</translation>
+    </message>
+    <message>
+        <source>Computer suspends after</source>
+        <translation>進入待機</translation>
+    </message>
+    <message>
+        <source>When the lid is closed</source>
+        <translation>筆記本合蓋時</translation>
+    </message>
+    <message>
+        <source>When the power button is pressed</source>
+        <translation>按電源按鈕時</translation>
+    </message>
+</context>
+<context>
+    <name>PowerPlansListview</name>
+    <message>
+        <source>High Performance</source>
+        <translation>高性能模式</translation>
+    </message>
+    <message>
+        <source>Balance Performance</source>
+        <translation>性能模式</translation>
+    </message>
+    <message>
+        <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
+        <translation>根據負載情況積極調整運行頻率</translation>
+    </message>
+    <message>
+        <source>Balanced</source>
+        <translation>平衡模式</translation>
+    </message>
+    <message>
+        <source>Power Saver</source>
+        <translation>節能模式</translation>
+    </message>
+    <message>
+        <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
+        <translation>性能優先，會顯著提升功耗和發熱</translation>
+    </message>
+    <message>
+        <source>Balancing performance and battery life, automatically adjusted according to usage</source>
+        <translation>兼顧性能和續航，根據使用情況自動調節</translation>
+    </message>
+    <message>
+        <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
+        <translation>續航優先，系統會犧牲一些性能表現來降低功耗</translation>
+    </message>
+</context>
+<context>
+    <name>PowerWorker</name>
+    <message>
+        <source>Minutes</source>
+        <translation>分鐘</translation>
+    </message>
+    <message>
+        <source>Hour</source>
+        <translation>小時</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation>從不</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyPolicyPage</name>
+    <message>
+        <source>Privacy Policy</source>
+        <translation>私隱政策</translation>
+    </message>
+    <message>
+        <source>Copy Link Address</source>
+        <translation>複製連結地址</translation>
+    </message>
+</context>
+<context>
+    <name>PwqualityManager</name>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Password must have at least %1 characters</source>
+        <translation>密碼長度不能少於%1個字符</translation>
+    </message>
+    <message>
+        <source>Password must be no more than %1 characters</source>
+        <translation>密碼長度不能超過%1個字符</translation>
+    </message>
+    <message>
+        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
+    </message>
+    <message>
+        <source>No more than %1 palindrome characters please</source>
+        <translation>迴文字符長度不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 monotonic characters please</source>
+        <translation>單調性字符不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 repeating characters please</source>
+        <translation>重複字符不超過%1位</translation>
+    </message>
+    <message>
+        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
+    </message>
+    <message>
+        <source>Password must not contain more than 4 palindrome characters</source>
+        <translation>密碼不得含有連續4個以上的迴文字符</translation>
+    </message>
+    <message>
+        <source>Do not use common words and combinations as password</source>
+        <translation>密碼不能是常見單詞及組合</translation>
+    </message>
+    <message>
+        <source>Create a strong password please</source>
+        <translation>密碼過於簡單，請增加密碼複雜度</translation>
+    </message>
+    <message>
+        <source>It does not meet password rules</source>
+        <translation>密碼不符合安全要求</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Control Center</source>
+        <translation>控制中心</translation>
+    </message>
+    <message>
+        <source>Activated</source>
+        <translation>已激活</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>查看</translation>
+    </message>
+    <message>
+        <source>To be activated</source>
+        <translation>待激活</translation>
+    </message>
+    <message>
+        <source>Activate</source>
+        <translation>激活</translation>
+    </message>
+    <message>
+        <source>Expired</source>
+        <translation>已過期</translation>
+    </message>
+    <message>
+        <source>In trial period</source>
+        <translation>試用期</translation>
+    </message>
+    <message>
+        <source>Trial expired</source>
+        <translation>試用期過期</translation>
+    </message>
+    <message>
+        <source>dde-control-center</source>
+        <translation>控制中心</translation>
+    </message>
+    <message>
+        <source>Touch Screen Settings</source>
+        <translation>觸控屏設置</translation>
+    </message>
+    <message>
+        <source>The settings of touch screen changed</source>
+        <translation>已變更觸控屏設置</translation>
+    </message>
+    <message>
+        <source>This system wallpaper is locked. Please contact your admin.</source>
+        <translation>當前系統壁紙已被鎖定，請聯繫管理員</translation>
+    </message>
+</context>
+<context>
+    <name>RegionFormatDialog</name>
+    <message>
+        <source>Regions and formats</source>
+        <translation>區域和格式</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <source>Default formats</source>
+        <translation>默認格式</translation>
+    </message>
+    <message>
+        <source>First day of week</source>
+        <translation>一週第一天</translation>
+    </message>
+    <message>
+        <source>Short date</source>
+        <translation>短日期</translation>
+    </message>
+    <message>
+        <source>Long date</source>
+        <translation>長日期</translation>
+    </message>
+    <message>
+        <source>Short time</source>
+        <translation>短時間</translation>
+    </message>
+    <message>
+        <source>Long time</source>
+        <translation>長時間</translation>
+    </message>
+    <message>
+        <source>Currency symbol</source>
+        <translation>貨幣符號</translation>
+    </message>
+    <message>
+        <source>Digit</source>
+        <translation>數字</translation>
+    </message>
+    <message>
+        <source>Paper size</source>
+        <translation>紙張</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+</context>
+<context>
+    <name>RegionsChooserWindow</name>
+    <message>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+</context>
+<context>
+    <name>RegisterDialog</name>
+    <message>
+        <source>Set a Password</source>
+        <translation>設置密碼</translation>
+    </message>
+    <message>
+        <source>8-64 characters</source>
+        <translation>請輸入8-64位密碼</translation>
+    </message>
+    <message>
+        <source>Repeat the password</source>
+        <translation>請再次輸入密碼</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>Passwords don&apos;t match</source>
+        <translation>兩次密碼輸入不一致</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduledShutdownDialog</name>
+    <message>
+        <source>Customize repetition time</source>
+        <translation>自定義重複時間</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+</context>
+<context>
+    <name>ScreenSaverPage</name>
+    <message>
+        <source>Screensaver</source>
+        <translation>屏幕保護</translation>
+    </message>
+    <message>
+        <source>preview</source>
+        <translation>全屏預覽</translation>
+    </message>
+    <message>
+        <source>Personalized screensaver</source>
+        <translation>個性化屏保</translation>
+    </message>
+    <message>
+        <source>setting</source>
+        <translation>設置</translation>
+    </message>
+    <message>
+        <source>idle time</source>
+        <translation>閒置時間</translation>
+    </message>
+    <message>
+        <source>1 minute</source>
+        <translation>1分鐘</translation>
+    </message>
+    <message>
+        <source>5 minute</source>
+        <translation>5分鐘</translation>
+    </message>
+    <message>
+        <source>10 minute</source>
+        <translation>10分鐘</translation>
+    </message>
+    <message>
+        <source>15 minute</source>
+        <translation>15分鐘</translation>
+    </message>
+    <message>
+        <source>30 minute</source>
+        <translation>30分鐘</translation>
+    </message>
+    <message>
+        <source>1 hour</source>
+        <translation>1小時</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>從不</translation>
+    </message>
+    <message>
+        <source>Password required for recovery</source>
+        <translation>恢復時需要密碼</translation>
+    </message>
+    <message>
+        <source>Picture slideshow screensaver</source>
+        <translation>圖片輪播屏保</translation>
+    </message>
+    <message>
+        <source>System screensaver</source>
+        <translation>系統屏保</translation>
+    </message>
+</context>
+<context>
+    <name>SearchableListViewPopup</name>
+    <message>
+        <source>Search</source>
+        <translation>搜索</translation>
+    </message>
+    <message>
+        <source>No search results</source>
+        <translation>無搜索結果</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutSettingDialog</name>
+    <message>
+        <source>Add custom shortcut</source>
+        <translation>添加自定義快捷鍵</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>名稱：</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>Command:</source>
+        <translation>命令：</translation>
+    </message>
+    <message>
+        <source>Shortcut</source>
+        <translation>快捷鍵</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+    <message>
+        <source>Please enter a new shortcut</source>
+        <translation>請輸入新的快捷鍵</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>添加</translation>
+    </message>
+    <message>
+        <source>Click Add to replace</source>
+        <translation>點擊添加替換</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcuts</name>
+    <message>
+        <source>Shortcuts</source>
+        <translation>快捷鍵</translation>
+    </message>
+    <message>
+        <source>System shortcut, custom shortcut</source>
+        <translation>系統快捷鍵、自定義快捷鍵</translation>
+    </message>
+    <message>
+        <source>Search shortcuts</source>
+        <translation>搜索快捷鍵</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Please enter a new shortcut</source>
+        <translation>請輸入新的快捷鍵</translation>
+    </message>
+    <message>
+        <source>Click</source>
+        <translation>點擊</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation>或</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>替換</translation>
+    </message>
+    <message>
+        <source>Restore default</source>
+        <translation>恢復默認</translation>
+    </message>
+    <message>
+        <source>Add custom shortcut</source>
+        <translation>添加快捷鍵</translation>
+    </message>
+</context>
+<context>
+    <name>SoundDevicemanagesPage</name>
+    <message>
+        <source>Output Devices</source>
+        <translation>輸出設備</translation>
+    </message>
+    <message>
+        <source>Select whether to enable the devices</source>
+        <translation>選擇是否啓用設備</translation>
+    </message>
+    <message>
+        <source>Input Devices</source>
+        <translation>輸入設備</translation>
+    </message>
+</context>
+<context>
+    <name>SoundEffectsPage</name>
+    <message>
+        <source>Sound Effects</source>
+        <translation>系統音效</translation>
+    </message>
+</context>
+<context>
+    <name>SoundModel</name>
+    <message>
+        <source>Boot up</source>
+        <translation>開機</translation>
+    </message>
+    <message>
+        <source>Shut down</source>
+        <translation>關機</translation>
+    </message>
+    <message>
+        <source>Log out</source>
+        <translation>註銷</translation>
+    </message>
+    <message>
+        <source>Wake up</source>
+        <translation>喚醒</translation>
+    </message>
+    <message>
+        <source>Volume +/-</source>
+        <translation>音量調節</translation>
+    </message>
+    <message>
+        <source>Notification</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <source>Low battery</source>
+        <translation>電量不足</translation>
+    </message>
+    <message>
+        <source>Send icon in Launcher to Desktop</source>
+        <translation>從啓動器發送圖標到桌面</translation>
+    </message>
+    <message>
+        <source>Empty Trash</source>
+        <translation>清空回收站</translation>
+    </message>
+    <message>
+        <source>Plug in</source>
+        <translation>電源接入</translation>
+    </message>
+    <message>
+        <source>Plug out</source>
+        <translation>電源拔出</translation>
+    </message>
+    <message>
+        <source>Removable device connected</source>
+        <translation>流動裝置接入</translation>
+    </message>
+    <message>
+        <source>Removable device removed</source>
+        <translation>流動裝置拔出</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>錯誤提示</translation>
+    </message>
+</context>
+<context>
+    <name>SpeakerPage</name>
+    <message>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Output Volume</source>
+        <translation>輸出音量</translation>
+    </message>
+    <message>
+        <source>Volume Boost</source>
+        <translation>音量增強</translation>
+    </message>
+    <message>
+        <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
+        <translation>音量大於100%時可能會導致音效失真，同時損害您的音頻輸出設備</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>右</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>輸出</translation>
+    </message>
+    <message>
+        <source>No output device for sound found</source>
+        <translation>沒有找到聲音輸出設備</translation>
+    </message>
+    <message>
+        <source>Left Right Balance</source>
+        <translation>左右平衡</translation>
+    </message>
+    <message>
+        <source>Mono audio</source>
+        <translation>單聲道音頻</translation>
+    </message>
+    <message>
+        <source>Merge left and right channels into a single channel</source>
+        <translation>將左聲道和右聲道合併成一個聲道</translation>
+    </message>
+    <message>
+        <source>Auto pause</source>
+        <translation>插拔管理</translation>
+    </message>
+    <message>
+        <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
+        <translation>外設插拔時音頻輸出是否自動暫停</translation>
+    </message>
+    <message>
+        <source>Output Devices</source>
+        <translation>輸出設備</translation>
+    </message>
+</context>
+<context>
+    <name>SyncInfoListModel</name>
+    <message>
+        <source>Sound</source>
+        <translation>聲音</translation>
+    </message>
+    <message>
+        <source>Power</source>
+        <translation>電源</translation>
+    </message>
+    <message>
+        <source>Mouse</source>
+        <translation>鼠標</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation>更新</translation>
+    </message>
+    <message>
+        <source>Screensaver</source>
+        <translation>屏幕保護</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeSelectView</name>
+    <message>
+        <source>More Wallpapers</source>
+        <translation>下載更多</translation>
+    </message>
+</context>
+<context>
+    <name>TimeAndDate</name>
+    <message>
+        <source>Auto sync time</source>
+        <translation>自動同步配置</translation>
+    </message>
+    <message>
+        <source>Ntp server</source>
+        <translation>伺服器</translation>
+    </message>
+    <message>
+        <source>System date and time</source>
+        <translation>系統日期和時間</translation>
+    </message>
+    <message>
+        <source>Customize</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>設置</translation>
+    </message>
+    <message>
+        <source>Server address</source>
+        <translation>伺服器地址</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>The ntp server address cannot be empty</source>
+        <translation>NTP 服務地址不能為空</translation>
+    </message>
+    <message>
+        <source>Use 24-hour format</source>
+        <translation>24小時制</translation>
+    </message>
+    <message>
+        <source>system time zone</source>
+        <translation>系統時區</translation>
+    </message>
+    <message>
+        <source>Timezone list</source>
+        <translation>時區列表</translation>
+    </message>
+</context>
+<context>
+    <name>TimeRange</name>
+    <message>
+        <source>from</source>
+        <translation>從</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation>至</translation>
+    </message>
+</context>
+<context>
+    <name>TimeoutDialog</name>
+    <message>
+        <source>Save the display settings?</source>
+        <translation>是否要保存顯示設置？</translation>
+    </message>
+    <message>
+        <source>Settings will be reverted in %1s.</source>
+        <translation>如無任何操作將在%1秒後還原。</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>還原</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+</context>
+<context>
+    <name>TimezoneDialog</name>
+    <message>
+        <source>Add time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Determine the time zone based on the current location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time zone:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Nearest City:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>保存</translation>
+    </message>
+</context>
+<context>
+    <name>TouchScreen</name>
+    <message>
+        <source>TouchScreen</source>
+        <translation>觸控屏</translation>
+    </message>
+    <message>
+        <source>Set up here when connecting the touch screen</source>
+        <translation>連接觸摸屏時在此處設置</translation>
+    </message>
+</context>
+<context>
+    <name>Touchpad</name>
+    <message>
+        <source>Basic Settings</source>
+        <translation>基礎設置</translation>
+    </message>
+    <message>
+        <source>Touchpad</source>
+        <translation>觸控板</translation>
+    </message>
+    <message>
+        <source>Pointer Speed</source>
+        <translation>指針速度</translation>
+    </message>
+    <message>
+        <source>Slow</source>
+        <translation>慢</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation>快</translation>
+    </message>
+    <message>
+        <source>Disable touchpad during input</source>
+        <translation>輸入時禁用觸摸板</translation>
+    </message>
+    <message>
+        <source>Tap to Click</source>
+        <translation>輕觸以點擊</translation>
+    </message>
+    <message>
+        <source>Natural Scrolling</source>
+        <translation>自然滾動</translation>
+    </message>
+    <message>
+        <source>Gesture</source>
+        <translation>手勢</translation>
+    </message>
+    <message>
+        <source>Three-finger gestures</source>
+        <translation>三指手勢</translation>
+    </message>
+    <message>
+        <source>Four-finger gestures</source>
+        <translation>四指手勢</translation>
+    </message>
+</context>
+<context>
+    <name>UserExperienceProgramPage</name>
+    <message>
+        <source>Join User Experience Program</source>
+        <translation>加入用户體驗計劃</translation>
+    </message>
+    <message>
+        <source>Copy Link Address</source>
+        <translation>複製連結地址</translation>
+    </message>
+</context>
+<context>
+    <name>VerifyDialog</name>
+    <message>
+        <source>Security Verification</source>
+        <translation>安全驗證</translation>
+    </message>
+    <message>
+        <source>The action is sensitive, please enter the login password first</source>
+        <translation>您正在進行敏感操作，請進行登錄密碼認證</translation>
+    </message>
+    <message>
+        <source>8-64 characters</source>
+        <translation>請輸入8-64位密碼</translation>
+    </message>
+    <message>
+        <source>Forgot Password?</source>
+        <translation>忘記密碼？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確定</translation>
+    </message>
+</context>
+<context>
+    <name>WallpaperPage</name>
+    <message>
+        <source>wallpaper</source>
+        <translation>壁紙</translation>
+    </message>
+    <message>
+        <source>Window rounded corners</source>
+        <translation>窗口圓角</translation>
+    </message>
+    <message>
+        <source>My pictures</source>
+        <translation>我的圖片</translation>
+    </message>
+    <message>
+        <source>System Wallpaper</source>
+        <translation>系統壁紙</translation>
+    </message>
+    <message>
+        <source>Solid color wallpaper</source>
+        <translation>純色壁紙</translation>
+    </message>
+    <message>
+        <source>Customizable wallpapers</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>fill style</source>
+        <translation>填充方式</translation>
+    </message>
+    <message>
+        <source>Automatic wallpaper change</source>
+        <translation>自動切換壁紙</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>從不</translation>
+    </message>
+    <message>
+        <source>30 second</source>
+        <translation>30秒</translation>
+    </message>
+    <message>
+        <source>1 minute</source>
+        <translation>1分鐘</translation>
+    </message>
+    <message>
+        <source>5 minute</source>
+        <translation>5分鐘</translation>
+    </message>
+    <message>
+        <source>10 minute</source>
+        <translation>10分鐘</translation>
+    </message>
+    <message>
+        <source>15 minute</source>
+        <translation>15分鐘</translation>
+    </message>
+    <message>
+        <source>30 minute</source>
+        <translation>30分鐘</translation>
+    </message>
+    <message>
+        <source>login</source>
+        <translation>登錄時</translation>
+    </message>
+    <message>
+        <source>wake up</source>
+        <translation>喚醒時</translation>
+    </message>
+    <message>
+        <source>System Wallapers</source>
+        <translation>系統壁紙</translation>
+    </message>
+    <message>
+        <source>Live Wallpaper</source>
+        <translation>動態壁紙</translation>
+    </message>
+    <message>
+        <source>1 hour</source>
+        <translation>1小時</translation>
+    </message>
+</context>
+<context>
+    <name>WallpaperSelectView</name>
+    <message>
+        <source>unfold</source>
+        <translation>收起</translation>
+    </message>
+    <message>
+        <source>show all</source>
+        <translation>顯示全部</translation>
+    </message>
+    <message>
+        <source>items</source>
+        <translation>張</translation>
+    </message>
+    <message>
+        <source>Set lock screen</source>
+        <translation>設置鎖屏</translation>
+    </message>
+    <message>
+        <source>Set desktop</source>
+        <translation>設置桌面</translation>
+    </message>
+</context>
+<context>
+    <name>WindowEffectPage</name>
+    <message>
+        <source>Interface and Effects</source>
+        <translation>界面效果</translation>
+    </message>
+    <message>
+        <source>Window Settings</source>
+        <translation>窗口設置</translation>
+    </message>
+    <message>
+        <source>Window rounded corners</source>
+        <translation>窗口圓角</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>小</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>大</translation>
+    </message>
+    <message>
+        <source>Enable transparent effects when moving windows</source>
+        <translation>窗口移動時啓用透明特效</translation>
+    </message>
+    <message>
+        <source>Window Minimize Effect</source>
+        <translation>最小化時效果</translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation>縮放</translation>
+    </message>
+    <message>
+        <source>Magic Lamp</source>
+        <translation>魔燈</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>不透明度調節</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation>低</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>高</translation>
+    </message>
+    <message>
+        <source>Scroll Bars</source>
+        <translation>滾動條</translation>
+    </message>
+    <message>
+        <source>Show on scrolling</source>
+        <translation>滾動時顯示</translation>
+    </message>
+    <message>
+        <source>Keep shown</source>
+        <translation>一直顯示</translation>
+    </message>
+    <message>
+        <source>Compact Display</source>
+        <translation>緊湊模式</translation>
+    </message>
+    <message>
+        <source>If enabled, more content is displayed in the window.</source>
+        <translation>開啓後，窗口將顯示更多內容</translation>
+    </message>
+    <message>
+        <source>Title Bar Height</source>
+        <translation>標題欄高度</translation>
+    </message>
+    <message>
+        <source>Only suitable for application window title bars drawn by the window manager.</source>
+        <translation>僅適用於窗口管理器繪製的應用標題欄</translation>
+    </message>
+    <message>
+        <source>Extremely small</source>
+        <translation>極小</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation>中</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation>中</translation>
+    </message>
+</context>
+<context>
+    <name>accounts</name>
+    <message>
+        <source>Account</source>
+        <translation>賬户</translation>
+    </message>
+    <message>
+        <source>Account manager</source>
+        <translation>賬户管理</translation>
+    </message>
+</context>
+<context>
+    <name>accountsMain</name>
+    <message>
+        <source>Other accounts</source>
+        <translation>其他賬户</translation>
+    </message>
+</context>
+<context>
+    <name>authentication</name>
+    <message>
+        <source>Biometric Authentication</source>
+        <translation>生物認證</translation>
+    </message>
+</context>
+<context>
+    <name>authenticationMain</name>
+    <message>
+        <source>Biometric Authentication</source>
+        <translation>生物認證</translation>
+    </message>
+    <message>
+        <source>Face</source>
+        <translation>人臉</translation>
+    </message>
+    <message>
+        <source>Up to 5 facial data can be entered</source>
+        <translation>最多可錄入5個人臉數據</translation>
+    </message>
+    <message>
+        <source>Fingerprint</source>
+        <translation>指紋</translation>
+    </message>
+    <message>
+        <source>Identifying user identity through scanning fingerprints</source>
+        <translation>通過對指紋的掃描進行用户身份的識別</translation>
+    </message>
+    <message>
+        <source>Iris</source>
+        <translation>虹膜</translation>
+    </message>
+    <message>
+        <source>Identity recognition through iris scanning</source>
+        <translation>通過掃描虹膜進行身份識別</translation>
+    </message>
+    <message>
+        <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
+        <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字符</translation>
+    </message>
+    <message>
+        <source>Use letters, numbers and underscores only</source>
+        <translation>只能由字母、數字、中文、下劃線組成</translation>
+    </message>
+    <message>
+        <source>No more than 15 characters</source>
+        <translation>不得超過15個字符</translation>
+    </message>
+    <message>
+        <source>This name already exists</source>
+        <translation>該名稱已存在</translation>
+    </message>
+    <message>
+        <source>Add a new </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>blueTooth</name>
+    <message>
+        <source>bluetooth</source>
+        <translation>藍牙</translation>
+    </message>
+    <message>
+        <source>Bluetooth settings, devices</source>
+        <translation>藍牙設置、設備管理</translation>
+    </message>
+</context>
+<context>
+    <name>commonInfoMain</name>
+    <message>
+        <source>Boot Menu</source>
+        <translation>啓動菜單</translation>
+    </message>
+    <message>
+        <source>Manage your boot menu</source>
+        <translation>管理您的開機啓動菜單</translation>
+    </message>
+    <message>
+        <source>Developer root permission management</source>
+        <translation>開發者Root權限管理</translation>
+    </message>
+    <message>
+        <source>Developer Options</source>
+        <translation>開發者選項</translation>
+    </message>
+</context>
+<context>
+    <name>datetime</name>
+    <message>
+        <source>Time and date</source>
+        <translation>時間和日期</translation>
+    </message>
+    <message>
+        <source>Time and date, time zone settings</source>
+        <translation>時間日期、時區設置</translation>
+    </message>
+    <message>
+        <source>Language and region</source>
+        <translation>語言和區域</translation>
+    </message>
+    <message>
+        <source>System language, region format</source>
+        <translation>系統語言、區域格式</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::AccountsController</name>
+    <message>
+        <source>Username must be between 3 and 32 characters</source>
+        <translation>用户名長度必須介於 3 到 32 個字符之間</translation>
+    </message>
+    <message>
+        <source>The first character must be a letter or number</source>
+        <translation>必須字母或者數字開頭</translation>
+    </message>
+    <message>
+        <source>Your username should not only have numbers</source>
+        <translation>用户名不能僅僅是數字</translation>
+    </message>
+    <message>
+        <source>The username has been used by other user accounts</source>
+        <translation>用户名和其他用户名重複</translation>
+    </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation>全名太長了</translation>
+    </message>
+    <message>
+        <source>The full name has been used by other user accounts</source>
+        <translation>全名和其他用户名重複</translation>
+    </message>
+    <message>
+        <source>Wrong password</source>
+        <translation>密碼錯誤</translation>
+    </message>
+    <message>
+        <source>Standard User</source>
+        <translation>標準用户</translation>
+    </message>
+    <message>
+        <source>Administrator</source>
+        <translation>管理員</translation>
+    </message>
+    <message>
+        <source>Customized</source>
+        <translation>自定義</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::AccountsWorker</name>
+    <message>
+        <source>Your host was removed from the domain server successfully</source>
+        <translation>您的主機成功退出了域伺服器</translation>
+    </message>
+    <message>
+        <source>Your host joins the domain server successfully</source>
+        <translation>您的主機成功加入了域伺服器</translation>
+    </message>
+    <message>
+        <source>Your host failed to leave the domain server</source>
+        <translation>您的主機退出域伺服器失敗</translation>
+    </message>
+    <message>
+        <source>Your host failed to join the domain server</source>
+        <translation>您的主機加入域伺服器失敗</translation>
+    </message>
+    <message>
+        <source>AD domain settings</source>
+        <translation>AD域設置</translation>
+    </message>
+    <message>
+        <source>Password not match</source>
+        <translation>密碼不一致</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::AvatarTypesModel</name>
+    <message>
+        <source>Dimensional</source>
+        <translation>立體風格</translation>
+    </message>
+    <message>
+        <source>Flat</source>
+        <translation>平面風格</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::BiometricAuthController</name>
+    <message>
+        <source>Use your face to unlock the device and make settings later</source>
+        <translation>使用人臉數據解鎖您的設備，之後還可進行更多設置</translation>
+    </message>
+    <message>
+        <source>Faceprint</source>
+        <translation>面紋</translation>
+    </message>
+    <message>
+        <source>Place your finger</source>
+        <translation>放置手指</translation>
+    </message>
+    <message>
+        <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
+        <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
+    </message>
+    <message>
+        <source>Lift your finger</source>
+        <translation>擡起手指</translation>
+    </message>
+    <message>
+        <source>Lift your finger and place it on the sensor again</source>
+        <translation>請擡起手指，再次按壓</translation>
+    </message>
+    <message>
+        <source>Scan the edges of your fingerprint</source>
+        <translation>錄入邊緣指紋</translation>
+    </message>
+    <message>
+        <source>Adjust the position to scan the edges of your fingerprint</source>
+        <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
+    </message>
+    <message>
+        <source>Lift your finger and do that again</source>
+        <translation>請擡起手指，再次按壓</translation>
+    </message>
+    <message>
+        <source>Fingerprint added</source>
+        <translation>成功添加指紋</translation>
+    </message>
+    <message>
+        <source>Scan Suspended</source>
+        <translation>錄入中斷</translation>
+    </message>
+    <message>
+        <source>Place the edges of your fingerprint on the sensor</source>
+        <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
+    </message>
+    <message>
+        <source>Iris</source>
+        <translation>虹膜</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::KeyboardController</name>
+    <message>
+        <source>This shortcut conflicts with [%1]</source>
+        <translation>此快捷鍵與[%1]衝突</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::PwqualityManager</name>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Password must have at least %1 characters</source>
+        <translation>密碼長度不能少於%1個字符</translation>
+    </message>
+    <message>
+        <source>Password must be no more than %1 characters</source>
+        <translation>密碼長度不能超過%1個字符</translation>
+    </message>
+    <message>
+        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
+    </message>
+    <message>
+        <source>No more than %1 palindrome characters please</source>
+        <translation>迴文字符長度不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 monotonic characters please</source>
+        <translation>單調性字符不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 repeating characters please</source>
+        <translation>重複字符不超過%1位</translation>
+    </message>
+    <message>
+        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
+    </message>
+    <message>
+        <source>Password must not contain more than 4 palindrome characters</source>
+        <translation>密碼不得含有連續4個以上的迴文字符</translation>
+    </message>
+    <message>
+        <source>Do not use common words and combinations as password</source>
+        <translation>密碼不能是常見單詞及組合</translation>
+    </message>
+    <message>
+        <source>Create a strong password please</source>
+        <translation>密碼過於簡單，請增加密碼複雜度</translation>
+    </message>
+    <message>
+        <source>It does not meet password rules</source>
+        <translation>密碼不符合安全要求</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::ShortcutModel</name>
+    <message>
+        <source>System</source>
+        <translation>系統</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation>窗口</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>工作區</translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation>輔助功能</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+</context>
+<context>
+    <name>deepinid</name>
+    <message>
+        <source>deepin ID</source>
+        <translation>deepin ID</translation>
+    </message>
+    <message>
+        <source>UOS ID</source>
+        <translation>UOS ID</translation>
+    </message>
+    <message>
+        <source>Cloud services</source>
+        <translation>雲服務</translation>
+    </message>
+</context>
+<context>
+    <name>defaultapp</name>
+    <message>
+        <source>Default App</source>
+        <translation>默認程序</translation>
+    </message>
+    <message>
+        <source>Set the default application for opening various types of files</source>
+        <translation>設置打開各類文件的默認程序</translation>
+    </message>
+</context>
+<context>
+    <name>defaultappMain</name>
+    <message>
+        <source>Webpage</source>
+        <translation>網頁</translation>
+    </message>
+    <message>
+        <source>Mail</source>
+        <translation>郵件</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>文本</translation>
+    </message>
+    <message>
+        <source>Music</source>
+        <translation>音樂</translation>
+    </message>
+    <message>
+        <source>Video</source>
+        <translation>視頻</translation>
+    </message>
+    <message>
+        <source>Picture</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Terminal</source>
+        <translation>終端</translation>
+    </message>
+</context>
+<context>
+    <name>device</name>
+    <message>
+        <source>Device</source>
+        <translation>設備</translation>
+    </message>
+</context>
+<context>
+    <name>display</name>
+    <message>
+        <source>Display</source>
+        <translation>顯示</translation>
+    </message>
+    <message>
+        <source>Brightness,resolution,scaling</source>
+        <translation>亮度、解像度、縮放</translation>
+    </message>
+</context>
+<context>
+    <name>displayMain</name>
+    <message>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <source>125%</source>
+        <translation>125%</translation>
+    </message>
+    <message>
+        <source>150%</source>
+        <translation>150%</translation>
+    </message>
+    <message>
+        <source>175%</source>
+        <translation>175%</translation>
+    </message>
+    <message>
+        <source>200%</source>
+        <translation>200%</translation>
+    </message>
+    <message>
+        <source>225%</source>
+        <translation>225%</translation>
+    </message>
+    <message>
+        <source>250%</source>
+        <translation>250%</translation>
+    </message>
+    <message>
+        <source>275%</source>
+        <translation>275%</translation>
+    </message>
+    <message>
+        <source>300%</source>
+        <translation>300%</translation>
+    </message>
+    <message>
+        <source>Duplicate</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <source>Extend</source>
+        <translation>擴展</translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation>默認</translation>
+    </message>
+    <message>
+        <source>Fit</source>
+        <translation>適應</translation>
+    </message>
+    <message>
+        <source>Stretch</source>
+        <translation>拉伸</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>居中</translation>
+    </message>
+    <message>
+        <source>Only on %1</source>
+        <translation>僅%1屏</translation>
+    </message>
+    <message>
+        <source>Hz</source>
+        <translation>赫茲</translation>
+    </message>
+    <message>
+        <source>Multiple Displays Settings</source>
+        <translation>多屏設置</translation>
+    </message>
+    <message>
+        <source>Identify</source>
+        <translation>識別</translation>
+    </message>
+    <message>
+        <source>Screen rearrangement will take effect in %1s after changes</source>
+        <translation>屏幕拼接將在修改完成%1s後生效</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Main Screen</source>
+        <translation>主屏幕</translation>
+    </message>
+    <message>
+        <source>Display And Layout</source>
+        <translation>顯示和佈局</translation>
+    </message>
+    <message>
+        <source>Brightness</source>
+        <translation>亮度</translation>
+    </message>
+    <message>
+        <source>Resolution</source>
+        <translation>解像度</translation>
+    </message>
+    <message>
+        <source>Resize Desktop</source>
+        <translation>桌面顯示</translation>
+    </message>
+    <message>
+        <source>Refresh Rate</source>
+        <translation>刷新率</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>方向</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>標準</translation>
+    </message>
+    <message>
+        <source>90°</source>
+        <translation>90度</translation>
+    </message>
+    <message>
+        <source>180°</source>
+        <translation>180度</translation>
+    </message>
+    <message>
+        <source>270°</source>
+        <translation>270度</translation>
+    </message>
+    <message>
+        <source>Display Scaling</source>
+        <translation>縮放</translation>
+    </message>
+    <message>
+        <source>The monitor only supports 100% display scaling</source>
+        <translation>當前屏幕僅支持1倍縮放</translation>
+    </message>
+    <message>
+        <source>Eye Comfort</source>
+        <translation>護眼模式</translation>
+    </message>
+    <message>
+        <source>Enable eye comfort</source>
+        <translation>開啓護眼模式</translation>
+    </message>
+    <message>
+        <source>Adjust screen display to warmer colors, reducing screen blue light</source>
+        <translation>調整屏幕顯示較暖的顏色，減少屏幕藍光</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>All day</source>
+        <translation>全天</translation>
+    </message>
+    <message>
+        <source>Sunset to Sunrise</source>
+        <translation>日落到日出</translation>
+    </message>
+    <message>
+        <source>Custom Time</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>from</source>
+        <translation>從</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation>至</translation>
+    </message>
+    <message>
+        <source>Color Temperature</source>
+        <translation>色温</translation>
+    </message>
+    <message>
+        <source> (Recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dock</name>
+    <message>
+        <source>Desktop and taskbar</source>
+        <translation>桌面和任務欄</translation>
+    </message>
+    <message>
+        <source>Desktop organization, taskbar mode, plugin area settings</source>
+        <translation>桌面整理、任務欄模式、插件區域設置</translation>
+    </message>
+</context>
+<context>
+    <name>keyboard</name>
+    <message>
+        <source>Keyboard</source>
+        <translation>鍵盤</translation>
+    </message>
+    <message>
+        <source>General Settings, keyboard layout, input method, shortcuts</source>
+        <translation>通用設置、鍵盤佈局、輸入法、快捷鍵</translation>
+    </message>
+</context>
+<context>
+    <name>keyboardMain</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Keyboard layout</source>
+        <translation>鍵盤佈局</translation>
+    </message>
+    <message>
+        <source>Set system default keyboard layout</source>
+        <translation>設置系統默認鍵盤佈局</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Dock</source>
+        <translation>任務欄</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Classic Mode</source>
+        <translation>經典模式</translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation>居中模式</translation>
+    </message>
+    <message>
+        <source>Dock size</source>
+        <translation>任務欄大小</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>小</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>大</translation>
+    </message>
+    <message>
+        <source>Position on the screen</source>
+        <translation>屏幕中的位置</translation>
+    </message>
+    <message>
+        <source>Top</source>
+        <translation>上</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>下</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>右</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>狀態</translation>
+    </message>
+    <message>
+        <source>Keep shown</source>
+        <translation>一直顯示</translation>
+    </message>
+    <message>
+        <source>Keep hidden</source>
+        <translation>一直隱藏</translation>
+    </message>
+    <message>
+        <source>Smart hide</source>
+        <translation>智能隱藏</translation>
+    </message>
+    <message>
+        <source>Multiple Displays</source>
+        <translation>多屏顯示</translation>
+    </message>
+    <message>
+        <source>Set the position of the taskbar on the screen</source>
+        <translation>設置任務欄在屏幕中的位置</translation>
+    </message>
+    <message>
+        <source>Only on main</source>
+        <translation>僅主屏顯示</translation>
+    </message>
+    <message>
+        <source>On screen where the cursor is</source>
+        <translation>跟隨鼠標位置顯示</translation>
+    </message>
+    <message>
+        <source>Plugin Area</source>
+        <translation>插件區域</translation>
+    </message>
+    <message>
+        <source>Select which icons appear in the Dock</source>
+        <translation>選擇顯示在任務欄插件區域的圖標</translation>
+    </message>
+</context>
+<context>
+    <name>mouse</name>
+    <message>
+        <source>Mouse and Touchpad</source>
+        <translation>鼠標與觸控板</translation>
+    </message>
+    <message>
+        <source>Common、Mouse、Touchpad</source>
+        <translation>通用、鼠標、觸控板</translation>
+    </message>
+</context>
+<context>
+    <name>mouseMain</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Mouse</source>
+        <translation>鼠標</translation>
+    </message>
+    <message>
+        <source>Touchpad</source>
+        <translation>觸控板</translation>
+    </message>
+</context>
+<context>
+    <name>notification</name>
+    <message>
+        <source>DND mode, app notifications</source>
+        <translation>勿擾模式、應用通知</translation>
+    </message>
+    <message>
+        <source>Notification</source>
+        <translation>通知</translation>
+    </message>
+</context>
+<context>
+    <name>notificationMain</name>
+    <message>
+        <source>Do Not Disturb Settings</source>
+        <translation>勿擾設置</translation>
+    </message>
+    <message>
+        <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
+        <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心查看所有消息。</translation>
+    </message>
+    <message>
+        <source>Enable Do Not Disturb</source>
+        <translation>啓用勿擾模式</translation>
+    </message>
+    <message>
+        <source>When the screen is locked</source>
+        <translation>在屏幕鎖屏時</translation>
+    </message>
+    <message>
+        <source>Number of notifications shown on the desktop</source>
+        <translation>通知橫幅展示數量</translation>
+    </message>
+    <message>
+        <source>App Notifications</source>
+        <translation>應用通知</translation>
+    </message>
+    <message>
+        <source>Allow Notifications</source>
+        <translation>允許通知</translation>
+    </message>
+    <message>
+        <source>Display notification on desktop or show unread messages in the notification center</source>
+        <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <translation>桌面</translation>
+    </message>
+    <message>
+        <source>Lock Screen</source>
+        <translation>鎖屏</translation>
+    </message>
+    <message>
+        <source>Notification Center</source>
+        <translation>通知中心</translation>
+    </message>
+    <message>
+        <source>Show message preview</source>
+        <translation>顯示消息預覽</translation>
+    </message>
+    <message>
+        <source>Play a sound</source>
+        <translation>通知時提示聲音</translation>
+    </message>
+</context>
+<context>
+    <name>personalization</name>
+    <message>
+        <source>Personalization</source>
+        <translation>個性化</translation>
+    </message>
+</context>
+<context>
+    <name>personalizationMain</name>
+    <message>
+        <source>Theme</source>
+        <translation>主題</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>外觀</translation>
+    </message>
+    <message>
+        <source>Window effect</source>
+        <translation>窗口效果</translation>
+    </message>
+    <message>
+        <source>Personalize your wallpaper and screensaver</source>
+        <translation>個性化您的壁紙和屏保</translation>
+    </message>
+    <message>
+        <source>Screensaver</source>
+        <translation>屏幕保護</translation>
+    </message>
+    <message>
+        <source>Colors and icons</source>
+        <translation>顏色和圖標</translation>
+    </message>
+    <message>
+        <source>Adjust accent color and theme icons</source>
+        <translation>調整活動色和主題圖標</translation>
+    </message>
+    <message>
+        <source>Font and font size</source>
+        <translation>字體和字號</translation>
+    </message>
+    <message>
+        <source>Change system font and size</source>
+        <translation>修改系統字體與字號</translation>
+    </message>
+    <message>
+        <source>Wallpaper</source>
+        <translation>壁紙</translation>
+    </message>
+    <message>
+        <source>Select light, dark or automatic theme appearance</source>
+        <translation>選擇淺色、深色或自動切換主題外觀</translation>
+    </message>
+    <message>
+        <source>Interface and effects, rounded corners</source>
+        <translation>界面和效果、窗口圓角</translation>
+    </message>
+</context>
+<context>
+    <name>power</name>
+    <message>
+        <source>Power saving settings, screen and suspend</source>
+        <translation>節能設置、屏幕和待機管理</translation>
+    </message>
+    <message>
+        <source>Power</source>
+        <translation>電源管理</translation>
+    </message>
+</context>
+<context>
+    <name>powerMain</name>
+    <message>
+        <source>General</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
+        <translation>性能模式、節能設置、喚醒設置、關機設置</translation>
+    </message>
+    <message>
+        <source>Plugged In</source>
+        <translation>使用電源</translation>
+    </message>
+    <message>
+        <source>Screen and suspend</source>
+        <translation>屏幕和待機管理</translation>
+    </message>
+    <message>
+        <source>On Battery</source>
+        <translation>使用電池</translation>
+    </message>
+    <message>
+        <source>screen and suspend, low battery, battery management</source>
+        <translation>屏幕和待機管理、低電量管理、電池管理</translation>
+    </message>
+</context>
+<context>
+    <name>privacy</name>
+    <message>
+        <source>Privacy and Security</source>
+        <translation>私隱和安全</translation>
+    </message>
+    <message>
+        <source>Camera, folder permissions</source>
+        <translation>攝像頭、文件夾權限</translation>
+    </message>
+</context>
+<context>
+    <name>privacyMain</name>
+    <message>
+        <source>Camera</source>
+        <translation>攝像頭</translation>
+    </message>
+    <message>
+        <source>Choose whether the application has access to the camera</source>
+        <translation>選擇應用是否有攝像頭的訪問權限</translation>
+    </message>
+    <message>
+        <source>Files and Folders</source>
+        <translation>文件和文件夾</translation>
+    </message>
+    <message>
+        <source>Choose whether the application has access to files and folders</source>
+        <translation>選擇應用是否有文件和文件夾的訪問權限</translation>
+    </message>
+</context>
+<context>
+    <name>sound</name>
+    <message>
+        <source>Sound</source>
+        <translation>聲音</translation>
+    </message>
+    <message>
+        <source>Output, input, sound effects, devices</source>
+        <translation>輸入、輸出、系統音效、設備管理</translation>
+    </message>
+</context>
+<context>
+    <name>soundMain</name>
+    <message>
+        <source>Settings</source>
+        <translation>設置</translation>
+    </message>
+    <message>
+        <source>Sound Effects</source>
+        <translation>系統音效</translation>
+    </message>
+    <message>
+        <source>Enable/disable sound effects</source>
+        <translation>開啓/關閉系統音效</translation>
+    </message>
+    <message>
+        <source>Enable/disable audio devices</source>
+        <translation>啓用/禁用音頻設備</translation>
+    </message>
+    <message>
+        <source>Devices</source>
+        <translation>設備管理</translation>
+    </message>
+</context>
+<context>
+    <name>system</name>
+    <message>
+        <source>Common settings</source>
+        <translation>常用設置</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系統</translation>
+    </message>
+</context>
+<context>
+    <name>systemInfo</name>
+    <message>
+        <source>Auxiliary Information</source>
+        <translation>輔助信息</translation>
+    </message>
+</context>
+<context>
+    <name>systemInfoMain</name>
+    <message>
+        <source>About This PC</source>
+        <translation>關於本機</translation>
+    </message>
+    <message>
+        <source>System version, device information</source>
+        <translation>系統版本、設備信息</translation>
+    </message>
+    <message>
+        <source>View the notice of open source software</source>
+        <translation>查看開源軟件聲明</translation>
+    </message>
+    <message>
+        <source>User Experience Program</source>
+        <translation>用户體驗計劃</translation>
+    </message>
+    <message>
+        <source>Join the user experience program to help improve the product</source>
+        <translation>加入用户體驗計劃，幫助改進產品</translation>
+    </message>
+    <message>
+        <source>End User License Agreement</source>
+        <translation>用户許可協議</translation>
+    </message>
+    <message>
+        <source>View the end  user license agreement</source>
+        <translation>查看最終用户許可協議</translation>
+    </message>
+    <message>
+        <source>Privacy Policy</source>
+        <translation>私隱政策</translation>
+    </message>
+    <message>
+        <source>View information about privacy policy</source>
+        <translation>查看私隱政策相關信息</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation>開源軟件聲明</translation>
+    </message>
+</context>
+<context>
+    <name>touchscreen</name>
+    <message>
+        <source>Touchscreen</source>
+        <translation>觸控屏</translation>
+    </message>
+    <message>
+        <source>Configuring Touchscreen</source>
+        <translation>觸控屏設置</translation>
+    </message>
+</context>
+<context>
+    <name>touchscreenMain</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+</context>
+<context>
+    <name>wacom</name>
+    <message>
+        <source>wacom</source>
+        <translation>數位板</translation>
+    </message>
+    <message>
+        <source>Configuring wacom</source>
+        <translation>數位板選項設置</translation>
+    </message>
+</context>
+<context>
+    <name>wacomMain</name>
+    <message>
+        <source>wacom</source>
+        <translation>數位板</translation>
+    </message>
+    <message>
+        <source>Wacom Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Pen Mode</source>
+        <translation>筆模式</translation>
+    </message>
+    <message>
+        <source>Mouse Mode</source>
+        <translation>鼠標模式</translation>
+    </message>
+    <message>
+        <source>Pressure Sensitivity</source>
+        <translation>壓感</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>輕</translation>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -1,133 +1,149 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="zh_TW" version="2.1">
-    <context>
-        <name>AccountSettings</name>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Add new user</source>
-            <translation>新增新使用者</translation>
-        </message>
-        <message>
-            <source>Set fullname</source>
-            <translation>設定全名</translation>
-        </message>
-        <message>
-            <source>Login settings</source>
-            <translation>登入設定</translation>
-        </message>
-        <message>
-            <source>Login Settings</source>
-            <translation>登入設定</translation>
-        </message>
-        <message>
-            <source>Login without password</source>
-            <translation>免密登入</translation>
-        </message>
-        <message>
-            <source>Delete current account</source>
-            <translation>刪除當前帳戶</translation>
-        </message>
-        <message>
-            <source>Group setting</source>
-            <translation>使用者組設定</translation>
-        </message>
-        <message>
-            <source>Account groups</source>
-            <translation>使用者組</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>Group name</source>
-            <translation>使用者組名稱</translation>
-        </message>
-        <message>
-            <source>Add group</source>
-            <translation>新增使用者組</translation>
-        </message>
-        <message>
-            <source>Auto login, login without password</source>
-            <translation>自動登入, 免密登入</translation>
-        </message>
-        <message>
-            <source>Auto login</source>
-            <translation>自動登入</translation>
-        </message>
-        <message>
-            <source>Account Information</source>
-            <translation>帳戶資訊</translation>
-        </message>
-        <message>
-            <source>Account name, account fullname, account type</source>
-            <translation>帳戶名，全名，帳戶型別</translation>
-        </message>
-        <message>
-            <source>Account name</source>
-            <translation>帳戶名</translation>
-        </message>
-        <message>
-            <source>Account fullname</source>
-            <translation>帳戶全名</translation>
-        </message>
-        <message>
-            <source>Account type</source>
-            <translation>帳戶型別</translation>
-        </message>
-        <message>
-            <source>The full name is too long</source>
-            <translation>名稱過長</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddFaceinfoDialog</name>
-        <message>
-            <source>Enroll Face</source>
-            <translation>新增人臉資料</translation>
-        </message>
-        <message>
-            <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
-            <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
-        </message>
-        <message>
-            <source>I have read and agree to the</source>
-            <translation>我已閱讀並同意</translation>
-        </message>
-        <message>
-            <source>Disclaimer</source>
-            <translation>《使用者免責宣告》</translation>
-        </message>
-        <message>
-            <source>Next</source>
-            <translation>下一步</translation>
-        </message>
-        <message>
-            <source>Face enrolled</source>
-            <translation>人臉錄入完成</translation>
-        </message>
-        <message>
-            <source>Failed to enroll your face</source>
-            <translation>人臉錄入失敗</translation>
-        </message>
-        <message>
-            <source>Done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Retry Enroll</source>
-            <translation>重新錄入</translation>
-        </message>
-        <message>
-            <source>Before using face recognition, please note that: 
+<TS version="2.1" language="zh_TW">
+<context>
+    <name>AccountSettings</name>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Add new user</source>
+        <translation>新增新使用者</translation>
+    </message>
+    <message>
+        <source>Set fullname</source>
+        <translation>設定全名</translation>
+    </message>
+    <message>
+        <source>Login settings</source>
+        <translation>登入設定</translation>
+    </message>
+    <message>
+        <source>Login Settings</source>
+        <translation>登入設定</translation>
+    </message>
+    <message>
+        <source>Login without password</source>
+        <translation>免密登入</translation>
+    </message>
+    <message>
+        <source>Delete current account</source>
+        <translation>刪除當前帳戶</translation>
+    </message>
+    <message>
+        <source>Group setting</source>
+        <translation>使用者組設定</translation>
+    </message>
+    <message>
+        <source>Account groups</source>
+        <translation>使用者組</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>Group name</source>
+        <translation>使用者組名稱</translation>
+    </message>
+    <message>
+        <source>Add group</source>
+        <translation>新增使用者組</translation>
+    </message>
+    <message>
+        <source>Auto login, login without password</source>
+        <translation>自動登入, 免密登入</translation>
+    </message>
+    <message>
+        <source>Auto login</source>
+        <translation>自動登入</translation>
+    </message>
+    <message>
+        <source>Account Information</source>
+        <translation>帳戶資訊</translation>
+    </message>
+    <message>
+        <source>Account name, account fullname, account type</source>
+        <translation>帳戶名，全名，帳戶型別</translation>
+    </message>
+    <message>
+        <source>Account name</source>
+        <translation>帳戶名</translation>
+    </message>
+    <message>
+        <source>Account fullname</source>
+        <translation>帳戶全名</translation>
+    </message>
+    <message>
+        <source>Account type</source>
+        <translation>帳戶型別</translation>
+    </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation>名稱過長</translation>
+    </message>
+    <message>
+        <source>Group names should be no more than 32 characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Group names cannot only have numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AddFaceinfoDialog</name>
+    <message>
+        <source>Enroll Face</source>
+        <translation>新增人臉資料</translation>
+    </message>
+    <message>
+        <source>Make sure all parts of your face are not covered by objects and are clearly visible. Your face should be well-lit as well.</source>
+        <translation>請確保五官清晰可見，避免佩戴帽子、墨鏡、口罩等物件，保證光線充足，避免陽光直射，以提高錄入成功率</translation>
+    </message>
+    <message>
+        <source>I have read and agree to the</source>
+        <translation>我已閱讀並同意</translation>
+    </message>
+    <message>
+        <source>Disclaimer</source>
+        <translation>《使用者免責宣告》</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>下一步</translation>
+    </message>
+    <message>
+        <source>Face enrolled</source>
+        <translation>人臉錄入完成</translation>
+    </message>
+    <message>
+        <source>Failed to enroll your face</source>
+        <translation>人臉錄入失敗</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Retry Enroll</source>
+        <translation>重新錄入</translation>
+    </message>
+    <message>
+        <source>Before using face recognition, please note that: 
 1. Your device may be unlocked by people or objects that look or appear similar to you.
 2. Face recognition is less secure than digital passwords and mixed passwords.
 3. The success rate of unlocking your device through face recognition will be reduced in a low-light, high-light, back-light, large angle scenario and other scenarios.
@@ -138,7 +154,7 @@ In order to better use of face recognition, please pay attention to the followin
 1. Please stay in a well-lit setting, avoid direct sunlight and other people appearing in the recorded screen.
 2. Please pay attention to the facial state when inputting data, and do not let your hats, hair, sunglasses, masks, heavy makeup and other factors to cover your facial features.
 3. Please avoid tilting or lowering your head, closing your eyes or showing only one side of your face, and make sure your front face appears clearly and completely in the prompt box.</source>
-            <translation>在使用人臉識別功能前，請注意以下事項：
+        <translation>在使用人臉識別功能前，請注意以下事項：
 1.您的裝置可能會被容貌、外形與您相近的人或物品解鎖。
 2.人臉識別的安全性低於數字密碼、混合密碼。
 3.在暗光、強光、逆光或角度過大等場景下，人臉識別的解鎖成功率會有所降低。
@@ -149,3983 +165,3983 @@ In order to better use of face recognition, please pay attention to the followin
 1.請保證光線充足，避免陽光直射並避免其他人出現在錄入的畫面中。
 2.請注意錄入資料時的面部狀態，避免衣帽、頭髮、墨鏡、口罩、濃妝等遮擋面部資訊。
 3.請避免仰頭、低頭、閉眼或僅露出側臉的情況，確保臉部正面清晰完整的出現在提示框內。</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddFingerDialog</name>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>Enroll Finger</source>
-            <translation>新增指紋資料</translation>
-        </message>
-        <message>
-            <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
-            <translation>將要錄入的手指放入指紋錄入器裡面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
-        </message>
-        <message>
-            <source>I have read and agree to the</source>
-            <translation>我已閱讀並同意</translation>
-        </message>
-        <message>
-            <source>Disclaimer</source>
-            <translation>《使用者免責宣告》</translation>
-        </message>
-        <message>
-            <source>Next</source>
-            <translation>下一步</translation>
-        </message>
-        <message>
-            <source>Retry Enroll</source>
-            <translation>重新錄入</translation>
-        </message>
-        <message>
-            <source>"Biometric authentication" is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through "biometric authentication", the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
+    </message>
+</context>
+<context>
+    <name>AddFingerDialog</name>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>Enroll Finger</source>
+        <translation>新增指紋資料</translation>
+    </message>
+    <message>
+        <source>Place the finger to be entered into the fingerprint sensor and move it from bottom to top. After completing the action, please lift your finger.</source>
+        <translation>將要錄入的手指放入指紋錄入器裡面餅從下往上移動手指,完成動作後請擡起您的手指</translation>
+    </message>
+    <message>
+        <source>I have read and agree to the</source>
+        <translation>我已閱讀並同意</translation>
+    </message>
+    <message>
+        <source>Disclaimer</source>
+        <translation>《使用者免責宣告》</translation>
+    </message>
+    <message>
+        <source>Next</source>
+        <translation>下一步</translation>
+    </message>
+    <message>
+        <source>Retry Enroll</source>
+        <translation>重新錄入</translation>
+    </message>
+    <message>
+        <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
-UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through "Service and Support" in the UOS.</source>
-            <translation>「生物認證」是統信軟體技術有限公司提供的一種對使用者進行身份認證的功能。通過「生物認證」，將採集的生物識別資料與儲存在裝置本地的生物識別資料進行比對，並根據比對結果來驗證使用者身份。
+UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
+        <translation>「生物認證」是統信軟體技術有限公司提供的一種對使用者進行身份認證的功能。通過「生物認證」，將採集的生物識別資料與儲存在裝置本地的生物識別資料進行比對，並根據比對結果來驗證使用者身份。
         請您注意，統信軟體不會收集或訪問您的生物識別資訊，此類資訊將會儲存在您的本地裝置中。請您僅在您的個人裝置中開啟生物認證功能，並使用您本人的生物識別資訊進行相關操作，並及時在該裝置上停用或清除他人的生物識別資訊，否則由此給您帶來的風險將由您承擔。
         統信軟體致力於研究與提高生物認證功能的安全性、精確性、與穩定性，但是，受限於環境、裝置、技術等因素和風險控制等原因，我們暫時無法保證您一定能通過生物認證，請您不要將生物認證作為登入統信作業系統的唯一途徑。若您在使用生物認證時有任何問題或建議的，可以通過系統內的「服務與支援」進行反饋。</translation>
-        </message>
-    </context>
-    <context>
-        <name>AutoLoginWarningDialog</name>
-        <message>
-            <source>"Auto Login" can be enabled for only one account, please disable it for the account "%1" first</source>
-            <translation>只允許一個帳戶開啟自動登入，請先關閉%1帳戶的自動登入，再進行操作</translation>
-        </message>
-        <message>
-            <source>Ok</source>
-            <translation>確 定</translation>
-        </message>
-    </context>
-    <context>
-        <name>AvatarSettingsDialog</name>
-        <message>
-            <source>Images</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Human</source>
-            <translation>人物</translation>
-        </message>
-        <message>
-            <source>Animal</source>
-            <translation>動物</translation>
-        </message>
-        <message>
-            <source>Scenery</source>
-            <translation>靜物</translation>
-        </message>
-        <message>
-            <source>Illustration</source>
-            <translation>創意插圖</translation>
-        </message>
-        <message>
-            <source>Emoji</source>
-            <translation>表情符號</translation>
-        </message>
-        <message>
-            <source>custom</source>
-            <translation>自定義圖片</translation>
-        </message>
-        <message>
-            <source>Cartoon style</source>
-            <translation>Q版風格</translation>
-        </message>
-        <message>
-            <source>Dimensional style</source>
-            <translation>立體風格</translation>
-        </message>
-        <message>
-            <source>Flat style</source>
-            <translation>平面風格</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>儲存</translation>
-        </message>
-    </context>
-    <context>
-        <name>BatteryPage</name>
-        <message>
-            <source>Screen and Suspend</source>
-            <translation>螢幕和待機</translation>
-        </message>
-        <message>
-            <source>Turn off the monitor after</source>
-            <translation>關閉顯示器</translation>
-        </message>
-        <message>
-            <source>Lock screen after</source>
-            <translation>自動鎖屏</translation>
-        </message>
-        <message>
-            <source>Computer suspends after</source>
-            <translation>進入待機</translation>
-        </message>
-        <message>
-            <source>When the lid is closed</source>
-            <translation>筆記本合蓋時</translation>
-        </message>
-        <message>
-            <source>When the power button is pressed</source>
-            <translation>按電源按鈕時</translation>
-        </message>
-        <message>
-            <source>Low Battery</source>
-            <translation>低電量管理</translation>
-        </message>
-        <message>
-            <source>Low battery notification</source>
-            <translation>低電量提醒</translation>
-        </message>
-        <message>
-            <source>Auto suspend</source>
-            <translation>自動待機</translation>
-        </message>
-        <message>
-            <source>Auto Hibernate</source>
-            <translation>自動休眠</translation>
-        </message>
-        <message>
-            <source>Low battery threshold</source>
-            <translation>低電量閾值</translation>
-        </message>
-        <message>
-            <source>Battery Management</source>
-            <translation>電池管理</translation>
-        </message>
-        <message>
-            <source>Display remaining using and charging time</source>
-            <translation>顯示剩餘使用時間及剩餘充電時間</translation>
-        </message>
-        <message>
-            <source>Maximum capacity</source>
-            <translation>最大容量</translation>
-        </message>
-        <message>
-            <source>Low battery level</source>
-            <translation>低電量時</translation>
-        </message>
-        <message>
-            <source>Disable</source>
-            <translation>從不</translation>
-        </message>
-    </context>
-    <context>
-        <name>BlueToothAdaptersModel</name>
-        <message>
-            <source>Bluetooth is turned off, and the name is displayed as "%1"</source>
-            <translation>藍牙已關閉，名稱顯示為"%1"</translation>
-        </message>
-        <message>
-            <source>Bluetooth is turned on, and the name is displayed as "%1"</source>
-            <translation>藍牙已打開，名稱顯示為 "%1"</translation>
-        </message>
-    </context>
-    <context>
-        <name>BlueToothDeviceListView</name>
-        <message>
-            <source>Disconnect</source>
-            <translation>斷開連線</translation>
-        </message>
-        <message>
-            <source>Connect</source>
-            <translation>連線</translation>
-        </message>
-        <message>
-            <source>Send Files</source>
-            <translation>傳送檔案</translation>
-        </message>
-        <message>
-            <source>Rename</source>
-            <translation>重新命名</translation>
-        </message>
-        <message>
-            <source>Remove Device</source>
-            <translation>移除裝置</translation>
-        </message>
-        <message>
-            <source>Select file</source>
-            <translation>選擇檔案</translation>
-        </message>
-    </context>
-    <context>
-        <name>BluetoothCtl</name>
-        <message>
-            <source>Edit</source>
-            <translation>修改</translation>
-        </message>
-        <message>
-            <source>Allow other Bluetooth devices to find this device</source>
-            <translation>允許其他藍牙裝置找到該裝置</translation>
-        </message>
-        <message>
-            <source>To use the Bluetooth function, please turn off</source>
-            <translation>如需使用藍牙功能，請關閉</translation>
-        </message>
-        <message>
-            <source>Airplane Mode</source>
-            <translation>飛航模式</translation>
-        </message>
-        <message>
-            <source>Bluetooth name cannot exceed 64 characters</source>
-            <translation>藍牙名稱不能超過64個字元</translation>
-        </message>
-    </context>
-    <context>
-        <name>BluetoothDeviceModel</name>
-        <message>
-            <source>Connected</source>
-            <translation>已連線</translation>
-        </message>
-        <message>
-            <source>Not connected</source>
-            <translation>未連線</translation>
-        </message>
-    </context>
-    <context>
-        <name>BootPage</name>
-        <message>
-            <source>Startup Settings</source>
-            <translation>啟動設定</translation>
-        </message>
-        <message>
-            <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
-            <translation>您可以點選菜單改變預設啟動項，也可以拖拽圖片到視窗改變背景圖片.</translation>
-        </message>
-        <message>
-            <source>grub start delay</source>
-            <translation>啟動延時</translation>
-        </message>
-        <message>
-            <source>theme</source>
-            <translation>主題</translation>
-        </message>
-        <message>
-            <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
-            <translation>開啟主題後您可以在開機時看到主題背景</translation>
-        </message>
-        <message>
-            <source>Boot menu verification</source>
-            <translation>啟動菜單驗證</translation>
-        </message>
-        <message>
-            <source>After opening, entering the menu editing requires a password.</source>
-            <translation>開啟後進入啟動菜單編輯需要密碼.</translation>
-        </message>
-        <message>
-            <source>Change Password</source>
-            <translation>修改密碼</translation>
-        </message>
-        <message>
-            <source>Change boot menu verification password</source>
-            <translation>修改啟動菜單驗證密碼</translation>
-        </message>
-        <message>
-            <source>Set the boot menu authentication password</source>
-            <translation>設定啟動菜單驗證密碼</translation>
-        </message>
-        <message>
-            <source>User Name :</source>
-            <translation>使用者名稱：</translation>
-        </message>
-        <message>
-            <source>root</source>
-            <translation>root</translation>
-        </message>
-        <message>
-            <source>New Password :</source>
-            <translation>新密碼：</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Passwords do not match</source>
-            <translation>密碼不一致</translation>
-        </message>
-        <message>
-            <source>Repeat password:</source>
-            <translation>確認密碼：</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Sure</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <source>Start animation</source>
-            <translation>啟動動畫</translation>
-        </message>
-        <message>
-            <source>Adjust the size of the logo animation on the system startup interface</source>
-            <translation>調整系統啟動介面的logo動畫尺寸大小</translation>
-        </message>
-    </context>
-    <context>
-        <name>Camera</name>
-        <message>
-            <source>Allow below apps to access your camera:</source>
-            <translation>允許下麵的應用訪問您的攝像頭</translation>
-        </message>
-    </context>
-    <context>
-        <name>CharaMangerModel</name>
-        <message>
-            <source>Fingerprint1</source>
-            <translation>指紋1</translation>
-        </message>
-        <message>
-            <source>Fingerprint2</source>
-            <translation>指紋2</translation>
-        </message>
-        <message>
-            <source>Fingerprint3</source>
-            <translation>指紋3</translation>
-        </message>
-        <message>
-            <source>Fingerprint4</source>
-            <translation>指紋4</translation>
-        </message>
-        <message>
-            <source>Fingerprint5</source>
-            <translation>指紋5</translation>
-        </message>
-        <message>
-            <source>Fingerprint6</source>
-            <translation>指紋6</translation>
-        </message>
-        <message>
-            <source>Fingerprint7</source>
-            <translation>指紋7</translation>
-        </message>
-        <message>
-            <source>Fingerprint8</source>
-            <translation>指紋8</translation>
-        </message>
-        <message>
-            <source>Fingerprint9</source>
-            <translation>指紋9</translation>
-        </message>
-        <message>
-            <source>Fingerprint10</source>
-            <translation>指紋10</translation>
-        </message>
-        <message>
-            <source>Scan failed</source>
-            <translation>指紋錄入失敗</translation>
-        </message>
-        <message>
-            <source>The fingerprint already exists</source>
-            <translation>指紋已存在</translation>
-        </message>
-        <message>
-            <source>Please scan other fingers</source>
-            <translation>請使用其他手指錄入</translation>
-        </message>
-        <message>
-            <source>Unknown error</source>
-            <translation>未知錯誤</translation>
-        </message>
-        <message>
-            <source>Scan suspended</source>
-            <translation>指紋錄入被中斷</translation>
-        </message>
-        <message>
-            <source>Cannot recognize</source>
-            <translation>無法識別</translation>
-        </message>
-        <message>
-            <source>Moved too fast</source>
-            <translation>接觸時間短</translation>
-        </message>
-        <message>
-            <source>Finger moved too fast, please do not lift until prompted</source>
-            <translation>接觸時間短，驗證時請勿移動手指</translation>
-        </message>
-        <message>
-            <source>Unclear fingerprint</source>
-            <translation>影像模糊</translation>
-        </message>
-        <message>
-            <source>Clean your finger or adjust the finger position, and try again</source>
-            <translation>請清潔手指或調整觸控位置，再次按壓指紋識別器</translation>
-        </message>
-        <message>
-            <source>Already scanned</source>
-            <translation>影像重複</translation>
-        </message>
-        <message>
-            <source>Adjust the finger position to scan your fingerprint fully</source>
-            <translation>請調整手指按壓區域以錄入更多指紋</translation>
-        </message>
-        <message>
-            <source>Finger moved too fast. Please do not lift until prompted</source>
-            <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
-        </message>
-        <message>
-            <source>Lift your finger and place it on the sensor again</source>
-            <translation>請擡起手指，再次按壓</translation>
-        </message>
-        <message>
-            <source>Position your face inside the frame</source>
-            <translation>請確保您的面部全部顯示在識別區域內</translation>
-        </message>
-        <message>
-            <source>Face enrolled</source>
-            <translation>人臉錄入完成</translation>
-        </message>
-        <message>
-            <source>Position a human face please</source>
-            <translation>請使用人類面容</translation>
-        </message>
-        <message>
-            <source>Keep away from the camera</source>
-            <translation>請遠離鏡頭</translation>
-        </message>
-        <message>
-            <source>Get closer to the camera</source>
-            <translation>請靠近鏡頭</translation>
-        </message>
-        <message>
-            <source>Do not position multiple faces inside the frame</source>
-            <translation>請不要多人入鏡</translation>
-        </message>
-        <message>
-            <source>Make sure the camera lens is clean</source>
-            <translation>請確保鏡頭清潔</translation>
-        </message>
-        <message>
-            <source>Do not enroll in dark, bright or backlit environments</source>
-            <translation>請避免在暗光、強光、逆光環境下操作</translation>
-        </message>
-        <message>
-            <source>Keep your face uncovered</source>
-            <translation>請保持面部無遮擋</translation>
-        </message>
-        <message>
-            <source>Scan timed out</source>
-            <translation>錄入超時</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Camera occupied!</source>
-            <translation>攝像頭被佔用！</translation>
-        </message>
-    </context>
-    <context>
-        <name>ColorAndIcons</name>
-        <message>
-            <source>Accent Color</source>
-            <translation>活動用色</translation>
-        </message>
-        <message>
-            <source>Icon Settings</source>
-            <translation>圖示設定</translation>
-        </message>
-        <message>
-            <source>Icon Theme</source>
-            <translation>圖示主題</translation>
-        </message>
-        <message>
-            <source>Customize your theme icon</source>
-            <translation>自定義您的主題圖示</translation>
-        </message>
-        <message>
-            <source>Cursor Theme</source>
-            <translation>游標主題</translation>
-        </message>
-        <message>
-            <source>Customize your theme cursor</source>
-            <translation>自定義您的主題游標</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComfirmDeleteDialog</name>
-        <message>
-            <source>Are you sure you want to delete this account?</source>
-            <translation>您確定要刪除此帳戶嗎？</translation>
-        </message>
-        <message>
-            <source>Delete account directory</source>
-            <translation>刪除帳戶目錄</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Delete</source>
-            <translation>刪除</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComfirmSafePage</name>
-        <message>
-            <source>Go to settings</source>
-            <translation>去設定</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-    </context>
-    <context>
-        <name>Common</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Repeat delay</source>
-            <translation>重複延遲</translation>
-        </message>
-        <message>
-            <source>Short</source>
-            <translation>短</translation>
-        </message>
-        <message>
-            <source>Long</source>
-            <translation>長</translation>
-        </message>
-        <message>
-            <source>Repeat rate</source>
-            <translation>重複速度</translation>
-        </message>
-        <message>
-            <source>Slow</source>
-            <translation>慢</translation>
-        </message>
-        <message>
-            <source>Fast</source>
-            <translation>快</translation>
-        </message>
-        <message>
-            <source>Numeric Keypad</source>
-            <translation>啟用數字鍵盤</translation>
-        </message>
-        <message>
-            <source>test here</source>
-            <translation>請在此輸入測試</translation>
-        </message>
-        <message>
-            <source>Caps lock prompt</source>
-            <translation>大寫鎖定提示</translation>
-        </message>
-        <message>
-            <source>Scroll Speed</source>
-            <translation>滾動速度</translation>
-        </message>
-        <message>
-            <source>Double Click Speed</source>
-            <translation>雙擊速度</translation>
-        </message>
-        <message>
-            <source>Double Click Test</source>
-            <translation>雙擊測試</translation>
-        </message>
-        <message>
-            <source>Left Hand Mode</source>
-            <translation>左手模式</translation>
-        </message>
-        <message>
-            <source>Enable Keyboard</source>
-            <translation>鍵盤</translation>
-        </message>
-    </context>
-    <context>
-        <name>CommonInfoWork</name>
-        <message>
-            <source>Large size</source>
-            <translation>大尺寸</translation>
-        </message>
-        <message>
-            <source>Small size</source>
-            <translation>小尺寸</translation>
-        </message>
-        <message>
-            <source>Failed to get root access</source>
-            <translation>進入開發者模式失敗</translation>
-        </message>
-        <message>
-            <source>Please sign in to your Union ID first</source>
-            <translation>請先登入Union ID</translation>
-        </message>
-        <message>
-            <source>Cannot read your PC information</source>
-            <translation>無法獲取硬體資訊</translation>
-        </message>
-        <message>
-            <source>No network connection</source>
-            <translation>無網路連線</translation>
-        </message>
-        <message>
-            <source>Certificate loading failed, unable to get root access</source>
-            <translation>證書載入失敗，無法進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Signature verification failed, unable to get root access</source>
-            <translation>簽名驗證失敗，無法進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Agree and Join User Experience Program</source>
-            <translation>同意並加入使用者體驗計劃</translation>
-        </message>
-        <message>
-            <source>The Disclaimer of Developer Mode</source>
-            <translation>開發者模式免責宣告</translation>
-        </message>
-        <message>
-            <source>Agree and Request Root Access</source>
-            <translation>同意並進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Start setting the new boot animation, please wait for a minute</source>
-            <translation>開始設定啟動新動畫，請稍等一會兒</translation>
-        </message>
-        <message>
-            <source>Setting new boot animation finished</source>
-            <translation>新的啟動動畫設定完成</translation>
-        </message>
-        <message>
-            <source>The settings will be applied after rebooting the system</source>
-            <translation>新的設定會在重啟系統後生效</translation>
-        </message>
-    </context>
-    <context>
-        <name>ConfirmManager</name>
-        <message>
-            <source>Password must contain numbers and letters</source>
-            <translation>密碼必須包含數字和字母</translation>
-        </message>
-        <message>
-            <source>Password must be between 8 and 64 characters</source>
-            <translation>密碼長度必須為8~64個字元</translation>
-        </message>
-    </context>
-    <context>
-        <name>CreateAccountDialog</name>
-        <message>
-            <source>Create a new account</source>
-            <translation>建立新使用者</translation>
-        </message>
-        <message>
-            <source>Account type</source>
-            <translation>帳戶型別</translation>
-        </message>
-        <message>
-            <source>UserName</source>
-            <translation>使用者名稱</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>FullName</source>
-            <translation>全名</translation>
-        </message>
-        <message>
-            <source>Optional</source>
-            <translation>選填</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Create account</source>
-            <translation>建立使用者</translation>
-        </message>
-    </context>
-    <context>
-        <name>CustomAvatarEmpatyArea</name>
-        <message>
-            <source>You haven't uploaded an avatar yet. Click or drag and drop to upload an image.</source>
-            <translation>您還沒有上傳過頭像，可點選或拖拽上傳圖片</translation>
-        </message>
-    </context>
-    <context>
-        <name>DCC_NAMESPACE::SystemInfoModel</name>
-        <message>
-            <source>available</source>
-            <translation>可用</translation>
-        </message>
-    </context>
-    <context>
-        <name>DCC_NAMESPACE::SystemInfoWork</name>
-        <message>
-            <source>https://www.deepin.org/en/agreement/privacy/</source>
-            <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
-        </message>
-        <message>
-            <source>https://www.uniontech.com/agreement/privacy-en</source>
-            <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
-        </message>
-        <message>
-            <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href="%1"&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href="%1"&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;統信軟體非常重視您的隱私。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及儲存您的資訊的隱私政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href="%1"&gt;點選此處&lt;/a&gt;檢視我們最新的隱私政策和/或通過訪問 &lt;a href="%1"&gt;%1&lt;/a&gt;線上檢視。請您務必認真閱讀、充分理解我們針對客戶隱私的做法，如果有任何疑問，請聯絡我們：support@uniontech.com。&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <source>https://www.uniontech.com/agreement/experience-en</source>
-            <translation>https://www.uniontech.com/agreement/experience-cn</translation>
-        </message>
-        <message>
-            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href="%1"&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
-            <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。詳細說明請參照Deepin隱私政策 (&lt;a href="%1"&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href="%1"&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。瞭解使用者體驗計劃，請訪問：&lt;a href="%1"&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <source>Agree and Join User Experience Program</source>
-            <translation>同意並加入使用者體驗計劃</translation>
-        </message>
-    </context>
-    <context>
-        <name>DateTimeSettingDialog</name>
-        <message>
-            <source>Date and time setting</source>
-            <translation>日期和時間設定</translation>
-        </message>
-        <message>
-            <source>Date</source>
-            <translation>日期</translation>
-        </message>
-        <message>
-            <source>Year</source>
-            <translation>年</translation>
-        </message>
-        <message>
-            <source>Month</source>
-            <translation>月</translation>
-        </message>
-        <message>
-            <source>Day</source>
-            <translation>日</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Confirm</source>
-            <translation>確認</translation>
-        </message>
-    </context>
-    <context>
-        <name>DatetimeModel</name>
-        <message>
-            <source>Tomorrow</source>
-            <translation>明天</translation>
-        </message>
-        <message>
-            <source>Yesterday</source>
-            <translation>昨天</translation>
-        </message>
-        <message>
-            <source>Today</source>
-            <translation>今天</translation>
-        </message>
-        <message>
-            <source>%1 hours earlier than local</source>
-            <translation>比本地早了 %1 小時</translation>
-        </message>
-        <message>
-            <source>%1 hours later than local</source>
-            <translation>比本地晚了 %1 小時</translation>
-        </message>
-        <message>
-            <source>Space</source>
-            <translation>空格</translation>
-        </message>
-        <message>
-            <source>Week</source>
-            <translation>星期/周</translation>
-        </message>
-        <message>
-            <source>First day of week</source>
-            <translation>一週首日</translation>
-        </message>
-        <message>
-            <source>Short date</source>
-            <translation>短日期</translation>
-        </message>
-        <message>
-            <source>Long date</source>
-            <translation>長日期</translation>
-        </message>
-        <message>
-            <source>Short time</source>
-            <translation>短時間</translation>
-        </message>
-        <message>
-            <source>Long time</source>
-            <translation>長時間</translation>
-        </message>
-        <message>
-            <source>Currency symbol</source>
-            <translation>貨幣符號</translation>
-        </message>
-        <message>
-            <source>Positive currency</source>
-            <translation>貨幣正數</translation>
-        </message>
-        <message>
-            <source>Negative currency</source>
-            <translation>貨幣負數</translation>
-        </message>
-        <message>
-            <source>Decimal symbol</source>
-            <translation>小數點</translation>
-        </message>
-        <message>
-            <source>Digit grouping symbol</source>
-            <translation>分隔符</translation>
-        </message>
-        <message>
-            <source>Digit grouping</source>
-            <translation>數字分組</translation>
-        </message>
-        <message>
-            <source>Page size</source>
-            <translation>紙張</translation>
-        </message>
-    </context>
-    <context>
-        <name>DatetimeWorker</name>
-        <message>
-            <source>Authentication is required to change NTP server</source>
-            <translation>修改 NTP 地址需要認證</translation>
-        </message>
-    </context>
-    <context>
-        <name>DccColorDialog</name>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>儲存</translation>
-        </message>
-    </context>
-    <context>
-        <name>DccWindow</name>
-        <message>
-            <source>Control Center provides the options for system settings.</source>
-            <translation>控制中心提供作業系統的所有設定選項。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDAccountSecurity</name>
-        <message>
-            <source>Bind WeChat</source>
-            <translation>繫結微信</translation>
-        </message>
-        <message>
-            <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
-            <translation>通過繫結微信，您可以安全快速地登入您的%1 ID和本地帳戶</translation>
-        </message>
-        <message>
-            <source>Unlinked</source>
-            <translation>未繫結</translation>
-        </message>
-        <message>
-            <source>Unbinding</source>
-            <translation>解綁</translation>
-        </message>
-        <message>
-            <source>Link</source>
-            <translation>去繫結</translation>
-        </message>
-        <message>
-            <source>Are you sure you want to unbind WeChat?</source>
-            <translation>您確定要解綁微信嗎？</translation>
-        </message>
-        <message>
-            <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
-            <translation>解綁微信後，您將無法使用微信掃碼登入%1 ID、微信掃碼登入本地帳戶</translation>
-        </message>
-        <message>
-            <source>Let me think it over</source>
-            <translation>我再想想</translation>
-        </message>
-        <message>
-            <source>Local Account Binding</source>
-            <translation>繫結本地帳戶</translation>
-        </message>
-        <message>
-            <source>After binding your local account, you can use the following functions:</source>
-            <translation>繫結本地帳戶後，您可以使用如下功能：</translation>
-        </message>
-        <message>
-            <source>WeChat Scan Code Login System</source>
-            <translation>微信掃碼登入系統</translation>
-        </message>
-        <message>
-            <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
-            <translation>使用%1 ID繫結的微信，掃碼登入本地帳戶</translation>
-        </message>
-        <message>
-            <source>Reset password via %1 ID</source>
-            <translation>通過%1 ID重置密碼</translation>
-        </message>
-        <message>
-            <source>Reset your local password via %1 ID in case you forget it.</source>
-            <translation>在您忘記本地帳戶密碼時，通過%1 ID重置密碼</translation>
-        </message>
-        <message>
-            <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
-            <translation>如需使用上述功能，請前往控制中心-帳戶，開啟相應選項</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDInterface</name>
-        <message>
-            <source>deepin</source>
-            <translation>deepin</translation>
-        </message>
-        <message>
-            <source>UOS</source>
-            <translation>UOS</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDLogin</name>
-        <message>
-            <source>Cloud Sync</source>
-            <translation>雲同步</translation>
-        </message>
-        <message>
-            <source>Manage your %1 ID and sync your personal data across devices.
+    </message>
+</context>
+<context>
+    <name>AutoLoginWarningDialog</name>
+    <message>
+        <source>&quot;Auto Login&quot; can be enabled for only one account, please disable it for the account &quot;%1&quot; first</source>
+        <translation>只允許一個帳戶開啟自動登入，請先關閉%1帳戶的自動登入，再進行操作</translation>
+    </message>
+    <message>
+        <source>Ok</source>
+        <translation>確 定</translation>
+    </message>
+</context>
+<context>
+    <name>AvatarSettingsDialog</name>
+    <message>
+        <source>Images</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Human</source>
+        <translation>人物</translation>
+    </message>
+    <message>
+        <source>Animal</source>
+        <translation>動物</translation>
+    </message>
+    <message>
+        <source>Scenery</source>
+        <translation>靜物</translation>
+    </message>
+    <message>
+        <source>Illustration</source>
+        <translation>創意插圖</translation>
+    </message>
+    <message>
+        <source>Emoji</source>
+        <translation>表情符號</translation>
+    </message>
+    <message>
+        <source>custom</source>
+        <translation>自定義圖片</translation>
+    </message>
+    <message>
+        <source>Cartoon style</source>
+        <translation>Q版風格</translation>
+    </message>
+    <message>
+        <source>Dimensional style</source>
+        <translation>立體風格</translation>
+    </message>
+    <message>
+        <source>Flat style</source>
+        <translation>平面風格</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+</context>
+<context>
+    <name>BatteryPage</name>
+    <message>
+        <source>Screen and Suspend</source>
+        <translation>螢幕和待機</translation>
+    </message>
+    <message>
+        <source>Turn off the monitor after</source>
+        <translation>關閉顯示器</translation>
+    </message>
+    <message>
+        <source>Lock screen after</source>
+        <translation>自動鎖屏</translation>
+    </message>
+    <message>
+        <source>Computer suspends after</source>
+        <translation>進入待機</translation>
+    </message>
+    <message>
+        <source>When the lid is closed</source>
+        <translation>筆記本合蓋時</translation>
+    </message>
+    <message>
+        <source>When the power button is pressed</source>
+        <translation>按電源按鈕時</translation>
+    </message>
+    <message>
+        <source>Low Battery</source>
+        <translation>低電量管理</translation>
+    </message>
+    <message>
+        <source>Low battery notification</source>
+        <translation>低電量提醒</translation>
+    </message>
+    <message>
+        <source>Auto suspend</source>
+        <translation>自動待機</translation>
+    </message>
+    <message>
+        <source>Auto Hibernate</source>
+        <translation>自動休眠</translation>
+    </message>
+    <message>
+        <source>Low battery threshold</source>
+        <translation>低電量閾值</translation>
+    </message>
+    <message>
+        <source>Battery Management</source>
+        <translation>電池管理</translation>
+    </message>
+    <message>
+        <source>Display remaining using and charging time</source>
+        <translation>顯示剩餘使用時間及剩餘充電時間</translation>
+    </message>
+    <message>
+        <source>Maximum capacity</source>
+        <translation>最大容量</translation>
+    </message>
+    <message>
+        <source>Low battery level</source>
+        <translation>低電量時</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>從不</translation>
+    </message>
+</context>
+<context>
+    <name>BlueToothAdaptersModel</name>
+    <message>
+        <source>Bluetooth is turned off, and the name is displayed as &quot;%1&quot;</source>
+        <translation>藍牙已關閉，名稱顯示為&quot;%1&quot;</translation>
+    </message>
+    <message>
+        <source>Bluetooth is turned on, and the name is displayed as &quot;%1&quot;</source>
+        <translation>藍牙已打開，名稱顯示為 &quot;%1&quot;</translation>
+    </message>
+</context>
+<context>
+    <name>BlueToothDeviceListView</name>
+    <message>
+        <source>Disconnect</source>
+        <translation>斷開連線</translation>
+    </message>
+    <message>
+        <source>Connect</source>
+        <translation>連線</translation>
+    </message>
+    <message>
+        <source>Send Files</source>
+        <translation>傳送檔案</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>重新命名</translation>
+    </message>
+    <message>
+        <source>Remove Device</source>
+        <translation>移除裝置</translation>
+    </message>
+    <message>
+        <source>Select file</source>
+        <translation>選擇檔案</translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothCtl</name>
+    <message>
+        <source>Edit</source>
+        <translation>修改</translation>
+    </message>
+    <message>
+        <source>Allow other Bluetooth devices to find this device</source>
+        <translation>允許其他藍牙裝置找到該裝置</translation>
+    </message>
+    <message>
+        <source>To use the Bluetooth function, please turn off</source>
+        <translation>如需使用藍牙功能，請關閉</translation>
+    </message>
+    <message>
+        <source>Airplane Mode</source>
+        <translation>飛航模式</translation>
+    </message>
+    <message>
+        <source>Bluetooth name cannot exceed 64 characters</source>
+        <translation>藍牙名稱不能超過64個字元</translation>
+    </message>
+</context>
+<context>
+    <name>BluetoothDeviceModel</name>
+    <message>
+        <source>Connected</source>
+        <translation>已連線</translation>
+    </message>
+    <message>
+        <source>Not connected</source>
+        <translation>未連線</translation>
+    </message>
+</context>
+<context>
+    <name>BootPage</name>
+    <message>
+        <source>Startup Settings</source>
+        <translation>啟動設定</translation>
+    </message>
+    <message>
+        <source>You can click the menu to change the default startup items, or drag the image to the window to change the background image.</source>
+        <translation>您可以點選菜單改變預設啟動項，也可以拖拽圖片到視窗改變背景圖片.</translation>
+    </message>
+    <message>
+        <source>grub start delay</source>
+        <translation>啟動延時</translation>
+    </message>
+    <message>
+        <source>theme</source>
+        <translation>主題</translation>
+    </message>
+    <message>
+        <source>After turning on the theme, you can see the theme background when you turn on the computer</source>
+        <translation>開啟主題後您可以在開機時看到主題背景</translation>
+    </message>
+    <message>
+        <source>Boot menu verification</source>
+        <translation>啟動菜單驗證</translation>
+    </message>
+    <message>
+        <source>After opening, entering the menu editing requires a password.</source>
+        <translation>開啟後進入啟動菜單編輯需要密碼.</translation>
+    </message>
+    <message>
+        <source>Change Password</source>
+        <translation>修改密碼</translation>
+    </message>
+    <message>
+        <source>Change boot menu verification password</source>
+        <translation>修改啟動菜單驗證密碼</translation>
+    </message>
+    <message>
+        <source>Set the boot menu authentication password</source>
+        <translation>設定啟動菜單驗證密碼</translation>
+    </message>
+    <message>
+        <source>User Name :</source>
+        <translation>使用者名稱：</translation>
+    </message>
+    <message>
+        <source>root</source>
+        <translation>root</translation>
+    </message>
+    <message>
+        <source>New Password :</source>
+        <translation>新密碼：</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Passwords do not match</source>
+        <translation>密碼不一致</translation>
+    </message>
+    <message>
+        <source>Repeat password:</source>
+        <translation>確認密碼：</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Sure</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>Start animation</source>
+        <translation>啟動動畫</translation>
+    </message>
+    <message>
+        <source>Adjust the size of the logo animation on the system startup interface</source>
+        <translation>調整系統啟動介面的logo動畫尺寸大小</translation>
+    </message>
+</context>
+<context>
+    <name>Camera</name>
+    <message>
+        <source>Allow below apps to access your camera:</source>
+        <translation>允許下麵的應用訪問您的攝像頭</translation>
+    </message>
+</context>
+<context>
+    <name>CharaMangerModel</name>
+    <message>
+        <source>Fingerprint1</source>
+        <translation>指紋1</translation>
+    </message>
+    <message>
+        <source>Fingerprint2</source>
+        <translation>指紋2</translation>
+    </message>
+    <message>
+        <source>Fingerprint3</source>
+        <translation>指紋3</translation>
+    </message>
+    <message>
+        <source>Fingerprint4</source>
+        <translation>指紋4</translation>
+    </message>
+    <message>
+        <source>Fingerprint5</source>
+        <translation>指紋5</translation>
+    </message>
+    <message>
+        <source>Fingerprint6</source>
+        <translation>指紋6</translation>
+    </message>
+    <message>
+        <source>Fingerprint7</source>
+        <translation>指紋7</translation>
+    </message>
+    <message>
+        <source>Fingerprint8</source>
+        <translation>指紋8</translation>
+    </message>
+    <message>
+        <source>Fingerprint9</source>
+        <translation>指紋9</translation>
+    </message>
+    <message>
+        <source>Fingerprint10</source>
+        <translation>指紋10</translation>
+    </message>
+    <message>
+        <source>Scan failed</source>
+        <translation>指紋錄入失敗</translation>
+    </message>
+    <message>
+        <source>The fingerprint already exists</source>
+        <translation>指紋已存在</translation>
+    </message>
+    <message>
+        <source>Please scan other fingers</source>
+        <translation>請使用其他手指錄入</translation>
+    </message>
+    <message>
+        <source>Unknown error</source>
+        <translation>未知錯誤</translation>
+    </message>
+    <message>
+        <source>Scan suspended</source>
+        <translation>指紋錄入被中斷</translation>
+    </message>
+    <message>
+        <source>Cannot recognize</source>
+        <translation>無法識別</translation>
+    </message>
+    <message>
+        <source>Moved too fast</source>
+        <translation>接觸時間短</translation>
+    </message>
+    <message>
+        <source>Finger moved too fast, please do not lift until prompted</source>
+        <translation>接觸時間短，驗證時請勿移動手指</translation>
+    </message>
+    <message>
+        <source>Unclear fingerprint</source>
+        <translation>影像模糊</translation>
+    </message>
+    <message>
+        <source>Clean your finger or adjust the finger position, and try again</source>
+        <translation>請清潔手指或調整觸控位置，再次按壓指紋識別器</translation>
+    </message>
+    <message>
+        <source>Already scanned</source>
+        <translation>影像重複</translation>
+    </message>
+    <message>
+        <source>Adjust the finger position to scan your fingerprint fully</source>
+        <translation>請調整手指按壓區域以錄入更多指紋</translation>
+    </message>
+    <message>
+        <source>Finger moved too fast. Please do not lift until prompted</source>
+        <translation>指紋採集間隙，請勿移動手指，直到提示您擡起</translation>
+    </message>
+    <message>
+        <source>Lift your finger and place it on the sensor again</source>
+        <translation>請擡起手指，再次按壓</translation>
+    </message>
+    <message>
+        <source>Position your face inside the frame</source>
+        <translation>請確保您的面部全部顯示在識別區域內</translation>
+    </message>
+    <message>
+        <source>Face enrolled</source>
+        <translation>人臉錄入完成</translation>
+    </message>
+    <message>
+        <source>Position a human face please</source>
+        <translation>請使用人類面容</translation>
+    </message>
+    <message>
+        <source>Keep away from the camera</source>
+        <translation>請遠離鏡頭</translation>
+    </message>
+    <message>
+        <source>Get closer to the camera</source>
+        <translation>請靠近鏡頭</translation>
+    </message>
+    <message>
+        <source>Do not position multiple faces inside the frame</source>
+        <translation>請不要多人入鏡</translation>
+    </message>
+    <message>
+        <source>Make sure the camera lens is clean</source>
+        <translation>請確保鏡頭清潔</translation>
+    </message>
+    <message>
+        <source>Do not enroll in dark, bright or backlit environments</source>
+        <translation>請避免在暗光、強光、逆光環境下操作</translation>
+    </message>
+    <message>
+        <source>Keep your face uncovered</source>
+        <translation>請保持面部無遮擋</translation>
+    </message>
+    <message>
+        <source>Scan timed out</source>
+        <translation>錄入超時</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Camera occupied!</source>
+        <translation>攝像頭被佔用！</translation>
+    </message>
+</context>
+<context>
+    <name>ColorAndIcons</name>
+    <message>
+        <source>Accent Color</source>
+        <translation>活動用色</translation>
+    </message>
+    <message>
+        <source>Icon Settings</source>
+        <translation>圖示設定</translation>
+    </message>
+    <message>
+        <source>Icon Theme</source>
+        <translation>圖示主題</translation>
+    </message>
+    <message>
+        <source>Customize your theme icon</source>
+        <translation>自定義您的主題圖示</translation>
+    </message>
+    <message>
+        <source>Cursor Theme</source>
+        <translation>游標主題</translation>
+    </message>
+    <message>
+        <source>Customize your theme cursor</source>
+        <translation>自定義您的主題游標</translation>
+    </message>
+</context>
+<context>
+    <name>ComfirmDeleteDialog</name>
+    <message>
+        <source>Are you sure you want to delete this account?</source>
+        <translation>您確定要刪除此帳戶嗎？</translation>
+    </message>
+    <message>
+        <source>Delete account directory</source>
+        <translation>刪除帳戶目錄</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Delete</source>
+        <translation>刪除</translation>
+    </message>
+</context>
+<context>
+    <name>ComfirmSafePage</name>
+    <message>
+        <source>Go to settings</source>
+        <translation>去設定</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>Common</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Repeat delay</source>
+        <translation>重複延遲</translation>
+    </message>
+    <message>
+        <source>Short</source>
+        <translation>短</translation>
+    </message>
+    <message>
+        <source>Long</source>
+        <translation>長</translation>
+    </message>
+    <message>
+        <source>Repeat rate</source>
+        <translation>重複速度</translation>
+    </message>
+    <message>
+        <source>Slow</source>
+        <translation>慢</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation>快</translation>
+    </message>
+    <message>
+        <source>Numeric Keypad</source>
+        <translation>啟用數字鍵盤</translation>
+    </message>
+    <message>
+        <source>test here</source>
+        <translation>請在此輸入測試</translation>
+    </message>
+    <message>
+        <source>Caps lock prompt</source>
+        <translation>大寫鎖定提示</translation>
+    </message>
+    <message>
+        <source>Scroll Speed</source>
+        <translation>滾動速度</translation>
+    </message>
+    <message>
+        <source>Double Click Speed</source>
+        <translation>雙擊速度</translation>
+    </message>
+    <message>
+        <source>Double Click Test</source>
+        <translation>雙擊測試</translation>
+    </message>
+    <message>
+        <source>Left Hand Mode</source>
+        <translation>左手模式</translation>
+    </message>
+    <message>
+        <source>Enable Keyboard</source>
+        <translation>鍵盤</translation>
+    </message>
+</context>
+<context>
+    <name>CommonInfoWork</name>
+    <message>
+        <source>Large size</source>
+        <translation>大尺寸</translation>
+    </message>
+    <message>
+        <source>Small size</source>
+        <translation>小尺寸</translation>
+    </message>
+    <message>
+        <source>Failed to get root access</source>
+        <translation>進入開發者模式失敗</translation>
+    </message>
+    <message>
+        <source>Please sign in to your Union ID first</source>
+        <translation>請先登入Union ID</translation>
+    </message>
+    <message>
+        <source>Cannot read your PC information</source>
+        <translation>無法獲取硬體資訊</translation>
+    </message>
+    <message>
+        <source>No network connection</source>
+        <translation>無網路連線</translation>
+    </message>
+    <message>
+        <source>Certificate loading failed, unable to get root access</source>
+        <translation>證書載入失敗，無法進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Signature verification failed, unable to get root access</source>
+        <translation>簽名驗證失敗，無法進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Agree and Join User Experience Program</source>
+        <translation>同意並加入使用者體驗計劃</translation>
+    </message>
+    <message>
+        <source>The Disclaimer of Developer Mode</source>
+        <translation>開發者模式免責宣告</translation>
+    </message>
+    <message>
+        <source>Agree and Request Root Access</source>
+        <translation>同意並進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Start setting the new boot animation, please wait for a minute</source>
+        <translation>開始設定啟動新動畫，請稍等一會兒</translation>
+    </message>
+    <message>
+        <source>Setting new boot animation finished</source>
+        <translation>新的啟動動畫設定完成</translation>
+    </message>
+    <message>
+        <source>The settings will be applied after rebooting the system</source>
+        <translation>新的設定會在重啟系統後生效</translation>
+    </message>
+</context>
+<context>
+    <name>ConfirmManager</name>
+    <message>
+        <source>Password must contain numbers and letters</source>
+        <translation>密碼必須包含數字和字母</translation>
+    </message>
+    <message>
+        <source>Password must be between 8 and 64 characters</source>
+        <translation>密碼長度必須為8~64個字元</translation>
+    </message>
+</context>
+<context>
+    <name>CreateAccountDialog</name>
+    <message>
+        <source>Create a new account</source>
+        <translation>建立新使用者</translation>
+    </message>
+    <message>
+        <source>Account type</source>
+        <translation>帳戶型別</translation>
+    </message>
+    <message>
+        <source>UserName</source>
+        <translation>使用者名稱</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>FullName</source>
+        <translation>全名</translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation>選填</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Create account</source>
+        <translation>建立使用者</translation>
+    </message>
+</context>
+<context>
+    <name>CustomAvatarEmpatyArea</name>
+    <message>
+        <source>You haven&apos;t uploaded an avatar yet. Click or drag and drop to upload an image.</source>
+        <translation>您還沒有上傳過頭像，可點選或拖拽上傳圖片</translation>
+    </message>
+</context>
+<context>
+    <name>DCC_NAMESPACE::SystemInfoModel</name>
+    <message>
+        <source>available</source>
+        <translation>可用</translation>
+    </message>
+</context>
+<context>
+    <name>DCC_NAMESPACE::SystemInfoWork</name>
+    <message>
+        <source>https://www.deepin.org/en/agreement/privacy/</source>
+        <translation>https://www.deepin.org/zh/agreement/privacy/</translation>
+    </message>
+    <message>
+        <source>https://www.uniontech.com/agreement/privacy-en</source>
+        <translation>https://www.uniontech.com/agreement/privacy-cn</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;We are deeply aware of the importance of your personal information to you. So we have the Privacy Policy that covers how we collect, use, share, transfer, publicly disclose, and store your information.&lt;/p&gt;&lt;p&gt;You can &lt;a href=&quot;%1&quot;&gt;click here&lt;/a&gt; to view our latest privacy policy and/or view it online by visiting &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;. Please read carefully and fully understand our practices on customer privacy. If you have any questions, please contact us at: support@uniontech.com.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;統信軟體非常重視您的隱私。因此我們制定了涵蓋如何收集、使用、共享、轉讓、公開披露以及儲存您的資訊的隱私政策。&lt;/p&gt;&lt;p&gt;您可以&lt;a href=&quot;%1&quot;&gt;點選此處&lt;/a&gt;檢視我們最新的隱私政策和/或通過訪問 &lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;線上檢視。請您務必認真閱讀、充分理解我們針對客戶隱私的做法，如果有任何疑問，請聯絡我們：support@uniontech.com。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>https://www.uniontech.com/agreement/experience-en</source>
+        <translation>https://www.uniontech.com/agreement/experience-cn</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, do not join User Experience Program. For details, please refer to Deepin Privacy Policy (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;).&lt;/p&gt;</source>
+        <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。詳細說明請參照Deepin隱私政策 (&lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;)。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>&lt;p&gt;Joining User Experience Program means that you grant and authorize us to collect and use the information of your device, system and applications. If you refuse our collection and use of the aforementioned information, please do not join it. For the details of User Experience Program, please visit &lt;a href=&quot;%1&quot;&gt; %1&lt;/a&gt;.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;開啟使用者體驗計劃視為您授權我們收集和使用您的裝置及系統資訊，以及應用軟體資訊，您可以關閉使用者體驗計劃以拒絕我們對前述資訊的收集和使用。瞭解使用者體驗計劃，請訪問：&lt;a href=&quot;%1&quot;&gt;%1&lt;/a&gt;。&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <source>Agree and Join User Experience Program</source>
+        <translation>同意並加入使用者體驗計劃</translation>
+    </message>
+</context>
+<context>
+    <name>DateTimeSettingDialog</name>
+    <message>
+        <source>Date and time setting</source>
+        <translation>日期和時間設定</translation>
+    </message>
+    <message>
+        <source>Date</source>
+        <translation>日期</translation>
+    </message>
+    <message>
+        <source>Year</source>
+        <translation>年</translation>
+    </message>
+    <message>
+        <source>Month</source>
+        <translation>月</translation>
+    </message>
+    <message>
+        <source>Day</source>
+        <translation>日</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確認</translation>
+    </message>
+</context>
+<context>
+    <name>DatetimeModel</name>
+    <message>
+        <source>Tomorrow</source>
+        <translation>明天</translation>
+    </message>
+    <message>
+        <source>Yesterday</source>
+        <translation>昨天</translation>
+    </message>
+    <message>
+        <source>Today</source>
+        <translation>今天</translation>
+    </message>
+    <message>
+        <source>%1 hours earlier than local</source>
+        <translation>比本地早了 %1 小時</translation>
+    </message>
+    <message>
+        <source>%1 hours later than local</source>
+        <translation>比本地晚了 %1 小時</translation>
+    </message>
+    <message>
+        <source>Space</source>
+        <translation>空格</translation>
+    </message>
+    <message>
+        <source>Week</source>
+        <translation>星期/周</translation>
+    </message>
+    <message>
+        <source>First day of week</source>
+        <translation>一週首日</translation>
+    </message>
+    <message>
+        <source>Short date</source>
+        <translation>短日期</translation>
+    </message>
+    <message>
+        <source>Long date</source>
+        <translation>長日期</translation>
+    </message>
+    <message>
+        <source>Short time</source>
+        <translation>短時間</translation>
+    </message>
+    <message>
+        <source>Long time</source>
+        <translation>長時間</translation>
+    </message>
+    <message>
+        <source>Currency symbol</source>
+        <translation>貨幣符號</translation>
+    </message>
+    <message>
+        <source>Positive currency</source>
+        <translation>貨幣正數</translation>
+    </message>
+    <message>
+        <source>Negative currency</source>
+        <translation>貨幣負數</translation>
+    </message>
+    <message>
+        <source>Decimal symbol</source>
+        <translation>小數點</translation>
+    </message>
+    <message>
+        <source>Digit grouping symbol</source>
+        <translation>分隔符</translation>
+    </message>
+    <message>
+        <source>Digit grouping</source>
+        <translation>數字分組</translation>
+    </message>
+    <message>
+        <source>Page size</source>
+        <translation>紙張</translation>
+    </message>
+</context>
+<context>
+    <name>DatetimeWorker</name>
+    <message>
+        <source>Authentication is required to change NTP server</source>
+        <translation>修改 NTP 地址需要認證</translation>
+    </message>
+</context>
+<context>
+    <name>DccColorDialog</name>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+</context>
+<context>
+    <name>DccWindow</name>
+    <message>
+        <source>Control Center provides the options for system settings.</source>
+        <translation>控制中心提供作業系統的所有設定選項。</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDAccountSecurity</name>
+    <message>
+        <source>Bind WeChat</source>
+        <translation>繫結微信</translation>
+    </message>
+    <message>
+        <source>By binding WeChat, you can securely and quickly log in to your %1 ID and local accounts.</source>
+        <translation>通過繫結微信，您可以安全快速地登入您的%1 ID和本地帳戶</translation>
+    </message>
+    <message>
+        <source>Unlinked</source>
+        <translation>未繫結</translation>
+    </message>
+    <message>
+        <source>Unbinding</source>
+        <translation>解綁</translation>
+    </message>
+    <message>
+        <source>Link</source>
+        <translation>去繫結</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to unbind WeChat?</source>
+        <translation>您確定要解綁微信嗎？</translation>
+    </message>
+    <message>
+        <source>After unbinding WeChat, you will not be able to use WeChat to scan the QR code to log in to %1 ID or local account.</source>
+        <translation>解綁微信後，您將無法使用微信掃碼登入%1 ID、微信掃碼登入本地帳戶</translation>
+    </message>
+    <message>
+        <source>Let me think it over</source>
+        <translation>我再想想</translation>
+    </message>
+    <message>
+        <source>Local Account Binding</source>
+        <translation>繫結本地帳戶</translation>
+    </message>
+    <message>
+        <source>After binding your local account, you can use the following functions:</source>
+        <translation>繫結本地帳戶後，您可以使用如下功能：</translation>
+    </message>
+    <message>
+        <source>WeChat Scan Code Login System</source>
+        <translation>微信掃碼登入系統</translation>
+    </message>
+    <message>
+        <source>Use WeChat, which is bound to your %1 ID, to scan code to log in to your local account.</source>
+        <translation>使用%1 ID繫結的微信，掃碼登入本地帳戶</translation>
+    </message>
+    <message>
+        <source>Reset password via %1 ID</source>
+        <translation>通過%1 ID重置密碼</translation>
+    </message>
+    <message>
+        <source>Reset your local password via %1 ID in case you forget it.</source>
+        <translation>在您忘記本地帳戶密碼時，通過%1 ID重置密碼</translation>
+    </message>
+    <message>
+        <source>To use the above features, please go to Control Center - Accounts and turn on the corresponding options.</source>
+        <translation>如需使用上述功能，請前往控制中心-帳戶，開啟相應選項</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDInterface</name>
+    <message>
+        <source>deepin</source>
+        <translation>deepin</translation>
+    </message>
+    <message>
+        <source>UOS</source>
+        <translation>UOS</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDLogin</name>
+    <message>
+        <source>Cloud Sync</source>
+        <translation>雲同步</translation>
+    </message>
+    <message>
+        <source>Manage your %1 ID and sync your personal data across devices.
 Sign in to %1 ID to get personalized features and services of Browser, App Store, and more.</source>
-            <translation>管理您的%1 ID，將您的個人資料在不同裝置之間同步。
+        <translation>管理您的%1 ID，將您的個人資料在不同裝置之間同步。
 登入%1 ID以獲取瀏覽器、應用商店、服務與支援等眾多應用的個性功能和服務。</translation>
-        </message>
-        <message>
-            <source>Sign In to %1 ID</source>
-            <translation>登入%1 ID</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDSyncService</name>
-        <message>
-            <source>Auto Sync</source>
-            <translation>自動同步</translation>
-        </message>
-        <message>
-            <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
-            <translation>將您的系統設定和個人資訊安全地儲存在雲端，並在您不同的裝置上保持同步</translation>
-        </message>
-        <message>
-            <source>System Settings</source>
-            <translation>系統設定</translation>
-        </message>
-        <message>
-            <source>Last sync time: %1</source>
-            <translation>最近同步時間：%1</translation>
-        </message>
-        <message>
-            <source>Clear cloud data</source>
-            <translation>清除雲端資料</translation>
-        </message>
-        <message>
-            <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
-            <translation>確定要清除您儲存在雲端的系統設定和個人資料嗎？</translation>
-        </message>
-        <message>
-            <source>Once the data is cleared, it cannot be recovered!</source>
-            <translation>資料清除後將無法恢復！</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Clear</source>
-            <translation>清除</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinIDUserInfo</name>
-        <message>
-            <source>Synchronization Service</source>
-            <translation>同步服務</translation>
-        </message>
-        <message>
-            <source>Account and Security</source>
-            <translation>帳戶與安全</translation>
-        </message>
-        <message>
-            <source>Sign out</source>
-            <translation>退出登入</translation>
-        </message>
-        <message>
-            <source>Go to web settings</source>
-            <translation>前往網頁設定</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinWorker</name>
-        <message>
-            <source>encrypt password failed</source>
-            <translation>加密密碼失敗</translation>
-        </message>
-        <message>
-            <source>Wrong password, %1 chances left</source>
-            <translation>密碼錯誤，您還可以嘗試%1次</translation>
-        </message>
-        <message>
-            <source>The login error has reached the limit today. You can reset the password and try again.</source>
-            <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
-        </message>
-        <message>
-            <source>Operation Successful</source>
-            <translation>操作成功</translation>
-        </message>
-    </context>
-    <context>
-        <name>DeepinidModel</name>
-        <message>
-            <source>Mainland China</source>
-            <translation>中國大陸</translation>
-        </message>
-        <message>
-            <source>Other regions</source>
-            <translation>其他地區</translation>
-        </message>
-        <message>
-            <source>The feature is not available at present, please activate your system first</source>
-            <translation>當前系統未啟用，暫無法使用該功能</translation>
-        </message>
-        <message>
-            <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
-            <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DetailItem</name>
-        <message>
-            <source>Please choose the default program to open '%1'</source>
-            <translation>選擇打開「%1」的預設程式</translation>
-        </message>
-        <message>
-            <source>add</source>
-            <translation>新增</translation>
-        </message>
-        <message>
-            <source>Open Desktop file</source>
-            <translation>打開Desktop檔案</translation>
-        </message>
-        <message>
-            <source>Apps (*.desktop)</source>
-            <translation>應用程式(*.desktop)</translation>
-        </message>
-        <message>
-            <source>All files (*)</source>
-            <translation>所有檔案(*)</translation>
-        </message>
-    </context>
-    <context>
-        <name>DevelopModePage</name>
-        <message>
-            <source>Root Access</source>
-            <translation>開發者模式</translation>
-        </message>
-        <message>
-            <source>Request Root Access</source>
-            <translation>進入開發者模式</translation>
-        </message>
-        <message>
-            <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
-            <translation>可獲得root使用許可權，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
-        </message>
-        <message>
-            <source>Allowed</source>
-            <translation>已進入</translation>
-        </message>
-        <message>
-            <source>Enter</source>
-            <translation>進入</translation>
-        </message>
-        <message>
-            <source>Online</source>
-            <translation>線上啟用</translation>
-        </message>
-        <message>
-            <source>Login UOS ID</source>
-            <translation>登入UOS ID</translation>
-        </message>
-        <message>
-            <source>Offline</source>
-            <translation>離線啟用</translation>
-        </message>
-        <message>
-            <source>Import Certificate</source>
-            <translation>匯入證書</translation>
-        </message>
-        <message>
-            <source>Select file</source>
-            <translation>選擇檔案</translation>
-        </message>
-        <message>
-            <source>Your UOS ID has been logged in, click to enter developer mode</source>
-            <translation>您的UOS ID已登入，點選進入開發者模式</translation>
-        </message>
-        <message>
-            <source>Please sign in to your UOS ID first and continue</source>
-            <translation>進入開發者模式需要登入UOS ID</translation>
-        </message>
-        <message>
-            <source>1.Export PC Info</source>
-            <translation>1.匯出機器資訊</translation>
-        </message>
-        <message>
-            <source>Export</source>
-            <translation>匯出</translation>
-        </message>
-        <message>
-            <source>2.please go to &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
-            <translation>2.前往 &lt;a href="http://www.chinauos.com/developMode"&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
-        </message>
-        <message>
-            <source>3.Import Certificate</source>
-            <translation>3.匯入證書</translation>
-        </message>
-        <message>
-            <source>To install and run unsigned apps, please go to &lt;a href="Security Center"&gt;Security Center&lt;/a&gt; to change the settings.</source>
-            <translation>如需安裝非應用商店來源的應用，前往 &lt;a href="Security Center"&gt;安全中心&lt;/a&gt; 進行設定。</translation>
-        </message>
-        <message>
-            <source>Development and debugging options</source>
-            <translation>開發除錯選項</translation>
-        </message>
-        <message>
-            <source>System logging level</source>
-            <translation>系統日誌記錄級別</translation>
-        </message>
-        <message>
-            <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
-            <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多儲存空間.</translation>
-        </message>
-        <message>
-            <source>Off</source>
-            <translation>關閉</translation>
-        </message>
-        <message>
-            <source>Debug</source>
-            <translation>除錯</translation>
-        </message>
-        <message>
-            <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
-            <translation>更改選項處理可能需要一分鐘，收到設定成功提示後，請重啟裝置方可生效。</translation>
-        </message>
-    </context>
-    <context>
-        <name>DisclaimerControl</name>
-        <message>
-            <source>Disclaimer</source>
-            <translation>《使用者免責宣告》</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Agree</source>
-            <translation>同意</translation>
-        </message>
-    </context>
-    <context>
-        <name>FileAndFolder</name>
-        <message>
-            <source>Allow below apps to access these files and folders:</source>
-            <translation>允許下麵的應用訪問您的檔案和資料夾</translation>
-        </message>
-        <message>
-            <source>Documents</source>
-            <translation>文件</translation>
-        </message>
-        <message>
-            <source>Desktop</source>
-            <translation>桌面</translation>
-        </message>
-        <message>
-            <source>Pictures</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Videos</source>
-            <translation>影片</translation>
-        </message>
-        <message>
-            <source>Music</source>
-            <translation>音樂</translation>
-        </message>
-        <message>
-            <source>Downloads</source>
-            <translation>下載</translation>
-        </message>
-        <message>
-            <source>folder</source>
-            <translation>資料夾</translation>
-        </message>
-    </context>
-    <context>
-        <name>FontSizePage</name>
-        <message>
-            <source>Size</source>
-            <translation>字號</translation>
-        </message>
-        <message>
-            <source>Standard Font</source>
-            <translation>標準字型</translation>
-        </message>
-        <message>
-            <source>Monospaced Font</source>
-            <translation>等寬字型</translation>
-        </message>
-    </context>
-    <context>
-        <name>GeneralPage</name>
-        <message>
-            <source>Power Plans</source>
-            <translation>效能模式</translation>
-        </message>
-        <message>
-            <source>Power Saving Settings</source>
-            <translation>節能設定</translation>
-        </message>
-        <message>
-            <source>Auto power saving on low battery</source>
-            <translation>低電量時自動開啟節能模式</translation>
-        </message>
-        <message>
-            <source>Low battery threshold</source>
-            <translation>低電量閾值</translation>
-        </message>
-        <message>
-            <source>Auto power saving on battery</source>
-            <translation>使用電池時自動開啟節能模式</translation>
-        </message>
-        <message>
-            <source>Wakeup Settings</source>
-            <translation>喚醒設定</translation>
-        </message>
-        <message>
-            <source>Password is required to wake up the computer</source>
-            <translation>待機恢復時需要密碼</translation>
-        </message>
-        <message>
-            <source>Password is required to wake up the monitor</source>
-            <translation>喚醒顯示器時需要密碼</translation>
-        </message>
-        <message>
-            <source>Shutdown Settings</source>
-            <translation>關機設定</translation>
-        </message>
-        <message>
-            <source>Scheduled Shutdown</source>
-            <translation>定時關機</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <source>Repeat</source>
-            <translation>重複</translation>
-        </message>
-        <message>
-            <source>Once</source>
-            <translation>一次</translation>
-        </message>
-        <message>
-            <source>Every day</source>
-            <translation>每天</translation>
-        </message>
-        <message>
-            <source>Working days</source>
-            <translation>工作日</translation>
-        </message>
-        <message>
-            <source>Custom Time</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>Decrease screen brightness on power saver</source>
-            <translation>節能模式時降低螢幕亮度</translation>
-        </message>
-    </context>
-    <context>
-        <name>GestureModel</name>
-        <message>
-            <source>Three-finger</source>
-            <translation>三指</translation>
-        </message>
-        <message>
-            <source>Four-finger</source>
-            <translation>四指</translation>
-        </message>
-        <message>
-            <source>Up</source>
-            <translation>向上</translation>
-        </message>
-        <message>
-            <source>Down</source>
-            <translation>向下</translation>
-        </message>
-        <message>
-            <source>Left</source>
-            <translation>向左</translation>
-        </message>
-        <message>
-            <source>Right</source>
-            <translation>向右</translation>
-        </message>
-        <message>
-            <source>tap</source>
-            <translation>點選</translation>
-        </message>
-    </context>
-    <context>
-        <name>HomePage</name>
-        <message>
-            <source>,</source>
-            <translation>、</translation>
-        </message>
-        <message>
-            <source>...</source>
-            <translation>等</translation>
-        </message>
-    </context>
-    <context>
-        <name>InterfaceEffectListview</name>
-        <message>
-            <source>Optimal Performance</source>
-            <translation>最佳效能</translation>
-        </message>
-        <message>
-            <source>Balance</source>
-            <translation>均衡</translation>
-        </message>
-        <message>
-            <source>Best Visuals</source>
-            <translation>最佳視覺</translation>
-        </message>
-        <message>
-            <source>Disable all interface and window effects for efficient system performance.</source>
-            <translation>關閉所有介面和視窗特效，保障系統高效執行</translation>
-        </message>
-        <message>
-            <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
-            <translation>限制部分視窗特效，保障出色的視覺效果，同時維持系統流暢執行</translation>
-        </message>
-        <message>
-            <source>Enable all interface and window effects for the best visual experience.</source>
-            <translation>啟用所有介面和視窗特效，體驗最佳視覺效果</translation>
-        </message>
-    </context>
-    <context>
-        <name>KeyboardLayout</name>
-        <message>
-            <source>Keyboard layout</source>
-            <translation>鍵盤佈局</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Add the corresponding input method in &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
-            <translation>如需新增或切換鍵盤佈局，請同時在 &lt;a style='text-decoration: none;' href='Manage Input Methods'&gt; 輸入法管理 &lt;/a&gt;  中新增對應的輸入法以確保生效</translation>
-        </message>
-        <message>
-            <source>Add new keyboard layout...</source>
-            <translation>新增鍵盤佈局...</translation>
-        </message>
-    </context>
-    <context>
-        <name>LangAndFormat</name>
-        <message>
-            <source>Language</source>
-            <translation>語言</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Other languages</source>
-            <translation>其他語言</translation>
-        </message>
-        <message>
-            <source>add</source>
-            <translation>新增</translation>
-        </message>
-        <message>
-            <source>Region</source>
-            <translation>區域</translation>
-        </message>
-        <message>
-            <source>Area</source>
-            <translation>地區</translation>
-        </message>
-        <message>
-            <source>Operating system and applications may provide you with local content based on your country and region</source>
-            <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
-        </message>
-        <message>
-            <source>Region and format</source>
-            <translation>區域格式</translation>
-        </message>
-        <message>
-            <source>Operating system and applications may set date and time formats based on regional formats</source>
-            <translation>作業系統和某些應用會根據區域格式設定日期和時間格式</translation>
-        </message>
-    </context>
-    <context>
-        <name>LangsChooserDialog</name>
-        <message>
-            <source>Add language</source>
-            <translation>新增語言</translation>
-        </message>
-        <message>
-            <source>Search</source>
-            <translation>搜尋</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Add</source>
-            <translation>新增</translation>
-        </message>
-    </context>
-    <context>
-        <name>LayoutsChooser</name>
-        <message>
-            <source>Add language</source>
-            <translation>新增語言</translation>
-        </message>
-        <message>
-            <source>Search</source>
-            <translation>搜尋</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Add</source>
-            <translation>新增</translation>
-        </message>
-    </context>
-    <context>
-        <name>LoginMethod</name>
-        <message>
-            <source>Login method</source>
-            <translation>登入方式</translation>
-        </message>
-        <message>
-            <source>Password, wechat, biometric authentication, security key</source>
-            <translation>密碼，微信掃碼，生物認證，安全金鑰</translation>
-        </message>
-        <message>
-            <source>Password</source>
-            <translation>密碼</translation>
-        </message>
-        <message>
-            <source>Modify password</source>
-            <translation>修改密碼</translation>
-        </message>
-        <message>
-            <source>Validity days</source>
-            <translation>有效天數</translation>
-        </message>
-        <message>
-            <source>Always</source>
-            <translation>長期有效</translation>
-        </message>
-    </context>
-    <context>
-        <name>LogoModule</name>
-        <message>
-            <source>Copyright© 2011-%1 Deepin Community</source>
-            <translation>Copyright © 2011-%1 深度社區</translation>
-        </message>
-        <message>
-            <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
-            <translation>Copyright © 2019-%1 統信軟體技術有限公司</translation>
-        </message>
-    </context>
-    <context>
-        <name>MicrophonePage</name>
-        <message>
-            <source>Automatic Noise Suppression</source>
-            <translation>噪音抑制</translation>
-        </message>
-        <message>
-            <source>Input Volume</source>
-            <translation>輸入音量</translation>
-        </message>
-        <message>
-            <source>Input Level</source>
-            <translation>反饋音量</translation>
-        </message>
-        <message>
-            <source>Input</source>
-            <translation>輸入</translation>
-        </message>
-        <message>
-            <source>No input device for sound found</source>
-            <translation>沒有找到聲音輸入裝置</translation>
-        </message>
-        <message>
-            <source>Input Devices</source>
-            <translation>輸入裝置</translation>
-        </message>
-    </context>
-    <context>
-        <name>Mouse</name>
-        <message>
-            <source>Mouse</source>
-            <translation>滑鼠</translation>
-        </message>
-        <message>
-            <source>Pointer Speed</source>
-            <translation>指標速度</translation>
-        </message>
-        <message>
-            <source>Slow</source>
-            <translation>慢</translation>
-        </message>
-        <message>
-            <source>Fast</source>
-            <translation>快</translation>
-        </message>
-        <message>
-            <source>Pointer Size</source>
-            <translation>指標大小</translation>
-        </message>
-        <message>
-            <source>Short</source>
-            <translation>短</translation>
-        </message>
-        <message>
-            <source>Long</source>
-            <translation>長</translation>
-        </message>
-        <message>
-            <source>Mouse Acceleration</source>
-            <translation>滑鼠加速</translation>
-        </message>
-        <message>
-            <source>Disable touchpad when a mouse is connected</source>
-            <translation>插入滑鼠時停用觸控板</translation>
-        </message>
-        <message>
-            <source>Natural Scrolling</source>
-            <translation>自然滾動</translation>
-        </message>
-    </context>
-    <context>
-        <name>MyDevice</name>
-        <message>
-            <source>My Devices</source>
-            <translation>我的裝置</translation>
-        </message>
-    </context>
-    <context>
-        <name>NativeInfoPage</name>
-        <message>
-            <source>UOS</source>
-            <translation>UOS</translation>
-        </message>
-        <message>
-            <source>Computer name</source>
-            <translation>計算機名</translation>
-        </message>
-        <message>
-            <source>It cannot start or end with dashes</source>
-            <translation>計算機名不能以 - 開頭結尾</translation>
-        </message>
-        <message>
-            <source>OS Name</source>
-            <translation>產品名稱</translation>
-        </message>
-        <message>
-            <source>Version</source>
-            <translation>版本號</translation>
-        </message>
-        <message>
-            <source>Edition</source>
-            <translation>版本</translation>
-        </message>
-        <message>
-            <source>Type</source>
-            <translation>型別</translation>
-        </message>
-        <message>
-            <source>bit</source>
-            <translation>位</translation>
-        </message>
-        <message>
-            <source>Authorization</source>
-            <translation>版本授權</translation>
-        </message>
-        <message>
-            <source>System installation time</source>
-            <translation>系統安裝日期</translation>
-        </message>
-        <message>
-            <source>Kernel</source>
-            <translation>核心版本</translation>
-        </message>
-        <message>
-            <source>Graphics Platform</source>
-            <translation>圖形平臺</translation>
-        </message>
-        <message>
-            <source>Processor</source>
-            <translation>處理器</translation>
-        </message>
-        <message>
-            <source>Memory</source>
-            <translation>記憶體</translation>
-        </message>
-        <message>
-            <source>1~63 characters please</source>
-            <translation>計算機名長度必須介於1到63個字元之間</translation>
-        </message>
-    </context>
-    <context>
-        <name>OtherDevice</name>
-        <message>
-            <source>Other Devices</source>
-            <translation>其他裝置</translation>
-        </message>
-        <message>
-            <source>Show Bluetooth devices without names</source>
-            <translation>顯示沒有名稱的藍牙裝置</translation>
-        </message>
-    </context>
-    <context>
-        <name>PasswordLayout</name>
-        <message>
-            <source>Current password</source>
-            <translation>當前密碼</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>Weak</source>
-            <translation>強度低</translation>
-        </message>
-        <message>
-            <source>Medium</source>
-            <translation>強度中</translation>
-        </message>
-        <message>
-            <source>Strong</source>
-            <translation>強度高</translation>
-        </message>
-        <message>
-            <source>Password</source>
-            <translation>密碼</translation>
-        </message>
-        <message>
-            <source>Repeat Password</source>
-            <translation>重複密碼</translation>
-        </message>
-        <message>
-            <source>Password hint</source>
-            <translation>密碼提示</translation>
-        </message>
-        <message>
-            <source>Optional</source>
-            <translation>選填</translation>
-        </message>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Passwords do not match</source>
-            <translation>密碼不一致</translation>
-        </message>
-        <message>
-            <source>New password should differ from the current one</source>
-            <translation>新密碼和舊密碼不能相同</translation>
-        </message>
-        <message>
-            <source>The hint is visible to all users. Do not include the password here.</source>
-            <translation>密碼提示對所有人可見，切勿包含具體密碼資訊</translation>
-        </message>
-    </context>
-    <context>
-        <name>PasswordModifyDialog</name>
-        <message>
-            <source>Modify password</source>
-            <translation>修改密碼</translation>
-        </message>
-        <message>
-            <source>Reset password</source>
-            <translation>重置密碼</translation>
-        </message>
-        <message>
-            <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
-            <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
-        </message>
-        <message>
-            <source>Resetting the password will clear the data stored in the keyring.</source>
-            <translation>重設密碼將會清除金鑰環內已儲存的資料</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-    </context>
-    <context>
-        <name>PersonalizationInterface</name>
-        <message>
-            <source>Light</source>
-            <translation>淺色</translation>
-        </message>
-        <message>
-            <source>Auto</source>
-            <translation>自動</translation>
-        </message>
-        <message>
-            <source>Dark</source>
-            <translation>深色</translation>
-        </message>
-    </context>
-    <context>
-        <name>PersonalizationWorker</name>
-        <message>
-            <source>Custom</source>
-            <translation>自定義</translation>
-        </message>
-    </context>
-    <context>
-        <name>PluginArea</name>
-        <message>
-            <source>Plugin Area</source>
-            <translation>外掛區域</translation>
-        </message>
-        <message>
-            <source>Select which icons appear in the Dock</source>
-            <translation>選擇顯示在工作列外掛區域的圖示</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerOperatorModel</name>
-        <message>
-            <source>Shut down</source>
-            <translation>關機</translation>
-        </message>
-        <message>
-            <source>Suspend</source>
-            <translation>待機</translation>
-        </message>
-        <message>
-            <source>Hibernate</source>
-            <translation>休眠</translation>
-        </message>
-        <message>
-            <source>Turn off the monitor</source>
-            <translation>關閉顯示器</translation>
-        </message>
-        <message>
-            <source>Show the shutdown Interface</source>
-            <translation>進入關機介面</translation>
-        </message>
-        <message>
-            <source>Do nothing</source>
-            <translation>無任何操作</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerPage</name>
-        <message>
-            <source>Screen and Suspend</source>
-            <translation>螢幕和待機</translation>
-        </message>
-        <message>
-            <source>Turn off the monitor after</source>
-            <translation>關閉顯示器</translation>
-        </message>
-        <message>
-            <source>Lock screen after</source>
-            <translation>自動鎖屏</translation>
-        </message>
-        <message>
-            <source>Computer suspends after</source>
-            <translation>進入待機</translation>
-        </message>
-        <message>
-            <source>When the lid is closed</source>
-            <translation>筆記本合蓋時</translation>
-        </message>
-        <message>
-            <source>When the power button is pressed</source>
-            <translation>按電源按鈕時</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerPlansListview</name>
-        <message>
-            <source>High Performance</source>
-            <translation>高效能模式</translation>
-        </message>
-        <message>
-            <source>Balance Performance</source>
-            <translation>效能模式</translation>
-        </message>
-        <message>
-            <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
-            <translation>根據負載情況積極調整執行頻率</translation>
-        </message>
-        <message>
-            <source>Balanced</source>
-            <translation>平衡模式</translation>
-        </message>
-        <message>
-            <source>Power Saver</source>
-            <translation>節能模式</translation>
-        </message>
-        <message>
-            <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
-            <translation>效能優先，會顯著提升功耗和發熱</translation>
-        </message>
-        <message>
-            <source>Balancing performance and battery life, automatically adjusted according to usage</source>
-            <translation>兼顧效能和續航，根據使用情況自動調節</translation>
-        </message>
-        <message>
-            <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
-            <translation>續航優先，系統會犧牲一些效能表現來降低功耗</translation>
-        </message>
-    </context>
-    <context>
-        <name>PowerWorker</name>
-        <message>
-            <source>Minutes</source>
-            <translation>分鐘</translation>
-        </message>
-        <message>
-            <source>Hour</source>
-            <translation>小時</translation>
-        </message>
-        <message>
-            <source>Never</source>
-            <translation>從不</translation>
-        </message>
-    </context>
-    <context>
-        <name>PrivacyPolicyPage</name>
-        <message>
-            <source>Privacy Policy</source>
-            <translation>隱私政策</translation>
-        </message>
-        <message>
-            <source>Copy Link Address</source>
-            <translation>複製連結地址</translation>
-        </message>
-    </context>
-    <context>
-        <name>PwqualityManager</name>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Password must have at least %1 characters</source>
-            <translation>密碼長度不能少於%1個字元</translation>
-        </message>
-        <message>
-            <source>Password must be no more than %1 characters</source>
-            <translation>密碼長度不能超過%1個字元</translation>
-        </message>
-        <message>
-            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
-        </message>
-        <message>
-            <source>No more than %1 palindrome characters please</source>
-            <translation>迴文字元長度不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 monotonic characters please</source>
-            <translation>單調性字元不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 repeating characters please</source>
-            <translation>重複字元不超過%1位</translation>
-        </message>
-        <message>
-            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
-        </message>
-        <message>
-            <source>Password must not contain more than 4 palindrome characters</source>
-            <translation>密碼不得含有連續4個以上的迴文字元</translation>
-        </message>
-        <message>
-            <source>Do not use common words and combinations as password</source>
-            <translation>密碼不能是常見單詞及組合</translation>
-        </message>
-        <message>
-            <source>Create a strong password please</source>
-            <translation>密碼過於簡單，請增加密碼複雜度</translation>
-        </message>
-        <message>
-            <source>It does not meet password rules</source>
-            <translation>密碼不符合安全要求</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <source>Control Center</source>
-            <translation>控制中心</translation>
-        </message>
-        <message>
-            <source>Activated</source>
-            <translation>已啟用</translation>
-        </message>
-        <message>
-            <source>View</source>
-            <translation>檢視</translation>
-        </message>
-        <message>
-            <source>To be activated</source>
-            <translation>待啟用</translation>
-        </message>
-        <message>
-            <source>Activate</source>
-            <translation>啟用</translation>
-        </message>
-        <message>
-            <source>Expired</source>
-            <translation>已過期</translation>
-        </message>
-        <message>
-            <source>In trial period</source>
-            <translation>試用期</translation>
-        </message>
-        <message>
-            <source>Trial expired</source>
-            <translation>試用期過期</translation>
-        </message>
-        <message>
-            <source>dde-control-center</source>
-            <translation>控制中心</translation>
-        </message>
-        <message>
-            <source>Touch Screen Settings</source>
-            <translation>觸控屏設定</translation>
-        </message>
-        <message>
-            <source>The settings of touch screen changed</source>
-            <translation>已變更觸控屏設定</translation>
-        </message>
-        <message>
-            <source>This system wallpaper is locked. Please contact your admin.</source>
-            <translation>當前系統壁紙已被鎖定，請聯絡管理員</translation>
-        </message>
-    </context>
-    <context>
-        <name>RegionFormatDialog</name>
-        <message>
-            <source>Regions and formats</source>
-            <translation>區域和格式</translation>
-        </message>
-        <message>
-            <source>Search</source>
-            <translation>搜尋</translation>
-        </message>
-        <message>
-            <source>Default formats</source>
-            <translation>預設格式</translation>
-        </message>
-        <message>
-            <source>First day of week</source>
-            <translation>一週第一天</translation>
-        </message>
-        <message>
-            <source>Short date</source>
-            <translation>短日期</translation>
-        </message>
-        <message>
-            <source>Long date</source>
-            <translation>長日期</translation>
-        </message>
-        <message>
-            <source>Short time</source>
-            <translation>短時間</translation>
-        </message>
-        <message>
-            <source>Long time</source>
-            <translation>長時間</translation>
-        </message>
-        <message>
-            <source>Currency symbol</source>
-            <translation>貨幣符號</translation>
-        </message>
-        <message>
-            <source>Digit</source>
-            <translation>數字</translation>
-        </message>
-        <message>
-            <source>Paper size</source>
-            <translation>紙張</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>儲存</translation>
-        </message>
-    </context>
-    <context>
-        <name>RegionsChooserWindow</name>
-        <message>
-            <source>Search</source>
-            <translation>搜尋</translation>
-        </message>
-    </context>
-    <context>
-        <name>RegisterDialog</name>
-        <message>
-            <source>Set a Password</source>
-            <translation>設定密碼</translation>
-        </message>
-        <message>
-            <source>8-64 characters</source>
-            <translation>請輸入8-64位密碼</translation>
-        </message>
-        <message>
-            <source>Repeat the password</source>
-            <translation>請再次輸入密碼</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Confirm</source>
-            <translation>確定</translation>
-        </message>
-        <message>
-            <source>Passwords don't match</source>
-            <translation>兩次密碼輸入不一致</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScheduledShutdownDialog</name>
-        <message>
-            <source>Customize repetition time</source>
-            <translation>自定義重複時間</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>儲存</translation>
-        </message>
-    </context>
-    <context>
-        <name>ScreenSaverPage</name>
-        <message>
-            <source>Screensaver</source>
-            <translation>螢幕保護</translation>
-        </message>
-        <message>
-            <source>preview</source>
-            <translation>全屏預覽</translation>
-        </message>
-        <message>
-            <source>Personalized screensaver</source>
-            <translation>個性化屏保</translation>
-        </message>
-        <message>
-            <source>setting</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <source>idle time</source>
-            <translation>閒置時間</translation>
-        </message>
-        <message>
-            <source>1 minute</source>
-            <translation>1分鐘</translation>
-        </message>
-        <message>
-            <source>5 minute</source>
-            <translation>5分鐘</translation>
-        </message>
-        <message>
-            <source>10 minute</source>
-            <translation>10分鐘</translation>
-        </message>
-        <message>
-            <source>15 minute</source>
-            <translation>15分鐘</translation>
-        </message>
-        <message>
-            <source>30 minute</source>
-            <translation>30分鐘</translation>
-        </message>
-        <message>
-            <source>1 hour</source>
-            <translation>1小時</translation>
-        </message>
-        <message>
-            <source>never</source>
-            <translation>從不</translation>
-        </message>
-        <message>
-            <source>Password required for recovery</source>
-            <translation>恢復時需要密碼</translation>
-        </message>
-        <message>
-            <source>Picture slideshow screensaver</source>
-            <translation>圖片輪播屏保</translation>
-        </message>
-        <message>
-            <source>System screensaver</source>
-            <translation>系統屏保</translation>
-        </message>
-    </context>
-    <context>
-        <name>SearchableListViewPopup</name>
-        <message>
-            <source>Search</source>
-            <translation>搜尋</translation>
-        </message>
-        <message>
-            <source>No search results</source>
-            <translation>無搜尋結果</translation>
-        </message>
-    </context>
-    <context>
-        <name>ShortcutSettingDialog</name>
-        <message>
-            <source>Add custom shortcut</source>
-            <translation>新增自定義快捷鍵</translation>
-        </message>
-        <message>
-            <source>Name:</source>
-            <translation>名稱：</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>Command:</source>
-            <translation>命令：</translation>
-        </message>
-        <message>
-            <source>Shortcut</source>
-            <translation>快捷鍵</translation>
-        </message>
-        <message>
-            <source>None</source>
-            <translation>無</translation>
-        </message>
-        <message>
-            <source>Please enter a new shortcut</source>
-            <translation>請輸入新的快捷鍵</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Add</source>
-            <translation>新增</translation>
-        </message>
-        <message>
-            <source>Click Add to replace</source>
-            <translation>點選新增替換</translation>
-        </message>
-    </context>
-    <context>
-        <name>Shortcuts</name>
-        <message>
-            <source>Shortcuts</source>
-            <translation>快捷鍵</translation>
-        </message>
-        <message>
-            <source>System shortcut, custom shortcut</source>
-            <translation>系統快捷鍵、自定義快捷鍵</translation>
-        </message>
-        <message>
-            <source>Search shortcuts</source>
-            <translation>搜尋快捷鍵</translation>
-        </message>
-        <message>
-            <source>Custom</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>done</source>
-            <translation>完成</translation>
-        </message>
-        <message>
-            <source>edit</source>
-            <translation>編輯</translation>
-        </message>
-        <message>
-            <source>Please enter a new shortcut</source>
-            <translation>請輸入新的快捷鍵</translation>
-        </message>
-        <message>
-            <source>Click</source>
-            <translation>點選</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>or</source>
-            <translation>或</translation>
-        </message>
-        <message>
-            <source>Replace</source>
-            <translation>替換</translation>
-        </message>
-        <message>
-            <source>Restore default</source>
-            <translation>恢復預設</translation>
-        </message>
-        <message>
-            <source>Add custom shortcut</source>
-            <translation>新增快捷鍵</translation>
-        </message>
-    </context>
-    <context>
-        <name>SoundDevicemanagesPage</name>
-        <message>
-            <source>Output Devices</source>
-            <translation>輸出裝置</translation>
-        </message>
-        <message>
-            <source>Select whether to enable the devices</source>
-            <translation>選擇是否啟用裝置</translation>
-        </message>
-        <message>
-            <source>Input Devices</source>
-            <translation>輸入裝置</translation>
-        </message>
-    </context>
-    <context>
-        <name>SoundEffectsPage</name>
-        <message>
-            <source>Sound Effects</source>
-            <translation>系統音效</translation>
-        </message>
-    </context>
-    <context>
-        <name>SoundModel</name>
-        <message>
-            <source>Boot up</source>
-            <translation>開機</translation>
-        </message>
-        <message>
-            <source>Shut down</source>
-            <translation>關機</translation>
-        </message>
-        <message>
-            <source>Log out</source>
-            <translation>登出</translation>
-        </message>
-        <message>
-            <source>Wake up</source>
-            <translation>喚醒</translation>
-        </message>
-        <message>
-            <source>Volume +/-</source>
-            <translation>音量調節</translation>
-        </message>
-        <message>
-            <source>Notification</source>
-            <translation>通知</translation>
-        </message>
-        <message>
-            <source>Low battery</source>
-            <translation>電量不足</translation>
-        </message>
-        <message>
-            <source>Send icon in Launcher to Desktop</source>
-            <translation>從啟動器傳送圖示到桌面</translation>
-        </message>
-        <message>
-            <source>Empty Trash</source>
-            <translation>清空回收站</translation>
-        </message>
-        <message>
-            <source>Plug in</source>
-            <translation>電源接入</translation>
-        </message>
-        <message>
-            <source>Plug out</source>
-            <translation>電源拔出</translation>
-        </message>
-        <message>
-            <source>Removable device connected</source>
-            <translation>行動裝置接入</translation>
-        </message>
-        <message>
-            <source>Removable device removed</source>
-            <translation>行動裝置拔出</translation>
-        </message>
-        <message>
-            <source>Error</source>
-            <translation>錯誤提示</translation>
-        </message>
-    </context>
-    <context>
-        <name>SpeakerPage</name>
-        <message>
-            <source>Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Output Volume</source>
-            <translation>輸出音量</translation>
-        </message>
-        <message>
-            <source>Volume Boost</source>
-            <translation>音量增強</translation>
-        </message>
-        <message>
-            <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
-            <translation>音量大於100%時可能會導致音效失真，同時損害您的音訊輸出裝置</translation>
-        </message>
-        <message>
-            <source>Left</source>
-            <translation>左</translation>
-        </message>
-        <message>
-            <source>Right</source>
-            <translation>右</translation>
-        </message>
-        <message>
-            <source>Output</source>
-            <translation>輸出</translation>
-        </message>
-        <message>
-            <source>No output device for sound found</source>
-            <translation>沒有找到聲音輸出裝置</translation>
-        </message>
-        <message>
-            <source>Left Right Balance</source>
-            <translation>左右平衡</translation>
-        </message>
-        <message>
-            <source>Mono audio</source>
-            <translation>單聲道音訊</translation>
-        </message>
-        <message>
-            <source>Merge left and right channels into a single channel</source>
-            <translation>將左聲道和右聲道合併成一個聲道</translation>
-        </message>
-        <message>
-            <source>Auto pause</source>
-            <translation>插拔管理</translation>
-        </message>
-        <message>
-            <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
-            <translation>外設插拔時音訊輸出是否自動暫停</translation>
-        </message>
-        <message>
-            <source>Output Devices</source>
-            <translation>輸出裝置</translation>
-        </message>
-    </context>
-    <context>
-        <name>SyncInfoListModel</name>
-        <message>
-            <source>Sound</source>
-            <translation>聲音</translation>
-        </message>
-        <message>
-            <source>Power</source>
-            <translation>電源</translation>
-        </message>
-        <message>
-            <source>Mouse</source>
-            <translation>滑鼠</translation>
-        </message>
-        <message>
-            <source>Update</source>
-            <translation>更新</translation>
-        </message>
-        <message>
-            <source>Screensaver</source>
-            <translation>螢幕保護</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThemeSelectView</name>
-        <message>
-            <source>More Wallpapers</source>
-            <translation>下載更多</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeAndDate</name>
-        <message>
-            <source>Auto sync time</source>
-            <translation>自動同步配置</translation>
-        </message>
-        <message>
-            <source>Ntp server</source>
-            <translation>伺服器</translation>
-        </message>
-        <message>
-            <source>System date and time</source>
-            <translation>系統日期和時間</translation>
-        </message>
-        <message>
-            <source>Customize</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>Settings</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <source>Server address</source>
-            <translation>伺服器地址</translation>
-        </message>
-        <message>
-            <source>Required</source>
-            <translation>必填</translation>
-        </message>
-        <message>
-            <source>The ntp server address cannot be empty</source>
-            <translation>NTP 服務地址不能為空</translation>
-        </message>
-        <message>
-            <source>Use 24-hour format</source>
-            <translation>24小時制</translation>
-        </message>
-        <message>
-            <source>system time zone</source>
-            <translation>系統時區</translation>
-        </message>
-        <message>
-            <source>Timezone list</source>
-            <translation>時區列表</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeRange</name>
-        <message>
-            <source>from</source>
-            <translation>從</translation>
-        </message>
-        <message>
-            <source>to</source>
-            <translation>至</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimeoutDialog</name>
-        <message>
-            <source>Save the display settings?</source>
-            <translation>是否要儲存顯示設定？</translation>
-        </message>
-        <message>
-            <source>Settings will be reverted in %1s.</source>
-            <translation>如無任何操作將在%1秒後還原。</translation>
-        </message>
-        <message>
-            <source>Revert</source>
-            <translation>還原</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>儲存</translation>
-        </message>
-    </context>
-    <context>
-        <name>TimezoneDialog</name>
-        <message>
-            <source>Add time zone</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Determine the time zone based on the current location</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Time zone:</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Nearest City:</source>
-            <translation type="unfinished"/>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Save</source>
-            <translation>儲存</translation>
-        </message>
-    </context>
-    <context>
-        <name>TouchScreen</name>
-        <message>
-            <source>TouchScreen</source>
-            <translation>觸控屏</translation>
-        </message>
-        <message>
-            <source>Set up here when connecting the touch screen</source>
-            <translation>連線觸控螢幕時在此處設定</translation>
-        </message>
-    </context>
-    <context>
-        <name>Touchpad</name>
-        <message>
-            <source>Basic Settings</source>
-            <translation>基礎設定</translation>
-        </message>
-        <message>
-            <source>Touchpad</source>
-            <translation>觸控板</translation>
-        </message>
-        <message>
-            <source>Pointer Speed</source>
-            <translation>指標速度</translation>
-        </message>
-        <message>
-            <source>Slow</source>
-            <translation>慢</translation>
-        </message>
-        <message>
-            <source>Fast</source>
-            <translation>快</translation>
-        </message>
-        <message>
-            <source>Disable touchpad during input</source>
-            <translation>輸入時停用觸控板</translation>
-        </message>
-        <message>
-            <source>Tap to Click</source>
-            <translation>輕觸以點選</translation>
-        </message>
-        <message>
-            <source>Natural Scrolling</source>
-            <translation>自然滾動</translation>
-        </message>
-        <message>
-            <source>Gesture</source>
-            <translation>手勢</translation>
-        </message>
-        <message>
-            <source>Three-finger gestures</source>
-            <translation>三指手勢</translation>
-        </message>
-        <message>
-            <source>Four-finger gestures</source>
-            <translation>四指手勢</translation>
-        </message>
-    </context>
-    <context>
-        <name>UserExperienceProgramPage</name>
-        <message>
-            <source>Join User Experience Program</source>
-            <translation>加入使用者體驗計劃</translation>
-        </message>
-        <message>
-            <source>Copy Link Address</source>
-            <translation>複製連結地址</translation>
-        </message>
-    </context>
-    <context>
-        <name>VerifyDialog</name>
-        <message>
-            <source>Security Verification</source>
-            <translation>安全驗證</translation>
-        </message>
-        <message>
-            <source>The action is sensitive, please enter the login password first</source>
-            <translation>您正在進行敏感操作，請進行登入密碼認證</translation>
-        </message>
-        <message>
-            <source>8-64 characters</source>
-            <translation>請輸入8-64位密碼</translation>
-        </message>
-        <message>
-            <source>Forgot Password?</source>
-            <translation>忘記密碼？</translation>
-        </message>
-        <message>
-            <source>Cancel</source>
-            <translation>取消</translation>
-        </message>
-        <message>
-            <source>Confirm</source>
-            <translation>確定</translation>
-        </message>
-    </context>
-    <context>
-        <name>WallpaperPage</name>
-        <message>
-            <source>wallpaper</source>
-            <translation>壁紙</translation>
-        </message>
-        <message>
-            <source>Window rounded corners</source>
-            <translation>視窗圓角</translation>
-        </message>
-        <message>
-            <source>My pictures</source>
-            <translation>我的圖片</translation>
-        </message>
-        <message>
-            <source>System Wallpaper</source>
-            <translation>系統壁紙</translation>
-        </message>
-        <message>
-            <source>Solid color wallpaper</source>
-            <translation>純色壁紙</translation>
-        </message>
-        <message>
-            <source>Customizable wallpapers</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>fill style</source>
-            <translation>填充方式</translation>
-        </message>
-        <message>
-            <source>Automatic wallpaper change</source>
-            <translation>自動切換壁紙</translation>
-        </message>
-        <message>
-            <source>never</source>
-            <translation>從不</translation>
-        </message>
-        <message>
-            <source>30 second</source>
-            <translation>30秒</translation>
-        </message>
-        <message>
-            <source>1 minute</source>
-            <translation>1分鐘</translation>
-        </message>
-        <message>
-            <source>5 minute</source>
-            <translation>5分鐘</translation>
-        </message>
-        <message>
-            <source>10 minute</source>
-            <translation>10分鐘</translation>
-        </message>
-        <message>
-            <source>15 minute</source>
-            <translation>15分鐘</translation>
-        </message>
-        <message>
-            <source>30 minute</source>
-            <translation>30分鐘</translation>
-        </message>
-        <message>
-            <source>login</source>
-            <translation>登入時</translation>
-        </message>
-        <message>
-            <source>wake up</source>
-            <translation>喚醒時</translation>
-        </message>
-        <message>
-            <source>System Wallapers</source>
-            <translation>系統壁紙</translation>
-        </message>
-        <message>
-            <source>Live Wallpaper</source>
-            <translation>動態壁紙</translation>
-        </message>
-        <message>
-            <source>1 hour</source>
-            <translation>1小時</translation>
-        </message>
-    </context>
-    <context>
-        <name>WallpaperSelectView</name>
-        <message>
-            <source>unfold</source>
-            <translation>收起</translation>
-        </message>
-        <message>
-            <source>show all</source>
-            <translation>顯示全部</translation>
-        </message>
-        <message>
-            <source>items</source>
-            <translation>張</translation>
-        </message>
-        <message>
-            <source>Set lock screen</source>
-            <translation>設定鎖屏</translation>
-        </message>
-        <message>
-            <source>Set desktop</source>
-            <translation>設定桌面</translation>
-        </message>
-    </context>
-    <context>
-        <name>WindowEffectPage</name>
-        <message>
-            <source>Interface and Effects</source>
-            <translation>介面效果</translation>
-        </message>
-        <message>
-            <source>Window Settings</source>
-            <translation>視窗設定</translation>
-        </message>
-        <message>
-            <source>Window rounded corners</source>
-            <translation>視窗圓角</translation>
-        </message>
-        <message>
-            <source>None</source>
-            <translation>無</translation>
-        </message>
-        <message>
-            <source>Small</source>
-            <translation>小</translation>
-        </message>
-        <message>
-            <source>Large</source>
-            <translation>大</translation>
-        </message>
-        <message>
-            <source>Enable transparent effects when moving windows</source>
-            <translation>視窗移動時啟用透明特效</translation>
-        </message>
-        <message>
-            <source>Window Minimize Effect</source>
-            <translation>最小化時效果</translation>
-        </message>
-        <message>
-            <source>Scale</source>
-            <translation>縮放</translation>
-        </message>
-        <message>
-            <source>Magic Lamp</source>
-            <translation>魔燈</translation>
-        </message>
-        <message>
-            <source>Opacity</source>
-            <translation>不透明度調節</translation>
-        </message>
-        <message>
-            <source>Low</source>
-            <translation>低</translation>
-        </message>
-        <message>
-            <source>High</source>
-            <translation>高</translation>
-        </message>
-        <message>
-            <source>Scroll Bars</source>
-            <translation>捲軸</translation>
-        </message>
-        <message>
-            <source>Show on scrolling</source>
-            <translation>滾動時顯示</translation>
-        </message>
-        <message>
-            <source>Keep shown</source>
-            <translation>一直顯示</translation>
-        </message>
-        <message>
-            <source>Compact Display</source>
-            <translation>緊湊模式</translation>
-        </message>
-        <message>
-            <source>If enabled, more content is displayed in the window.</source>
-            <translation>開啟後，視窗將顯示更多內容</translation>
-        </message>
-        <message>
-            <source>Title Bar Height</source>
-            <translation>標題欄高度</translation>
-        </message>
-        <message>
-            <source>Only suitable for application window title bars drawn by the window manager.</source>
-            <translation>僅適用於視窗管理器繪製的應用標題欄</translation>
-        </message>
-        <message>
-            <source>Extremely small</source>
-            <translation>極小</translation>
-        </message>
-        <message>
-            <source>Medium</source>
-            <translation>中</translation>
-            <comment>describe size of window rounded corners</comment>
-        </message>
-        <message>
-            <source>Medium</source>
-            <translation>中</translation>
-            <comment>describe height of window title bar</comment>
-        </message>
-    </context>
-    <context>
-        <name>accounts</name>
-        <message>
-            <source>Account</source>
-            <translation>帳戶</translation>
-        </message>
-        <message>
-            <source>Account manager</source>
-            <translation>帳戶管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>accountsMain</name>
-        <message>
-            <source>Other accounts</source>
-            <translation>其他帳戶</translation>
-        </message>
-    </context>
-    <context>
-        <name>authentication</name>
-        <message>
-            <source>Biometric Authentication</source>
-            <translation>生物認證</translation>
-        </message>
-    </context>
-    <context>
-        <name>authenticationMain</name>
-        <message>
-            <source>Biometric Authentication</source>
-            <translation>生物認證</translation>
-        </message>
-        <message>
-            <source>Face</source>
-            <translation>人臉</translation>
-        </message>
-        <message>
-            <source>Up to 5 facial data can be entered</source>
-            <translation>最多可錄入5個人臉資料</translation>
-        </message>
-        <message>
-            <source>Fingerprint</source>
-            <translation>指紋</translation>
-        </message>
-        <message>
-            <source>Identifying user identity through scanning fingerprints</source>
-            <translation>通過對指紋的掃描進行使用者身份的識別</translation>
-        </message>
-        <message>
-            <source>Iris</source>
-            <translation>虹膜</translation>
-        </message>
-        <message>
-            <source>Identity recognition through iris scanning</source>
-            <translation>通過掃描虹膜進行身份識別</translation>
-        </message>
-        <message>
-            <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
-            <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字元</translation>
-        </message>
-        <message>
-            <source>Use letters, numbers and underscores only</source>
-            <translation>只能由字母、數字、中文、下劃線組成</translation>
-        </message>
-        <message>
-            <source>No more than 15 characters</source>
-            <translation>不得超過15個字元</translation>
-        </message>
-        <message>
-            <source>Add a new</source>
-            <translation>新增新的</translation>
-        </message>
-        <message>
-            <source>This name already exists</source>
-            <translation>該名稱已存在</translation>
-        </message>
-    </context>
-    <context>
-        <name>blueTooth</name>
-        <message>
-            <source>bluetooth</source>
-            <translation>藍牙</translation>
-        </message>
-        <message>
-            <source>Bluetooth settings, devices</source>
-            <translation>藍牙設定、裝置管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>commonInfoMain</name>
-        <message>
-            <source>Boot Menu</source>
-            <translation>啟動菜單</translation>
-        </message>
-        <message>
-            <source>Manage your boot menu</source>
-            <translation>管理您的開機啟動菜單</translation>
-        </message>
-        <message>
-            <source>Developer root permission management</source>
-            <translation>開發者Root許可權管理</translation>
-        </message>
-        <message>
-            <source>Developer Options</source>
-            <translation>開發者選項</translation>
-        </message>
-    </context>
-    <context>
-        <name>datetime</name>
-        <message>
-            <source>Time and date</source>
-            <translation>時間和日期</translation>
-        </message>
-        <message>
-            <source>Time and date, time zone settings</source>
-            <translation>時間日期、時區設定</translation>
-        </message>
-        <message>
-            <source>Language and region</source>
-            <translation>語言和區域</translation>
-        </message>
-        <message>
-            <source>System language, region format</source>
-            <translation>系統語言、區域格式</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::AccountsController</name>
-        <message>
-            <source>Username must be between 3 and 32 characters</source>
-            <translation>使用者名稱長度必須介於 3 到 32 個字元之間</translation>
-        </message>
-        <message>
-            <source>The first character must be a letter or number</source>
-            <translation>必須字母或者數字開頭</translation>
-        </message>
-        <message>
-            <source>Your username should not only have numbers</source>
-            <translation>使用者名稱不能僅僅是數字</translation>
-        </message>
-        <message>
-            <source>The username has been used by other user accounts</source>
-            <translation>使用者名稱和其他使用者名稱重複</translation>
-        </message>
-        <message>
-            <source>The full name is too long</source>
-            <translation>全名太長了</translation>
-        </message>
-        <message>
-            <source>The full name has been used by other user accounts</source>
-            <translation>全名和其他使用者名稱重複</translation>
-        </message>
-        <message>
-            <source>Wrong password</source>
-            <translation>密碼錯誤</translation>
-        </message>
-        <message>
-            <source>Standard User</source>
-            <translation>標準使用者</translation>
-        </message>
-        <message>
-            <source>Administrator</source>
-            <translation>管理員</translation>
-        </message>
-        <message>
-            <source>Customized</source>
-            <translation>自定義</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::AccountsWorker</name>
-        <message>
-            <source>Your host was removed from the domain server successfully</source>
-            <translation>您的主機成功退出了域伺服器</translation>
-        </message>
-        <message>
-            <source>Your host joins the domain server successfully</source>
-            <translation>您的主機成功加入了域伺服器</translation>
-        </message>
-        <message>
-            <source>Your host failed to leave the domain server</source>
-            <translation>您的主機退出域伺服器失敗</translation>
-        </message>
-        <message>
-            <source>Your host failed to join the domain server</source>
-            <translation>您的主機加入域伺服器失敗</translation>
-        </message>
-        <message>
-            <source>AD domain settings</source>
-            <translation>AD域設定</translation>
-        </message>
-        <message>
-            <source>Password not match</source>
-            <translation>密碼不一致</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::AvatarTypesModel</name>
-        <message>
-            <source>Dimensional</source>
-            <translation>立體風格</translation>
-        </message>
-        <message>
-            <source>Flat</source>
-            <translation>平面風格</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::BiometricAuthController</name>
-        <message>
-            <source>Use your face to unlock the device and make settings later</source>
-            <translation>使用人臉資料解鎖您的裝置，之後還可進行更多設定</translation>
-        </message>
-        <message>
-            <source>Faceprint</source>
-            <translation>麵紋</translation>
-        </message>
-        <message>
-            <source>Place your finger</source>
-            <translation>放置手指</translation>
-        </message>
-        <message>
-            <source>Place your finger firmly on the sensor until you're asked to lift it</source>
-            <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
-        </message>
-        <message>
-            <source>Lift your finger</source>
-            <translation>擡起手指</translation>
-        </message>
-        <message>
-            <source>Lift your finger and place it on the sensor again</source>
-            <translation>請擡起手指，再次按壓</translation>
-        </message>
-        <message>
-            <source>Scan the edges of your fingerprint</source>
-            <translation>錄入邊緣指紋</translation>
-        </message>
-        <message>
-            <source>Adjust the position to scan the edges of your fingerprint</source>
-            <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
-        </message>
-        <message>
-            <source>Lift your finger and do that again</source>
-            <translation>請擡起手指，再次按壓</translation>
-        </message>
-        <message>
-            <source>Fingerprint added</source>
-            <translation>成功新增指紋</translation>
-        </message>
-        <message>
-            <source>Scan Suspended</source>
-            <translation>錄入中斷</translation>
-        </message>
-        <message>
-            <source>Place the edges of your fingerprint on the sensor</source>
-            <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
-        </message>
-        <message>
-            <source>Iris</source>
-            <translation>虹膜</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::KeyboardController</name>
-        <message>
-            <source>This shortcut conflicts with [%1]</source>
-            <translation>此快捷鍵與[%1]衝突</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::PwqualityManager</name>
-        <message>
-            <source>Password cannot be empty</source>
-            <translation>密碼不能為空</translation>
-        </message>
-        <message>
-            <source>Password must have at least %1 characters</source>
-            <translation>密碼長度不能少於%1個字元</translation>
-        </message>
-        <message>
-            <source>Password must be no more than %1 characters</source>
-            <translation>密碼長度不能超過%1個字元</translation>
-        </message>
-        <message>
-            <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）組成</translation>
-        </message>
-        <message>
-            <source>No more than %1 palindrome characters please</source>
-            <translation>迴文字元長度不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 monotonic characters please</source>
-            <translation>單調性字元不超過%1位</translation>
-        </message>
-        <message>
-            <source>No more than %1 repeating characters please</source>
-            <translation>重複字元不超過%1位</translation>
-        </message>
-        <message>
-            <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/)</source>
-            <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:"'&lt;&gt;,.?/）三種類型組成</translation>
-        </message>
-        <message>
-            <source>Password must not contain more than 4 palindrome characters</source>
-            <translation>密碼不得含有連續4個以上的迴文字元</translation>
-        </message>
-        <message>
-            <source>Do not use common words and combinations as password</source>
-            <translation>密碼不能是常見單詞及組合</translation>
-        </message>
-        <message>
-            <source>Create a strong password please</source>
-            <translation>密碼過於簡單，請增加密碼複雜度</translation>
-        </message>
-        <message>
-            <source>It does not meet password rules</source>
-            <translation>密碼不符合安全要求</translation>
-        </message>
-    </context>
-    <context>
-        <name>dccV25::ShortcutModel</name>
-        <message>
-            <source>System</source>
-            <translation>系統</translation>
-        </message>
-        <message>
-            <source>Window</source>
-            <translation>視窗</translation>
-        </message>
-        <message>
-            <source>Workspace</source>
-            <translation>工作區</translation>
-        </message>
-        <message>
-            <source>AssistiveTools</source>
-            <translation>輔助功能</translation>
-        </message>
-        <message>
-            <source>Custom</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>None</source>
-            <translation>無</translation>
-        </message>
-    </context>
-    <context>
-        <name>deepinid</name>
-        <message>
-            <source>deepin ID</source>
-            <translation>deepin ID</translation>
-        </message>
-        <message>
-            <source>UOS ID</source>
-            <translation>UOS ID</translation>
-        </message>
-        <message>
-            <source>Cloud services</source>
-            <translation>雲服務</translation>
-        </message>
-    </context>
-    <context>
-        <name>defaultapp</name>
-        <message>
-            <source>Default App</source>
-            <translation>預設程式</translation>
-        </message>
-        <message>
-            <source>Set the default application for opening various types of files</source>
-            <translation>設定打開各類檔案的預設程式</translation>
-        </message>
-    </context>
-    <context>
-        <name>defaultappMain</name>
-        <message>
-            <source>Webpage</source>
-            <translation>網頁</translation>
-        </message>
-        <message>
-            <source>Mail</source>
-            <translation>郵件</translation>
-        </message>
-        <message>
-            <source>Text</source>
-            <translation>文字</translation>
-        </message>
-        <message>
-            <source>Music</source>
-            <translation>音樂</translation>
-        </message>
-        <message>
-            <source>Video</source>
-            <translation>影片</translation>
-        </message>
-        <message>
-            <source>Picture</source>
-            <translation>圖片</translation>
-        </message>
-        <message>
-            <source>Terminal</source>
-            <translation>終端</translation>
-        </message>
-    </context>
-    <context>
-        <name>device</name>
-        <message>
-            <source>Device</source>
-            <translation>裝置</translation>
-        </message>
-    </context>
-    <context>
-        <name>display</name>
-        <message>
-            <source>Display</source>
-            <translation>顯示</translation>
-        </message>
-        <message>
-            <source>Brightness,resolution,scaling</source>
-            <translation>亮度、解析度、縮放</translation>
-        </message>
-    </context>
-    <context>
-        <name>displayMain</name>
-        <message>
-            <source>100%</source>
-            <translation>100%</translation>
-        </message>
-        <message>
-            <source>125%</source>
-            <translation>125%</translation>
-        </message>
-        <message>
-            <source>150%</source>
-            <translation>150%</translation>
-        </message>
-        <message>
-            <source>175%</source>
-            <translation>175%</translation>
-        </message>
-        <message>
-            <source>200%</source>
-            <translation>200%</translation>
-        </message>
-        <message>
-            <source>225%</source>
-            <translation>225%</translation>
-        </message>
-        <message>
-            <source>250%</source>
-            <translation>250%</translation>
-        </message>
-        <message>
-            <source>275%</source>
-            <translation>275%</translation>
-        </message>
-        <message>
-            <source>300%</source>
-            <translation>300%</translation>
-        </message>
-        <message>
-            <source>Duplicate</source>
-            <translation>複製</translation>
-        </message>
-        <message>
-            <source>Extend</source>
-            <translation>擴充套件</translation>
-        </message>
-        <message>
-            <source>Default</source>
-            <translation>預設</translation>
-        </message>
-        <message>
-            <source>Fit</source>
-            <translation>適應</translation>
-        </message>
-        <message>
-            <source>Stretch</source>
-            <translation>拉伸</translation>
-        </message>
-        <message>
-            <source>Center</source>
-            <translation>居中</translation>
-        </message>
-        <message>
-            <source>Only on %1</source>
-            <translation>僅%1屏</translation>
-        </message>
-        <message>
-            <source>(Recommended)</source>
-            <translation>（推薦）</translation>
-        </message>
-        <message>
-            <source>Hz</source>
-            <translation>赫茲</translation>
-        </message>
-        <message>
-            <source>Multiple Displays Settings</source>
-            <translation>多屏設定</translation>
-        </message>
-        <message>
-            <source>Identify</source>
-            <translation>識別</translation>
-        </message>
-        <message>
-            <source>Screen rearrangement will take effect in %1s after changes</source>
-            <translation>螢幕拼接將在修改完成%1s後生效</translation>
-        </message>
-        <message>
-            <source>Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Main Screen</source>
-            <translation>主螢幕</translation>
-        </message>
-        <message>
-            <source>Display And Layout</source>
-            <translation>顯示和佈局</translation>
-        </message>
-        <message>
-            <source>Brightness</source>
-            <translation>亮度</translation>
-        </message>
-        <message>
-            <source>Resolution</source>
-            <translation>解析度</translation>
-        </message>
-        <message>
-            <source>Resize Desktop</source>
-            <translation>桌面顯示</translation>
-        </message>
-        <message>
-            <source>Refresh Rate</source>
-            <translation>重新整理率</translation>
-        </message>
-        <message>
-            <source>Rotation</source>
-            <translation>方向</translation>
-        </message>
-        <message>
-            <source>Standard</source>
-            <translation>標準</translation>
-        </message>
-        <message>
-            <source>90°</source>
-            <translation>90度</translation>
-        </message>
-        <message>
-            <source>180°</source>
-            <translation>180度</translation>
-        </message>
-        <message>
-            <source>270°</source>
-            <translation>270度</translation>
-        </message>
-        <message>
-            <source>Display Scaling</source>
-            <translation>縮放</translation>
-        </message>
-        <message>
-            <source>The monitor only supports 100% display scaling</source>
-            <translation>當前螢幕僅支援1倍縮放</translation>
-        </message>
-        <message>
-            <source>Eye Comfort</source>
-            <translation>護眼模式</translation>
-        </message>
-        <message>
-            <source>Enable eye comfort</source>
-            <translation>開啟護眼模式</translation>
-        </message>
-        <message>
-            <source>Adjust screen display to warmer colors, reducing screen blue light</source>
-            <translation>調整螢幕顯示較暖的顏色，減少螢幕藍光</translation>
-        </message>
-        <message>
-            <source>Time</source>
-            <translation>時間</translation>
-        </message>
-        <message>
-            <source>All day</source>
-            <translation>全天</translation>
-        </message>
-        <message>
-            <source>Sunset to Sunrise</source>
-            <translation>日落到日出</translation>
-        </message>
-        <message>
-            <source>Custom Time</source>
-            <translation>自定義</translation>
-        </message>
-        <message>
-            <source>from</source>
-            <translation>從</translation>
-        </message>
-        <message>
-            <source>to</source>
-            <translation>至</translation>
-        </message>
-        <message>
-            <source>Color Temperature</source>
-            <translation>色溫</translation>
-        </message>
-    </context>
-    <context>
-        <name>dock</name>
-        <message>
-            <source>Desktop and taskbar</source>
-            <translation>桌面和工作列</translation>
-        </message>
-        <message>
-            <source>Desktop organization, taskbar mode, plugin area settings</source>
-            <translation>桌面整理、工作列模式、外掛區域設定</translation>
-        </message>
-    </context>
-    <context>
-        <name>keyboard</name>
-        <message>
-            <source>Keyboard</source>
-            <translation>鍵盤</translation>
-        </message>
-        <message>
-            <source>General Settings, keyboard layout, input method, shortcuts</source>
-            <translation>通用設定、鍵盤佈局、輸入法、快捷鍵</translation>
-        </message>
-    </context>
-    <context>
-        <name>keyboardMain</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Keyboard layout</source>
-            <translation>鍵盤佈局</translation>
-        </message>
-        <message>
-            <source>Set system default keyboard layout</source>
-            <translation>設定系統預設鍵盤佈局</translation>
-        </message>
-    </context>
-    <context>
-        <name>main</name>
-        <message>
-            <source>Dock</source>
-            <translation>工作列</translation>
-        </message>
-        <message>
-            <source>Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Classic Mode</source>
-            <translation>經典模式</translation>
-        </message>
-        <message>
-            <source>Centered Mode</source>
-            <translation>居中模式</translation>
-        </message>
-        <message>
-            <source>Dock size</source>
-            <translation>工作列大小</translation>
-        </message>
-        <message>
-            <source>Small</source>
-            <translation>小</translation>
-        </message>
-        <message>
-            <source>Large</source>
-            <translation>大</translation>
-        </message>
-        <message>
-            <source>Position on the screen</source>
-            <translation>螢幕中的位置</translation>
-        </message>
-        <message>
-            <source>Top</source>
-            <translation>上</translation>
-        </message>
-        <message>
-            <source>Bottom</source>
-            <translation>下</translation>
-        </message>
-        <message>
-            <source>Left</source>
-            <translation>左</translation>
-        </message>
-        <message>
-            <source>Right</source>
-            <translation>右</translation>
-        </message>
-        <message>
-            <source>Status</source>
-            <translation>狀態</translation>
-        </message>
-        <message>
-            <source>Keep shown</source>
-            <translation>一直顯示</translation>
-        </message>
-        <message>
-            <source>Keep hidden</source>
-            <translation>一直隱藏</translation>
-        </message>
-        <message>
-            <source>Smart hide</source>
-            <translation>智慧隱藏</translation>
-        </message>
-        <message>
-            <source>Multiple Displays</source>
-            <translation>多屏顯示</translation>
-        </message>
-        <message>
-            <source>Set the position of the taskbar on the screen</source>
-            <translation>設定工作列在螢幕中的位置</translation>
-        </message>
-        <message>
-            <source>Only on main</source>
-            <translation>僅主屏顯示</translation>
-        </message>
-        <message>
-            <source>On screen where the cursor is</source>
-            <translation>跟隨滑鼠位置顯示</translation>
-        </message>
-        <message>
-            <source>Plugin Area</source>
-            <translation>外掛區域</translation>
-        </message>
-        <message>
-            <source>Select which icons appear in the Dock</source>
-            <translation>選擇顯示在工作列外掛區域的圖示</translation>
-        </message>
-    </context>
-    <context>
-        <name>mouse</name>
-        <message>
-            <source>Mouse and Touchpad</source>
-            <translation>滑鼠與觸控板</translation>
-        </message>
-        <message>
-            <source>Common、Mouse、Touchpad</source>
-            <translation>通用、滑鼠、觸控板</translation>
-        </message>
-    </context>
-    <context>
-        <name>mouseMain</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Mouse</source>
-            <translation>滑鼠</translation>
-        </message>
-        <message>
-            <source>Touchpad</source>
-            <translation>觸控板</translation>
-        </message>
-    </context>
-    <context>
-        <name>notification</name>
-        <message>
-            <source>DND mode, app notifications</source>
-            <translation>勿擾模式、應用通知</translation>
-        </message>
-        <message>
-            <source>Notification</source>
-            <translation>通知</translation>
-        </message>
-    </context>
-    <context>
-        <name>notificationMain</name>
-        <message>
-            <source>Do Not Disturb Settings</source>
-            <translation>勿擾設定</translation>
-        </message>
-        <message>
-            <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
-            <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心檢視所有消息。</translation>
-        </message>
-        <message>
-            <source>Enable Do Not Disturb</source>
-            <translation>啟用勿擾模式</translation>
-        </message>
-        <message>
-            <source>When the screen is locked</source>
-            <translation>在螢幕鎖屏時</translation>
-        </message>
-        <message>
-            <source>Number of notifications shown on the desktop</source>
-            <translation>通知橫幅展示數量</translation>
-        </message>
-        <message>
-            <source>App Notifications</source>
-            <translation>應用通知</translation>
-        </message>
-        <message>
-            <source>Allow Notifications</source>
-            <translation>允許通知</translation>
-        </message>
-        <message>
-            <source>Display notification on desktop or show unread messages in the notification center</source>
-            <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
-        </message>
-        <message>
-            <source>Desktop</source>
-            <translation>桌面</translation>
-        </message>
-        <message>
-            <source>Lock Screen</source>
-            <translation>鎖屏</translation>
-        </message>
-        <message>
-            <source>Notification Center</source>
-            <translation>通知中心</translation>
-        </message>
-        <message>
-            <source>Show message preview</source>
-            <translation>顯示消息預覽</translation>
-        </message>
-        <message>
-            <source>Play a sound</source>
-            <translation>通知時提示聲音</translation>
-        </message>
-    </context>
-    <context>
-        <name>personalization</name>
-        <message>
-            <source>Personalization</source>
-            <translation>個性化</translation>
-        </message>
-    </context>
-    <context>
-        <name>personalizationMain</name>
-        <message>
-            <source>Theme</source>
-            <translation>主題</translation>
-        </message>
-        <message>
-            <source>Appearance</source>
-            <translation>外觀</translation>
-        </message>
-        <message>
-            <source>Window effect</source>
-            <translation>視窗效果</translation>
-        </message>
-        <message>
-            <source>Personalize your wallpaper and screensaver</source>
-            <translation>個性化您的壁紙和屏保</translation>
-        </message>
-        <message>
-            <source>Screensaver</source>
-            <translation>螢幕保護</translation>
-        </message>
-        <message>
-            <source>Colors and icons</source>
-            <translation>顏色和圖示</translation>
-        </message>
-        <message>
-            <source>Adjust accent color and theme icons</source>
-            <translation>調整活動色和主題圖示</translation>
-        </message>
-        <message>
-            <source>Font and font size</source>
-            <translation>字型和字號</translation>
-        </message>
-        <message>
-            <source>Change system font and size</source>
-            <translation>修改系統字型與字號</translation>
-        </message>
-        <message>
-            <source>Wallpaper</source>
-            <translation>壁紙</translation>
-        </message>
-        <message>
-            <source>Select light, dark or automatic theme appearance</source>
-            <translation>選擇淺色、深色或自動切換主題外觀</translation>
-        </message>
-        <message>
-            <source>Interface and effects, rounded corners</source>
-            <translation>介面和效果、視窗圓角</translation>
-        </message>
-    </context>
-    <context>
-        <name>power</name>
-        <message>
-            <source>Power saving settings, screen and suspend</source>
-            <translation>節能設定、螢幕和待機管理</translation>
-        </message>
-        <message>
-            <source>Power</source>
-            <translation>電源管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>powerMain</name>
-        <message>
-            <source>General</source>
-            <translation>通用</translation>
-        </message>
-        <message>
-            <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
-            <translation>效能模式、節能設定、喚醒設定、關機設定</translation>
-        </message>
-        <message>
-            <source>Plugged In</source>
-            <translation>使用電源</translation>
-        </message>
-        <message>
-            <source>Screen and suspend</source>
-            <translation>螢幕和待機管理</translation>
-        </message>
-        <message>
-            <source>On Battery</source>
-            <translation>使用電池</translation>
-        </message>
-        <message>
-            <source>screen and suspend, low battery, battery management</source>
-            <translation>螢幕和待機管理、低電量管理、電池管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>privacy</name>
-        <message>
-            <source>Privacy and Security</source>
-            <translation>隱私和安全</translation>
-        </message>
-        <message>
-            <source>Camera, folder permissions</source>
-            <translation>攝像頭、資料夾許可權</translation>
-        </message>
-    </context>
-    <context>
-        <name>privacyMain</name>
-        <message>
-            <source>Camera</source>
-            <translation>攝像頭</translation>
-        </message>
-        <message>
-            <source>Choose whether the application has access to the camera</source>
-            <translation>選擇應用是否有攝像頭的訪問許可權</translation>
-        </message>
-        <message>
-            <source>Files and Folders</source>
-            <translation>檔案和資料夾</translation>
-        </message>
-        <message>
-            <source>Choose whether the application has access to files and folders</source>
-            <translation>選擇應用是否有檔案和資料夾的訪問許可權</translation>
-        </message>
-    </context>
-    <context>
-        <name>sound</name>
-        <message>
-            <source>Sound</source>
-            <translation>聲音</translation>
-        </message>
-        <message>
-            <source>Output, input, sound effects, devices</source>
-            <translation>輸入、輸出、系統音效、裝置管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>soundMain</name>
-        <message>
-            <source>Settings</source>
-            <translation>設定</translation>
-        </message>
-        <message>
-            <source>Sound Effects</source>
-            <translation>系統音效</translation>
-        </message>
-        <message>
-            <source>Enable/disable sound effects</source>
-            <translation>開啟/關閉系統音效</translation>
-        </message>
-        <message>
-            <source>Enable/disable audio devices</source>
-            <translation>啟用/停用音訊裝置</translation>
-        </message>
-        <message>
-            <source>Devices</source>
-            <translation>裝置管理</translation>
-        </message>
-    </context>
-    <context>
-        <name>system</name>
-        <message>
-            <source>Common settings</source>
-            <translation>常用設定</translation>
-        </message>
-        <message>
-            <source>System</source>
-            <translation>系統</translation>
-        </message>
-    </context>
-    <context>
-        <name>systemInfo</name>
-        <message>
-            <source>Auxiliary Information</source>
-            <translation>輔助資訊</translation>
-        </message>
-    </context>
-    <context>
-        <name>systemInfoMain</name>
-        <message>
-            <source>About This PC</source>
-            <translation>關於本機</translation>
-        </message>
-        <message>
-            <source>System version, device information</source>
-            <translation>系統版本、裝置資訊</translation>
-        </message>
-        <message>
-            <source>View the notice of open source software</source>
-            <translation>檢視開源軟體宣告</translation>
-        </message>
-        <message>
-            <source>User Experience Program</source>
-            <translation>使用者體驗計劃</translation>
-        </message>
-        <message>
-            <source>Join the user experience program to help improve the product</source>
-            <translation>加入使用者體驗計劃，幫助改進產品</translation>
-        </message>
-        <message>
-            <source>End User License Agreement</source>
-            <translation>使用者許可協議</translation>
-        </message>
-        <message>
-            <source>View the end  user license agreement</source>
-            <translation>檢視終端使用者許可協議</translation>
-        </message>
-        <message>
-            <source>Privacy Policy</source>
-            <translation>隱私政策</translation>
-        </message>
-        <message>
-            <source>View information about privacy policy</source>
-            <translation>檢視隱私政策相關資訊</translation>
-        </message>
-        <message>
-            <source>Open Source Software Notice</source>
-            <translation>開源軟體宣告</translation>
-        </message>
-    </context>
-    <context>
-        <name>touchscreen</name>
-        <message>
-            <source>Touchscreen</source>
-            <translation>觸控屏</translation>
-        </message>
-        <message>
-            <source>Configuring Touchscreen</source>
-            <translation>觸控屏設定</translation>
-        </message>
-    </context>
-    <context>
-        <name>touchscreenMain</name>
-        <message>
-            <source>Common</source>
-            <translation>通用</translation>
-        </message>
-    </context>
-    <context>
-        <name>wacom</name>
-        <message>
-            <source>wacom</source>
-            <translation>數位板</translation>
-        </message>
-        <message>
-            <source>Configuring wacom</source>
-            <translation>數位板選項設定</translation>
-        </message>
-    </context>
-    <context>
-        <name>wacomMain</name>
-        <message>
-            <source>wacom</source>
-            <translation>數位板</translation>
-        </message>
-        <message>
-            <source>Wacom Mode</source>
-            <translation>模式</translation>
-        </message>
-        <message>
-            <source>Pen Mode</source>
-            <translation>筆模式</translation>
-        </message>
-        <message>
-            <source>Mouse Mode</source>
-            <translation>滑鼠模式</translation>
-        </message>
-        <message>
-            <source>Pressure Sensitivity</source>
-            <translation>壓感</translation>
-        </message>
-        <message>
-            <source>Light</source>
-            <translation>輕</translation>
-        </message>
-    </context>
+    </message>
+    <message>
+        <source>Sign In to %1 ID</source>
+        <translation>登入%1 ID</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDSyncService</name>
+    <message>
+        <source>Auto Sync</source>
+        <translation>自動同步</translation>
+    </message>
+    <message>
+        <source>Securely store system settings and personal data in the cloud, and keep them in sync across devices</source>
+        <translation>將您的系統設定和個人資訊安全地儲存在雲端，並在您不同的裝置上保持同步</translation>
+    </message>
+    <message>
+        <source>System Settings</source>
+        <translation>系統設定</translation>
+    </message>
+    <message>
+        <source>Last sync time: %1</source>
+        <translation>最近同步時間：%1</translation>
+    </message>
+    <message>
+        <source>Clear cloud data</source>
+        <translation>清除雲端資料</translation>
+    </message>
+    <message>
+        <source>Are you sure you want to clear your system settings and personal data saved in the cloud?</source>
+        <translation>確定要清除您儲存在雲端的系統設定和個人資料嗎？</translation>
+    </message>
+    <message>
+        <source>Once the data is cleared, it cannot be recovered!</source>
+        <translation>資料清除後將無法恢復！</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Clear</source>
+        <translation>清除</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinIDUserInfo</name>
+    <message>
+        <source>Synchronization Service</source>
+        <translation>同步服務</translation>
+    </message>
+    <message>
+        <source>Account and Security</source>
+        <translation>帳戶與安全</translation>
+    </message>
+    <message>
+        <source>Sign out</source>
+        <translation>退出登入</translation>
+    </message>
+    <message>
+        <source>Go to web settings</source>
+        <translation>前往網頁設定</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinWorker</name>
+    <message>
+        <source>encrypt password failed</source>
+        <translation>加密密碼失敗</translation>
+    </message>
+    <message>
+        <source>Wrong password, %1 chances left</source>
+        <translation>密碼錯誤，您還可以嘗試%1次</translation>
+    </message>
+    <message>
+        <source>The login error has reached the limit today. You can reset the password and try again.</source>
+        <translation>密碼錯誤已達今日上限，可重置密碼再試</translation>
+    </message>
+    <message>
+        <source>Operation Successful</source>
+        <translation>操作成功</translation>
+    </message>
+</context>
+<context>
+    <name>DeepinidModel</name>
+    <message>
+        <source>Mainland China</source>
+        <translation>中國大陸</translation>
+    </message>
+    <message>
+        <source>Other regions</source>
+        <translation>其他地區</translation>
+    </message>
+    <message>
+        <source>The feature is not available at present, please activate your system first</source>
+        <translation>當前系統未啟用，暫無法使用該功能</translation>
+    </message>
+    <message>
+        <source>Subject to your local laws and regulations, it is currently unavailable in your region.</source>
+        <translation>受限於您當地的法律法規，同步服務暫未覆蓋您所在地區，敬請期待。</translation>
+    </message>
+</context>
+<context>
+    <name>DetailItem</name>
+    <message>
+        <source>Please choose the default program to open &apos;%1&apos;</source>
+        <translation>選擇打開「%1」的預設程式</translation>
+    </message>
+    <message>
+        <source>add</source>
+        <translation>新增</translation>
+    </message>
+    <message>
+        <source>Open Desktop file</source>
+        <translation>打開Desktop檔案</translation>
+    </message>
+    <message>
+        <source>Apps (*.desktop)</source>
+        <translation>應用程式(*.desktop)</translation>
+    </message>
+    <message>
+        <source>All files (*)</source>
+        <translation>所有檔案(*)</translation>
+    </message>
+</context>
+<context>
+    <name>DevelopModePage</name>
+    <message>
+        <source>Root Access</source>
+        <translation>開發者模式</translation>
+    </message>
+    <message>
+        <source>Request Root Access</source>
+        <translation>進入開發者模式</translation>
+    </message>
+    <message>
+        <source>After entering the developer mode, you can obtain root permissions, but it may also damage the system integrity, so please use it with caution.</source>
+        <translation>可獲得root使用許可權，但同時也可能導致系統完教性遭到破壞，請謹慎使用。</translation>
+    </message>
+    <message>
+        <source>Allowed</source>
+        <translation>已進入</translation>
+    </message>
+    <message>
+        <source>Enter</source>
+        <translation>進入</translation>
+    </message>
+    <message>
+        <source>Online</source>
+        <translation>線上啟用</translation>
+    </message>
+    <message>
+        <source>Login UOS ID</source>
+        <translation>登入UOS ID</translation>
+    </message>
+    <message>
+        <source>Offline</source>
+        <translation>離線啟用</translation>
+    </message>
+    <message>
+        <source>Import Certificate</source>
+        <translation>匯入證書</translation>
+    </message>
+    <message>
+        <source>Select file</source>
+        <translation>選擇檔案</translation>
+    </message>
+    <message>
+        <source>Your UOS ID has been logged in, click to enter developer mode</source>
+        <translation>您的UOS ID已登入，點選進入開發者模式</translation>
+    </message>
+    <message>
+        <source>Please sign in to your UOS ID first and continue</source>
+        <translation>進入開發者模式需要登入UOS ID</translation>
+    </message>
+    <message>
+        <source>1.Export PC Info</source>
+        <translation>1.匯出機器資訊</translation>
+    </message>
+    <message>
+        <source>Export</source>
+        <translation>匯出</translation>
+    </message>
+    <message>
+        <source>2.please go to &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; to Download offline certificate.</source>
+        <translation>2.前往 &lt;a href=&quot;http://www.chinauos.com/developMode&quot;&gt;http：//www.chinauos.com/developMode&lt;/a&gt; 下載離線證書.</translation>
+    </message>
+    <message>
+        <source>3.Import Certificate</source>
+        <translation>3.匯入證書</translation>
+    </message>
+    <message>
+        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
+        <translation>如需安裝非應用商店來源的應用，前往 &lt;a href=&quot;Security Center&quot;&gt;安全中心&lt;/a&gt; 進行設定。</translation>
+    </message>
+    <message>
+        <source>Development and debugging options</source>
+        <translation>開發除錯選項</translation>
+    </message>
+    <message>
+        <source>System logging level</source>
+        <translation>系統日誌記錄級別</translation>
+    </message>
+    <message>
+        <source>Changing the options results in more detailed logging that may degrade system performance and/or take up more storage space.</source>
+        <translation>更改此選項可以獲得更詳細的日誌記錄，這些日誌可能會降低系統性能和/或佔用更多儲存空間.</translation>
+    </message>
+    <message>
+        <source>Off</source>
+        <translation>關閉</translation>
+    </message>
+    <message>
+        <source>Debug</source>
+        <translation>除錯</translation>
+    </message>
+    <message>
+        <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
+        <translation>更改選項處理可能需要一分鐘，收到設定成功提示後，請重啟裝置方可生效。</translation>
+    </message>
+</context>
+<context>
+    <name>DisclaimerControl</name>
+    <message>
+        <source>Disclaimer</source>
+        <translation>《使用者免責宣告》</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Agree</source>
+        <translation>同意</translation>
+    </message>
+</context>
+<context>
+    <name>FileAndFolder</name>
+    <message>
+        <source>Allow below apps to access these files and folders:</source>
+        <translation>允許下麵的應用訪問您的檔案和資料夾</translation>
+    </message>
+    <message>
+        <source>Documents</source>
+        <translation>文件</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <translation>桌面</translation>
+    </message>
+    <message>
+        <source>Pictures</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Videos</source>
+        <translation>影片</translation>
+    </message>
+    <message>
+        <source>Music</source>
+        <translation>音樂</translation>
+    </message>
+    <message>
+        <source>Downloads</source>
+        <translation>下載</translation>
+    </message>
+    <message>
+        <source>folder</source>
+        <translation>資料夾</translation>
+    </message>
+</context>
+<context>
+    <name>FontSizePage</name>
+    <message>
+        <source>Size</source>
+        <translation>字號</translation>
+    </message>
+    <message>
+        <source>Standard Font</source>
+        <translation>標準字型</translation>
+    </message>
+    <message>
+        <source>Monospaced Font</source>
+        <translation>等寬字型</translation>
+    </message>
+</context>
+<context>
+    <name>GeneralPage</name>
+    <message>
+        <source>Power Plans</source>
+        <translation>效能模式</translation>
+    </message>
+    <message>
+        <source>Power Saving Settings</source>
+        <translation>節能設定</translation>
+    </message>
+    <message>
+        <source>Auto power saving on low battery</source>
+        <translation>低電量時自動開啟節能模式</translation>
+    </message>
+    <message>
+        <source>Low battery threshold</source>
+        <translation>低電量閾值</translation>
+    </message>
+    <message>
+        <source>Auto power saving on battery</source>
+        <translation>使用電池時自動開啟節能模式</translation>
+    </message>
+    <message>
+        <source>Wakeup Settings</source>
+        <translation>喚醒設定</translation>
+    </message>
+    <message>
+        <source>Password is required to wake up the computer</source>
+        <translation>待機恢復時需要密碼</translation>
+    </message>
+    <message>
+        <source>Password is required to wake up the monitor</source>
+        <translation>喚醒顯示器時需要密碼</translation>
+    </message>
+    <message>
+        <source>Shutdown Settings</source>
+        <translation>關機設定</translation>
+    </message>
+    <message>
+        <source>Scheduled Shutdown</source>
+        <translation>定時關機</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>Repeat</source>
+        <translation>重複</translation>
+    </message>
+    <message>
+        <source>Once</source>
+        <translation>一次</translation>
+    </message>
+    <message>
+        <source>Every day</source>
+        <translation>每天</translation>
+    </message>
+    <message>
+        <source>Working days</source>
+        <translation>工作日</translation>
+    </message>
+    <message>
+        <source>Custom Time</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Decrease screen brightness on power saver</source>
+        <translation>節能模式時降低螢幕亮度</translation>
+    </message>
+</context>
+<context>
+    <name>GestureModel</name>
+    <message>
+        <source>Three-finger</source>
+        <translation>三指</translation>
+    </message>
+    <message>
+        <source>Four-finger</source>
+        <translation>四指</translation>
+    </message>
+    <message>
+        <source>Up</source>
+        <translation>向上</translation>
+    </message>
+    <message>
+        <source>Down</source>
+        <translation>向下</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>向左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>向右</translation>
+    </message>
+    <message>
+        <source>tap</source>
+        <translation>點選</translation>
+    </message>
+</context>
+<context>
+    <name>HomePage</name>
+    <message>
+        <source>,</source>
+        <translation>、</translation>
+    </message>
+    <message>
+        <source>...</source>
+        <translation>等</translation>
+    </message>
+</context>
+<context>
+    <name>InterfaceEffectListview</name>
+    <message>
+        <source>Optimal Performance</source>
+        <translation>最佳效能</translation>
+    </message>
+    <message>
+        <source>Balance</source>
+        <translation>均衡</translation>
+    </message>
+    <message>
+        <source>Best Visuals</source>
+        <translation>最佳視覺</translation>
+    </message>
+    <message>
+        <source>Disable all interface and window effects for efficient system performance.</source>
+        <translation>關閉所有介面和視窗特效，保障系統高效執行</translation>
+    </message>
+    <message>
+        <source>Limit some window effects for excellent visuals while maintaining smooth system performance.</source>
+        <translation>限制部分視窗特效，保障出色的視覺效果，同時維持系統流暢執行</translation>
+    </message>
+    <message>
+        <source>Enable all interface and window effects for the best visual experience.</source>
+        <translation>啟用所有介面和視窗特效，體驗最佳視覺效果</translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardLayout</name>
+    <message>
+        <source>Keyboard layout</source>
+        <translation>鍵盤佈局</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Add the corresponding input method in &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt;Input Method Management&lt;/a&gt; to ensure the keyboard layout works when added or switched.</source>
+        <translation>如需新增或切換鍵盤佈局，請同時在 &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Manage Input Methods&apos;&gt; 輸入法管理 &lt;/a&gt;  中新增對應的輸入法以確保生效</translation>
+    </message>
+    <message>
+        <source>Add new keyboard layout...</source>
+        <translation>新增鍵盤佈局...</translation>
+    </message>
+</context>
+<context>
+    <name>LangAndFormat</name>
+    <message>
+        <source>Language</source>
+        <translation>語言</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Other languages</source>
+        <translation>其他語言</translation>
+    </message>
+    <message>
+        <source>add</source>
+        <translation>新增</translation>
+    </message>
+    <message>
+        <source>Region</source>
+        <translation>區域</translation>
+    </message>
+    <message>
+        <source>Area</source>
+        <translation>地區</translation>
+    </message>
+    <message>
+        <source>Operating system and applications may provide you with local content based on your country and region</source>
+        <translation>作業系統和應用可能會根據你所在的國家和地區向你提供本地內容</translation>
+    </message>
+    <message>
+        <source>Region and format</source>
+        <translation>區域格式</translation>
+    </message>
+    <message>
+        <source>Operating system and applications may set date and time formats based on regional formats</source>
+        <translation>作業系統和某些應用會根據區域格式設定日期和時間格式</translation>
+    </message>
+</context>
+<context>
+    <name>LangsChooserDialog</name>
+    <message>
+        <source>Add language</source>
+        <translation>新增語言</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜尋</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>新增</translation>
+    </message>
+</context>
+<context>
+    <name>LayoutsChooser</name>
+    <message>
+        <source>Add language</source>
+        <translation>新增語言</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜尋</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>新增</translation>
+    </message>
+</context>
+<context>
+    <name>LoginMethod</name>
+    <message>
+        <source>Login method</source>
+        <translation>登入方式</translation>
+    </message>
+    <message>
+        <source>Password, wechat, biometric authentication, security key</source>
+        <translation>密碼，微信掃碼，生物認證，安全金鑰</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>密碼</translation>
+    </message>
+    <message>
+        <source>Modify password</source>
+        <translation>修改密碼</translation>
+    </message>
+    <message>
+        <source>Validity days</source>
+        <translation>有效天數</translation>
+    </message>
+    <message>
+        <source>Always</source>
+        <translation>長期有效</translation>
+    </message>
+</context>
+<context>
+    <name>LogoModule</name>
+    <message>
+        <source>Copyright© 2011-%1 Deepin Community</source>
+        <translation>Copyright © 2011-%1 深度社區</translation>
+    </message>
+    <message>
+        <source>Copyright© 2019-%1 UnionTech Software Technology Co., LTD</source>
+        <translation>Copyright © 2019-%1 統信軟體技術有限公司</translation>
+    </message>
+</context>
+<context>
+    <name>MicrophonePage</name>
+    <message>
+        <source>Automatic Noise Suppression</source>
+        <translation>噪音抑制</translation>
+    </message>
+    <message>
+        <source>Input Volume</source>
+        <translation>輸入音量</translation>
+    </message>
+    <message>
+        <source>Input Level</source>
+        <translation>反饋音量</translation>
+    </message>
+    <message>
+        <source>Input</source>
+        <translation>輸入</translation>
+    </message>
+    <message>
+        <source>No input device for sound found</source>
+        <translation>沒有找到聲音輸入裝置</translation>
+    </message>
+    <message>
+        <source>Input Devices</source>
+        <translation>輸入裝置</translation>
+    </message>
+</context>
+<context>
+    <name>Mouse</name>
+    <message>
+        <source>Mouse</source>
+        <translation>滑鼠</translation>
+    </message>
+    <message>
+        <source>Pointer Speed</source>
+        <translation>指標速度</translation>
+    </message>
+    <message>
+        <source>Slow</source>
+        <translation>慢</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation>快</translation>
+    </message>
+    <message>
+        <source>Pointer Size</source>
+        <translation>指標大小</translation>
+    </message>
+    <message>
+        <source>Short</source>
+        <translation>短</translation>
+    </message>
+    <message>
+        <source>Long</source>
+        <translation>長</translation>
+    </message>
+    <message>
+        <source>Mouse Acceleration</source>
+        <translation>滑鼠加速</translation>
+    </message>
+    <message>
+        <source>Disable touchpad when a mouse is connected</source>
+        <translation>插入滑鼠時停用觸控板</translation>
+    </message>
+    <message>
+        <source>Natural Scrolling</source>
+        <translation>自然滾動</translation>
+    </message>
+</context>
+<context>
+    <name>MyDevice</name>
+    <message>
+        <source>My Devices</source>
+        <translation>我的裝置</translation>
+    </message>
+</context>
+<context>
+    <name>NativeInfoPage</name>
+    <message>
+        <source>UOS</source>
+        <translation>UOS</translation>
+    </message>
+    <message>
+        <source>Computer name</source>
+        <translation>計算機名</translation>
+    </message>
+    <message>
+        <source>It cannot start or end with dashes</source>
+        <translation>計算機名不能以 - 開頭結尾</translation>
+    </message>
+    <message>
+        <source>OS Name</source>
+        <translation>產品名稱</translation>
+    </message>
+    <message>
+        <source>Version</source>
+        <translation>版本號</translation>
+    </message>
+    <message>
+        <source>Edition</source>
+        <translation>版本</translation>
+    </message>
+    <message>
+        <source>Type</source>
+        <translation>型別</translation>
+    </message>
+    <message>
+        <source>bit</source>
+        <translation>位</translation>
+    </message>
+    <message>
+        <source>Authorization</source>
+        <translation>版本授權</translation>
+    </message>
+    <message>
+        <source>System installation time</source>
+        <translation>系統安裝日期</translation>
+    </message>
+    <message>
+        <source>Kernel</source>
+        <translation>核心版本</translation>
+    </message>
+    <message>
+        <source>Graphics Platform</source>
+        <translation>圖形平臺</translation>
+    </message>
+    <message>
+        <source>Processor</source>
+        <translation>處理器</translation>
+    </message>
+    <message>
+        <source>Memory</source>
+        <translation>記憶體</translation>
+    </message>
+    <message>
+        <source>1~63 characters please</source>
+        <translation>計算機名長度必須介於1到63個字元之間</translation>
+    </message>
+</context>
+<context>
+    <name>OtherDevice</name>
+    <message>
+        <source>Other Devices</source>
+        <translation>其他裝置</translation>
+    </message>
+    <message>
+        <source>Show Bluetooth devices without names</source>
+        <translation>顯示沒有名稱的藍牙裝置</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordLayout</name>
+    <message>
+        <source>Current password</source>
+        <translation>當前密碼</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>Weak</source>
+        <translation>強度低</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <translation>強度中</translation>
+    </message>
+    <message>
+        <source>Strong</source>
+        <translation>強度高</translation>
+    </message>
+    <message>
+        <source>Password</source>
+        <translation>密碼</translation>
+    </message>
+    <message>
+        <source>Repeat Password</source>
+        <translation>重複密碼</translation>
+    </message>
+    <message>
+        <source>Password hint</source>
+        <translation>密碼提示</translation>
+    </message>
+    <message>
+        <source>Optional</source>
+        <translation>選填</translation>
+    </message>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Passwords do not match</source>
+        <translation>密碼不一致</translation>
+    </message>
+    <message>
+        <source>New password should differ from the current one</source>
+        <translation>新密碼和舊密碼不能相同</translation>
+    </message>
+    <message>
+        <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation>密碼提示對所有人可見，切勿包含具體密碼資訊</translation>
+    </message>
+</context>
+<context>
+    <name>PasswordModifyDialog</name>
+    <message>
+        <source>Modify password</source>
+        <translation>修改密碼</translation>
+    </message>
+    <message>
+        <source>Reset password</source>
+        <translation>重置密碼</translation>
+    </message>
+    <message>
+        <source>Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.</source>
+        <translation>建議密碼長度8位以上，同時包含大寫字母、小寫字母、數字、符號中的3中密碼更安全</translation>
+    </message>
+    <message>
+        <source>Resetting the password will clear the data stored in the keyring.</source>
+        <translation>重設密碼將會清除金鑰環內已儲存的資料</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+</context>
+<context>
+    <name>PersonalizationInterface</name>
+    <message>
+        <source>Light</source>
+        <translation>淺色</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation>自動</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation>深色</translation>
+    </message>
+</context>
+<context>
+    <name>PersonalizationWorker</name>
+    <message>
+        <source>Custom</source>
+        <translation>自定義</translation>
+    </message>
+</context>
+<context>
+    <name>PluginArea</name>
+    <message>
+        <source>Plugin Area</source>
+        <translation>外掛區域</translation>
+    </message>
+    <message>
+        <source>Select which icons appear in the Dock</source>
+        <translation>選擇顯示在工作列外掛區域的圖示</translation>
+    </message>
+</context>
+<context>
+    <name>PowerOperatorModel</name>
+    <message>
+        <source>Shut down</source>
+        <translation>關機</translation>
+    </message>
+    <message>
+        <source>Suspend</source>
+        <translation>待機</translation>
+    </message>
+    <message>
+        <source>Hibernate</source>
+        <translation>休眠</translation>
+    </message>
+    <message>
+        <source>Turn off the monitor</source>
+        <translation>關閉顯示器</translation>
+    </message>
+    <message>
+        <source>Show the shutdown Interface</source>
+        <translation>進入關機介面</translation>
+    </message>
+    <message>
+        <source>Do nothing</source>
+        <translation>無任何操作</translation>
+    </message>
+</context>
+<context>
+    <name>PowerPage</name>
+    <message>
+        <source>Screen and Suspend</source>
+        <translation>螢幕和待機</translation>
+    </message>
+    <message>
+        <source>Turn off the monitor after</source>
+        <translation>關閉顯示器</translation>
+    </message>
+    <message>
+        <source>Lock screen after</source>
+        <translation>自動鎖屏</translation>
+    </message>
+    <message>
+        <source>Computer suspends after</source>
+        <translation>進入待機</translation>
+    </message>
+    <message>
+        <source>When the lid is closed</source>
+        <translation>筆記本合蓋時</translation>
+    </message>
+    <message>
+        <source>When the power button is pressed</source>
+        <translation>按電源按鈕時</translation>
+    </message>
+</context>
+<context>
+    <name>PowerPlansListview</name>
+    <message>
+        <source>High Performance</source>
+        <translation>高效能模式</translation>
+    </message>
+    <message>
+        <source>Balance Performance</source>
+        <translation>效能模式</translation>
+    </message>
+    <message>
+        <source>Aggressively adjust CPU operating frequency based on CPU load condition</source>
+        <translation>根據負載情況積極調整執行頻率</translation>
+    </message>
+    <message>
+        <source>Balanced</source>
+        <translation>平衡模式</translation>
+    </message>
+    <message>
+        <source>Power Saver</source>
+        <translation>節能模式</translation>
+    </message>
+    <message>
+        <source>Prioritize performance, which will significantly increase power consumption and heat generation</source>
+        <translation>效能優先，會顯著提升功耗和發熱</translation>
+    </message>
+    <message>
+        <source>Balancing performance and battery life, automatically adjusted according to usage</source>
+        <translation>兼顧效能和續航，根據使用情況自動調節</translation>
+    </message>
+    <message>
+        <source>Prioritize battery life, which the system will sacrifice some performance to reduce power consumption</source>
+        <translation>續航優先，系統會犧牲一些效能表現來降低功耗</translation>
+    </message>
+</context>
+<context>
+    <name>PowerWorker</name>
+    <message>
+        <source>Minutes</source>
+        <translation>分鐘</translation>
+    </message>
+    <message>
+        <source>Hour</source>
+        <translation>小時</translation>
+    </message>
+    <message>
+        <source>Never</source>
+        <translation>從不</translation>
+    </message>
+</context>
+<context>
+    <name>PrivacyPolicyPage</name>
+    <message>
+        <source>Privacy Policy</source>
+        <translation>隱私政策</translation>
+    </message>
+    <message>
+        <source>Copy Link Address</source>
+        <translation>複製連結地址</translation>
+    </message>
+</context>
+<context>
+    <name>PwqualityManager</name>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Password must have at least %1 characters</source>
+        <translation>密碼長度不能少於%1個字元</translation>
+    </message>
+    <message>
+        <source>Password must be no more than %1 characters</source>
+        <translation>密碼長度不能超過%1個字元</translation>
+    </message>
+    <message>
+        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
+    </message>
+    <message>
+        <source>No more than %1 palindrome characters please</source>
+        <translation>迴文字元長度不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 monotonic characters please</source>
+        <translation>單調性字元不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 repeating characters please</source>
+        <translation>重複字元不超過%1位</translation>
+    </message>
+    <message>
+        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
+    </message>
+    <message>
+        <source>Password must not contain more than 4 palindrome characters</source>
+        <translation>密碼不得含有連續4個以上的迴文字元</translation>
+    </message>
+    <message>
+        <source>Do not use common words and combinations as password</source>
+        <translation>密碼不能是常見單詞及組合</translation>
+    </message>
+    <message>
+        <source>Create a strong password please</source>
+        <translation>密碼過於簡單，請增加密碼複雜度</translation>
+    </message>
+    <message>
+        <source>It does not meet password rules</source>
+        <translation>密碼不符合安全要求</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <source>Control Center</source>
+        <translation>控制中心</translation>
+    </message>
+    <message>
+        <source>Activated</source>
+        <translation>已啟用</translation>
+    </message>
+    <message>
+        <source>View</source>
+        <translation>檢視</translation>
+    </message>
+    <message>
+        <source>To be activated</source>
+        <translation>待啟用</translation>
+    </message>
+    <message>
+        <source>Activate</source>
+        <translation>啟用</translation>
+    </message>
+    <message>
+        <source>Expired</source>
+        <translation>已過期</translation>
+    </message>
+    <message>
+        <source>In trial period</source>
+        <translation>試用期</translation>
+    </message>
+    <message>
+        <source>Trial expired</source>
+        <translation>試用期過期</translation>
+    </message>
+    <message>
+        <source>dde-control-center</source>
+        <translation>控制中心</translation>
+    </message>
+    <message>
+        <source>Touch Screen Settings</source>
+        <translation>觸控屏設定</translation>
+    </message>
+    <message>
+        <source>The settings of touch screen changed</source>
+        <translation>已變更觸控屏設定</translation>
+    </message>
+    <message>
+        <source>This system wallpaper is locked. Please contact your admin.</source>
+        <translation>當前系統壁紙已被鎖定，請聯絡管理員</translation>
+    </message>
+</context>
+<context>
+    <name>RegionFormatDialog</name>
+    <message>
+        <source>Regions and formats</source>
+        <translation>區域和格式</translation>
+    </message>
+    <message>
+        <source>Search</source>
+        <translation>搜尋</translation>
+    </message>
+    <message>
+        <source>Default formats</source>
+        <translation>預設格式</translation>
+    </message>
+    <message>
+        <source>First day of week</source>
+        <translation>一週第一天</translation>
+    </message>
+    <message>
+        <source>Short date</source>
+        <translation>短日期</translation>
+    </message>
+    <message>
+        <source>Long date</source>
+        <translation>長日期</translation>
+    </message>
+    <message>
+        <source>Short time</source>
+        <translation>短時間</translation>
+    </message>
+    <message>
+        <source>Long time</source>
+        <translation>長時間</translation>
+    </message>
+    <message>
+        <source>Currency symbol</source>
+        <translation>貨幣符號</translation>
+    </message>
+    <message>
+        <source>Digit</source>
+        <translation>數字</translation>
+    </message>
+    <message>
+        <source>Paper size</source>
+        <translation>紙張</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+</context>
+<context>
+    <name>RegionsChooserWindow</name>
+    <message>
+        <source>Search</source>
+        <translation>搜尋</translation>
+    </message>
+</context>
+<context>
+    <name>RegisterDialog</name>
+    <message>
+        <source>Set a Password</source>
+        <translation>設定密碼</translation>
+    </message>
+    <message>
+        <source>8-64 characters</source>
+        <translation>請輸入8-64位密碼</translation>
+    </message>
+    <message>
+        <source>Repeat the password</source>
+        <translation>請再次輸入密碼</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確定</translation>
+    </message>
+    <message>
+        <source>Passwords don&apos;t match</source>
+        <translation>兩次密碼輸入不一致</translation>
+    </message>
+</context>
+<context>
+    <name>ScheduledShutdownDialog</name>
+    <message>
+        <source>Customize repetition time</source>
+        <translation>自定義重複時間</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+</context>
+<context>
+    <name>ScreenSaverPage</name>
+    <message>
+        <source>Screensaver</source>
+        <translation>螢幕保護</translation>
+    </message>
+    <message>
+        <source>preview</source>
+        <translation>全屏預覽</translation>
+    </message>
+    <message>
+        <source>Personalized screensaver</source>
+        <translation>個性化屏保</translation>
+    </message>
+    <message>
+        <source>setting</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>idle time</source>
+        <translation>閒置時間</translation>
+    </message>
+    <message>
+        <source>1 minute</source>
+        <translation>1分鐘</translation>
+    </message>
+    <message>
+        <source>5 minute</source>
+        <translation>5分鐘</translation>
+    </message>
+    <message>
+        <source>10 minute</source>
+        <translation>10分鐘</translation>
+    </message>
+    <message>
+        <source>15 minute</source>
+        <translation>15分鐘</translation>
+    </message>
+    <message>
+        <source>30 minute</source>
+        <translation>30分鐘</translation>
+    </message>
+    <message>
+        <source>1 hour</source>
+        <translation>1小時</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>從不</translation>
+    </message>
+    <message>
+        <source>Password required for recovery</source>
+        <translation>恢復時需要密碼</translation>
+    </message>
+    <message>
+        <source>Picture slideshow screensaver</source>
+        <translation>圖片輪播屏保</translation>
+    </message>
+    <message>
+        <source>System screensaver</source>
+        <translation>系統屏保</translation>
+    </message>
+</context>
+<context>
+    <name>SearchableListViewPopup</name>
+    <message>
+        <source>Search</source>
+        <translation>搜尋</translation>
+    </message>
+    <message>
+        <source>No search results</source>
+        <translation>無搜尋結果</translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutSettingDialog</name>
+    <message>
+        <source>Add custom shortcut</source>
+        <translation>新增自定義快捷鍵</translation>
+    </message>
+    <message>
+        <source>Name:</source>
+        <translation>名稱：</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>Command:</source>
+        <translation>命令：</translation>
+    </message>
+    <message>
+        <source>Shortcut</source>
+        <translation>快捷鍵</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+    <message>
+        <source>Please enter a new shortcut</source>
+        <translation>請輸入新的快捷鍵</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>新增</translation>
+    </message>
+    <message>
+        <source>Click Add to replace</source>
+        <translation>點選新增替換</translation>
+    </message>
+</context>
+<context>
+    <name>Shortcuts</name>
+    <message>
+        <source>Shortcuts</source>
+        <translation>快捷鍵</translation>
+    </message>
+    <message>
+        <source>System shortcut, custom shortcut</source>
+        <translation>系統快捷鍵、自定義快捷鍵</translation>
+    </message>
+    <message>
+        <source>Search shortcuts</source>
+        <translation>搜尋快捷鍵</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>done</source>
+        <translation>完成</translation>
+    </message>
+    <message>
+        <source>edit</source>
+        <translation>編輯</translation>
+    </message>
+    <message>
+        <source>Please enter a new shortcut</source>
+        <translation>請輸入新的快捷鍵</translation>
+    </message>
+    <message>
+        <source>Click</source>
+        <translation>點選</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>or</source>
+        <translation>或</translation>
+    </message>
+    <message>
+        <source>Replace</source>
+        <translation>替換</translation>
+    </message>
+    <message>
+        <source>Restore default</source>
+        <translation>恢復預設</translation>
+    </message>
+    <message>
+        <source>Add custom shortcut</source>
+        <translation>新增快捷鍵</translation>
+    </message>
+</context>
+<context>
+    <name>SoundDevicemanagesPage</name>
+    <message>
+        <source>Output Devices</source>
+        <translation>輸出裝置</translation>
+    </message>
+    <message>
+        <source>Select whether to enable the devices</source>
+        <translation>選擇是否啟用裝置</translation>
+    </message>
+    <message>
+        <source>Input Devices</source>
+        <translation>輸入裝置</translation>
+    </message>
+</context>
+<context>
+    <name>SoundEffectsPage</name>
+    <message>
+        <source>Sound Effects</source>
+        <translation>系統音效</translation>
+    </message>
+</context>
+<context>
+    <name>SoundModel</name>
+    <message>
+        <source>Boot up</source>
+        <translation>開機</translation>
+    </message>
+    <message>
+        <source>Shut down</source>
+        <translation>關機</translation>
+    </message>
+    <message>
+        <source>Log out</source>
+        <translation>登出</translation>
+    </message>
+    <message>
+        <source>Wake up</source>
+        <translation>喚醒</translation>
+    </message>
+    <message>
+        <source>Volume +/-</source>
+        <translation>音量調節</translation>
+    </message>
+    <message>
+        <source>Notification</source>
+        <translation>通知</translation>
+    </message>
+    <message>
+        <source>Low battery</source>
+        <translation>電量不足</translation>
+    </message>
+    <message>
+        <source>Send icon in Launcher to Desktop</source>
+        <translation>從啟動器傳送圖示到桌面</translation>
+    </message>
+    <message>
+        <source>Empty Trash</source>
+        <translation>清空回收站</translation>
+    </message>
+    <message>
+        <source>Plug in</source>
+        <translation>電源接入</translation>
+    </message>
+    <message>
+        <source>Plug out</source>
+        <translation>電源拔出</translation>
+    </message>
+    <message>
+        <source>Removable device connected</source>
+        <translation>行動裝置接入</translation>
+    </message>
+    <message>
+        <source>Removable device removed</source>
+        <translation>行動裝置拔出</translation>
+    </message>
+    <message>
+        <source>Error</source>
+        <translation>錯誤提示</translation>
+    </message>
+</context>
+<context>
+    <name>SpeakerPage</name>
+    <message>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Output Volume</source>
+        <translation>輸出音量</translation>
+    </message>
+    <message>
+        <source>Volume Boost</source>
+        <translation>音量增強</translation>
+    </message>
+    <message>
+        <source>If the volume is louder than 100%, it may distort audio and be harmful to output devices</source>
+        <translation>音量大於100%時可能會導致音效失真，同時損害您的音訊輸出裝置</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>右</translation>
+    </message>
+    <message>
+        <source>Output</source>
+        <translation>輸出</translation>
+    </message>
+    <message>
+        <source>No output device for sound found</source>
+        <translation>沒有找到聲音輸出裝置</translation>
+    </message>
+    <message>
+        <source>Left Right Balance</source>
+        <translation>左右平衡</translation>
+    </message>
+    <message>
+        <source>Mono audio</source>
+        <translation>單聲道音訊</translation>
+    </message>
+    <message>
+        <source>Merge left and right channels into a single channel</source>
+        <translation>將左聲道和右聲道合併成一個聲道</translation>
+    </message>
+    <message>
+        <source>Auto pause</source>
+        <translation>插拔管理</translation>
+    </message>
+    <message>
+        <source>Whether the audio will be automatically paused when the current audio device is unplugged</source>
+        <translation>外設插拔時音訊輸出是否自動暫停</translation>
+    </message>
+    <message>
+        <source>Output Devices</source>
+        <translation>輸出裝置</translation>
+    </message>
+</context>
+<context>
+    <name>SyncInfoListModel</name>
+    <message>
+        <source>Sound</source>
+        <translation>聲音</translation>
+    </message>
+    <message>
+        <source>Power</source>
+        <translation>電源</translation>
+    </message>
+    <message>
+        <source>Mouse</source>
+        <translation>滑鼠</translation>
+    </message>
+    <message>
+        <source>Update</source>
+        <translation>更新</translation>
+    </message>
+    <message>
+        <source>Screensaver</source>
+        <translation>螢幕保護</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeSelectView</name>
+    <message>
+        <source>More Wallpapers</source>
+        <translation>下載更多</translation>
+    </message>
+</context>
+<context>
+    <name>TimeAndDate</name>
+    <message>
+        <source>Auto sync time</source>
+        <translation>自動同步配置</translation>
+    </message>
+    <message>
+        <source>Ntp server</source>
+        <translation>伺服器</translation>
+    </message>
+    <message>
+        <source>System date and time</source>
+        <translation>系統日期和時間</translation>
+    </message>
+    <message>
+        <source>Customize</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>Server address</source>
+        <translation>伺服器地址</translation>
+    </message>
+    <message>
+        <source>Required</source>
+        <translation>必填</translation>
+    </message>
+    <message>
+        <source>The ntp server address cannot be empty</source>
+        <translation>NTP 服務地址不能為空</translation>
+    </message>
+    <message>
+        <source>Use 24-hour format</source>
+        <translation>24小時制</translation>
+    </message>
+    <message>
+        <source>system time zone</source>
+        <translation>系統時區</translation>
+    </message>
+    <message>
+        <source>Timezone list</source>
+        <translation>時區列表</translation>
+    </message>
+</context>
+<context>
+    <name>TimeRange</name>
+    <message>
+        <source>from</source>
+        <translation>從</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation>至</translation>
+    </message>
+</context>
+<context>
+    <name>TimeoutDialog</name>
+    <message>
+        <source>Save the display settings?</source>
+        <translation>是否要儲存顯示設定？</translation>
+    </message>
+    <message>
+        <source>Settings will be reverted in %1s.</source>
+        <translation>如無任何操作將在%1秒後還原。</translation>
+    </message>
+    <message>
+        <source>Revert</source>
+        <translation>還原</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+</context>
+<context>
+    <name>TimezoneDialog</name>
+    <message>
+        <source>Add time zone</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Determine the time zone based on the current location</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Time zone:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Nearest City:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Save</source>
+        <translation>儲存</translation>
+    </message>
+</context>
+<context>
+    <name>TouchScreen</name>
+    <message>
+        <source>TouchScreen</source>
+        <translation>觸控屏</translation>
+    </message>
+    <message>
+        <source>Set up here when connecting the touch screen</source>
+        <translation>連線觸控螢幕時在此處設定</translation>
+    </message>
+</context>
+<context>
+    <name>Touchpad</name>
+    <message>
+        <source>Basic Settings</source>
+        <translation>基礎設定</translation>
+    </message>
+    <message>
+        <source>Touchpad</source>
+        <translation>觸控板</translation>
+    </message>
+    <message>
+        <source>Pointer Speed</source>
+        <translation>指標速度</translation>
+    </message>
+    <message>
+        <source>Slow</source>
+        <translation>慢</translation>
+    </message>
+    <message>
+        <source>Fast</source>
+        <translation>快</translation>
+    </message>
+    <message>
+        <source>Disable touchpad during input</source>
+        <translation>輸入時停用觸控板</translation>
+    </message>
+    <message>
+        <source>Tap to Click</source>
+        <translation>輕觸以點選</translation>
+    </message>
+    <message>
+        <source>Natural Scrolling</source>
+        <translation>自然滾動</translation>
+    </message>
+    <message>
+        <source>Gesture</source>
+        <translation>手勢</translation>
+    </message>
+    <message>
+        <source>Three-finger gestures</source>
+        <translation>三指手勢</translation>
+    </message>
+    <message>
+        <source>Four-finger gestures</source>
+        <translation>四指手勢</translation>
+    </message>
+</context>
+<context>
+    <name>UserExperienceProgramPage</name>
+    <message>
+        <source>Join User Experience Program</source>
+        <translation>加入使用者體驗計劃</translation>
+    </message>
+    <message>
+        <source>Copy Link Address</source>
+        <translation>複製連結地址</translation>
+    </message>
+</context>
+<context>
+    <name>VerifyDialog</name>
+    <message>
+        <source>Security Verification</source>
+        <translation>安全驗證</translation>
+    </message>
+    <message>
+        <source>The action is sensitive, please enter the login password first</source>
+        <translation>您正在進行敏感操作，請進行登入密碼認證</translation>
+    </message>
+    <message>
+        <source>8-64 characters</source>
+        <translation>請輸入8-64位密碼</translation>
+    </message>
+    <message>
+        <source>Forgot Password?</source>
+        <translation>忘記密碼？</translation>
+    </message>
+    <message>
+        <source>Cancel</source>
+        <translation>取消</translation>
+    </message>
+    <message>
+        <source>Confirm</source>
+        <translation>確定</translation>
+    </message>
+</context>
+<context>
+    <name>WallpaperPage</name>
+    <message>
+        <source>wallpaper</source>
+        <translation>壁紙</translation>
+    </message>
+    <message>
+        <source>Window rounded corners</source>
+        <translation>視窗圓角</translation>
+    </message>
+    <message>
+        <source>My pictures</source>
+        <translation>我的圖片</translation>
+    </message>
+    <message>
+        <source>System Wallpaper</source>
+        <translation>系統壁紙</translation>
+    </message>
+    <message>
+        <source>Solid color wallpaper</source>
+        <translation>純色壁紙</translation>
+    </message>
+    <message>
+        <source>Customizable wallpapers</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>fill style</source>
+        <translation>填充方式</translation>
+    </message>
+    <message>
+        <source>Automatic wallpaper change</source>
+        <translation>自動切換壁紙</translation>
+    </message>
+    <message>
+        <source>never</source>
+        <translation>從不</translation>
+    </message>
+    <message>
+        <source>30 second</source>
+        <translation>30秒</translation>
+    </message>
+    <message>
+        <source>1 minute</source>
+        <translation>1分鐘</translation>
+    </message>
+    <message>
+        <source>5 minute</source>
+        <translation>5分鐘</translation>
+    </message>
+    <message>
+        <source>10 minute</source>
+        <translation>10分鐘</translation>
+    </message>
+    <message>
+        <source>15 minute</source>
+        <translation>15分鐘</translation>
+    </message>
+    <message>
+        <source>30 minute</source>
+        <translation>30分鐘</translation>
+    </message>
+    <message>
+        <source>login</source>
+        <translation>登入時</translation>
+    </message>
+    <message>
+        <source>wake up</source>
+        <translation>喚醒時</translation>
+    </message>
+    <message>
+        <source>System Wallapers</source>
+        <translation>系統壁紙</translation>
+    </message>
+    <message>
+        <source>Live Wallpaper</source>
+        <translation>動態壁紙</translation>
+    </message>
+    <message>
+        <source>1 hour</source>
+        <translation>1小時</translation>
+    </message>
+</context>
+<context>
+    <name>WallpaperSelectView</name>
+    <message>
+        <source>unfold</source>
+        <translation>收起</translation>
+    </message>
+    <message>
+        <source>show all</source>
+        <translation>顯示全部</translation>
+    </message>
+    <message>
+        <source>items</source>
+        <translation>張</translation>
+    </message>
+    <message>
+        <source>Set lock screen</source>
+        <translation>設定鎖屏</translation>
+    </message>
+    <message>
+        <source>Set desktop</source>
+        <translation>設定桌面</translation>
+    </message>
+</context>
+<context>
+    <name>WindowEffectPage</name>
+    <message>
+        <source>Interface and Effects</source>
+        <translation>介面效果</translation>
+    </message>
+    <message>
+        <source>Window Settings</source>
+        <translation>視窗設定</translation>
+    </message>
+    <message>
+        <source>Window rounded corners</source>
+        <translation>視窗圓角</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>小</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>大</translation>
+    </message>
+    <message>
+        <source>Enable transparent effects when moving windows</source>
+        <translation>視窗移動時啟用透明特效</translation>
+    </message>
+    <message>
+        <source>Window Minimize Effect</source>
+        <translation>最小化時效果</translation>
+    </message>
+    <message>
+        <source>Scale</source>
+        <translation>縮放</translation>
+    </message>
+    <message>
+        <source>Magic Lamp</source>
+        <translation>魔燈</translation>
+    </message>
+    <message>
+        <source>Opacity</source>
+        <translation>不透明度調節</translation>
+    </message>
+    <message>
+        <source>Low</source>
+        <translation>低</translation>
+    </message>
+    <message>
+        <source>High</source>
+        <translation>高</translation>
+    </message>
+    <message>
+        <source>Scroll Bars</source>
+        <translation>捲軸</translation>
+    </message>
+    <message>
+        <source>Show on scrolling</source>
+        <translation>滾動時顯示</translation>
+    </message>
+    <message>
+        <source>Keep shown</source>
+        <translation>一直顯示</translation>
+    </message>
+    <message>
+        <source>Compact Display</source>
+        <translation>緊湊模式</translation>
+    </message>
+    <message>
+        <source>If enabled, more content is displayed in the window.</source>
+        <translation>開啟後，視窗將顯示更多內容</translation>
+    </message>
+    <message>
+        <source>Title Bar Height</source>
+        <translation>標題欄高度</translation>
+    </message>
+    <message>
+        <source>Only suitable for application window title bars drawn by the window manager.</source>
+        <translation>僅適用於視窗管理器繪製的應用標題欄</translation>
+    </message>
+    <message>
+        <source>Extremely small</source>
+        <translation>極小</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe size of window rounded corners</comment>
+        <translation>中</translation>
+    </message>
+    <message>
+        <source>Medium</source>
+        <comment>describe height of window title bar</comment>
+        <translation>中</translation>
+    </message>
+</context>
+<context>
+    <name>accounts</name>
+    <message>
+        <source>Account</source>
+        <translation>帳戶</translation>
+    </message>
+    <message>
+        <source>Account manager</source>
+        <translation>帳戶管理</translation>
+    </message>
+</context>
+<context>
+    <name>accountsMain</name>
+    <message>
+        <source>Other accounts</source>
+        <translation>其他帳戶</translation>
+    </message>
+</context>
+<context>
+    <name>authentication</name>
+    <message>
+        <source>Biometric Authentication</source>
+        <translation>生物認證</translation>
+    </message>
+</context>
+<context>
+    <name>authenticationMain</name>
+    <message>
+        <source>Biometric Authentication</source>
+        <translation>生物認證</translation>
+    </message>
+    <message>
+        <source>Face</source>
+        <translation>人臉</translation>
+    </message>
+    <message>
+        <source>Up to 5 facial data can be entered</source>
+        <translation>最多可錄入5個人臉資料</translation>
+    </message>
+    <message>
+        <source>Fingerprint</source>
+        <translation>指紋</translation>
+    </message>
+    <message>
+        <source>Identifying user identity through scanning fingerprints</source>
+        <translation>通過對指紋的掃描進行使用者身份的識別</translation>
+    </message>
+    <message>
+        <source>Iris</source>
+        <translation>虹膜</translation>
+    </message>
+    <message>
+        <source>Identity recognition through iris scanning</source>
+        <translation>通過掃描虹膜進行身份識別</translation>
+    </message>
+    <message>
+        <source>Use letters, numbers and underscores only, and no more than 15 characters</source>
+        <translation>只能由字母、數字、中文、下劃線組成，且不超過15個字元</translation>
+    </message>
+    <message>
+        <source>Use letters, numbers and underscores only</source>
+        <translation>只能由字母、數字、中文、下劃線組成</translation>
+    </message>
+    <message>
+        <source>No more than 15 characters</source>
+        <translation>不得超過15個字元</translation>
+    </message>
+    <message>
+        <source>This name already exists</source>
+        <translation>該名稱已存在</translation>
+    </message>
+    <message>
+        <source>Add a new </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>blueTooth</name>
+    <message>
+        <source>bluetooth</source>
+        <translation>藍牙</translation>
+    </message>
+    <message>
+        <source>Bluetooth settings, devices</source>
+        <translation>藍牙設定、裝置管理</translation>
+    </message>
+</context>
+<context>
+    <name>commonInfoMain</name>
+    <message>
+        <source>Boot Menu</source>
+        <translation>啟動菜單</translation>
+    </message>
+    <message>
+        <source>Manage your boot menu</source>
+        <translation>管理您的開機啟動菜單</translation>
+    </message>
+    <message>
+        <source>Developer root permission management</source>
+        <translation>開發者Root許可權管理</translation>
+    </message>
+    <message>
+        <source>Developer Options</source>
+        <translation>開發者選項</translation>
+    </message>
+</context>
+<context>
+    <name>datetime</name>
+    <message>
+        <source>Time and date</source>
+        <translation>時間和日期</translation>
+    </message>
+    <message>
+        <source>Time and date, time zone settings</source>
+        <translation>時間日期、時區設定</translation>
+    </message>
+    <message>
+        <source>Language and region</source>
+        <translation>語言和區域</translation>
+    </message>
+    <message>
+        <source>System language, region format</source>
+        <translation>系統語言、區域格式</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::AccountsController</name>
+    <message>
+        <source>Username must be between 3 and 32 characters</source>
+        <translation>使用者名稱長度必須介於 3 到 32 個字元之間</translation>
+    </message>
+    <message>
+        <source>The first character must be a letter or number</source>
+        <translation>必須字母或者數字開頭</translation>
+    </message>
+    <message>
+        <source>Your username should not only have numbers</source>
+        <translation>使用者名稱不能僅僅是數字</translation>
+    </message>
+    <message>
+        <source>The username has been used by other user accounts</source>
+        <translation>使用者名稱和其他使用者名稱重複</translation>
+    </message>
+    <message>
+        <source>The full name is too long</source>
+        <translation>全名太長了</translation>
+    </message>
+    <message>
+        <source>The full name has been used by other user accounts</source>
+        <translation>全名和其他使用者名稱重複</translation>
+    </message>
+    <message>
+        <source>Wrong password</source>
+        <translation>密碼錯誤</translation>
+    </message>
+    <message>
+        <source>Standard User</source>
+        <translation>標準使用者</translation>
+    </message>
+    <message>
+        <source>Administrator</source>
+        <translation>管理員</translation>
+    </message>
+    <message>
+        <source>Customized</source>
+        <translation>自定義</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::AccountsWorker</name>
+    <message>
+        <source>Your host was removed from the domain server successfully</source>
+        <translation>您的主機成功退出了域伺服器</translation>
+    </message>
+    <message>
+        <source>Your host joins the domain server successfully</source>
+        <translation>您的主機成功加入了域伺服器</translation>
+    </message>
+    <message>
+        <source>Your host failed to leave the domain server</source>
+        <translation>您的主機退出域伺服器失敗</translation>
+    </message>
+    <message>
+        <source>Your host failed to join the domain server</source>
+        <translation>您的主機加入域伺服器失敗</translation>
+    </message>
+    <message>
+        <source>AD domain settings</source>
+        <translation>AD域設定</translation>
+    </message>
+    <message>
+        <source>Password not match</source>
+        <translation>密碼不一致</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::AvatarTypesModel</name>
+    <message>
+        <source>Dimensional</source>
+        <translation>立體風格</translation>
+    </message>
+    <message>
+        <source>Flat</source>
+        <translation>平面風格</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::BiometricAuthController</name>
+    <message>
+        <source>Use your face to unlock the device and make settings later</source>
+        <translation>使用人臉資料解鎖您的裝置，之後還可進行更多設定</translation>
+    </message>
+    <message>
+        <source>Faceprint</source>
+        <translation>麵紋</translation>
+    </message>
+    <message>
+        <source>Place your finger</source>
+        <translation>放置手指</translation>
+    </message>
+    <message>
+        <source>Place your finger firmly on the sensor until you&apos;re asked to lift it</source>
+        <translation>請以手指壓指紋收集器，然後根據提示擡起</translation>
+    </message>
+    <message>
+        <source>Lift your finger</source>
+        <translation>擡起手指</translation>
+    </message>
+    <message>
+        <source>Lift your finger and place it on the sensor again</source>
+        <translation>請擡起手指，再次按壓</translation>
+    </message>
+    <message>
+        <source>Scan the edges of your fingerprint</source>
+        <translation>錄入邊緣指紋</translation>
+    </message>
+    <message>
+        <source>Adjust the position to scan the edges of your fingerprint</source>
+        <translation>請調整按壓區域，繼續錄入邊緣指紋</translation>
+    </message>
+    <message>
+        <source>Lift your finger and do that again</source>
+        <translation>請擡起手指，再次按壓</translation>
+    </message>
+    <message>
+        <source>Fingerprint added</source>
+        <translation>成功新增指紋</translation>
+    </message>
+    <message>
+        <source>Scan Suspended</source>
+        <translation>錄入中斷</translation>
+    </message>
+    <message>
+        <source>Place the edges of your fingerprint on the sensor</source>
+        <translation>請以手指邊緣壓指紋收集器，然後根據提示擡起</translation>
+    </message>
+    <message>
+        <source>Iris</source>
+        <translation>虹膜</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::KeyboardController</name>
+    <message>
+        <source>This shortcut conflicts with [%1]</source>
+        <translation>此快捷鍵與[%1]衝突</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::PwqualityManager</name>
+    <message>
+        <source>Password cannot be empty</source>
+        <translation>密碼不能為空</translation>
+    </message>
+    <message>
+        <source>Password must have at least %1 characters</source>
+        <translation>密碼長度不能少於%1個字元</translation>
+    </message>
+    <message>
+        <source>Password must be no more than %1 characters</source>
+        <translation>密碼長度不能超過%1個字元</translation>
+    </message>
+    <message>
+        <source>Password can only contain English letters (case-sensitive), numbers or special symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼只能由英文（區分大小寫）、數字或特殊符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）組成</translation>
+    </message>
+    <message>
+        <source>No more than %1 palindrome characters please</source>
+        <translation>迴文字元長度不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 monotonic characters please</source>
+        <translation>單調性字元不超過%1位</translation>
+    </message>
+    <message>
+        <source>No more than %1 repeating characters please</source>
+        <translation>重複字元不超過%1位</translation>
+    </message>
+    <message>
+        <source>Password must contain uppercase letters, lowercase letters, numbers and symbols (~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/)</source>
+        <translation>密碼必須由大寫字母、小寫字母、數字、符號（~`!@#$%^&amp;*()-_+=|\{}[]:&quot;&apos;&lt;&gt;,.?/）三種類型組成</translation>
+    </message>
+    <message>
+        <source>Password must not contain more than 4 palindrome characters</source>
+        <translation>密碼不得含有連續4個以上的迴文字元</translation>
+    </message>
+    <message>
+        <source>Do not use common words and combinations as password</source>
+        <translation>密碼不能是常見單詞及組合</translation>
+    </message>
+    <message>
+        <source>Create a strong password please</source>
+        <translation>密碼過於簡單，請增加密碼複雜度</translation>
+    </message>
+    <message>
+        <source>It does not meet password rules</source>
+        <translation>密碼不符合安全要求</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::ShortcutModel</name>
+    <message>
+        <source>System</source>
+        <translation>系統</translation>
+    </message>
+    <message>
+        <source>Window</source>
+        <translation>視窗</translation>
+    </message>
+    <message>
+        <source>Workspace</source>
+        <translation>工作區</translation>
+    </message>
+    <message>
+        <source>AssistiveTools</source>
+        <translation>輔助功能</translation>
+    </message>
+    <message>
+        <source>Custom</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>None</source>
+        <translation>無</translation>
+    </message>
+</context>
+<context>
+    <name>deepinid</name>
+    <message>
+        <source>deepin ID</source>
+        <translation>deepin ID</translation>
+    </message>
+    <message>
+        <source>UOS ID</source>
+        <translation>UOS ID</translation>
+    </message>
+    <message>
+        <source>Cloud services</source>
+        <translation>雲服務</translation>
+    </message>
+</context>
+<context>
+    <name>defaultapp</name>
+    <message>
+        <source>Default App</source>
+        <translation>預設程式</translation>
+    </message>
+    <message>
+        <source>Set the default application for opening various types of files</source>
+        <translation>設定打開各類檔案的預設程式</translation>
+    </message>
+</context>
+<context>
+    <name>defaultappMain</name>
+    <message>
+        <source>Webpage</source>
+        <translation>網頁</translation>
+    </message>
+    <message>
+        <source>Mail</source>
+        <translation>郵件</translation>
+    </message>
+    <message>
+        <source>Text</source>
+        <translation>文字</translation>
+    </message>
+    <message>
+        <source>Music</source>
+        <translation>音樂</translation>
+    </message>
+    <message>
+        <source>Video</source>
+        <translation>影片</translation>
+    </message>
+    <message>
+        <source>Picture</source>
+        <translation>圖片</translation>
+    </message>
+    <message>
+        <source>Terminal</source>
+        <translation>終端</translation>
+    </message>
+</context>
+<context>
+    <name>device</name>
+    <message>
+        <source>Device</source>
+        <translation>裝置</translation>
+    </message>
+</context>
+<context>
+    <name>display</name>
+    <message>
+        <source>Display</source>
+        <translation>顯示</translation>
+    </message>
+    <message>
+        <source>Brightness,resolution,scaling</source>
+        <translation>亮度、解析度、縮放</translation>
+    </message>
+</context>
+<context>
+    <name>displayMain</name>
+    <message>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <source>125%</source>
+        <translation>125%</translation>
+    </message>
+    <message>
+        <source>150%</source>
+        <translation>150%</translation>
+    </message>
+    <message>
+        <source>175%</source>
+        <translation>175%</translation>
+    </message>
+    <message>
+        <source>200%</source>
+        <translation>200%</translation>
+    </message>
+    <message>
+        <source>225%</source>
+        <translation>225%</translation>
+    </message>
+    <message>
+        <source>250%</source>
+        <translation>250%</translation>
+    </message>
+    <message>
+        <source>275%</source>
+        <translation>275%</translation>
+    </message>
+    <message>
+        <source>300%</source>
+        <translation>300%</translation>
+    </message>
+    <message>
+        <source>Duplicate</source>
+        <translation>複製</translation>
+    </message>
+    <message>
+        <source>Extend</source>
+        <translation>擴充套件</translation>
+    </message>
+    <message>
+        <source>Default</source>
+        <translation>預設</translation>
+    </message>
+    <message>
+        <source>Fit</source>
+        <translation>適應</translation>
+    </message>
+    <message>
+        <source>Stretch</source>
+        <translation>拉伸</translation>
+    </message>
+    <message>
+        <source>Center</source>
+        <translation>居中</translation>
+    </message>
+    <message>
+        <source>Only on %1</source>
+        <translation>僅%1屏</translation>
+    </message>
+    <message>
+        <source>Hz</source>
+        <translation>赫茲</translation>
+    </message>
+    <message>
+        <source>Multiple Displays Settings</source>
+        <translation>多屏設定</translation>
+    </message>
+    <message>
+        <source>Identify</source>
+        <translation>識別</translation>
+    </message>
+    <message>
+        <source>Screen rearrangement will take effect in %1s after changes</source>
+        <translation>螢幕拼接將在修改完成%1s後生效</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Main Screen</source>
+        <translation>主螢幕</translation>
+    </message>
+    <message>
+        <source>Display And Layout</source>
+        <translation>顯示和佈局</translation>
+    </message>
+    <message>
+        <source>Brightness</source>
+        <translation>亮度</translation>
+    </message>
+    <message>
+        <source>Resolution</source>
+        <translation>解析度</translation>
+    </message>
+    <message>
+        <source>Resize Desktop</source>
+        <translation>桌面顯示</translation>
+    </message>
+    <message>
+        <source>Refresh Rate</source>
+        <translation>重新整理率</translation>
+    </message>
+    <message>
+        <source>Rotation</source>
+        <translation>方向</translation>
+    </message>
+    <message>
+        <source>Standard</source>
+        <translation>標準</translation>
+    </message>
+    <message>
+        <source>90°</source>
+        <translation>90度</translation>
+    </message>
+    <message>
+        <source>180°</source>
+        <translation>180度</translation>
+    </message>
+    <message>
+        <source>270°</source>
+        <translation>270度</translation>
+    </message>
+    <message>
+        <source>Display Scaling</source>
+        <translation>縮放</translation>
+    </message>
+    <message>
+        <source>The monitor only supports 100% display scaling</source>
+        <translation>當前螢幕僅支援1倍縮放</translation>
+    </message>
+    <message>
+        <source>Eye Comfort</source>
+        <translation>護眼模式</translation>
+    </message>
+    <message>
+        <source>Enable eye comfort</source>
+        <translation>開啟護眼模式</translation>
+    </message>
+    <message>
+        <source>Adjust screen display to warmer colors, reducing screen blue light</source>
+        <translation>調整螢幕顯示較暖的顏色，減少螢幕藍光</translation>
+    </message>
+    <message>
+        <source>Time</source>
+        <translation>時間</translation>
+    </message>
+    <message>
+        <source>All day</source>
+        <translation>全天</translation>
+    </message>
+    <message>
+        <source>Sunset to Sunrise</source>
+        <translation>日落到日出</translation>
+    </message>
+    <message>
+        <source>Custom Time</source>
+        <translation>自定義</translation>
+    </message>
+    <message>
+        <source>from</source>
+        <translation>從</translation>
+    </message>
+    <message>
+        <source>to</source>
+        <translation>至</translation>
+    </message>
+    <message>
+        <source>Color Temperature</source>
+        <translation>色溫</translation>
+    </message>
+    <message>
+        <source> (Recommended)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dock</name>
+    <message>
+        <source>Desktop and taskbar</source>
+        <translation>桌面和工作列</translation>
+    </message>
+    <message>
+        <source>Desktop organization, taskbar mode, plugin area settings</source>
+        <translation>桌面整理、工作列模式、外掛區域設定</translation>
+    </message>
+</context>
+<context>
+    <name>keyboard</name>
+    <message>
+        <source>Keyboard</source>
+        <translation>鍵盤</translation>
+    </message>
+    <message>
+        <source>General Settings, keyboard layout, input method, shortcuts</source>
+        <translation>通用設定、鍵盤佈局、輸入法、快捷鍵</translation>
+    </message>
+</context>
+<context>
+    <name>keyboardMain</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Keyboard layout</source>
+        <translation>鍵盤佈局</translation>
+    </message>
+    <message>
+        <source>Set system default keyboard layout</source>
+        <translation>設定系統預設鍵盤佈局</translation>
+    </message>
+</context>
+<context>
+    <name>main</name>
+    <message>
+        <source>Dock</source>
+        <translation>工作列</translation>
+    </message>
+    <message>
+        <source>Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Classic Mode</source>
+        <translation>經典模式</translation>
+    </message>
+    <message>
+        <source>Centered Mode</source>
+        <translation>居中模式</translation>
+    </message>
+    <message>
+        <source>Dock size</source>
+        <translation>工作列大小</translation>
+    </message>
+    <message>
+        <source>Small</source>
+        <translation>小</translation>
+    </message>
+    <message>
+        <source>Large</source>
+        <translation>大</translation>
+    </message>
+    <message>
+        <source>Position on the screen</source>
+        <translation>螢幕中的位置</translation>
+    </message>
+    <message>
+        <source>Top</source>
+        <translation>上</translation>
+    </message>
+    <message>
+        <source>Bottom</source>
+        <translation>下</translation>
+    </message>
+    <message>
+        <source>Left</source>
+        <translation>左</translation>
+    </message>
+    <message>
+        <source>Right</source>
+        <translation>右</translation>
+    </message>
+    <message>
+        <source>Status</source>
+        <translation>狀態</translation>
+    </message>
+    <message>
+        <source>Keep shown</source>
+        <translation>一直顯示</translation>
+    </message>
+    <message>
+        <source>Keep hidden</source>
+        <translation>一直隱藏</translation>
+    </message>
+    <message>
+        <source>Smart hide</source>
+        <translation>智慧隱藏</translation>
+    </message>
+    <message>
+        <source>Multiple Displays</source>
+        <translation>多屏顯示</translation>
+    </message>
+    <message>
+        <source>Set the position of the taskbar on the screen</source>
+        <translation>設定工作列在螢幕中的位置</translation>
+    </message>
+    <message>
+        <source>Only on main</source>
+        <translation>僅主屏顯示</translation>
+    </message>
+    <message>
+        <source>On screen where the cursor is</source>
+        <translation>跟隨滑鼠位置顯示</translation>
+    </message>
+    <message>
+        <source>Plugin Area</source>
+        <translation>外掛區域</translation>
+    </message>
+    <message>
+        <source>Select which icons appear in the Dock</source>
+        <translation>選擇顯示在工作列外掛區域的圖示</translation>
+    </message>
+</context>
+<context>
+    <name>mouse</name>
+    <message>
+        <source>Mouse and Touchpad</source>
+        <translation>滑鼠與觸控板</translation>
+    </message>
+    <message>
+        <source>Common、Mouse、Touchpad</source>
+        <translation>通用、滑鼠、觸控板</translation>
+    </message>
+</context>
+<context>
+    <name>mouseMain</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Mouse</source>
+        <translation>滑鼠</translation>
+    </message>
+    <message>
+        <source>Touchpad</source>
+        <translation>觸控板</translation>
+    </message>
+</context>
+<context>
+    <name>notification</name>
+    <message>
+        <source>DND mode, app notifications</source>
+        <translation>勿擾模式、應用通知</translation>
+    </message>
+    <message>
+        <source>Notification</source>
+        <translation>通知</translation>
+    </message>
+</context>
+<context>
+    <name>notificationMain</name>
+    <message>
+        <source>Do Not Disturb Settings</source>
+        <translation>勿擾設定</translation>
+    </message>
+    <message>
+        <source>App notifications will not be shown on desktop and the sounds will be silenced, but you can view all messages in the notification center.</source>
+        <translation>所有應用消息橫幅將會被隱藏，通知聲音將會靜音，您可在通知中心檢視所有消息。</translation>
+    </message>
+    <message>
+        <source>Enable Do Not Disturb</source>
+        <translation>啟用勿擾模式</translation>
+    </message>
+    <message>
+        <source>When the screen is locked</source>
+        <translation>在螢幕鎖屏時</translation>
+    </message>
+    <message>
+        <source>Number of notifications shown on the desktop</source>
+        <translation>通知橫幅展示數量</translation>
+    </message>
+    <message>
+        <source>App Notifications</source>
+        <translation>應用通知</translation>
+    </message>
+    <message>
+        <source>Allow Notifications</source>
+        <translation>允許通知</translation>
+    </message>
+    <message>
+        <source>Display notification on desktop or show unread messages in the notification center</source>
+        <translation>可以顯示通知橫幅，或在通知中心顯示未讀消息</translation>
+    </message>
+    <message>
+        <source>Desktop</source>
+        <translation>桌面</translation>
+    </message>
+    <message>
+        <source>Lock Screen</source>
+        <translation>鎖屏</translation>
+    </message>
+    <message>
+        <source>Notification Center</source>
+        <translation>通知中心</translation>
+    </message>
+    <message>
+        <source>Show message preview</source>
+        <translation>顯示消息預覽</translation>
+    </message>
+    <message>
+        <source>Play a sound</source>
+        <translation>通知時提示聲音</translation>
+    </message>
+</context>
+<context>
+    <name>personalization</name>
+    <message>
+        <source>Personalization</source>
+        <translation>個性化</translation>
+    </message>
+</context>
+<context>
+    <name>personalizationMain</name>
+    <message>
+        <source>Theme</source>
+        <translation>主題</translation>
+    </message>
+    <message>
+        <source>Appearance</source>
+        <translation>外觀</translation>
+    </message>
+    <message>
+        <source>Window effect</source>
+        <translation>視窗效果</translation>
+    </message>
+    <message>
+        <source>Personalize your wallpaper and screensaver</source>
+        <translation>個性化您的壁紙和屏保</translation>
+    </message>
+    <message>
+        <source>Screensaver</source>
+        <translation>螢幕保護</translation>
+    </message>
+    <message>
+        <source>Colors and icons</source>
+        <translation>顏色和圖示</translation>
+    </message>
+    <message>
+        <source>Adjust accent color and theme icons</source>
+        <translation>調整活動色和主題圖示</translation>
+    </message>
+    <message>
+        <source>Font and font size</source>
+        <translation>字型和字號</translation>
+    </message>
+    <message>
+        <source>Change system font and size</source>
+        <translation>修改系統字型與字號</translation>
+    </message>
+    <message>
+        <source>Wallpaper</source>
+        <translation>壁紙</translation>
+    </message>
+    <message>
+        <source>Select light, dark or automatic theme appearance</source>
+        <translation>選擇淺色、深色或自動切換主題外觀</translation>
+    </message>
+    <message>
+        <source>Interface and effects, rounded corners</source>
+        <translation>介面和效果、視窗圓角</translation>
+    </message>
+</context>
+<context>
+    <name>power</name>
+    <message>
+        <source>Power saving settings, screen and suspend</source>
+        <translation>節能設定、螢幕和待機管理</translation>
+    </message>
+    <message>
+        <source>Power</source>
+        <translation>電源管理</translation>
+    </message>
+</context>
+<context>
+    <name>powerMain</name>
+    <message>
+        <source>General</source>
+        <translation>通用</translation>
+    </message>
+    <message>
+        <source>Power plans, power saving settings, wakeup settings, shutdown settings</source>
+        <translation>效能模式、節能設定、喚醒設定、關機設定</translation>
+    </message>
+    <message>
+        <source>Plugged In</source>
+        <translation>使用電源</translation>
+    </message>
+    <message>
+        <source>Screen and suspend</source>
+        <translation>螢幕和待機管理</translation>
+    </message>
+    <message>
+        <source>On Battery</source>
+        <translation>使用電池</translation>
+    </message>
+    <message>
+        <source>screen and suspend, low battery, battery management</source>
+        <translation>螢幕和待機管理、低電量管理、電池管理</translation>
+    </message>
+</context>
+<context>
+    <name>privacy</name>
+    <message>
+        <source>Privacy and Security</source>
+        <translation>隱私和安全</translation>
+    </message>
+    <message>
+        <source>Camera, folder permissions</source>
+        <translation>攝像頭、資料夾許可權</translation>
+    </message>
+</context>
+<context>
+    <name>privacyMain</name>
+    <message>
+        <source>Camera</source>
+        <translation>攝像頭</translation>
+    </message>
+    <message>
+        <source>Choose whether the application has access to the camera</source>
+        <translation>選擇應用是否有攝像頭的訪問許可權</translation>
+    </message>
+    <message>
+        <source>Files and Folders</source>
+        <translation>檔案和資料夾</translation>
+    </message>
+    <message>
+        <source>Choose whether the application has access to files and folders</source>
+        <translation>選擇應用是否有檔案和資料夾的訪問許可權</translation>
+    </message>
+</context>
+<context>
+    <name>sound</name>
+    <message>
+        <source>Sound</source>
+        <translation>聲音</translation>
+    </message>
+    <message>
+        <source>Output, input, sound effects, devices</source>
+        <translation>輸入、輸出、系統音效、裝置管理</translation>
+    </message>
+</context>
+<context>
+    <name>soundMain</name>
+    <message>
+        <source>Settings</source>
+        <translation>設定</translation>
+    </message>
+    <message>
+        <source>Sound Effects</source>
+        <translation>系統音效</translation>
+    </message>
+    <message>
+        <source>Enable/disable sound effects</source>
+        <translation>開啟/關閉系統音效</translation>
+    </message>
+    <message>
+        <source>Enable/disable audio devices</source>
+        <translation>啟用/停用音訊裝置</translation>
+    </message>
+    <message>
+        <source>Devices</source>
+        <translation>裝置管理</translation>
+    </message>
+</context>
+<context>
+    <name>system</name>
+    <message>
+        <source>Common settings</source>
+        <translation>常用設定</translation>
+    </message>
+    <message>
+        <source>System</source>
+        <translation>系統</translation>
+    </message>
+</context>
+<context>
+    <name>systemInfo</name>
+    <message>
+        <source>Auxiliary Information</source>
+        <translation>輔助資訊</translation>
+    </message>
+</context>
+<context>
+    <name>systemInfoMain</name>
+    <message>
+        <source>About This PC</source>
+        <translation>關於本機</translation>
+    </message>
+    <message>
+        <source>System version, device information</source>
+        <translation>系統版本、裝置資訊</translation>
+    </message>
+    <message>
+        <source>View the notice of open source software</source>
+        <translation>檢視開源軟體宣告</translation>
+    </message>
+    <message>
+        <source>User Experience Program</source>
+        <translation>使用者體驗計劃</translation>
+    </message>
+    <message>
+        <source>Join the user experience program to help improve the product</source>
+        <translation>加入使用者體驗計劃，幫助改進產品</translation>
+    </message>
+    <message>
+        <source>End User License Agreement</source>
+        <translation>使用者許可協議</translation>
+    </message>
+    <message>
+        <source>View the end  user license agreement</source>
+        <translation>檢視終端使用者許可協議</translation>
+    </message>
+    <message>
+        <source>Privacy Policy</source>
+        <translation>隱私政策</translation>
+    </message>
+    <message>
+        <source>View information about privacy policy</source>
+        <translation>檢視隱私政策相關資訊</translation>
+    </message>
+    <message>
+        <source>Open Source Software Notice</source>
+        <translation>開源軟體宣告</translation>
+    </message>
+</context>
+<context>
+    <name>touchscreen</name>
+    <message>
+        <source>Touchscreen</source>
+        <translation>觸控屏</translation>
+    </message>
+    <message>
+        <source>Configuring Touchscreen</source>
+        <translation>觸控屏設定</translation>
+    </message>
+</context>
+<context>
+    <name>touchscreenMain</name>
+    <message>
+        <source>Common</source>
+        <translation>通用</translation>
+    </message>
+</context>
+<context>
+    <name>wacom</name>
+    <message>
+        <source>wacom</source>
+        <translation>數位板</translation>
+    </message>
+    <message>
+        <source>Configuring wacom</source>
+        <translation>數位板選項設定</translation>
+    </message>
+</context>
+<context>
+    <name>wacomMain</name>
+    <message>
+        <source>wacom</source>
+        <translation>數位板</translation>
+    </message>
+    <message>
+        <source>Wacom Mode</source>
+        <translation>模式</translation>
+    </message>
+    <message>
+        <source>Pen Mode</source>
+        <translation>筆模式</translation>
+    </message>
+    <message>
+        <source>Mouse Mode</source>
+        <translation>滑鼠模式</translation>
+    </message>
+    <message>
+        <source>Pressure Sensitivity</source>
+        <translation>壓感</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation>輕</translation>
+    </message>
+</context>
 </TS>


### PR DESCRIPTION
Add a user group error message

Log: Add a user group error message
pms: BUG-292935

## Summary by Sourcery

Add front-end validation and error alerts for user group names, enforce naming rules, and prevent duplicate group creation

Enhancements:
- Validate group names in AccountSettings.qml for max length (32), format (letters, numbers, underscores, dashes, must start with a letter), and non-numeric-only input
- Show localized error messages and restore last valid input when validation fails
- Add AccountsController::groupExists to detect duplicate group names and block creation

Documentation:
- Introduce new translation entries for group name error messages in all language TS files