### PR TITLE
fix: Modify the height spacing

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -245,6 +245,8 @@ DccObject {
             property int dlgStatus: passwordDlgStatus.Init
             Column {
                 spacing: 0
+                Layout.topMargin: 4
+                Layout.bottomMargin: 4
                 Label {
                     height: 20
                     text: dccObj.displayName
@@ -259,7 +261,7 @@ DccObject {
                     Label {
                         height: 20
                         text: dccObj.description
-                        font: DTK.fontManager.t8
+                        font: DTK.fontManager.t10
                         horizontalAlignment: Qt.AlignLeft
                         verticalAlignment: Qt.AlignVCenter
                         leftPadding: 15
@@ -272,6 +274,7 @@ DccObject {
                         visible: dccData.mode().grubEditAuthEnabled
                         horizontalAlignment: Qt.AlignLeft
                         verticalAlignment: Qt.AlignVCenter
+                        font: DTK.fontManager.t10
                         color:"#5A000000"
                         // 超链接点击事件
                         onLinkActivated: function(url) {


### PR DESCRIPTION
Modify the height spacing

Log: Modify the height spacing
pms: BUG-304433

## Summary by Sourcery

Fix vertical spacing and font sizing in BootPage.qml to resolve layout inconsistencies.

Bug Fixes:
- Add top and bottom layout margins of 4 to the main content column to correct vertical spacing issues.
- Increase description and authorization link label fonts from t8 to t10 for consistent height and readability.