### PR TITLE
fix: Fixed the issue of user group clicking

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -694,6 +694,14 @@ DccObject {
                     rightMargin: groupview.lrMargin
                 }
 
+                MouseArea {
+                    anchors.fill: parent
+                    enabled: !groupSettings.isEditing && !editLabel.focus
+                    onClicked: {
+                        dccData.setGroup(settings.userId, model.display, !editButton.checked)
+                    }
+                }
+
                 contentItem: RowLayout {
                     Item {
                         id: editContainer


### PR DESCRIPTION
Fixed the issue of user group clicking

Log: Fixed the issue of user group clicking
pms: BUG-298601

## Summary by Sourcery

Bug Fixes:
- Fix user group clicking issue by adding a MouseArea to toggle group assignment when not editing