### PR TITLE
fix: update translation with QuickLogin and Lock Dock

### DIFF
--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -52,10 +52,6 @@
         <translation>إضافة مجموعة</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>تسجيل الدخول تلقائي، تسجيل الدخول بدون كلمة مرور</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>تسجيل الدخول التلقائي</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3765,6 +3769,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>حدد أي الرموز تظهر في السلة</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -52,10 +52,6 @@
         <translation>إضافة مجموعة</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>تسجيل الدخول التلقائي، الدخول بدون كلمة مرور</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>تسجيل الدخول التلقائي</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3769,6 +3773,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>تحديد أيقونات تظهر في ميناء الطور</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -52,10 +52,6 @@
         <translation>গ্রুপ যোগ করুন</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>অটো লগইন, পাসওয়ার্ড ব্যবহার করে লগইন করুন</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>অটো লগইন</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3791,6 +3795,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>ডোকে দেখানো চিহ্নগুলি কোনগুলি নির্বাচন করুন</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -52,10 +52,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -52,10 +52,6 @@
         <translation>Afegeix-hi un grup</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Entrada automàtica, inici de sessió sense contrasenya</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Entrada automàtica</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3775,6 +3779,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Seleccioneu quines icones apareixen a l&apos;acoblador.</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -52,10 +52,6 @@
         <translation>Gruppe hinzufügen</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Auto-Login, Anmelden ohne Passwort</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Auto-Anmeldung</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3760,6 +3764,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Wähle die Icons aus, die im Dock erscheinen</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -52,10 +52,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -52,10 +52,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -52,10 +52,6 @@
         <translation>Añadir grupo</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Inicio de sesión automático, inicio de sesión sin contraseña</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Inicio de sesión automático</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3776,6 +3780,10 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Seleccione los iconos que aparecerán en el muelle</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -52,10 +52,6 @@
         <translation>Lisa grup</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Automaatne sisselogimine, sisselogimine salasõna vaba</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automaatne sisselogimine</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3768,6 +3772,10 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Vali, mida ikonna punkte kuvatakse</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -52,10 +52,6 @@
         <translation>Lisää ryhmä</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Kirjaudu ilman salasanaa</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automaattinen kirjautuminen</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3772,6 +3776,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Valitse paneelissa näkyvät kuvakkeet</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -52,10 +52,6 @@
         <translation>Ajouter un groupe</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Se connecter automatiquement, se connecter sans mot de passe</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Se connecter automatiquement</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3791,6 +3795,10 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Sélectionnez les icônes qui apparaissent dans la barre des tâches</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -52,10 +52,6 @@
         <translation>Engadir grupo</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Iniciar sesión automático, iniciar sesión sen contrasinal</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Iniciar sesión automático</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3790,6 +3794,10 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Selecciona que ícones aparecen no Dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -52,10 +52,6 @@
         <translation>הוספת קבוצה</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>כניסה אוטומטית, כניסה בלי סיסמה</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>כניסה אוטומטית</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3760,6 +3764,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>בחר את סמלים המופיעים ב- Dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -52,10 +52,6 @@
         <translation>Csoport hozzáadása</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Automatikus bejelentkezés, jelszó nélkül bejelentkezés</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automatikus bejelentkezés</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3787,6 +3791,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Melyik ikonok megjelennek a dockban</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -52,10 +52,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -52,10 +52,6 @@
         <translation>グループを追加</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>自動ログイン、パスワードレスログイン</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>自動ログイン</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3774,6 +3778,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>ドックに表示するアイコンの選択</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -52,10 +52,6 @@
         <translation>Жеке салынамасы қосу</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Авто жүктелдік айту, пароль арқылы жүктелдік айту</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Авто жүктелдік айту</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3761,6 +3765,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Докта көрсөтілген иконкаларды таңдау</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -52,10 +52,6 @@
         <translation>그룹 추가</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>자동 로그인, 비밀번호 없이 로그인</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>자동 로그인</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3812,6 +3816,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>选择哪些图标出现在 Dock 中</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -52,10 +52,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -52,10 +52,6 @@
         <translation>Pridėti grupę</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Automatiškas prisijungimas, prisijungti be slaptažodžio</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automatiškas prisijungimas</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3785,6 +3789,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Pasirinkite, kurias ikonas turėtų rodytis Dock&apos;e</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -52,10 +52,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -52,10 +52,6 @@
         <translation>समूह जोड्नुहोस्</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>प्रतिबिम्बित लॉगइन, पासवर्ड छैनको प्रकारमा लॉगइन गर्नुहोस्</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>प्रतिबिम्बित लॉगइन</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3765,6 +3769,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>डोकमा दिखाउने चिनाहराहरू निर्धारित गर्नुहोस्</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -52,10 +52,6 @@
         <translation>Nieuwe groep</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Automatisch aanmelden zonder wachtwoord</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automatisch aanmelden</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3773,6 +3777,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Geef aan welke pictogrammen op het dock moeten worden getoond</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -52,10 +52,6 @@
         <translation>Dodaj grupę</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Automatyczne logowanie bez hasła</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automatyczne logowanie</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3775,6 +3779,10 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Wybierz, które ikony pojawią się w doku</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -52,10 +52,6 @@
         <translation>Adicionar grupo</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Login automático, login sem senha</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Login automático</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3760,6 +3764,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Selecione quais ícones devem aparecer na dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -52,10 +52,6 @@
         <translation>إضافة مجموعة</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>تسجيل دخول تلقائي، تسجيل الدخول بدون كلمة مرور</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>تسجيل دخول تلقائي</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3774,6 +3778,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Выберите, какие иконки отображаются в панели</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -52,10 +52,6 @@
         <translation>Dodaj skupino</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Samodejni prijavo, prijavi se brez gesla</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Samodejni prijavo</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3764,6 +3768,10 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Izberi, kateri ikone pojavejo se v Docku</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -52,10 +52,6 @@
         <translation>Shto grup</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Hyrje vetvetiu, hyni pa fjalëkalim</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Hyrje e automatizuar</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3775,6 +3779,10 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Përzgjidhni cilat ikona shfaqen te Paneli</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -52,10 +52,6 @@
         <translation>Lägg till grupp</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Automatisk inloggning, inloggning utan lösenord</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Automatisk inloggning</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3777,6 +3781,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Välj vilka ikoner som visas i bänken</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -52,10 +52,6 @@
         <translation>เพิ่มกลุ่ม</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>เข้าสู่ระบบอัตโนมัติ, เข้าสู่ระบบโดยไม่ต้องใช้รหัสผ่าน</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>เข้าสู่ระบบอัตโนมัติ</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3763,6 +3767,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>เลือกไอคอนที่แสดงในด็อก</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -52,10 +52,6 @@
         <translation>Grup ekle</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Otomatik giriş</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3760,6 +3764,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Rıhtım&apos;da hangi simgelerin görüneceğini seçin</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -52,10 +52,6 @@
         <translation>Додати групу</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Автоматичний вхід, вхід без пароля</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Автоматичний вхід</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3774,6 +3778,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Виберіть, які піктограми буде показано на бічній панелі</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -44,10 +44,6 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation type="unfinished"></translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3759,6 +3763,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Select which icons appear in the Dock</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -52,10 +52,6 @@
         <translation>Thêm nhóm</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>Đăng nhập tự động, đăng nhập không cần mật khẩu</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>Đăng nhập tự động</translation>
     </message>
@@ -97,6 +93,14 @@
     </message>
     <message>
         <source>The group name has been used</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -3787,6 +3791,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>Chọn biểu tượng nào xuất hiện trong Dock</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -52,10 +52,6 @@
         <translation>添加用户组</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>自动登录, 免密登录</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>自动登录</translation>
     </message>
@@ -98,6 +94,14 @@
     <message>
         <source>The group name has been used</source>
         <translation>组名与其他组名重复</translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation>快速登录，自动登录，免密登录</translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
+        <translation>使用登录信息快速载入桌面</translation>
     </message>
 </context>
 <context>
@@ -3775,6 +3779,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>选择显示在任务栏插件区域的图标</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由调节</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -52,10 +52,6 @@
         <translation>添加用户組</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>自動登錄, 免密登錄</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>自動登錄</translation>
     </message>
@@ -85,19 +81,27 @@
     </message>
     <message>
         <source>Group names should be no more than 32 characters</source>
-        <translation type="unfinished"></translation>
+        <translation>組名不允許超出32個字符</translation>
     </message>
     <message>
         <source>Group names cannot only have numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>組名不能使用純數字</translation>
     </message>
     <message>
         <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
-        <translation type="unfinished"></translation>
+        <translation>僅使用字母、數字、下劃線和破折號，並且必需以字母開頭</translation>
     </message>
     <message>
         <source>The group name has been used</source>
-        <translation type="unfinished"></translation>
+        <translation>組名與其他組名重複</translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation>快速登錄，自動登錄，免密登錄</translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
+        <translation>使用登錄信息快速載入桌面</translation>
     </message>
 </context>
 <context>
@@ -3644,7 +3648,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source> (Recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation> （推薦）</translation>
     </message>
 </context>
 <context>
@@ -3773,6 +3777,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>選擇顯示在任務欄插件區域的圖標</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由調節</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -52,10 +52,6 @@
         <translation>新增使用者組</translation>
     </message>
     <message>
-        <source>Auto login, login without password</source>
-        <translation>自動登入, 免密登入</translation>
-    </message>
-    <message>
         <source>Auto login</source>
         <translation>自動登入</translation>
     </message>
@@ -85,19 +81,27 @@
     </message>
     <message>
         <source>Group names should be no more than 32 characters</source>
-        <translation type="unfinished"></translation>
+        <translation>組名不允許超出32個字符</translation>
     </message>
     <message>
         <source>Group names cannot only have numbers</source>
-        <translation type="unfinished"></translation>
+        <translation>組名不能使用純數字</translation>
     </message>
     <message>
         <source>Use letters,numbers,underscores and dashes only, and must start with a letter</source>
-        <translation type="unfinished"></translation>
+        <translation>僅使用字母、數字、下劃線和破折號，並且必需以字母開頭</translation>
     </message>
     <message>
         <source>The group name has been used</source>
-        <translation type="unfinished"></translation>
+        <translation>組名與其他組名重複</translation>
+    </message>
+    <message>
+        <source>quick login, Auto login, login without password</source>
+        <translation>快速登錄，自動登錄，免密登錄</translation>
+    </message>
+    <message>
+        <source>Quickly load DDE with your login information</source>
+        <translation>使用登錄信息快速載入桌面</translation>
     </message>
 </context>
 <context>
@@ -3644,7 +3648,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source> (Recommended)</source>
-        <translation type="unfinished"></translation>
+        <translation> （推薦）</translation>
     </message>
 </context>
 <context>
@@ -3773,6 +3777,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Select which icons appear in the Dock</source>
         <translation>選擇顯示在工作列外掛區域的圖示</translation>
+    </message>
+    <message>
+        <source>Lock the Dock</source>
+        <translation>禁用自由調節</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
as title.

Log:

## Summary by Sourcery

Update translation files to support new QuickLogin and Lock Dock options, improve group name validation messages, and remove deprecated composite auto-login string.

Documentation:
- Remove outdated composite "Auto login, login without password" translation entries
- Add translations for QuickLogin strings: "quick login, Auto login, login without password" and "Quickly load DDE with your login information"
- Add translation for the "Lock the Dock" label
- Complete translations for group name validation messages across locales
- Fill in missing translation for " (Recommended)"