### PR TITLE
fix: add POST_BUILD to custom commands

### DIFF
--- a/misc/DdeControlCenterPluginMacros.cmake
+++ b/misc/DdeControlCenterPluginMacros.cmake
@@ -12,7 +12,7 @@ macro(dcc_build_plugin)
         SOURCES ${qml_files}
     )
     set(plugin_dirs ${PROJECT_BINARY_DIR}/lib/${DDE_CONTROL_CENTER_PLUGIN_DIR}/${_config_NAME}/)
-    add_custom_command(TARGET ${_config_NAME}_qml
+    add_custom_command(TARGET ${_config_NAME}_qml POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${qml_root_dir} ${plugin_dirs}
     )
 

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -88,7 +88,7 @@ file(GLOB_RECURSE qmlFiles  "${DCC_PROJECT_ROOT_DIR}/qml/*.*")
 add_custom_target(${Control_Center_Name}_qml ALL
     SOURCES ${qmlFiles}
 )
-add_custom_command(TARGET ${Control_Center_Name}_qml
+add_custom_command(TARGET ${Control_Center_Name}_qml POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory "${DCC_PROJECT_ROOT_DIR}/qml" ${DCC_LIBDIR}
 )
 


### PR DESCRIPTION
1. Added POST_BUILD parameter to add_custom_command in both DdeControlCenterPluginMacros.cmake and CMakeLists.txt
2. Ensures QML files are copied after the build completes rather than during build
3. Prevents potential race conditions during parallel builds
4. Maintains proper build order dependencies in CMake

fix: 为自定义命令添加 POST_BUILD 参数

1. 在 DdeControlCenterPluginMacros.cmake 和 CMakeLists.txt 中都为 add_custom_command 添加了 POST_BUILD 参数
2. 确保 QML 文件在构建完成后复制而不是在构建过程中复制
3. 防止并行构建时潜在的竞争条件
4. 在 CMake 中保持正确的构建顺序依赖关系

## Summary by Sourcery

Ensure QML files are copied after build by adding POST_BUILD to custom CMake commands, preventing race conditions and preserving correct build-order dependencies.

Bug Fixes:
- Prevent race conditions during parallel builds by deferring QML file copying until after the build

Build:
- Add POST_BUILD parameter to add_custom_command in DdeControlCenterPluginMacros.cmake and CMakeLists.txt for QML file copying