### PR TITLE
style: add unused parameter markers and fix member order

### DIFF
--- a/src/plugin-authentication/operation/biometricauthcontroller.cpp
+++ b/src/plugin-authentication/operation/biometricauthcontroller.cpp
@@ -199,6 +199,7 @@ void BiometricAuthController::requestRenameFinger(const QString &id, const QStri
 
 void BiometricAuthController::onThumbsListChanged(const QStringList &thumbs)
 {
+    Q_UNUSED(thumbs)
     // TODO
 }
 
@@ -343,12 +344,13 @@ void BiometricAuthController::requestStopIrisEnroll()
 
 void BiometricAuthController::requestRemoveIris(const QString &id)
 {
-
+    Q_UNUSED(id)
 }
 
 void BiometricAuthController::requestRenameIris(const QString &id, const QString &newName)
 {
-
+    Q_UNUSED(id)
+    Q_UNUSED(newName)
 }
 } // namespace dccV25
 

--- a/src/plugin-authentication/operation/charamangermodel.cpp
+++ b/src/plugin-authentication/operation/charamangermodel.cpp
@@ -226,6 +226,8 @@ void CharaMangerModel::onFingerEnrollStatusChanged(int code, const QString& msg)
 
 void CharaMangerModel::onTouch(const QString &id, bool pressed)
 {
+    Q_UNUSED(id)
+    Q_UNUSED(pressed)
 }
 
 void CharaMangerModel::refreshEnrollResult(CharaMangerModel::EnrollResult enrollRes)

--- a/src/plugin-dock/operation/dccdockexport.cpp
+++ b/src/plugin-dock/operation/dccdockexport.cpp
@@ -34,8 +34,8 @@ DGUI_USE_NAMESPACE;
 
 DccDockExport::DccDockExport(QObject *parent) 
 : QObject(parent)
-, m_pluginModel(new DockPluginModel(this))
 , m_dockDbusProxy(new DockDBusProxy(this))
+, m_pluginModel(new DockPluginModel(this))
 {
     initData();
 }

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -576,6 +576,7 @@ void PersonalizationAppearanceContext::treeland_personalization_appearance_conte
 
 void PersonalizationAppearanceContext::treeland_personalization_appearance_context_v1_window_opacity(uint32_t opacity)
 {
+    Q_UNUSED(opacity)
     // Using the value of the appearance module, this is an invalid value
     // m_model->setOpacity(opacity / 100.0);
 }

--- a/src/plugin-power/operation/powermodel.h
+++ b/src/plugin-power/operation/powermodel.h
@@ -338,7 +338,7 @@ private:
     bool m_scheduledShutdownState;
     QString m_shutdownTime;
     QVariantList m_customShutdownWeekDays;
-    uint32_t m_shutdownRepetition;
+    int m_shutdownRepetition;
     int m_weekBegins;
     int m_lowPowerAction;
     QString m_enableScheduledShutdown;


### PR DESCRIPTION
1. Added Q_UNUSED macros for unused parameters in multiple methods to suppress compiler warnings
2. Reordered member initialization in DccDockExport constructor for consistency
3. Changed uint32_t to int for shutdownRepetition in PowerModel to match usage context
4. These changes improve code quality and maintainability without affecting functionality

style: 添加未使用参数标记并修复成员顺序

1. 在多个方法中添加 Q_UNUSED 宏标记未使用参数以消除编译器警告
2. 在 DccDockExport 构造函数中重新排序成员初始化以保持一致性
3. 将 PowerModel 中的 shutdownRepetition 从 uint32_t 改为 int 以匹配使用 场景
4. 这些改动提高了代码质量和可维护性而不影响功能

pms: TASK-368711

## Summary by Sourcery

Add unused parameter markers, fix member initialization order, and adjust a variable type to improve code style and maintain consistency

Enhancements:
- Suppress compiler warnings by marking unused function parameters with Q_UNUSED
- Reorder member initializers in DccDockExport constructor for consistent ordering
- Change PowerModel’s shutdownRepetition from uint32_t to int to match usage context