### PR TITLE
fix: Add notification jump processing

### DIFF
--- a/src/plugin-notification/operation/appssourcemodel.cpp
+++ b/src/plugin-notification/operation/appssourcemodel.cpp
@@ -17,6 +17,7 @@ AppsSourceModel::AppsSourceModel(QObject *parent)
 QHash<int, QByteArray> AppsSourceModel::roleNames() const
 {
     QHash<int, QByteArray> names= QAbstractItemModel::roleNames();
+    names[AppIdRole] = "AppId";
     names[AppNameRole] = "AppName";
     names[AppIconRole] = "AppIcon";
     names[EnableNotificationRole] = "EnableNotification";
@@ -60,6 +61,8 @@ QVariant AppsSourceModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case Qt::DisplayRole:
         return QVariant::fromValue(m_appItemModels.at(index.row()));
+    case AppIdRole:
+        return m_appItemModels.at(index.row())->getActName();
     case AppNameRole:
         return m_appItemModels.at(index.row())->softName();
     case AppIconRole:

--- a/src/plugin-notification/operation/appssourcemodel.h
+++ b/src/plugin-notification/operation/appssourcemodel.h
@@ -11,7 +11,8 @@ class AppItemModel;
 
 enum AppsSourceModelRole
 {
-    AppNameRole = Qt::UserRole + 1,
+    AppIdRole = Qt::UserRole + 1,
+    AppNameRole,
     AppIconRole,
     EnableNotificationRole,
     EnablePreviewRole,

--- a/src/plugin-notification/qml/notificationMain.qml
+++ b/src/plugin-notification/qml/notificationMain.qml
@@ -1,5 +1,4 @@
 // SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
-//
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.0
 import QtQuick.Controls 2.0
@@ -50,8 +49,7 @@ DccObject {
             weight: 20
             pageType: DccObject.Item
             visible: dccData.sysItemModel.disturbMode
-            page: TimeRange {
-            }
+            page: TimeRange {}
         }
         DccObject {
             name: "enableDoNotDisturbLock"
@@ -116,7 +114,7 @@ DccObject {
 
     DccObject {
         id: applicationList
-        name: "applicationList"
+        name: "list"
         parentName: "notification"
         weight: 50
         pageType: DccObject.Item
@@ -124,8 +122,8 @@ DccObject {
         DccRepeater {
             model: dccData.appListModel()
             delegate: DccObject {
-                name: "notificationItem" + index
-                parentName: "applicationList"
+                name: model.AppId
+                parentName: "notification/list"
                 pageType: DccObject.MenuEditor
                 weight: 10 + index
                 icon: model.AppIcon
@@ -139,13 +137,13 @@ DccObject {
                         }
                     }
                 }
-                DccObject{
-                    name: "notificationItemDetails" + index
-                    parentName: "applicationList/" + "notificationItem" + index
-                    DccObject{
+                DccObject {
+                    name: "notificationItemDetails"
+                    parentName: "notification/list/" + model.AppId
+                    DccObject {
                         backgroundType: DccObject.Normal
-                        name: "allowNotifications" + index
-                        parentName: "applicationList/notificationItem" + index + "/" + "notificationItemDetails" + index
+                        name: "allowNotifications"
+                        parentName: "notification/list/" + model.AppId + "/notificationItemDetails"
                         displayName: qsTr("Allow Notifications")
                         description: qsTr("Display notification on desktop or show unread messages in the notification center")
                         icon: model.AppIcon
@@ -163,8 +161,8 @@ DccObject {
                         }
                     }
                     DccObject {
-                        name: "notificationItemDetailsType" + index
-                        parentName: "applicationList/notificationItem" + index + "/" + "notificationItemDetails" + index
+                        name: "notificationItemDetailsType"
+                        parentName: "notification/list/" + model.AppId + "/notificationItemDetails"
                         backgroundType: DccObject.Normal
                         visible: model.EnableNotification
                         weight: 20
@@ -214,16 +212,16 @@ DccObject {
                         }
                     }
                     DccObject {
-                        name: "notificationSettingsGroup" + index
-                        parentName: "applicationList/notificationItem" + index + "/" + "notificationItemDetails" + index
+                        name: "notificationSettingsGroup"
+                        parentName: "notification/list/" + model.AppId + "/notificationItemDetails"
                         pageType: DccObject.Item
                         backgroundType: DccObject.Normal
                         visible: model.EnableNotification
                         weight: 30
                         page: DccGroupView {}
                         DccObject {
-                            name: "notificationPreview" + index
-                            parentName: "applicationList/notificationItem" + index + "/" + "notificationItemDetails" + index +"/"+"notificationSettingsGroup" + index
+                            name: "notificationPreview"
+                            parentName: "notification/list/" + model.AppId + "/notificationItemDetails/notificationSettingsGroup"
                             displayName: qsTr("Show message preview")
                             pageType: DccObject.Item
                             weight: 10
@@ -240,8 +238,8 @@ DccObject {
                             }
                         }
                         DccObject {
-                            name: "notificationSound" + index
-                            parentName: "applicationList/notificationItem" + index + "/" + "notificationItemDetails" + index +"/"+"notificationSettingsGroup" + index
+                            name: "notificationSound"
+                            parentName: "notification/list/" + model.AppId + "/notificationItemDetails/notificationSettingsGroup"
                             displayName: qsTr("Play a sound")
                             pageType: DccObject.Item
                             weight: 20


### PR DESCRIPTION
Add notification jump processing

pms: TASK-361721

## Summary by Sourcery

Expose application identifiers to QML and refactor notificationMain.qml to use those identifiers for dynamic item naming, enabling notification jump processing.

New Features:
- Expose AppIdRole in AppsSourceModel to provide application identifiers to QML.

Enhancements:
- Refactor QML dynamic object naming and parent references in notificationMain.qml to use model.AppId instead of index-based concatenations.