### PR TITLE
fix: The fixed issue is prompt for creating a user with the same name

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -42,6 +42,8 @@ static bool isUserGroupName(int gid, const QString &name)
 AccountsController::AccountsController(QObject *parent)
     : QObject{ parent }
 {
+    qmlRegisterType<CreationResult>("AccountsController", 1, 0, "CreationResult");
+    
     m_model = new UserModel(this);
     m_worker = new AccountsWorker(m_model, this);
 
@@ -84,6 +86,8 @@ AccountsController::AccountsController(QObject *parent)
     
     connect(m_worker, &AccountsWorker::accountCreationFinished, this, [this](CreationResult *result) {
         m_isCreatingUser = false;
+        Q_EMIT accountCreationFinished(result->type(), result->message());
+        
         if (result->type() == CreationResult::NoError) {
             QTimer::singleShot(100, this, [this]() {
                 if (!m_model->userList().isEmpty()) {

--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -7,10 +7,12 @@
 
 #include "usermodel.h"
 #include "accountsworker.h"
+#include "creationresult.h"
 
 #include <QObject>
 #include <QSortFilterProxyModel>
 #include <QHash>
+#include <QtQml/qqml.h>
 
 namespace dccV25 {
 
@@ -111,6 +113,7 @@ signals:
     void requestCreateGroup(const QString &userId);
     void requestClearEmptyGroup(const QString &userId);
     void showSafetyPage(const QString &errorTips);
+    void accountCreationFinished(CreationResult::ResultType resultType, const QString &message);
 protected:
     bool isSystemAdmin(const User *user) const;
     int adminCount() const;

--- a/src/plugin-accounts/operation/creationresult.h
+++ b/src/plugin-accounts/operation/creationresult.h
@@ -20,6 +20,7 @@ public:
         Canceled,           // 用户取消认证或关闭认证窗口
         NoError
     };
+    Q_ENUM(ResultType)
 
     explicit CreationResult(QObject *parent = 0);
     explicit CreationResult(ResultType type, const QString &message, QObject *parent = 0);


### PR DESCRIPTION
The fixed issue is prompt for creating a user with the same name

Log: The fixed issue is prompt for creating a user with the same name
pms: BUG-292925

## Summary by Sourcery

Improve account creation flow by handling backend responses in the UI and showing inline alerts on errors.

Bug Fixes:
- Display inline error alerts when a user creation fails due to duplicate usernames or password validation errors.

Enhancements:
- Register CreationResult enum and emit accountCreationFinished signals from AccountsController to QML.
- Add a QML Connections block in CreateAccountDialog to process creation results, showing field-specific alerts or closing the dialog on success.
- Disable the "Create account" button after submission to prevent duplicate requests.