### PR TITLE
fix: Fixed some copywriting errors

### DIFF
--- a/src/plugin-accounts/qml/LoginMethod.qml
+++ b/src/plugin-accounts/qml/LoginMethod.qml
@@ -73,7 +73,7 @@ DccTitleObject {
             DccObject {
                 name: loginMethodTitle.parentName + "PasswordModify"
                 parentName: passwordGroupView.name
-                displayName: qsTr("Modify password")
+                displayName: dccData.currentUserId() === loginMethodTitle.userId ? qsTr("Modify password") : qsTr("Reset password")
                 backgroundType: DccObject.ClickStyle
                 weight: 12
                 enabled: dccData.currentUserId() === loginMethodTitle.userId || (dccData.curUserIsSysAdmin() && !dccData.isOnline(loginMethodTitle.userId))

--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -163,7 +163,7 @@ ColumnLayout {
     ListModel {
         id: passwordModel
         ListElement {
-            name: qsTr("Password")
+            name: ""
             placeholder: qsTr("Required")
             echoButtonVisible: true
         }
@@ -261,7 +261,7 @@ ColumnLayout {
                     rightPadding: 10
 
                     contentItem: PasswordItem {
-                        label.text: model.name
+                        label.text: model.name === "" ? (pwdLayout.currentPwdVisible ? qsTr("Password") : qsTr("New password")) : model.name
                         edit {
                             placeholderText: model.placeholder
                             echoButtonVisible: model.echoButtonVisible

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">ሁል ጊዜ</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -1699,6 +1699,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation> תמיד</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">استعادة كلمة المرور</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1915,6 +1919,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>ستكون الإجابة المرئية لجميع المستخدمين. لا تضمن كلمة المرور هنا.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -1699,6 +1699,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>دائماً</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">إعادة تعيين كلمة المرور</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1915,6 +1919,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>تظهر الملاحظة لجميع المستخدمين. لا تضمن كلمة المرور هنا.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Винаги</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -1700,6 +1700,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>সবসময়</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">পাসওয়ার্ড পুনরায় সেট করুন</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1916,6 +1920,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>হিন্ট সব উপযোক্তার দৃশ্যমান। এখানে পাসওয়ার্ড লিখবেন না।</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="ca">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ca">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -206,7 +208,7 @@ Per tal d&apos;usar millor el reconeixement facial, presteu atenció als aspecte
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>L&apos;autenticació biomètrica ​​és una funció per a l&apos;autenticació de la identitat d&apos;usuari proporcionada per UnionTech Software Technology Co., Ltd. Mitjançant l&apos;autenticació biomètrica, les dades biomètriques recollides es compararan amb les emmagatzemades al dispositiu i la identitat de l&apos;usuari es verificarà en funció del resultat de la comparació.
@@ -1344,10 +1346,6 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
         <translation>3. Importeu el certificat</translation>
     </message>
     <message>
-        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation>Per instal·lar i executar aplicacions sense signar, aneu al &lt;a href=&quot;Security Center&quot;&gt;Centre de seguretat&lt;/a&gt; per canviar-ne la configuració.</translation>
-    </message>
-    <message>
         <source>Development and debugging options</source>
         <translation>Opcions de desenvolupament i depuració</translation>
     </message>
@@ -1370,6 +1368,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
         <translation>El canvi d&apos;opció pot trigar fins a un minut a processar-se; després de rebre una sol·licitud de configuració correcta, reinicieu el dispositiu perquè tingui efecte.</translation>
+    </message>
+    <message>
+        <source>To install and run unsigned apps, please go to &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Security Center&apos;&gt; Security Center &lt;/a&gt; to change the settings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1707,6 +1709,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Restableix la contrasenya</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1923,6 +1929,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>La pista és visible per a tots els usuaris. No hi poseu la contrasenya.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Vždy</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation type="unfinished">Nápověda je viditelná všem uživatelům. Nepište sem heslo.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Altid</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation type="unfinished">Hjælpen er synlig for alle brugere. Inkludér ikke adgangskoden her.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Immer</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation type="unfinished">Der Hinweis ist für alle Benutzer sichtbar. Geben Sie hier nicht das Passwort ein.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_de_CH.ts
+++ b/translations/dde-control-center_de_CH.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_de_DE.ts
+++ b/translations/dde-control-center_de_DE.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Πάντα</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Always</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Always</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -1710,6 +1710,10 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
         <source>Always</source>
         <translation>Siempre</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Restablecer contraseña</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1926,6 +1930,10 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>La pista es visible para todos los usuarios. No incluya aquí la contraseña.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es_419.ts
+++ b/translations/dde-control-center_es_419.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_AR.ts
+++ b/translations/dde-control-center_es_AR.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_CL.ts
+++ b/translations/dde-control-center_es_CL.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_es_MX.ts
+++ b/translations/dde-control-center_es_MX.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Siempre</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation type="unfinished">La sugerencia es visible para todos los usuarios. No mencione la contraseña aqui.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -1702,6 +1702,10 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
         <source>Always</source>
         <translation>Jätkuvalt</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Palunusteele avada parool</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1918,6 +1922,10 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Aidatakenutus on kõigile kasutajatele nähtav. Parooli siia ei sisesta.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="fi">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="fi">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -206,7 +208,7 @@ Kasvojentunnistuksen paremman toimivuuden varmistamiseksi huomioi seuraavat asia
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>&quot;Biometrinen todennus&quot; on UnionTech Software Technology Co., Ltd:n kehittämä toiminto käyttäjän identiteetin tunnistamiseen. &quot;Biometrisen todentamisen&quot; avulla kerättyjä biometrisiä tietoja verrataan tietokoneeseen tallennettuihin tietoihin ja varmistetaan näiden tietojen perusteella.
@@ -1341,10 +1343,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>3. Tuo varmenne</translation>
     </message>
     <message>
-        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation>Jos haluat asentaa ja käyttää allekirjoittamattomia sovelluksia, siirry &lt;a href=&quot;Security Center&quot;&gt;Turvakeskukseen&lt;/a&gt; ja muuta asetuksia.</translation>
-    </message>
-    <message>
         <source>Development and debugging options</source>
         <translation>Kehitys- ja vianetsinnän valinnat</translation>
     </message>
@@ -1367,6 +1365,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
         <translation>Asetuksen muuttaminen voi kestää minuutin. Kun olet saanut ilmoituksen valmistumisesta, käynnistä tietokone uudelleen, jotta asetus tulee voimaan.</translation>
+    </message>
+    <message>
+        <source>To install and run unsigned apps, please go to &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Security Center&apos;&gt; Security Center &lt;/a&gt; to change the settings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1704,6 +1706,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Aina</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Palauta salasana</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1920,6 +1926,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Vihje näkyy kaikille tietokoneen käyttäjille. Älä lisää salasanaa tähän.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -1724,6 +1724,10 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
         <source>Always</source>
         <translation>Toujours</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Réinitialiser le mot de passe</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1940,6 +1944,10 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>L&apos;indice est visible pour tous les utilisateurs. Ne pas inclure le mot de passe ici.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -1699,6 +1699,10 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Restablecer contrasinal</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1915,6 +1919,10 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>A pista é visible para todos os usuarios. Non inclúis o contrasinal aquí.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>תמיד</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">אפס את הסיסמה</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>האזהרה מופיעה לכל משתמשים. אל תכתוב כאן את הסיסמה.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">हमेशा</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Uvijek</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -1696,6 +1696,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>M Mindig</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Jelszó visszaállítása</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1912,6 +1916,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>A segítség az összes felhasználó számára látható. Nem írd a jelszót ide.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Միշտ</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Selalu</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -1708,6 +1708,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>いつも</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">パスワードをリセット</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1924,6 +1928,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>ヒントはすべてのユーザーに表示されます。ヒントにパスワードを含めないでください。</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">ყოველთვის</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -1695,6 +1695,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Әр күн</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Құпия сөзі азайту</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1911,6 +1915,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Көрсеткіш бар пользоваттерге түсінікті. Құпия сөзді бұттан көрсетуі мүмкін.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -1721,6 +1721,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>항상</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">비밀번호 초기화</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1937,6 +1941,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>힌트는 모든 사용자가 볼 수 있습니다. 여기에 비밀번호는 포함하지 마십시오.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Atstatyti slaptažodį</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Priminimas yra visiems vartotojams išsakytas. Slaptažodžio įrašymas čia yra netinkamas.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Үргэлж</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Sentiasa</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Alltid</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -1699,6 +1699,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>सदैव</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">पासवर्ड पुनर्व्यवस्थापन गर्नुहोस्</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1915,6 +1919,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>उपदेश सभी उपयोगकर्ताहरूले देख्न सक्छ। यस यादीमा पासवर्ड छैन्द</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -1707,6 +1707,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1922,6 +1926,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">ਹਮੇਸ਼ਾਂ</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -1709,6 +1709,10 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
         <source>Always</source>
         <translation>Zawsze</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Zresetuj hasło</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1925,6 +1929,10 @@ Zaloguj się do %1 ID, aby uzyskać usługi i funkcje Przeglądarki, sklepu App 
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Wskazówka jest widoczna dla wszystkich użytkowników. Nie podawaj tutaj swojego hasła.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Sempre</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation type="unfinished">A dica é visível para todos os utilizadores. Não inclua aqui a palavra-passe.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -1,4 +1,6 @@
-<?xml version="1.0" ?><!DOCTYPE TS><TS version="2.1" language="pt_BR">
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="pt_BR">
 <context>
     <name>AccountSettings</name>
     <message>
@@ -196,7 +198,7 @@ In order to better use of face recognition, please pay attention to the followin
     <message>
         <source>&quot;Biometric authentication&quot; is a function for user identity authentication provided by UnionTech Software Technology Co., Ltd. Through &quot;biometric authentication&quot;, the biometric data collected will be compared with that stored in the device, and the user identity will be verified based on the comparison result.
 
-Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people's biometric information on that device, otherwise you will bear the risk arising therefrom.
+Please be noted that UnionTech Software Technology Co., Ltd. will not collect or access your biometric information, which will be stored on your local device. Please only enable the biometric authentication in your personal device and use your own biometric information for related operations, and promptly disable or delete other people&apos;s biometric information on that device, otherwise you will bear the risk arising therefrom.
 
 UnionTech Software Technology Co., Ltd. is committed to research and improve the security, accuracy and stability of biometric authentication. However, due to environmental, equipment, technical and other factors and risk control, there is no guarantee that you will pass the biometric authentication temporarily. Therefore, please do not take biometric authentication as the only way to log in to UOS. If you have any questions or suggestions when using the biometric authentication, you can give feedback through &quot;Service and Support&quot; in the UOS.</source>
         <translation>&quot;A autenticação biométrica&quot; ​​é uma função para autenticação de identidade do usuário fornecida pela UnionTech Software Technology Co., Ltd. Por meio da &quot;autenticação biométrica&quot;, os dados biométricos coletados serão comparados com os armazenados no dispositivo, e a identidade do usuário será verificada com base no resultado da comparação.Observe que a UnionTech Software Technology Co., Ltd. não coletará ou acessará suas informações biométricas, que serão armazenadas em seu dispositivo local. Habilite apenas a autenticação biométrica em seu dispositivo pessoal e use suas próprias informações biométricas para operações relacionadas, e desabilite ou exclua imediatamente as informações biométricas de outras pessoas naquele dispositivo, caso contrário, você arcará com o risco decorrente disso.A UnionTech Software Technology Co., Ltd. está comprometida em pesquisar e melhorar a segurança, precisão e estabilidade da autenticação biométrica. No entanto, devido a fatores ambientais, de equipamento, técnicos e outros e controle de risco, não há garantia de que você passará pela autenticação biométrica temporariamente. Portanto, não tome a autenticação biométrica como a única maneira de fazer login no UOS.  Caso tenha alguma dúvida ou sugestão ao usar a autenticação biométrica, você pode nos dar um feedback através de &quot;Serviço e Suporte&quot; no UOS.</translation>
@@ -1329,10 +1331,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>3.Importar certificado</translation>
     </message>
     <message>
-        <source>To install and run unsigned apps, please go to &lt;a href=&quot;Security Center&quot;&gt;Security Center&lt;/a&gt; to change the settings.</source>
-        <translation>Para instalar e executar aplicativos não assinados, acesse &lt;a href=&quot;Security Center&quot;&gt;Central de Segurança&lt;/a&gt; para alterar as configurações.</translation>
-    </message>
-    <message>
         <source>Development and debugging options</source>
         <translation>Opções do desenvolvedor e depuração</translation>
     </message>
@@ -1355,6 +1353,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Changing the option may take up to a minute to process, after receiving a successful setting prompt, please reboot the device to take effect.</source>
         <translation>A alteração da opção pode levar até um minuto para ser processada. Após receber um prompt de configuração bem-sucedida, reinicie o dispositivo para que a configuração tenha efeito.</translation>
+    </message>
+    <message>
+        <source>To install and run unsigned apps, please go to &lt;a style=&apos;text-decoration: none;&apos; href=&apos;Security Center&apos;&gt; Security Center &lt;/a&gt; to change the settings.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -1692,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Sempre</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Redefinir senha</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1908,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>A dica é visível para todos os usuários. Não inclua a senha aqui</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Mereu</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -1708,6 +1708,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Всегда</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Сбросить пароль</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1924,6 +1928,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Подсказка видна всем пользователям. Не включайте тут пароль.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">සැමවිටම</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Vždy</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -1698,6 +1698,10 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
         <source>Always</source>
         <translation>Zavedno</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Ponastavi geslo</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1914,6 +1918,10 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Opomba je vidna za vse uporabnike. Tu ne vključujte gesla.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -1709,6 +1709,10 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
         <source>Always</source>
         <translation>Përherë</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Ricaktoni fjalëkalimin</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1925,6 +1929,10 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Ndihmëza është e dukshme për krejt përdoruesit. Këtu mos përfshini fjalëkalimin.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">Увек</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -1711,6 +1711,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Återställ lösenord</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1927,6 +1931,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Tipsen är synlig för alla användare. Ange inte lösenordet här.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -1697,6 +1697,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>ตลอดเวลา</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">รีเซ็ตรหัสผ่าน</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1913,6 +1917,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>คำใบ้จะปรากฏให้ผู้ใช้ทุกคนเห็น กรุณาอย่าใส่รหัสผ่านในที่นี้</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Her zaman</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Parolayı sıfırla</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>İpucu tüm kullanıcılar tarafından görülebilir. Parolayı buraya dahil etmeyin.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished">ئۇزاق ئۈنۈملۈك</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1910,6 +1914,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation type="unfinished">پارول ئەسكەرتىشىنى ھەممە ئادەم كۆرەلەيدۇ، كونكرېت پارول ئۇچۇرلىرىنى كىرگۈزمەڭ</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -1708,6 +1708,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Завжди</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Скинути пароль</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1924,6 +1928,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Підказку буде показано усім користувачам. Не включайте до неї пароля.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -1694,6 +1694,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1909,6 +1913,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>New password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -1721,6 +1721,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>Luôn luôn</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">Khôi phục mật khẩu</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1937,6 +1941,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>Lời nhắc sẽ hiển thị cho tất cả người dùng. Không bao gồm mật khẩu ở đây.</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -393,7 +393,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Allow other Bluetooth devices to find this device</source>
-        <translation>允许其他蓝牙设备找到该设备</translation>
+        <translation>允许蓝牙设备可被发现</translation>
     </message>
     <message>
         <source>To use the Bluetooth function, please turn off</source>
@@ -451,7 +451,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Change Password</source>
-        <translation>修改密码</translation>
+        <translation>重设密码</translation>
     </message>
     <message>
         <source>Change boot menu verification password</source>
@@ -1709,6 +1709,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>长期有效</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation>重置密码</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1925,6 +1929,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>密码提示对所有人可见，切勿包含具体密码信息</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation>新密码</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -1707,6 +1707,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>長期有效</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">重置密碼</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1923,6 +1927,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>密碼提示對所有人可見，切勿包含具體密碼信息</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -1707,6 +1707,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>Always</source>
         <translation>長期有效</translation>
     </message>
+    <message>
+        <source>Reset password</source>
+        <translation type="unfinished">重置密碼</translation>
+    </message>
 </context>
 <context>
     <name>LogoModule</name>
@@ -1923,6 +1927,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>The hint is visible to all users. Do not include the password here.</source>
         <translation>密碼提示對所有人可見，切勿包含具體密碼資訊</translation>
+    </message>
+    <message>
+        <source>New password</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Fixed some copywriting errors

Log: Fixed some copywriting errors
pms: BUG-304989
     BUG-293875
     BUG-305093

## Summary by Sourcery

Fix copywriting errors in translation files and improve password UI labels in QML components.

Bug Fixes:
- Standardize XML headers and encoding declarations across TS translation files
- Correct apostrophe encoding and punctuation in multiple translation strings
- Remove outdated translation entries for unsigned app installation prompts

Enhancements:
- Add new i18n keys for "Reset password" and "New password" to translation files
- Update QML logic to conditionally show "Modify password" or "Reset password" based on user context
- Adjust password input component to toggle label between "Password" and "New password" dynamically