### PR TITLE
fix: resolve caps lock toggle functionality in keyboard plugin

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -135,6 +135,9 @@ bool KeyboardController::capsLock() const
 
 void KeyboardController::setCapsLock(bool newCapsLock)
 {
+    if (capsLock() == newCapsLock)
+        return;
+
     m_worker->setCapsLock(newCapsLock);
 }
 

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -78,16 +78,14 @@ void KeyboardDBusProxy::onLangSelectorStartServiceProcessFinished(QDBusPendingCa
 }
 
 //Keyboard
-int KeyboardDBusProxy::capslockToggle()
+bool KeyboardDBusProxy::capslockToggle()
 {
-    return QDBusPendingReply<int>(m_dBusKeybingdingInter->asyncCall(QStringLiteral("GetCapsLockState")));
+    return qvariant_cast<bool>(m_dBusKeyboardInter->property("CapslockToggle"));
 }
 
-void KeyboardDBusProxy::setCapslockToggle(int value)
+void KeyboardDBusProxy::setCapslockToggle(bool value)
 {
-    QList<QVariant> argumentList;
-    argumentList << QVariant::fromValue(value);
-    m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SetCapsLockState"), argumentList);
+    m_dBusKeyboardInter->setProperty("CapslockToggle", QVariant::fromValue(value));
 }
 
 QString KeyboardDBusProxy::currentLayout()

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -72,9 +72,9 @@ public:
     explicit KeyboardDBusProxy(QObject *parent = nullptr);
 
     //Keyboard
-    Q_PROPERTY(int CapslockToggle READ capslockToggle WRITE setCapslockToggle NOTIFY CapslockToggleChanged)
-    int capslockToggle();
-    void setCapslockToggle(int value);
+    Q_PROPERTY(bool CapslockToggle READ capslockToggle WRITE setCapslockToggle NOTIFY CapslockToggleChanged)
+    bool capslockToggle();
+    void setCapslockToggle(bool value);
 
     Q_PROPERTY(QString CurrentLayout READ currentLayout WRITE setCurrentLayout NOTIFY CurrentLayoutChanged)
     QString currentLayout();


### PR DESCRIPTION
- Changed CapslockToggle property from int to bool for type consistency
- Updated D-Bus method calls to use property-based approach
- Added state check to prevent redundant caps lock operations

Log: resolve caps lock toggle functionality in keyboard plugin
pms: BUG-319489