### PR TITLE
fix: standardize icon naming in TimeAndDate component

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -230,7 +230,7 @@ DccObject {
                         }
                     }
                     icon {
-                        name: addr.readOnly ? "edit" : "ok"
+                        name: addr.readOnly ? "dcc-edit" : "ok"
                         width: 16
                         height: 16
                     }


### PR DESCRIPTION
- Updated icon name from "edit" to "dcc-edit" for consistency with DCC icon conventions.

Log: standardize icon naming in TimeAndDate component
pms: BUG-319165

## Summary by Sourcery

Bug Fixes:
- Replace "edit" icon with "dcc-edit" for the read-only state in TimeAndDate.qml