### PR TITLE
fix: Modify the processing method of the identify window

### DIFF
--- a/src/plugin-display/qml/ScreenItem.qml
+++ b/src/plugin-display/qml/ScreenItem.qml
@@ -29,6 +29,27 @@ Rectangle {
         visible: false
         fillMode: Image.PreserveAspectCrop
         asynchronous: true
+        cache: true
+        smooth: true
+        sourceSize {
+            width: parent.width * Screen.devicePixelRatio
+            height: parent.height * Screen.devicePixelRatio
+        }
+        onStatusChanged: {
+            if (status === Image.Loading) {
+                loadingPlaceholder.visible = true
+            } else {
+                loadingPlaceholder.visible = false
+            }
+        }
+    }
+
+    Rectangle {
+        id: loadingPlaceholder
+        anchors.fill: parent
+        color: "#3f3f3f"
+        visible: false
+        radius: root.radius
     }
     OpacityMask {
         anchors.fill: parent

--- a/src/plugin-display/qml/ScreenRecognize.qml
+++ b/src/plugin-display/qml/ScreenRecognize.qml
@@ -8,6 +8,7 @@ import org.deepin.dcc 1.0
 Window {
     id: root
     property string name: "screen"
+    signal escPressed
 
     flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
     D.DWindow.enabled: true
@@ -17,16 +18,16 @@ Window {
     height: control.implicitHeight + 24
     minimumWidth: 200
     onClosing: destroy(10)
-    Timer {
-        interval: 5000
-        running: root.visible
-        onTriggered: root.close()
-    }
     Text {
         id: control
         anchors.centerIn: parent
         text: root.name
         font: D.DTK.fontManager.t4
         color: control.palette.brightText
+    }
+    Shortcut {
+        sequence: "Esc"
+        onActivated: escPressed()
+        onActivatedAmbiguously: escPressed()
     }
 }

--- a/src/plugin-display/qml/displayMain.qml
+++ b/src/plugin-display/qml/displayMain.qml
@@ -320,7 +320,7 @@ DccObject {
             visible: dccData.virtualScreens.length > 1 || (dccData.virtualScreens.length === 1 && dccData.virtualScreens[0].screenItems.length > 1)
             pageType: DccObject.Item
             page: Item {
-                implicitHeight: identifyBut.implicitHeight + 10
+                implicitHeight: identifyBut.implicitHeight + 4
                 DccLabel {
                     anchors.fill: parent
                     horizontalAlignment: Text.AlignHCenter
@@ -331,23 +331,44 @@ DccObject {
                     text: qsTr("Screen rearrangement will take effect in %1s after changes").arg(2)
                     clip: true
                 }
-                Button {
+                D.Button {
                     id: identifyBut
+                    property var recognizes: []
+                    implicitHeight: 24
+                    implicitWidth: 72
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
-                    anchors.rightMargin: 5
+                    anchors.rightMargin: 7
                     text: dccObj.displayName
+                    function closeWindow() {
+                        recognizeTimer.stop()
+                        for (var obj of identifyBut.recognizes) {
+                            obj.close()
+                        }
+                        identifyBut.recognizes = []
+                    }
+                    Timer {
+                        id: recognizeTimer
+                        repeat: false
+                        interval: 5000
+                        onTriggered: identifyBut.closeWindow()
+                    }
                     onClicked: {
                         // if (!dccData.isX11) {
                         //     return
                         // }
+                        identifyBut.closeWindow()
                         for (var i = 0; i < dccData.virtualScreens.length; i++) {
                             var item = dccData.virtualScreens[i]
-                            recognize.createObject(this, {
-                                                       "screen": getQtScreen(item),
-                                                       "name": item.name
-                                                   }).show()
+                            var obj = recognize.createObject(this, {
+                                                                 "screen": getQtScreen(item),
+                                                                 "name": item.name
+                                                             })
+                            obj.show()
+                            obj.escPressed.connect(identifyBut.closeWindow)
+                            recognizes.push(obj)
                         }
+                        recognizeTimer.restart()
                     }
                 }
             }


### PR DESCRIPTION
Modify the processing method of the identify window

pms: BUG-304155
pms: BUG-304441
pms: BUG-308779

## Summary by Sourcery

Improve identify window behavior and enhance screen item image handling in the display plugin.

Enhancements:
- Auto-close screen recognition overlays after 5 seconds or on Esc press
- Track and close multiple recognition windows via a centralized closeWindow function
- Adjust identify button layout with updated height and right margin
- Add image caching, smoothing, and a loading placeholder to screen item previews
- Replace internal timer in ScreenRecognize with an external timer and Esc shortcut