### PR TITLE
fix: ScheduledShutdownDialog cancel behavior on close

### DIFF
--- a/src/plugin-power/qml/ScheduledShutdownDialog.qml
+++ b/src/plugin-power/qml/ScheduledShutdownDialog.qml
@@ -48,6 +48,9 @@ D.DialogWindow {
     // only accept close event , the app can quit normally
     onClosing: function(close) {
         close.accepted = true
+        // 当用户点击关闭按钮或按ESC键关闭对话框时，触发取消事件
+        selectDayDialog.selectedDays = dccData.model.customShutdownWeekDays.length === 0 ? [1, 2, 3, 4, 5] : dccData.model.customShutdownWeekDays.slice()
+        selectDayDialog.cancel()
     }
 
     ColumnLayout {


### PR DESCRIPTION
Reset selected days to default when dialog is closed via ESC/close button Add fallback to weekdays 1-5 if custom shutdown days are empty

pms: BUG-318839

## Summary by Sourcery

Bug Fixes:
- Reset selected days to custom shutdown weekdays if available or default to Monday–Friday when the dialog is canceled via close or ESC.