### PR TITLE
fix: Fixed the failure of uploading an avatar

### DIFF
--- a/src/plugin-accounts/qml/AvatarSettingsDialog.qml
+++ b/src/plugin-accounts/qml/AvatarSettingsDialog.qml
@@ -37,10 +37,12 @@ D.DialogWindow {
             title: "Please choose an image"
             folder: StandardPaths.writableLocation(StandardPaths.PicturesLocation)
             onAccepted: {
-                dialog.currentAvatar = fileDialog.selectedFile
-                // 23 dcc 选中自定义就会出发设置图标
-                dialog.accepted();
-
+                let selectedFile = fileDialog.selectedFile || fileDialog.file || fileDialog.fileUrl
+                if (selectedFile) {
+                    dialog.currentAvatar = selectedFile.toString()
+                    // 23 dcc 选中自定义就会出发设置图标
+                    dialog.accepted();
+                }
                 fileDlgLoader.active = false
             }
             onRejected: {


### PR DESCRIPTION
Fixed the failure of uploading an avatar

Log: Fixed the failure of uploading an avatar
pms: BUG-317415

## Summary by Sourcery

Bug Fixes:
- Add fallback checks for fileDialog.selectedFile, fileDialog.file, and fileDialog.fileUrl before assigning dialog.currentAvatar and invoking dialog.accepted().