### PR TITLE
fix: Fix default display for unnamed Bluetooth

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothdevicemodel.cpp
+++ b/src/plugin-bluetooth/operation/bluetoothdevicemodel.cpp
@@ -5,7 +5,7 @@
 
 BluetoothDeviceModel::BluetoothDeviceModel(QObject *parent)
     : QAbstractListModel(parent)
-    , m_displaySwitch(true)
+    , m_displaySwitch(false)
 {
 }
 


### PR DESCRIPTION
Fix default display for unnamed Bluetooth

Log: Fix default display for unnamed Bluetooth
pms: BUG-283349

## Summary by Sourcery

Bug Fixes:
- Disable the display switch by default for unnamed Bluetooth devices.