### PR TITLE
fix: resolve volume icon hover effect issues in SpeakerPage

### DIFF
--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -63,15 +63,35 @@ DccObject {
                     font: DTK.fontManager.t7
                     text: root.toPercent(voiceTipsSlider.value)
                 }
-                IconButton {
+                ActionButton {
                     Layout.alignment: Qt.AlignVCenter
                     icon {
                         name: dccData.model().speakerOn ? "sound_off" : "small_volume"
                         width: 16
                         height: 16
                     }
-                    implicitWidth: 24
+                    property Palette textColor: parent.textColor
+                    palette.windowText: ColorSelector.textColor
                     flat: !hovered
+                    implicitWidth: 24
+                    implicitHeight: 24
+                    hoverEnabled: enabled
+                    background: Rectangle {
+                        property Palette pressedColor: Palette {
+                            normal: Qt.rgba(0, 0, 0, 0.2)
+                            normalDark: Qt.rgba(1, 1, 1, 0.25)
+                        }
+                        property Palette hoveredColor: Palette {
+                            normal: Qt.rgba(0, 0, 0, 0.1)
+                            normalDark: Qt.rgba(1, 1, 1, 0.1)
+                        }
+                        radius: DS.Style.control.radius
+                        color: parent.pressed ? ColorSelector.pressedColor : (parent.hovered ? ColorSelector.hoveredColor : "transparent")
+                        border {
+                            color: parent.palette.highlight
+                            width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                        }
+                    }
 
                     onClicked: {
                         dccData.worker().setSinkMute()


### PR DESCRIPTION
- Replace IconButton with ActionButton for proper hover state support
- Add background styling with hover and pressed color palettes
- Implement correct visual feedback for volume control interaction

Log: resolve volume icon hover effect issues in SpeakerPage
pms: BUG-319083

## Summary by Sourcery

Improve the speaker volume button by replacing IconButton with ActionButton and adding background styling and color palettes to deliver correct hover, pressed, and focus feedback.

Bug Fixes:
- Restore proper hover and pressed visual feedback on the volume control icon

Enhancements:
- Replace IconButton with ActionButton to support hover and pressed states
- Add background styling with hover and pressed color palettes and focus border