### PR TITLE
fix: align placeholder text to left in custom NTP server input field

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -185,7 +185,7 @@ DccObject {
                     placeholderText: qsTr("Required")
                     alertText: qsTr("The ntp server address cannot be empty")
                     alertDuration: 3000
-                    horizontalAlignment: TextInput.AlignRight
+                    horizontalAlignment: background.visible ? TextInput.AlignLeft : TextInput.AlignRight
                     anchors{
                         rightMargin: 5
                         right: editBtn.left


### PR DESCRIPTION
- Set conditional alignment to display placeholder text properly when background is visible.

Log: align placeholder text to left in custom NTP server input field
pms: BUG-319111

## Summary by Sourcery

Bug Fixes:
- Fix placeholder alignment for the custom NTP server input to left when background is visible, retaining right alignment otherwise