### PR TITLE
fix: reduce excessive spacing between setting sections in TimeAndDate

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -55,7 +55,12 @@ DccObject {
         pageType: DccObject.Item
         page: DccGroupView {}
 
-        onParentItemChanged: item => { if (item) item.topPadding = 10 }
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 10
+                item.bottomPadding = 5
+            }
+        }
 
         DccObject {
             id: ntpSettings
@@ -293,7 +298,7 @@ DccObject {
             }
         }
 
-        onParentItemChanged: item => { if (item) item.topPadding = 10 }
+        onParentItemChanged: item => { if (item) item.topPadding = 5 }
     }
 
     DccObject {


### PR DESCRIPTION
- Adjusted padding values to minimize gaps between setting groups
- Added bottomPadding to dateTimeGroup and reduced topPadding in timezoneGroup

Log: reduce excessive spacing between setting sections in TimeAndDate
pms: BUG-319333

## Summary by Sourcery

Bug Fixes:
- Reduce vertical spacing between TimeAndDate setting sections by adjusting top and bottom padding values