### PR TITLE
fix: Fixed text position anomalies

### DIFF
--- a/src/plugin-accounts/qml/LoginMethod.qml
+++ b/src/plugin-accounts/qml/LoginMethod.qml
@@ -79,10 +79,12 @@ DccTitleObject {
                 enabled: dccData.currentUserId() === loginMethodTitle.userId || (dccData.curUserIsSysAdmin() && !dccData.isOnline(loginMethodTitle.userId))
                 pageType: DccObject.Editor
                 page: D.IconLabel {
-                    icon.name: "arrow_ordinary_right"
-                    icon.palette: DTK.makeIconPalette(control.palette)
-                    icon.mode: control.ColorSelector.controlState
-                    icon.theme: control.ColorSelector.controlTheme
+                    icon {
+                        name: "arrow_ordinary_right"
+                        palette: D.DTK.makeIconPalette(parent.palette)
+                        mode: parent.D.ColorSelector.controlState
+                        theme: parent.D.ColorSelector.controlTheme
+                    }
                     opacity: enabled ? 1 : 0.4
                 }
                 onActive: {

--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -140,7 +140,7 @@ DccObject {
 
                 LineEdit {
                     id: hostNameEdit
-                    horizontalAlignment: Text.AlignHCenter
+                    horizontalAlignment: TextInput.AlignLeft
                     text: dccData.systemInfoMode().hostName
                     visible: false
                     showAlert: false


### PR DESCRIPTION
Fixed text position anomalies

Log: Fixed text position anomalies
pms: BUG-319477

## Summary by Sourcery

Fix text position anomalies in QML UI components by restructuring icon property definitions and refining text alignment logic.

Bug Fixes:
- Restructure icon property assignments in LoginMethod.qml under a nested icon block for correct palette and state references
- Adjust host name LineEdit horizontal alignment in NativeInfoPage.qml to align left when editable and center otherwise