### PR TITLE
fix: resolve spacing and font issues in touchpad components

### DIFF
--- a/src/plugin-mouse/qml/GestureGroup.qml
+++ b/src/plugin-mouse/qml/GestureGroup.qml
@@ -32,7 +32,9 @@ Rectangle {
                 Layout.fillWidth: true
                 leftPadding: 10
                 rightPadding: 10
-                implicitHeight: 45
+                topPadding: 0
+                bottomPadding: 0
+                implicitHeight: 36
                 cascadeSelected: true
                 backgroundVisible: root.backgroundVisible
                 text: model.descriptionRole
@@ -53,6 +55,7 @@ Rectangle {
                     }
                 }
                 background: DccItemBackground {
+                    backgroundType: DccObject.Normal
                     separatorVisible: true
                 }
 

--- a/src/plugin-mouse/qml/Touchpad.qml
+++ b/src/plugin-mouse/qml/Touchpad.qml
@@ -21,8 +21,16 @@ DccObject {
         page: ColumnLayout {
             Label {
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font.pixelSize: D.DTK.fontManager.t5.pixelSize
+                font.weight: 500
+                color: D.DTK.themeType === D.ApplicationHelper.LightType ?
+                    Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                 text: dccObj.displayName
+            }
+        }
+        onParentItemChanged: item => {
+            if (item) {
+                item.bottomPadding = 4
             }
         }
     }
@@ -42,6 +50,12 @@ DccObject {
                 if (checked !== dccData.tapEnabled) {
                     dccData.tapEnabled = checked;
                 }
+            }
+        }
+        onParentItemChanged: item => {
+            if (item) {
+                item.topInset = 4
+                item.bottomInset = 3
             }
         }
     }
@@ -118,7 +132,12 @@ DccObject {
             }
 
         }
-
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 0
+                item.bottomPadding = 3
+            }
+        }
     }
 
     DccObject {
@@ -192,6 +211,12 @@ DccObject {
         page: DccGroupView {
         }
 
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 3
+                item.bottomPadding = 8
+            }
+        }
     }
 
     DccObject {
@@ -205,12 +230,20 @@ DccObject {
         page: ColumnLayout {
             Label {
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font.pixelSize: D.DTK.fontManager.t5.pixelSize
+                font.weight: 500
+                color: D.DTK.themeType === D.ApplicationHelper.LightType ?
+                    Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                 text: dccObj.displayName
             }
-
         }
 
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 8
+                item.bottomPadding = 4
+            }
+        }
     }
 
     DccObject {
@@ -259,6 +292,12 @@ DccObject {
         page: DccGroupView {
         }
 
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 4
+                item.bottomPadding = 6
+            }
+        }
     }
 
     DccObject {
@@ -273,12 +312,18 @@ DccObject {
         page: ColumnLayout {
             Label {
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
             }
 
         }
 
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 6
+                item.bottomPadding = 3
+            }
+        }
     }
 
     DccObject {
@@ -289,7 +334,6 @@ DccObject {
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: GestureGroup {
-
             model: dccData.threeFingerGestureModel()
 
             onComboIndexChanged: function (index, actionDec){
@@ -301,7 +345,12 @@ DccObject {
             }
 
         }
-
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 3
+                item.bottomPadding = 6
+            }
+        }
     }
 
     DccObject {
@@ -315,12 +364,17 @@ DccObject {
         page: ColumnLayout {
             Label {
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
             }
 
         }
-
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 6
+                item.bottomPadding = 3
+            }
+        }
     }
 
     DccObject {
@@ -341,6 +395,11 @@ DccObject {
             }
         }
 
+        onParentItemChanged: item => {
+            if (item) {
+                item.topPadding = 3
+            }
+        }
     }
 
 }

--- a/src/plugin-mouse/qml/mouseMain.qml
+++ b/src/plugin-mouse/qml/mouseMain.qml
@@ -40,7 +40,7 @@ DccObject {
         visible: dccData.tpadExist
         weight: 200
         page: DccRightView {
-            spacing: 5
+            spacing: 0
         }
         Touchpad {}
     }


### PR DESCRIPTION
- Adjusted padding and spacing properties for better touchpad layout
- Updated font properties for improved text consistency

Log: resolve spacing and font issues in touchpad components
pms: BUG-304357

## Summary by Sourcery

Resolve spacing and font inconsistencies across touchpad UI components

Bug Fixes:
- Standardize label fonts to use specified pixel sizes, weight 500, and theme-aware colors in Touchpad.qml
- Apply uniform top and bottom paddings and insets via onParentItemChanged handlers across multiple DccObject pages
- Adjust GestureGroup padding and reduce implicitHeight for more compact layout
- Remove excess spacing in the main touchpad right view by setting spacing to zero