### PR TITLE
refactor: reorganize shutdown time signal and handling

### DIFF
--- a/src/plugin-power/operation/powerdbusproxy.h
+++ b/src/plugin-power/operation/powerdbusproxy.h
@@ -146,6 +146,7 @@ signals:
     void LowPowerNotifyEnableChanged(bool value) const;
     void LowPowerNotifyThresholdChanged(int value) const;
     void LowPowerAutoSleepThresholdChanged(int value) const;
+    void ShutdownTimeChanged(const QString &time);
     // SystemPower
     void PowerSavingModeAutoChanged(bool value) const;
     void PowerSavingModeEnabledChanged(bool value) const;
@@ -158,7 +159,6 @@ signals:
     void BatteryCapacityChanged(double value) const;
     void noPasswdLoginChanged(bool value);
     void ScheduledShutdownStateChanged(bool value);
-    void ShutdownTimeChanged(const QString &time);
     void ShutdownRepetitionChanged(int repetition);
     void CustomShutdownWeekDaysChanged(const QByteArray &value);
     void LowPowerActionChanged(int action);

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -226,12 +226,13 @@ DccObject {
             pageType: DccObject.Editor
             page: RowLayout {
                 DccTimeRange {
+                    id: timeRange
                     Layout.preferredWidth: 100
                     hour: dccData.model.shutdownTime.split(':')[0]
                     minute: dccData.model.shutdownTime.split(':')[1]
-                    property string timeStr: `${String(hour).padStart(2, '0')}:${String(minute).padStart(2, '0')}`
-                    onTimeStrChanged: {
-                        dccData.worker.setShutdownTime(timeStr)
+
+                    onTimeChanged: {
+                        dccData.worker.setShutdownTime(timeRange.timeString)
                     }
                 }
             }


### PR DESCRIPTION
1. Moved ShutdownTimeChanged signal declaration to be grouped with related signals in powerdbusproxy.h
2. Simplified time handling in GeneralPage.qml by using built-in timeString property from DccTimeRange
3. Added debug logging for shutdown time changes
4. Removed redundant timeStr property and string formatting logic

The changes improve code organization and maintainability by:
- Grouping related signals together in the header file
- Using built-in component functionality instead of custom formatting
- Adding visibility into time changes through logging

refactor: 重新组织关机时间信号和处理

1. 将ShutdownTimeChanged信号声明移动到powerdbusproxy.h中相关信号分组
2. 在GeneralPage.qml中使用DccTimeRange内置的timeString属性简化时间处理
3. 添加关机时间变更的调试日志
4. 移除冗余的timeStr属性和字符串格式化逻辑

这些改动通过以下方式提高了代码组织和可维护性:
- 在头文件中将相关信号分组
- 使用内置组件功能替代自定义格式化
- 通过日志记录增加时间变更的可见性

pms: BUG-320727

## Summary by Sourcery

Refactor shutdown time handling by regrouping the signal declaration in the header and streamlining QML logic to use the built-in timeString property, remove custom formatting, and introduce debug logs.

Enhancements:
- Reorganize ShutdownTimeChanged signal declaration alongside related signals in powerdbusproxy.h
- Simplify shutdown time updates in GeneralPage.qml by using DccTimeRange.timeString and onTimeChanged
- Remove redundant timeStr property and custom formatting logic
- Add debug logging for shutdown time changes