### PR TITLE
chore: bump version to 6.1.31

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.1.31) unstable; urgency=medium
+
+  * fix: Open all keyboard layouts
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Thu, 19 Jun 2025 16:43:03 +0800
+
 dde-control-center (6.1.30) unstable; urgency=medium
 
   * fix: hide pressure sensitivity settings in mouse mode


### PR DESCRIPTION
update changelog to 6.1.31

## Summary by Sourcery

Chores:
- Update Debian changelog entry for version 6.1.31