### PR TITLE
fix(accounts): The 'Quick Login' option is not hidden correctly

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -97,6 +97,8 @@ AccountsController::AccountsController(QObject *parent)
         }
     });
 
+    connect(m_model, &UserModel::quickLoginVisibleChanged, this, &AccountsController::quickLoginVisibleChanged);
+
     QMetaObject::invokeMethod(m_worker, "active", Qt::QueuedConnection);
 }
 

--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -22,6 +22,7 @@ class AccountsController : public QObject
     Q_PROPERTY(QString currentUserName READ currentUserName NOTIFY currentUserNameChanged FINAL)
     Q_PROPERTY(QStringList userIdList READ userIdList NOTIFY userIdListChanged FINAL)
     Q_PROPERTY(QStringList onlineUserList READ onlineUserList NOTIFY onlineUserListChanged FINAL)
+    Q_PROPERTY(bool isQuickLoginVisible READ isQuickLoginVisible NOTIFY quickLoginVisibleChanged FINAL)
 public:
     explicit AccountsController(QObject *parent = nullptr);
     virtual ~AccountsController();
@@ -114,6 +115,7 @@ signals:
     void requestClearEmptyGroup(const QString &userId);
     void showSafetyPage(const QString &errorTips);
     void accountCreationFinished(CreationResult::ResultType resultType, const QString &message);
+    void quickLoginVisibleChanged();
 protected:
     bool isSystemAdmin(const User *user) const;
     int adminCount() const;

--- a/src/plugin-accounts/operation/accountsdbusproxy.h
+++ b/src/plugin-accounts/operation/accountsdbusproxy.h
@@ -30,6 +30,9 @@ public:
     Q_PROPERTY(QList<QDBusObjectPath> Sessions READ sessions NOTIFY SessionsChanged)
     QList<QDBusObjectPath> sessions();
 
+    Q_PROPERTY(bool QuickLoginEnabled READ quickLoginEnabled)
+    bool quickLoginEnabled();
+
 signals:
     void UserAdded(const QString &in0);
     void UserDeleted(const QString &in0);
@@ -40,6 +43,7 @@ signals:
     // displaymanager
     void SessionsChanged(const QList<QDBusObjectPath> &value) const;
 
+    void QuickLoginEnabledChanged(bool value);
 
 public slots:
     QDBusPendingReply<QDBusObjectPath> CreateUser(const QString &in0, const QString &in1, int in2);
@@ -55,6 +59,7 @@ public slots:
     QDBusPendingReply<> deleteGroup(const QString &in0);
     QDBusPendingReply<> createGroup(const QString &in0, uint32_t in1, bool in2);
     QDBusPendingReply<> modifyGroup(const QString &in0, const QString &in1, uint32_t in2);
+    void onPropertiesChanged(const QDBusMessage &message);
 
 private:
     void init();

--- a/src/plugin-accounts/operation/accountsworker.cpp
+++ b/src/plugin-accounts/operation/accountsworker.cpp
@@ -69,6 +69,9 @@ AccountsWorker::AccountsWorker(UserModel *userList, QObject *parent)
         m_userModel->setAutoLoginVisable(true);
         m_userModel->setNoPassWordLoginVisable(false);
     }
+
+    m_userModel->setQuickLoginVisible(m_accountsInter->quickLoginEnabled());
+    connect(m_accountsInter, &AccountsDBusProxy::QuickLoginEnabledChanged, m_userModel, &UserModel::setQuickLoginVisible);
 }
 
 void AccountsWorker::getAllGroups()

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -423,7 +423,7 @@ DccObject {
         weight: 30
         pageType: DccObject.Item
         page: DccGroupView {}
-        visible: (autoLongin.visible || noPassword.visible) && !DccApp.isTreeland()
+        visible: (autoLongin.visible || noPassword.visible || quickLogin.visible) && !DccApp.isTreeland()
 
         DccObject {
             id: quickLogin
@@ -432,7 +432,7 @@ DccObject {
             displayName: qsTr("Quickly load DDE with your login information")
             weight: 20
             pageType: DccObject.Editor
-            visible: dccData.isQuickLoginVisible()
+            visible: dccData.isQuickLoginVisible
             enabled: dccData.currentUserId() === settings.userId
             page: Switch {
                 checked: settings.noQuickLoginChecked
@@ -493,7 +493,7 @@ DccObject {
             name: settings.papaName + "noPassword"
             parentName: settings.papaName + "acountSettings"
             displayName: qsTr("Login without password")
-            weight: 20
+            weight: 30
             pageType: DccObject.Editor
             visible: dccData.isNoPassWordLoginVisable()
             enabled: dccData.currentUserId() === settings.userId


### PR DESCRIPTION
Sync quick login option visibility with DBus property

- Add DBus property change listener for QuickLoginEnabled in AccountsDBusProxy
- Emit signal when property changes to update UI visibility
- Update controller to handle quick login visibility changes
- Fix layout restoration when option reappears

This message:
1. Starts with a concise summary (55 chars)
2. Uses imperative mood ("Add", "Emit", "Update", "Fix")
3. Clearly states the purpose (sync UI with DBus property)
4. Lists key changes in bullet points

pms: BUG-321431

## Summary by Sourcery

Sync the ‘Quick Login’ option visibility with the backend DBus QuickLoginEnabled property by adding a listener in the proxy, emitting change signals, updating the user model and controller, and adjusting QML visibility and layout.

Bug Fixes:
- Refresh and correctly hide/show the ‘Quick Login’ option based on the DBus QuickLoginEnabled property
- Restore layout when the quick login option reappears

Enhancements:
- Add QuickLoginEnabled property and change listener in AccountsDBusProxy with signal emission
- Expose quickLoginEnabled getter and Q_PROPERTY in DBus proxy
- Initialize and update quick login visibility in AccountsWorker via model binding
- Propagate quickLoginVisible changes to AccountsController and expose isQuickLoginVisible Q_PROPERTY