### PR TITLE
fix: remove duplicate Numeric Keypad display names in keyboard settings

### DIFF
--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -199,7 +199,6 @@ DccObject {
     DccObject {
         name: "EditTesting"
         parentName: "RepeatRateGroup"
-        displayName: qsTr("Numeric Keypad")
         weight: 60
         visible: dccData.keyboardEnabled
         backgroundType: DccObject.Normal
@@ -220,7 +219,6 @@ DccObject {
     DccObject {
         name: "KeypadSettings"
         parentName: "KeyboardCommon"
-        displayName: qsTr("Numeric Keypad")
         weight: 70
         visible: dccData.keyboardEnabled
         pageType: DccObject.Item


### PR DESCRIPTION
- Removed redundant displayName properties to prevent duplicate entries in search results

Log: remove duplicate Numeric Keypad display names in keyboard settings
pms: BUG-305711

## Summary by Sourcery

Bug Fixes:
- Remove duplicate displayName properties for Numeric Keypad in Common.qml