### PR TITLE
fix: Fixed the wrong selection of the active color

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -641,8 +641,8 @@ DccObject {
                                 width: 228
                                 height: 148
                                 border.width: model.checkStatus ? 2 : 0
-                                border.color: "#6A005BFF"
-                                radius: 8
+                                border.color: parent.palette.highlight
+                                radius: 10
 
                                 color: "transparent"
 


### PR DESCRIPTION
Fixed the wrong selection of the active color

Log: Fixed the wrong selection of the active color
pms: BUG-319485

## Summary by Sourcery

Use palette.highlight for active border color and increase border radius

Bug Fixes:
- Bind the active border color to parent.palette.highlight instead of a hard-coded hex value

Enhancements:
- Adjust border corner radius from 8 to 10