### PR TITLE
fix: position regions chooser window at mouse click position

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -273,6 +273,7 @@ DccObject {
 
                 onClicked: function (mouse) {
                     if (!regionWndow.isVisible()) {
+                        regionWndow.mousePosition = mouseArea.mapToGlobal(mouse.x, mouse.y + rowlayout.implicitHeight)
                         regionWndow.show()
                     }
 

--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -12,6 +12,7 @@ Loader {
     required property var viewModel
     property int currentIndex: -1
     property string currentText
+    property point mousePosition: Qt.point(0, 0)
     signal selectedRegion(string region)
 
     function show() {
@@ -132,6 +133,10 @@ Loader {
 
     onLoaded: {
         item.show()
+        if (loader.mousePosition.x !== 0 || loader.mousePosition.y !== 0) {
+            item.x = loader.mousePosition.x
+            item.y = loader.mousePosition.y
+        }
         Qt.callLater(item.requestActivate);
     }
 }


### PR DESCRIPTION
- Added mouse position tracking to properly position the regions chooser window
- Updated RegionsChooserWindow to use the mouse coordinates for positioning

Log: position regions chooser window at mouse click position
pms: BUG-319409

## Summary by Sourcery

Position the regions chooser window at the user’s mouse click location in QML

Bug Fixes:
- Track mouse position on region selection click and pass it to RegionsChooserWindow
- Use the passed mouse coordinates to set the window’s x and y position when loading