### PR TITLE
fix: add shortcut clearing functionality in keyboard module

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -290,6 +290,17 @@ void KeyboardController::modifyShortcut(const QString &id, const QString &accels
     m_worker->modifyShortcutEdit(shortcut);
 }
 
+void KeyboardController::clearShortcut(const QString &id, const int &type)
+{
+    ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id, type](ShortcutInfo *info){ return id == info->id && type == info->type; });
+    if (!shortcut) {
+        qWarning() << "shortcut not found..." << id << type;
+        return;
+    }
+
+    m_worker->onDisableShortcut(shortcut);
+}
+
 void KeyboardController::resetAllShortcuts()
 {
     m_worker->resetAll();

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -68,6 +68,7 @@ public Q_SLOTS:
     void modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels);
     void modifyShortcut(const QString &id, const QString &accels, const int &type);
     void deleteCustomShortcut(const QString &id);
+    void clearShortcut(const QString &id, const int &type);
 
     void resetAllShortcuts();
 

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -187,6 +187,18 @@ DccObject {
                                     dccData.modifyShortcut(model.id, accels, model.type)
                             }
 
+                            function clearShortcut() {
+                                dccData.clearShortcut(model.id, model.type)
+
+                                focus = false
+                                keys = dccData.formatKeys("")
+                                conflictText.visible = false
+
+                                shortcutSettingsBody.conflictAccels = ""
+                                shortcutView.editItem = null
+                                shortcutView.conflictText = null
+                            }
+
                             function restore() {
                                 edit.keys = model.keySequence
                                 conflictText.visible = false
@@ -296,7 +308,7 @@ DccObject {
                         shortcutView.restoreShortcutView()
                     }
                     function onRequestClear() {
-                        onRequestRestore()
+                        shortcutView.editItem.clearShortcut()
                     }
                     function onKeyConflicted(oldAccels, newAccels) {
                         if (shortcutView.conflictText)


### PR DESCRIPTION
- Added clearShortcut method to KeyboardController to properly handle shortcut removal
- Implemented UI functionality to clear keyboard shortcuts
- Connected clear button action to the new clearing functionality

Log: add shortcut clearing functionality in keyboard module
pms: BUG-282461

## Summary by Sourcery

Implement keyboard shortcut clearing by introducing a clearShortcut API in the controller, wiring it to the UI, and correcting the clear button behavior.

New Features:
- Add clearShortcut method to KeyboardController and expose it to QML
- Provide UI support for clearing keyboard shortcuts and connect clear button to the new action

Bug Fixes:
- Fix clear button action to invoke clearShortcut instead of restoring the shortcut

Enhancements:
- Reset UI state after clearing a shortcut, including focus, key display, and conflict indicators