### PR TITLE
fix: round volume values to avoid floating point precision issues

### DIFF
--- a/src/plugin-sound/operation/sounddbusproxy.cpp
+++ b/src/plugin-sound/operation/sounddbusproxy.cpp
@@ -228,7 +228,9 @@ void SoundDBusProxy::SetVolumeSink(double in0, bool in1)
 {
     if (m_defaultSink) {
         QList<QVariant> argumentList;
-        argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
+        // Round in0 to 2 decimal places to avoid floating point precision issues
+        double roundedIn0 = qRound(in0 * 100.0) / 100.0;
+        argumentList << QVariant::fromValue(roundedIn0) << QVariant::fromValue(in1);
         m_defaultSink->asyncCallWithArgumentList(QStringLiteral("SetVolume"), argumentList);
     }
 }


### PR DESCRIPTION
- Added rounding to two decimal places for volume values to prevent floating point precision issues when setting volume to 110% but displaying as 109%.

Log: round volume values to avoid floating point precision issues
pms: BUG-299231

## Summary by Sourcery

Bug Fixes:
- Round volume input to two decimal places to avoid floating point precision issues when setting volume.