### PR TITLE
fix: prevent focus on keyboard shortcut edit buttons

### DIFF
--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -82,6 +82,7 @@ Control {
                     D.IconButton {
                         id: editButton
                         visible: control.showEditButtons
+                        focusPolicy: Qt.NoFocus
                         hoverEnabled: true
                         icon.name: "edit"
                         icon.width: 16
@@ -113,6 +114,7 @@ Control {
                     D.IconButton {
                         id: removeButton
                         visible: control.showEditButtons
+                        focusPolicy: Qt.NoFocus
                         hoverEnabled: true
                         icon.name: "user-trash-symbolic"
                         icon.width: 24


### PR DESCRIPTION
- Added Qt.NoFocus policy to edit and remove buttons in KeySequenceDisplay component.

Log: prevent focus on keyboard shortcut edit buttons
pms: BUG-321545

## Summary by Sourcery

Bug Fixes:
- Add Qt.NoFocus focus policy to edit and remove buttons to disable focus on those controls