### PR TITLE
chore: avoid hard-code compiler options in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,12 +105,6 @@ add_definitions(-DLOCALE_I18N_PATH="${LOCALE_I18N_PATH}")
 set(POSITION_INDEPENDENT_CODE True)
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
-string(REGEX REPLACE "-D_FORTIFY_SOURCE=[0-9]*" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}" )
-string(REGEX REPLACE "-D_FORTIFY_SOURCE=[0-9]*" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" )
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fstack-protector-all -D_FORTIFY_SOURCE=3  -Wall -Wl,--as-need -Wl,-E")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fstack-protector-all -D_FORTIFY_SOURCE=3  -Wall -Wl,--as-need -Wl,-E")
-set(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -z relro -z now -z noexecstack")
-ADD_DEFINITIONS(${SAFE_COMPILER})
 
 # Install settings
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)

--- a/dcc-old/CMakeLists.txt
+++ b/dcc-old/CMakeLists.txt
@@ -78,9 +78,6 @@ endif ()
 
 add_definitions(-DLOCALE_I18N_PATH="${LOCALE_I18N_PATH}")
 
-# 增加安全编译参数
-ADD_DEFINITIONS(${SAFE_COMPILER})
-
 # Install settings
 if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX /usr)

--- a/debian/rules
+++ b/debian/rules
@@ -3,8 +3,13 @@ include /usr/share/dpkg/default.mk
 export QT_SELECT = qt6
 VERSION = $(DEB_VERSION_UPSTREAM)
 PACK_VER = $(shell echo $(VERSION) | awk -F'[+_~-]' '{print $$1}')
+
+export DEB_BUILD_MAINT_OPTIONS = hardening=+all
+export DEB_CFLAGS_MAINT_APPEND = -Wall -Wl,-E
+export DEB_CXXFLAGS_MAINT_APPEND = -Wall -Wl,-E
+export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed -Wl,-z,relro -Wl,-z,now -Wl,-z,noexecstack
+
 %:
 	dh $@ --parallel
 override_dh_auto_configure:
 	dh_auto_configure -- -DCVERSION=$(DEB_VERSION_UPSTREAM) -DDVERSION=$(PACK_VER) -DUSE_DEEPIN_ZONE=ON
-


### PR DESCRIPTION
避免在 CMakeLists.txt 中硬编码编译选项。暂时移至 debian/rules 中。

Related: PMS-309221

cc @felixonmars

## Summary by Sourcery

Remove hard-coded compiler and linker flags from CMakeLists files and relocate security compiler options into the Debian packaging rules.

Chores:
- Remove statically defined -fstack-protector, _FORTIFY_SOURCE, warning, and linker flags from CMakeLists.txt and dcc-old/CMakeLists.txt
- Move security and compiler option definitions into debian/rules