### PR TITLE
fix: preserve balance when toggling mono audio and adjust UI weights

### DIFF
--- a/src/plugin-sound/operation/sounddbusproxy.cpp
+++ b/src/plugin-sound/operation/sounddbusproxy.cpp
@@ -343,16 +343,18 @@ bool SoundDBusProxy::audioMono()
 
 void SoundDBusProxy::setAudioMono(bool audioMono)
 {
+    double oldBalance = balanceSink();
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(audioMono);
     QDBusPendingCall call = m_audioInter->asyncCallWithArgumentList(QStringLiteral("SetMono"), argumentList);
 
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, call, watcher] {
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, call, watcher, oldBalance] {
         if (call.isError()) {
             qWarning() << " set Audio Mono error: " << call.error().message();
         }
         Q_EMIT AudioMonoChanged(this->audioMono());
         watcher->deleteLater();
+        SetBalanceSink(oldBalance,true);
     });
 }

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -148,8 +148,9 @@ DccObject {
             name: "volumeBalance"
             parentName: "sound/outPut/outputGroup"
             displayName: qsTr("Left Right Balance")
-            weight: 30
+            weight: 40
             pageType: DccObject.Editor
+            visible: !dccData.model().audioMono
             page: RowLayout {
                 Label {
                     Layout.alignment: Qt.AlignVCenter
@@ -187,7 +188,7 @@ DccObject {
             parentName: "sound/outPut/outputGroup"
             displayName: qsTr("Mono audio")
             description: qsTr("Merge left and right channels into a single channel")
-            weight: 40
+            weight: 30
             pageType: DccObject.Editor
             page: Switch {
                 checked: dccData.model().audioMono


### PR DESCRIPTION
- Store previous balance value before enabling mono audio
- Restore balance after mono audio state changes
- Adjust weight values for balance and mono controls
- Add visibility condition for balance control based on mono state

Log: resolve audio balance preservation issues
pms: BUG-294273

## Summary by Sourcery

Preserve user-defined left-right audio balance when toggling mono audio and improve control ordering and visibility in the UI.

Bug Fixes:
- Store and restore the previous balance value when mono audio is enabled or disabled to prevent balance reset

Enhancements:
- Increase the weight of the balance control and decrease the weight of the mono audio toggle for improved layout
- Hide the balance control when mono audio is active