### PR TITLE
fix: Modify the issue of incomplete text display in Crumb

### DIFF
--- a/qml/Crumb.qml
+++ b/qml/Crumb.qml
@@ -80,7 +80,6 @@ FocusScope {
                     hoverEnabled: enabled
                     onImplicitWidthChanged: root.updateLayout()
                     contentItem: RowLayout {
-                        clip: true
                         spacing: 6
                         DccLabel {
                             Layout.fillWidth: true
@@ -147,7 +146,6 @@ FocusScope {
                     onImplicitWidthChanged: root.updateLayout()
                     contentItem: DccLabel {
                         text: model.display
-                        clip: true
                         elide: Text.ElideLeft
                         color: parent.palette.highlight
                     }


### PR DESCRIPTION
Modify the issue of incomplete text display in Crumb

pms: BUG-321405

## Summary by Sourcery

Fix incomplete text display in Crumb by removing hard clipping from label containers to allow proper text elision and full rendering.

Bug Fixes:
- Remove 'clip: true' from the RowLayout contentItem to prevent cutting off label text.
- Remove 'clip: true' from the DccLabel in the crumb display to restore complete text visibility.