### PR TITLE
fix: resolve oversized edit button font in language settings

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -36,7 +36,7 @@ DccObject {
                 id: button
                 checkable: true
                 visible: langRepeater.count > 1
-                font.pointSize: 12
+                font.pixelSize: DTK.fontManager.t8.pixelSize
                 checked: languageListTiltle.isEditing
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                 Layout.rightMargin: 10


### PR DESCRIPTION
- Replace static font.pointSize with dynamic font.pixelSize
- Implement DTK.fontManager.t8.pixelSize for consistent text scaling
- Preserve original layout alignment properties

Log: Fix oversized edit button font in language format settings
pms: BUG-321625

## Summary by Sourcery

Use dynamic pixel-based font sizing for the edit button in language settings to resolve oversized text and maintain original layout alignment.

Bug Fixes:
- Fix oversized edit button font in language format settings

Enhancements:
- Replace static font.pointSize with DTK.fontManager.t8.pixelSize for consistent text scaling