### PR TITLE
fix: Fixed the issue that custom avatars were displayed incorrectly

### DIFF
--- a/src/plugin-accounts/qml/AvatarSettingsDialog.qml
+++ b/src/plugin-accounts/qml/AvatarSettingsDialog.qml
@@ -175,6 +175,10 @@ D.DialogWindow {
                             scrollView.sections = sections.length > 0 ? sections : [""]
                             scrollView.filter = model.filter
                             scrollView.ScrollBar.vertical.position = 0
+                            
+                            if (dialog.currentAvatar && dialog.currentAvatar.indexOf("/icons/local/") === -1) {
+                                dialog.currentAvatar = ""
+                            }
                         }
                     }
                 }
@@ -226,7 +230,6 @@ D.DialogWindow {
                         iconSource: dialog.currentAvatar
                         onCroppedImage: function(file) {
                             dialog.currentAvatar = file
-                            dialog.accepted();
                         }
                     }
 


### PR DESCRIPTION
Fixed the issue that custom avatars were displayed incorrectly

Log: Fixed the issue that custom avatars were displayed incorrectly
pms: BUG-298675

## Summary by Sourcery

Fix the custom avatar display by validating avatar source paths and preventing premature dialog acceptance when cropping.

Bug Fixes:
- Clear currentAvatar when its path isn’t under "/icons/local/" to avoid displaying invalid custom avatars
- Remove automatic dialog.accepted() call in onCroppedImage handler to prevent unintended avatar confirmation