### PR TITLE
fix(power): The first modification of custom shutdown does not take e…

### DIFF
--- a/src/plugin-power/operation/powermodel.h
+++ b/src/plugin-power/operation/powermodel.h
@@ -195,6 +195,7 @@ public:
 
     inline int shutdownRepetition() const { return m_shutdownRepetition; }
     void setShutdownRepetition(int repetition);
+    Q_INVOKABLE void refreshShutdownRepetition() { Q_EMIT shutdownRepetitionChanged(m_shutdownRepetition); }
 
     inline int weekBegins() const { return m_weekBegins; }
     void setWeekBegins(int value);

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -265,14 +265,15 @@ DccObject {
                     id: selectDayDialogforCombobox
 
                     onCancel: {
-                        shutdownRepetitionCombobox.currentIndex = dccData.model.shutdownRepetition
+                        // 通过Q_INVOKABLE方法触发信号更新，直接赋值currentIndex会导致属性绑定失效
+                        dccData.model.refreshShutdownRepetition()
                     }
 
                     onAccept: {
-                        if (shutdownRepetitionCombobox.currentIndex === dccData.model.shutdownRepetition) {
+                        if (dccData.model.shutdownRepetition === 3) {
                             return
                         }
-                        dccData.worker.setShutdownRepetition(shutdownRepetitionCombobox.currentIndex)
+                        dccData.worker.setShutdownRepetition(3)
                     }
                 }
             }


### PR DESCRIPTION
…ffect

update shutdown repetition handling and refresh logic

- Add Q_INVOKABLE `refreshShutdownRepetition` to trigger signal updates
- Modify dialog cancel/accept logic to use refresh method
- Hardcode shutdown repetition value to 3 in accept handler
- Ensure UI consistency when canceling repetition selection

pms: BUG-320743

## Summary by Sourcery

Ensure custom shutdown repetition updates are applied immediately by adding an explicit refresh mechanism and simplifying the dialog logic.

Bug Fixes:
- Fix initial custom shutdown repetition change not taking effect

Enhancements:
- Add Q_INVOKABLE refreshShutdownRepetition in PowerModel to re-emit shutdownRepetitionChanged and restore combobox binding on dialog cancel
- Simplify dialog accept logic by hardcoding shutdown repetition to 3 and preventing redundant updates to maintain UI consistency