### PR TITLE
fix: Modify the button style

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -21,7 +21,10 @@ DccObject {
         page: Label {
             leftPadding: 5
             bottomPadding: 5
-            font: DTK.fontManager.t4
+            font.pixelSize: DTK.fontManager.t5.pixelSize
+            font.weight: 500
+            color: DTK.themeType === ApplicationHelper.LightType ?
+                    Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
             text: dccObj.displayName
         }
     }
@@ -569,6 +572,7 @@ DccObject {
                 }
             }
         }
+        onParentItemChanged: item => { if (item) item.bottomPadding = 0 }
     }
 
     DccObject {
@@ -579,19 +583,30 @@ DccObject {
         weight: 60
         pageType: DccObject.Item
         page: ColumnLayout {
+            Layout.topMargin: 0
+            Layout.bottomMargin: 0
             spacing: 0
             Label {
                 leftPadding: 5
-                topPadding: 20
-                font: DTK.fontManager.t4
+                topPadding: 10
+                font.pixelSize: DTK.fontManager.t5.pixelSize
+                font.weight: 500
+                color: DTK.themeType === ApplicationHelper.LightType ?
+                        Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
                 text: dccObj.displayName
             }
             Label {
                 leftPadding: 5
                 bottomPadding: 5
-                font: DTK.fontManager.t6
+                font: DTK.fontManager.t8
                 text: dccObj.description
                 opacity: 0.7
+            }
+        }
+        onParentItemChanged: item => { 
+            if (item) {
+                item.topPadding = 0
+                item.bottomPadding = 0
             }
         }
     }

--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -282,18 +282,21 @@ DccObject {
             displayName: qsTr("Authorization") + ":"
             visible: dccData.systemInfoMode().showAuthorization()
             page: RowLayout {
+                spacing: 8
                 Label {
+                    id: jihuo
                     color: dccData.systemInfoMode().licenseStatusColor
                     horizontalAlignment: Text.AlignLeft
                     text: dccData.systemInfoMode().licenseStatusText
                 }
 
-                ToolButton {
+                Button {
                     text: dccData.systemInfoMode().licenseActionText
                     ColorSelector.family: Palette.CommonColor
+                    implicitHeight: 30
+                    implicitWidth: 50
                     flat: false
                     visible: dccData.systemInfoMode().showDetail
-                    opacity: 0.7
                     onClicked: {
                         dccData.systemInfoWork().showActivatorDialog()
                     }


### PR DESCRIPTION
Modify the button style

Log: Modify the button style
pms: BUG-304889

## Summary by Sourcery

Refine button appearance and layout consistency across QML pages by adjusting font sizes, weights, colors, paddings, and spacing, and replacing the old ToolButton with the updated Button component.

Enhancements:
- Standardize button usage in NativeInfoPage by swapping out ToolButton for Button with defined implicit sizes and added spacing.
- Adjust label font pixel sizes, weights, and theme-dependent colors in BootPage and detail pages for improved readability.
- Remove default top/bottom paddings and set explicit layout margins and spacings to streamline page layouts.