### PR TITLE
fix: Add image caching processing

### DIFF
--- a/qml/DccWindow.qml
+++ b/qml/DccWindow.qml
@@ -71,7 +71,7 @@ D.ApplicationWindow {
         autoHideOnFullscreen: true
         focus: true
         leftContent: D.ActionButton {
-            property D.Palette textColor: parent.textColor
+            textColor: parent.textColor
             palette.windowText: D.ColorSelector.textColor
             anchors {
                 verticalCenter: parent.verticalCenter
@@ -128,7 +128,7 @@ D.ApplicationWindow {
             }
             D.ActionButton {
                 id: breakBut
-                property D.Palette textColor: parent.textColor
+                textColor: parent.textColor
                 palette.windowText: D.ColorSelector.textColor
                 implicitHeight: 30
                 implicitWidth: 30

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -5,6 +5,7 @@ set(DCCFrame_Name ${DCC_FRAME_Library})
 file(GLOB DCCFrame_SRCS
     "${DCC_PROJECT_ROOT_DIR}/include/*.h"
     "frame/*.cpp"
+    "frame/*.h"
 )
 
 add_library(${DCCFrame_Name} SHARED

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -4,6 +4,7 @@
 #include "dccmanager.h"
 
 #include "dccapp.h"
+#include "dccimageprovider.h"
 #include "dccobject_p.h"
 #include "navigationmodel.h"
 #include "pluginmanager.h"
@@ -52,6 +53,7 @@ DccManager::DccManager(QObject *parent)
     , m_engine(nullptr)
     , m_navModel(new NavigationModel(this))
     , m_searchModel(new SearchModel(this))
+    , m_imageProvider(nullptr)
     , m_showTimer(nullptr)
 {
     m_hideObjects->setName("_hide");
@@ -102,6 +104,8 @@ void DccManager::init()
     auto paths = m_engine->importPathList();
     paths.prepend(DefaultModuleDirectory);
     m_engine->setImportPathList(paths);
+    m_imageProvider = new DccImageProvider();
+    m_engine->addImageProvider("DccImage", m_imageProvider);
     QStringList dciPaths = Dtk::Gui::DIconTheme::dciThemeSearchPaths();
     dciPaths << QStringLiteral(DefaultModuleDirectory);
     Dtk::Gui::DIconTheme::setDciThemeSearchPaths(dciPaths);
@@ -376,6 +380,13 @@ QAbstractItemModel *DccManager::navModel() const
 QSortFilterProxyModel *DccManager::searchModel() const
 {
     return m_searchModel;
+}
+
+void DccManager::cacheImage(const QString &id, const QSize &thumbnailSize)
+{
+    if (m_imageProvider) {
+        m_imageProvider->cacheImage(id, thumbnailSize);
+    }
 }
 
 void DccManager::show()
@@ -898,6 +909,7 @@ void DccManager::clearData()
     if (m_plugins->isDeleting()) {
         return;
     }
+    m_imageProvider = nullptr;
     m_plugins->beginDelete();
     clearShowParam();
 

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -23,6 +23,7 @@ namespace dccV25 {
 class NavigationModel;
 class SearchModel;
 class PluginManager;
+class DccImageProvider;
 
 class DccManager : public DccApp, protected QDBusContext
 {
@@ -65,6 +66,7 @@ public Q_SLOTS:
     QWindow *mainWindow() const override;
     QAbstractItemModel *navModel() const override;
     QSortFilterProxyModel *searchModel() const override;
+    void cacheImage(const QString &id, const QSize &thumbnailSize = QSize());
 
     void show();
     void showHelp();
@@ -123,6 +125,7 @@ private:
     QQmlApplicationEngine *m_engine;
     NavigationModel *m_navModel;
     SearchModel *m_searchModel;
+    DccImageProvider *m_imageProvider;
     // DBus调用时，对应项还没加载完成，此处保存跳转参数
     QTimer *m_showTimer;
     QString m_showUrl;

--- a/src/dde-control-center/frame/dccimageprovider.cpp
+++ b/src/dde-control-center/frame/dccimageprovider.cpp
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "dccimageprovider.h"
+
+#include <QMutexLocker>
+
+namespace dccV25 {
+const QSize THUMBNAIL_ICON_SIZE(400, 300);
+
+class CacheImageResponse : public QQuickImageResponse
+{
+public:
+    CacheImageResponse(const QString &id, const QSize &requestedSize, DccImageProvider *provider)
+        : QQuickImageResponse()
+    {
+        QImage *img = provider->cacheImage(id, QSize(), this, requestedSize);
+        if (img) {
+            setImage(img, requestedSize);
+        }
+    }
+
+    QQuickTextureFactory *textureFactory() const override { return QQuickTextureFactory::textureFactoryForImage(m_image); }
+
+    void setImage(QImage *image, const QSize &requestedSize)
+    {
+        m_image = requestedSize.isValid() ? image->scaled(requestedSize) : *image;
+        Q_EMIT finished();
+    }
+
+private:
+    QImage m_image;
+};
+
+class ImageTask : public QRunnable
+{
+public:
+    explicit ImageTask(const QString &id, const QSize &thumbnailSize, DccImageProvider *provider, CacheImageResponse *response, const QSize &requestedSize)
+        : QRunnable()
+        , m_id(id)
+        , m_size(thumbnailSize.isValid() ? thumbnailSize : THUMBNAIL_ICON_SIZE)
+        , m_requestedSize(requestedSize)
+        , m_provider(provider)
+        , m_response(response)
+    {
+    }
+
+protected:
+    void run() override;
+
+protected:
+    QString m_id;
+    QSize m_size;
+    QSize m_requestedSize;
+    DccImageProvider *m_provider;
+    CacheImageResponse *m_response;
+};
+
+void ImageTask::run()
+{
+    QImage *image = new QImage();
+    QUrl url(m_id);
+    if (image->load(url.toLocalFile())) {
+        *image = image->scaled(m_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        if (m_provider->insert(m_id, image) && m_response) {
+            m_response->setImage(image, m_requestedSize);
+        }
+    } else {
+        delete image;
+    }
+}
+
+DccImageProvider::DccImageProvider()
+    : QQuickAsyncImageProvider()
+    , m_cache(80)
+    , m_threadPool(new QThreadPool(this))
+{
+}
+
+QImage *DccImageProvider::cacheImage(const QString &id, const QSize &thumbnailSize)
+{
+    return cacheImage(id, thumbnailSize, nullptr, QSize());
+}
+
+QImage *DccImageProvider::cacheImage(const QString &id, const QSize &thumbnailSize, CacheImageResponse *response, const QSize &requestedSize)
+{
+    QMutexLocker<QMutex> locker(&m_mutex);
+    if (m_cache.contains(id)) {
+        return m_cache.object(id);
+    }
+    m_threadPool->start(new ImageTask(id, thumbnailSize, this, response, requestedSize));
+    return nullptr;
+}
+
+QQuickImageResponse *DccImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize)
+{
+    return new CacheImageResponse(id, requestedSize, this);
+}
+
+bool DccImageProvider::insert(const QString &id, QImage *img)
+{
+    QMutexLocker<QMutex> locker(&m_mutex);
+    return m_cache.insert(id, img);
+}
+
+} // namespace dccV25

--- a/src/dde-control-center/frame/dccimageprovider.h
+++ b/src/dde-control-center/frame/dccimageprovider.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef DCCIMAGEPROVIDER_H
+#define DCCIMAGEPROVIDER_H
+#include <QCache>
+#include <QMutex>
+#include <QObject>
+#include <QQuickAsyncImageProvider>
+#include <QThreadPool>
+
+namespace dccV25 {
+class CacheImageResponse;
+
+class DccImageProvider : public QQuickAsyncImageProvider
+{
+    Q_OBJECT
+public:
+    explicit DccImageProvider();
+
+    QImage *cacheImage(const QString &id, const QSize &thumbnailSize);
+    QImage *cacheImage(const QString &id, const QSize &thumbnailSize, CacheImageResponse *response, const QSize &requestedSize);
+    bool insert(const QString &id, QImage *img);
+
+    QQuickImageResponse *requestImageResponse(const QString &id, const QSize &requestedSize) override;
+
+private:
+    QCache<QString, QImage> m_cache;
+    QThreadPool *m_threadPool;
+    QMutex m_mutex;
+};
+} // namespace dccV25
+#endif // DCCIMAGEPROVIDER_H

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -140,6 +140,7 @@ void DisplayModulePrivate::updateVirtualScreens()
         DccScreen *screen = DccScreenPrivate::New(monitors, m_worker, q_ptr);
         q_ptr->connect(screen, &DccScreen::rotateChanged, q_ptr, &DisplayModule::applyChanged, Qt::QueuedConnection);
         q_ptr->connect(screen, &DccScreen::currentModeChanged, q_ptr, &DisplayModule::applyChanged, Qt::QueuedConnection);
+        q_ptr->connect(screen, &DccScreen::wallpaperChanged, q_ptr, &DisplayModule::wallpaperChanged);
         m_virtualScreens << screen;
     }
     if (changed) {

--- a/src/plugin-display/operation/displaymodule.h
+++ b/src/plugin-display/operation/displaymodule.h
@@ -74,6 +74,7 @@ Q_SIGNALS:
     void colorTemperatureModeChanged();
     void colorTemperatureChanged();
     void customColorTempTimePeriodChanged();
+    void wallpaperChanged();
 
 private:
     QScopedPointer<DisplayModulePrivate> d_ptrDisplayModule;

--- a/src/plugin-display/qml/ScreenItem.qml
+++ b/src/plugin-display/qml/ScreenItem.qml
@@ -24,7 +24,7 @@ Rectangle {
     Image {
         id: image
         anchors.fill: parent
-        source: screen.wallpaper
+        source: "image://DccImage/" + screen.wallpaper
         mipmap: true
         fillMode: Image.PreserveAspectCrop
         asynchronous: true

--- a/src/plugin-display/qml/displayMain.qml
+++ b/src/plugin-display/qml/displayMain.qml
@@ -137,10 +137,27 @@ DccObject {
             isGroup: false
         }
         DccObject {
+            id: groundObj
+            function cacheImage() {
+                for (var i = 0; i < dccData.virtualScreens.length; i++) {
+                    var screen = dccData.virtualScreens[i]
+                    DccApp.cacheImage(screen.wallpaper)
+                }
+            }
+            Connections {
+                target: dccData
+                function onVirtualScreensChanged() {
+                    groundObj.cacheImage()
+                }
+                function onWallpaperChanged() {
+                    groundObj.cacheImage()
+                }
+            }
             name: "monitorsGround"
             parentName: "monitorControl"
             weight: 10
             enabled: dccData.virtualScreens.length > 1
+            Component.onCompleted: cacheImage()
             pageType: DccObject.Item
             page: Item {
                 id: monitorsGround


### PR DESCRIPTION
Add image caching processing

pms: BUG-315789

DccImageProvider使用线程加载图片并缓存，使用时在Image的source加上"image://DccImage/"前缀即可

## Summary by Sourcery

Enable threaded wallpaper image caching and retrieval by integrating a new DccImageProvider into the QML engine and updating display components to preload and use cached images for virtual screens.

New Features:
- Introduce DccImageProvider for asynchronous, threaded image loading and caching.

Enhancements:
- Preload and cache wallpaper images for virtual screens on startup and when wallpaper settings change.
- Update QML wallpaper Image sources to use the "image://DccImage/" cache provider prefix.

Build:
- Include DccImageProvider headers in the CMake build file.

Chores:
- Remove redundant property wrapper declarations in DccWindow.qml.