### PR TITLE
fix: Fix symbolic link error

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothworker.cpp
+++ b/src/plugin-bluetooth/operation/bluetoothworker.cpp
@@ -316,3 +316,9 @@ void BluetoothWorker::showBluetoothTransDialog(const QString &address, const QSt
 
     m_bluetoothDBusProxy->showBluetoothTransDialog(address, fileList);
 }
+
+void BluetoothWorker::ignoreDevice(const BluetoothAdapter *adapter, const BluetoothDevice *device)
+{
+    Q_UNUSED(adapter)
+    Q_UNUSED(device)
+}

--- a/src/plugin-datetime/operation/keyboard/metadata.cpp
+++ b/src/plugin-datetime/operation/keyboard/metadata.cpp
@@ -76,9 +76,3 @@ bool MetaData::operator >(const MetaData &md) const
     int x = QString::compare(m_pinyin, md.m_pinyin, Qt::CaseInsensitive);
     return x > 0;
 }
-
-QDebug &operator<<(QDebug dbg, const MetaData &md)
-{
-    dbg.nospace() << QString("key: %1, text: %2").arg(md.key(), md.text());
-    return dbg.maybeSpace();
-}

--- a/src/plugin-datetime/operation/keyboard/metadata.h
+++ b/src/plugin-datetime/operation/keyboard/metadata.h
@@ -36,10 +36,7 @@ private:
     QString m_pinyin;
     bool m_section;
     bool m_selected;
-    friend QDebug &operator<<(QDebug dbg, const MetaData &md);
 };
-
-QDebug &operator<<(QDebug dbg, const MetaData &md);
 
 }
 Q_DECLARE_METATYPE(dccV25::MetaData)

--- a/src/plugin-sound/operation/soundmodel.cpp
+++ b/src/plugin-sound/operation/soundmodel.cpp
@@ -714,3 +714,9 @@ void SoundModel::setOutPutPortCombo(const QStringList& outPutPort)
     Q_EMIT outPutPortComboChanged(m_outPutPortCombo);
 }
 
+QString SoundModel::getListName(int index) const
+{
+    Q_UNUSED(index)
+    return QString();
+}
+


### PR DESCRIPTION
Fix symbolic link error

Log: Fix symbolic link error

## Summary by Sourcery

Resolve linker errors by stubbing missing plugin methods and removing duplicate debug operator

Bug Fixes:
- Add no-op implementations for BluetoothWorker::ignoreDevice and SoundModel::getListName to satisfy missing symbols
- Comment out the QDebug operator<< overload for MetaData to eliminate duplicate symbol conflicts