### PR TITLE
fix: The fingerprint animation is too small

### DIFF
--- a/src/plugin-authentication/qml/AddFingerDialog.qml
+++ b/src/plugin-authentication/qml/AddFingerDialog.qml
@@ -145,7 +145,7 @@ D.DialogWindow {
                         anchors.centerIn: parent
                         name: dccData.fingertipImagePath
                         retainWhileLoading: true
-                        sourceSize: Qt.size(100, 100)
+                        sourceSize: Qt.size(150, 150)
                     }
                 }
 


### PR DESCRIPTION
Increase fingerprint image size in AddFingerDialog

Update sourceSize from 100x100 to 150x150 for better visibility of the fingerprint image during enrollment. The larger size improves user experience when verifying fingerprint input.

pms: BUG-317119

## Summary by Sourcery

Bug Fixes:
- Increase fingerprint image size from 100x100 to 150x150 for better fingerprint animation visibility