### PR TITLE
chore: bump version to 6.1.34

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-control-center (6.1.34) unstable; urgency=medium
+
+  * refactor: clean up code and optimize variable declarations
+  * fix: The fingerprint animation is too small
+  * feat: Add development and debugging options to the community version
+
+ -- caixiangrong <caixiangrong@uniontech.com>  Fri, 04 Jul 2025 09:28:25 +0800
+
 dde-control-center (6.1.33) unstable; urgency=medium
 
   * fix: Fix symbolic link error


### PR DESCRIPTION
update changelog to 6.1.34

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version bump to 6.1.34