### PR TITLE
fix: prevent bottom clipping at maximum font size

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -91,6 +91,13 @@ DccObject {
             pageType: DccObject.Editor
             property bool showCustom: false
             property string customAddr
+
+            onParentItemChanged: item => {
+                if (item) {
+                    item.rightPadding = DS.Style.comboBox.spacing
+                }
+            }
+
             page: Item {
                 implicitHeight: 36
                 implicitWidth: dccData.ntpEnabled ? 280 : 80
@@ -99,6 +106,7 @@ DccObject {
                     id: comboBox
                     property var serverList: dccData.ntpServerList
                     flat: true
+                    padding: 0
                     visible: dccData.ntpEnabled
                     anchors.fill: parent
                     hoverEnabled: true
@@ -311,6 +319,13 @@ DccObject {
         weight: 12
         backgroundType: DccObject.Normal
         pageType: DccObject.Editor
+
+        onParentItemChanged: item => {
+            if (item) {
+                item.rightPadding = DS.Style.comboBox.spacing
+            }
+        }
+
         page: Item {
             id: systemTimezoneItem
             implicitWidth: rowlayout.implicitWidth


### PR DESCRIPTION
- Add dynamic padding adjustment for comboBox items
- Optimize layout spacing in TimeAndDate component

Log: Fix text bottom clipping issue when using maximum English font size
pms: BUG-322093

## Summary by Sourcery

Prevent bottom clipping of text at maximum font size in the TimeAndDate component by dynamically adjusting comboBox padding and optimizing layout spacing.

Enhancements:
- Add onParentItemChanged handlers to apply style-based rightPadding to comboBox container items
- Set comboBox padding to zero to align with updated spacing rules