### PR TITLE
fix: prevent duplicate shortcut conflict errors

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -46,7 +46,7 @@ KeyboardController::KeyboardController(QObject *parent)
             // have conflict
             if (conflict) {
                 // self conflict
-                if (conflict == current && conflict->accels == current->accels) {
+                if (current == nullptr || (conflict == current && conflict->accels == current->accels)) {
                     Q_EMIT requestRestore();
                     return;
                 }

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -164,7 +164,7 @@ D.DialogWindow {
         Connections {
             target: dccData
             function onRequestRestore() {
-                edit.keys = [qsTr("None")]
+                edit.keys = ddialog.keySequence
                 conflictText.text = ""
             }
             function onRequestClear() {


### PR DESCRIPTION
- Add null check for current shortcut in keyboard controller conflict detection
- Restore original key sequence in dialog when resolving self-conflict

Log: fix abnormal conflict alerts when modifying to same shortcut key
pms: BUG-322875

## Summary by Sourcery

Prevent duplicate shortcut conflict errors when modifying a shortcut to its current value and restore the original key sequence in the conflict resolution dialog.

Bug Fixes:
- Add null check for the current shortcut in conflict detection to avoid self-conflict errors.
- Restore the original key sequence in the shortcut setting dialog when resolving a self-conflict instead of showing “None”