### PR TITLE
fix: fix region and format panel layout in TimeAndDate dialog

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -23,7 +23,8 @@ Loader {
 
     sourceComponent: DialogWindow {
         id: ddialog
-        width: 640
+        width: 738
+        height: 636
         minimumWidth: width
         minimumHeight: height
         maximumWidth: minimumWidth
@@ -41,6 +42,8 @@ Loader {
 
             RowLayout {
                 ColumnLayout {
+                    Layout.preferredWidth: 348
+                    Layout.maximumWidth: 348
                     SearchEdit {
                         id: searchEdit
                         Layout.fillWidth: true
@@ -128,7 +131,8 @@ Loader {
 
                 ColumnLayout {
                     Layout.fillHeight: true
-                    width: 300
+                    Layout.preferredWidth: 348
+                    Layout.maximumWidth: 348
                     spacing: 0
                     Label {
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop | Qt.H


### PR DESCRIPTION
- Set fixed dialog dimensions (738x636) for stable container
- Apply fixed width constraints (348px) on left/right columns
- Ensure both region list and format preview maintain fixed positions

Log: resolve display issues in TimeAndDate component
pms: BUG-321937

## Summary by Sourcery

Ensure consistent layout in the TimeAndDate RegionFormatDialog by fixing its dimensions and constraining panel widths.

Bug Fixes:
- Set the dialog to fixed dimensions (738×636) to prevent unintended resizing.
- Apply fixed 348px width constraints on both left and right columns.
- Lock the region list and format preview panels in place to resolve display issues.