### PR TITLE
fix: Fixed the user group focus issue

### DIFF
--- a/src/plugin-accounts/operation/accountlistmodel.cpp
+++ b/src/plugin-accounts/operation/accountlistmodel.cpp
@@ -94,6 +94,7 @@ GroupListModel::GroupListModel(const QString &id, QObject *parent)
             if (m_groups.count() > 1 && m_groups.last().isEmpty())
                 return;
 
+            m_isCreatingGroup = true;
             int index = m_groups.count();
             beginInsertRows(QModelIndex(), index, index);
             m_groups << "";
@@ -135,29 +136,11 @@ void GroupListModel::updateGroups(const QStringList &groups) {
     if (m_groups == groups)
         return;
 
-    int oldSize = m_groups.size();
-    int newSize = groups.size();
-    int minSize = qMin(oldSize, newSize);
-    
-    for (int i = 0; i < minSize; ++i) {
-        if (m_groups[i] != groups[i]) {
-            m_groups[i] = groups[i];
-            emit dataChanged(index(i), index(i));
-        }
-    }
-    
-    if (newSize > oldSize) {
-        beginInsertRows(QModelIndex(), oldSize, newSize - 1);
-        for (int i = oldSize; i < newSize; ++i) {
-            m_groups.append(groups[i]);
-        }
-        endInsertRows();
-    }
-    else if (oldSize > newSize) {
-        beginRemoveRows(QModelIndex(), newSize, oldSize - 1);
-        m_groups = groups;
-        endRemoveRows();
-    }
+    beginResetModel();
+    m_groups = groups;
+    endResetModel();
+
+    Q_EMIT groupsUpdated();
 }
 
 int GroupListModel::rowCount(const QModelIndex &) const

--- a/src/plugin-accounts/operation/accountlistmodel.h
+++ b/src/plugin-accounts/operation/accountlistmodel.h
@@ -26,6 +26,8 @@ public:
 
 class GroupListModel : public QAbstractListModel
 {
+    Q_OBJECT
+    Q_PROPERTY(bool isCreatingGroup READ isCreatingGroup WRITE setCreatingGroup)
 public:
     explicit GroupListModel(const QString &id, QObject *parent = nullptr);
     enum GroupListRole {
@@ -44,9 +46,16 @@ public:
     virtual int rowCount(const QModelIndex &parent) const override;
     virtual QVariant data(const QModelIndex &index, int role) const override;
     virtual QHash<int, QByteArray> roleNames() const override;
+    
+    bool isCreatingGroup() const { return m_isCreatingGroup; }
+    Q_INVOKABLE void setCreatingGroup(const bool &isCreatingGroup) { m_isCreatingGroup = isCreatingGroup; }
+
+signals:
+    void groupsUpdated();
 private:
     QString m_userId;
     QStringList m_groups;
+    bool m_isCreatingGroup = false;
 };
 
 }

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -631,11 +631,36 @@ DccObject {
         page: ListView {
             id: groupview
             property int lrMargin: DccUtils.getMargin(width)
+            property int conY: 0
             spacing: 0
             currentIndex: -1
             activeFocusOnTab: false
             keyNavigationEnabled: false
             clip: false
+
+            function qmlListModelUpdata() {
+                if (model && model.isCreatingGroup) {
+                    model.setCreatingGroup(false)
+                    Qt.callLater(function () {
+                        groupview.positionViewAtEnd()
+                    })
+                } else {
+                    groupview.contentY = conY
+                }
+            }
+
+            Connections {
+                target: model
+                function onGroupsUpdated() {
+                    qmlListModelUpdata()
+                }
+            }
+
+            onContentYChanged: {
+                if(contentY != -50) {
+                    conY = contentY
+                }
+            }
             anchors {
                 left: parent ? parent.left : undefined
                 right: parent ? parent.right : undefined
@@ -806,7 +831,8 @@ DccObject {
                                 if (model.display.length < 1) {
                                     dccData.requestClearEmptyGroup(settings.userId)
                                 } else {
-                                    text = model.display
+                                    var elidedText = metrics.elidedText(model.display, Text.ElideRight, editTextWidth)
+                                    text = elidedText
                                 }
                                 return
                             }


### PR DESCRIPTION
Fixed the user group focus issue

Log: Fixed the user group focus issue
pms: BUG-321215

## Summary by Sourcery

Fix user group focus issue by simplifying group model updates, introducing a creation flag to trigger auto-scrolling on new groups, preserving and restoring ListView scroll position, and applying text elision to group names.

Bug Fixes:
- Ensure the group list view scrolls to new entries on creation and retains its previous scroll position.

Enhancements:
- Simplify GroupListModel::updateGroups by resetting the entire model and emitting a groupsUpdated signal.
- Add an isCreatingGroup Q_PROPERTY and signal to flag new group insertions for auto-scroll behavior.
- Implement QML logic to store and restore ListView contentY and scroll to the end when a new group is created.
- Enable right-side elision of group names in the UI to prevent text overflow.