### PR TITLE
fix: prevent bottom button occlusion in RegionFormatDialog

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -65,7 +65,7 @@ Loader {
                         property string selectedLangKey: ""
                         property string selectedLocaleKey: ""
                         Layout.fillWidth: true
-                        height: 500
+                        Layout.fillHeight: true
                         clip: true
                         model: regionFormatLoader.viewModel
                         currentIndex: regionFormatLoader.currentIndex


### PR DESCRIPTION
- Replace fixed height property with Layout.fillHeight for dynamic vertical allocation
- Optimize scroll area layout constraints to ensure button visibility
- Adjust content margins to maintain proper spacing

Log: Fix bottom button being obscured in region format selection dialog
pms: BUG-321937