### PR TITLE
fix: hide balance control for handsfree devices

### DIFF
--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -151,7 +151,9 @@ DccObject {
             displayName: qsTr("Left Right Balance")
             weight: 40
             pageType: DccObject.Editor
-            visible: !dccData.model().audioMono
+            visible: !dccData.model().audioMono &&
+                (!dccData.model().showBluetoothMode ||
+                !dccData.model().outPutPortCombo[dccData.model().outPutPortComboIndex].toLowerCase().startsWith("handsfree"))
             page: RowLayout {
                 Label {
                     Layout.alignment: Qt.AlignVCenter


### PR DESCRIPTION
- Hide left-right balance settings when handsfree port detected

Log: resolve balance control visibility in SpeakerPage
pms: BUG-299133

## Summary by Sourcery

Bug Fixes:
- Hide left-right balance settings when a handsfree output port is detected.