### PR TITLE
fix: Fixed the dynamic display in Security Center

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -708,3 +708,8 @@ void CommonInfoWork::setPlymouthFactor(int factor)
     Q_EMIT settingScaling(true);
 }
 
+bool CommonInfoWork::isSecurityCenterInstalled()
+{
+    return QFileInfo::exists("/usr/bin/deepin-defender-scanner");
+}
+

--- a/src/plugin-commoninfo/operation/commoninfowork.h
+++ b/src/plugin-commoninfo/operation/commoninfowork.h
@@ -45,6 +45,7 @@ public:
     Q_INVOKABLE void importCertificate(QString filePath);
     Q_INVOKABLE void exportMessage(QString filePath);
     Q_INVOKABLE void setBackground(const QString &path);
+    Q_INVOKABLE bool isSecurityCenterInstalled();
 
 public Q_SLOTS:
     void setBootDelay(bool value);

--- a/src/plugin-commoninfo/qml/DevelopModePage.qml
+++ b/src/plugin-commoninfo/qml/DevelopModePage.qml
@@ -379,12 +379,16 @@ DccObject {
                 bottomPadding: 5
                 color: D.DTK.themeType === D.ApplicationHelper.LightType ? "#64000000" : "#64FFFFFF"
                 textFormat: Text.RichText
-                text: qsTr("To install and run unsigned apps, please go to <a style='text-decoration: none;' href='Security Center'> Security Center </a> to change the settings.")
+                text: dccData.work().isSecurityCenterInstalled() ?
+                    qsTr("To install and run unsigned apps, please go to <a style='text-decoration: none;' href='Security Center'> Security Center </a> to change the settings.") :
+                    qsTr("To install and run unsigned apps, please go to Security Center to change the settings.")
                 font: D.DTK.fontManager.t10
                 // 超链接点击事件
                 onLinkActivated: function(url) {
-                    console.log("点击的链接是: " + url)
-                    dccData.work().jumpToSecurityCenter();
+                    if (dccData.work().isSecurityCenterInstalled()) {
+                        console.log("点击的链接是: " + url)
+                        dccData.work().jumpToSecurityCenter();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixed the dynamic display in Security Center

Log: Fixed the dynamic display in Security Center
pms: BUG-315855

## Summary by Sourcery

Introduce a backend check for Security Center installation and use it to conditionally render and enable the Security Center link in the DevelopModePage UI, with a fallback plain text message when it’s not available.

Bug Fixes:
- Prevent invalid navigation by disabling the Security Center link when the Security Center application is not installed

Enhancements:
- Add CommonInfoWork.isSecurityCenterInstalled() Q_INVOKABLE method to detect Security Center binaries
- Update the DevelopModePage prompt to conditionally display an active link or fallback message based on installation status