### PR TITLE
feat: implement avatar caching system

### DIFF
--- a/src/plugin-deepinid/operation/deepinidmodel.h
+++ b/src/plugin-deepinid/operation/deepinidmodel.h
@@ -7,6 +7,7 @@
 
 #include "syncinfolistmodel.h"
 #include "appinfolistmodel.h"
+#include "downloadurl.h"
 
 #include <QObject>
 #include <QVariantMap>
@@ -66,6 +67,9 @@ public:
 
     Q_INVOKABLE QString warnTipsMessage(); // 获取警告提示信息
 
+protected Q_SLOTS:
+    void updateAvatarPath();
+
 signals:
     void loginStateChanged(bool loginState);
     void avatarChanged(const QString &avatar);
@@ -97,6 +101,7 @@ private:
     QString m_lastSyncTime;    // 上次同步时间
     SyncInfoListModel *m_syncInfoListModel;
     AppInfoListModel *m_appInfoListModel;
+    DownloadUrl *m_downloader;
 };
 
 #endif // DEEPINIDMODEL_H

--- a/src/plugin-deepinid/operation/downloadurl.cpp
+++ b/src/plugin-deepinid/operation/downloadurl.cpp
@@ -1,0 +1,112 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "downloadurl.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+#include <QNetworkReply>
+#include <QFile>
+#include <QTimer>
+#include <QPixmap>
+#include <QDebug>
+#include <QEventLoop>
+
+DownloadUrl::DownloadUrl(QObject *parent)
+    : QObject(parent)
+    , m_isReady(true)
+{
+
+}
+
+DownloadUrl::~DownloadUrl()
+{
+
+}
+
+void DownloadUrl::downloadFileFromURL(const QString &url, const QString &filePath, bool fullname)
+{
+    if (url.isEmpty())
+        return;
+
+    QString fileName;
+    fileName = fullname ? filePath : filePath + url.right(url.size() - url.lastIndexOf("/"));
+    if (fileName.contains("default.png", Qt::CaseInsensitive)) {
+        fileName = fileName.remove("png").append("svg");
+    }
+    qDebug() << "Download file from URL, URL: " << url << ", fileName: " << fileName << ", ready: " << m_isReady;
+
+    if (!m_isReady)
+        return;
+    m_isReady = false;
+    fileName = fileName + ".tmp";
+    m_retryMap.insert(fileName, url);
+
+    QNetworkAccessManager manager;
+    QNetworkRequest request;
+    QEventLoop loop;
+    QTimer timer;
+
+    request.setUrl(QUrl(url));
+    request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, QNetworkRequest::NoLessSafeRedirectPolicy);
+    QSslConfiguration config = QSslConfiguration::defaultConfiguration();
+    config.setPeerVerifyMode(QSslSocket::VerifyNone);
+    request.setSslConfiguration(config);
+
+    QNetworkReply *pReply = manager.get(request);
+    connect(pReply, &QNetworkReply::finished, &loop, &QEventLoop::quit);
+    connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
+    if (pReply) {
+        timer.setSingleShot(true);
+        timer.start(10 * 1000);
+        loop.exec();
+        if (QNetworkReply::NoError == pReply->error()) {
+            QByteArray replyData = pReply->readAll();
+
+            QFile file(fileName);
+            file.open(QIODevice::WriteOnly);
+            if (!file.isOpen()) {
+                m_isReady = true;
+                return;
+            }
+
+            if (file.write(replyData) <= 0) {
+                qWarning() << "On download file failed, reply data is empty: " << url;
+                file.remove();
+            } else {
+                file.close();
+                if (m_retryMap.contains(file.fileName()))
+                    m_retryMap.remove(file.fileName());
+
+                const QString fileName = file.fileName().left(file.fileName().length() - 4);
+                QFile::rename(file.fileName(), fileName);
+                qInfo() << "On download file, file name: " << fileName;
+                Q_EMIT fileDownloaded(fileName);
+            }
+        } else {
+            qWarning() << "Download failed:" << url << pReply->errorString();
+            QString url = pReply->url().toString();
+            if (m_retryMap.value(fileName) != url)
+                qWarning() << "Download file error, url: " << m_retryMap.value(fileName) << " is different from " << url;
+        }
+
+        pReply->close();
+        pReply->deleteLater();
+        pReply = nullptr;
+        m_isReady = true;
+        if (!m_retryMap.isEmpty())
+            onDownloadFileError(m_retryMap.begin().key(), m_retryMap.begin().value());
+    }
+}
+
+void DownloadUrl::onDownloadFileError(const QString &url, const QString &fileName)
+{
+    qDebug() << "Download file error, will try again after 20 seconds if url is valid";
+    if (url.isEmpty())
+        return;
+
+    QTimer::singleShot(20000, this, [=] {
+        qInfo() << "Retry to download file " << url << " to " << fileName;
+        downloadFileFromURL(url, fileName, true);
+    });
+}

--- a/src/plugin-deepinid/operation/downloadurl.h
+++ b/src/plugin-deepinid/operation/downloadurl.h
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QObject>
+#include <QMap>
+
+class DownloadUrl : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DownloadUrl(QObject *parent = nullptr);
+    virtual ~DownloadUrl();
+    void downloadFileFromURL(const QString &url, const QString &filePath, bool fullname = false);
+
+Q_SIGNALS:
+    void fileDownloaded(const QString &fileName);
+
+public Q_SLOTS:
+    void onDownloadFileError(const QString &url, const QString &fileName);
+
+private:
+    bool m_isReady;
+    QMap<QString, QString> m_retryMap;
+};


### PR DESCRIPTION
1. Added DownloadUrl class for downloading and caching avatar images
2. Implemented local avatar caching in ~/.cache/deepin/dde-control- center/sync
3. Added retry mechanism for failed downloads with 20s delay
4. Added logging using QLoggingCategory for debugging
5. Emit avatarChanged signal when avatar is updated

The changes improve user experience by:
- Reducing network requests by caching avatars locally
- Providing fallback options when network is unavailable
- Adding robust error handling and retry logic
- Improving debugging capabilities with logging

feat: 实现头像缓存系统

1. 添加 DownloadUrl 类用于下载和缓存头像图片
2. 在 ~/.cache/deepin/dde-control-center/sync 实现本地头像缓存
3. 为下载失败添加20秒延迟的重试机制
4. 使用 QLoggingCategory 添加日志记录用于调试
5. 头像更新时发送 avatarChanged 信号

这些改进提升了用户体验：
- 通过本地缓存减少网络请求
- 在网络不可用时提供备用方案
- 添加健壮的错误处理和重试逻辑
- 通过日志记录增强调试能力

pms: Bug-318567

## Summary by Sourcery

Implement local avatar caching with retryable downloads, debug logging, and avatarChanged signal emission

New Features:
- Introduce a local avatar caching system that stores downloaded avatars under ~/.cache/deepin/dde-control-center/sync with a default fallback

Enhancements:
- Add a DownloadUrl class that downloads avatars with a 20 s retry mechanism and QLoggingCategory-based debug logging