### PR TITLE
fix: Fixed the sorting issue of Bluetooth devices

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothdevicemodel.h
+++ b/src/plugin-bluetooth/operation/bluetoothdevicemodel.h
@@ -43,6 +43,8 @@ public:
     void updateAllData();
 
     void moveToTop(const QString &deviceId);
+    
+    void reorderDevices();
 
     // Basic functionality:
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;

--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -125,9 +125,6 @@ Rectangle {
                                         font.pointSize: 8
                                     }
                                 }
-                                onLoaded: {
-                                    item.show()
-                                }
                             }
                         }
 


### PR DESCRIPTION
Fixed the sorting issue of Bluetooth devices

Log: Fixed the sorting issue of Bluetooth devices
pms: BUG-299469

## Summary by Sourcery

Fix the ordering of Bluetooth devices so that connected devices are always listed before disconnected ones and clean up redundant QML code.

Bug Fixes:
- Introduce a reorderDevices method to group connected devices before disconnected ones and integrate it into device updates and additions.

Chores:
- Remove obsolete onLoaded handler in BlueToothDeviceListView QML.