### PR TITLE
fix: unify Chinese translation of NTP server references

### DIFF
--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -1092,7 +1092,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     <name>DatetimeWorker</name>
     <message>
         <source>Authentication is required to change NTP server</source>
-        <translation>修改 NTP 地址需要认证</translation>
+        <translation>修改时间服务器需要认证</translation>
     </message>
 </context>
 <context>
@@ -2734,7 +2734,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>The ntp server address cannot be empty</source>
-        <translation>NTP 服务地址不能为空</translation>
+        <translation>时间服务器地址不能为空</translation>
     </message>
     <message>
         <source>Use 24-hour format</source>


### PR DESCRIPTION
- Standardized "NTP server" terminology to "时间服务器" across translation files
- Updated authentication message and empty address warning in datetime module

Log: resolve display issues in TimeAndDate component
pms: BUG-303429

## Summary by Sourcery

Unify Chinese translation of NTP server references by updating authentication requirement and empty address warning messages

Documentation:
- Standardize "NTP server" terminology to "时间服务器" in authentication requirement prompt
- Standardize "NTP server" terminology to "时间服务器" in empty address warning