### PR TITLE
fix: Fixed the Bluetooth speaker icon error

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothdevice.h
+++ b/src/plugin-bluetooth/operation/bluetoothdevice.h
@@ -22,6 +22,7 @@ static const QMap<QString,QString> deviceType2Icon {
         {"input-gaming","bluetooth_other"},
         {"input-tablet","bluetooth_touchpad"},
         {"audio-card","bluetooth_pheadset"},
+        {"audio-headset","bluetooth_clang"},
         {"network-wireless","bluetooth_lan"},
         {"camera-video","bluetooth_vidicon"},
         {"printer","bluetooth_print"},


### PR DESCRIPTION
Fixed the Bluetooth speaker icon error

Log: Fixed the Bluetooth speaker icon error
pms: BUG-284093

## Summary by Sourcery

Bug Fixes:
- Add 'audio-headset' to deviceType2Icon map with the 'bluetooth_clang' icon