### PR TITLE
fix: adjust text opacity in LangAndFormat for better visibility

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -38,7 +38,7 @@ DccObject {
                 font.pixelSize: DTK.fontManager.t5.pixelSize
                 font.weight: 500
                 color: DTK.themeType === ApplicationHelper.LightType ?
-                    Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                    Qt.rgba(0, 0, 0, 0.7) : Qt.rgba(1, 1, 1, 0.7)
             }
 
             Button {
@@ -234,7 +234,7 @@ DccObject {
                 font.pixelSize: DTK.fontManager.t5.pixelSize
                 font.weight: 500
                 color: DTK.themeType === ApplicationHelper.LightType ?
-                    Qt.rgba(0, 0, 0, 1) : Qt.rgba(1, 1, 1, 1)
+                    Qt.rgba(0, 0, 0, 0.7) : Qt.rgba(1, 1, 1, 0.7)
             }
         }
 


### PR DESCRIPTION
- Changed color alpha values from 1 to 0.7 in both light/dark themes
- Improved text readability through opacity adjustment

Log: resolve display issues in TimeAndDate component
pms: BUG-323909

## Summary by Sourcery

Bug Fixes:
- Reduce text opacity in LangAndFormat.qml for both light and dark themes to mitigate visibility issues in the TimeAndDate component.