### PR TITLE
fix: The issue of renaming user groups is fixed

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -928,6 +928,12 @@ DccObject {
                             if (showAlert)
                                 showAlert = false
                             
+                            if (text.length < 1 && lastValidText.length > 0 && !readOnly) {
+                                Qt.callLater(function() {
+                                    editLabel.forceActiveFocus()
+                                })
+                            }
+                            
                             var isNewGroup = (model.display.length === 0)
                             
                             if (text.length > 32) {
@@ -971,6 +977,7 @@ DccObject {
                                 } else {
                                     var elidedText = metrics.elidedText(model.display, Text.ElideRight, editTextWidth)
                                     text = elidedText
+                                    readOnly = true
                                 }
                                 return
                             }
@@ -978,7 +985,14 @@ DccObject {
                             if (dccData.groupExists(text) && text !== model.display) {
                                 showAlert = true
                                 alertText = qsTr("The group name has been used")
-                                readOnly = false
+                                return
+                            }
+                            
+                            if (text === model.display) {
+                                completeText = text
+                                var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
+                                text = elidedText
+                                readOnly = true
                                 return
                             }
                             
@@ -990,6 +1004,7 @@ DccObject {
                             completeText = text
                             var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
                             text = elidedText
+                            readOnly = true
                         }
                         onFocusChanged: {
                             if (focus || text.length > 0 || editLabel.readOnly)

--- a/src/plugin-accounts/qml/EditActionLabel.qml
+++ b/src/plugin-accounts/qml/EditActionLabel.qml
@@ -37,8 +37,6 @@ D.LineEdit {
         if (showAlert)
             showAlert = false
 
-        edit.readOnly = true
-
         finished()
     }
 


### PR DESCRIPTION
The issue of renaming user groups is fixed

Log: The issue of renaming user groups is fixed
pms: BUG-321217

## Summary by Sourcery

Refine group renaming UI to correctly manage editing states, focus behavior, and prevent invalid or redundant edits.

Bug Fixes:
- Regain input focus when the group name is cleared after a valid entry
- Prevent further edits on duplicate or over-length group names

Enhancements:
- Automatically elide and lock the field when the name is unchanged or exceeds the max length
- Remove redundant read-only enforcement in EditActionLabel for smoother edit completion