### PR TITLE
fix: Fix password error prompt issue

### DIFF
--- a/src/plugin-accounts/operation/accountsworker.cpp
+++ b/src/plugin-accounts/operation/accountsworker.cpp
@@ -325,7 +325,7 @@ void AccountsWorker::checkPwdLimitLevel(int level)
         return;
     }
     QDBusReply<int> pwdLimitLevel = interface.call("GetPwdLimitLevel");
-    if (pwdLimitLevel.error().type() == QDBusError::NoError && pwdLimitLevel > level) {
+    if (pwdLimitLevel.error().type() == QDBusError::NoError && pwdLimitLevel >= level) {
         QDBusReply<QString> errorTips = interface.call("GetPwdError");
         Q_EMIT showSafetyPage(errorTips);
     }

--- a/src/plugin-accounts/qml/CreateAccountDialog.qml
+++ b/src/plugin-accounts/qml/CreateAccountDialog.qml
@@ -244,6 +244,7 @@ D.DialogWindow {
                                                 showAlert = true
                                             }
                                         }
+                                        pwdLayout.currentName = text
                                     } else {
                                         var colonRegex = /:/
                                         var lengthRegex = /^.{0,32}$/

--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -13,6 +13,7 @@ ColumnLayout {
     property string userId
     property string name: dccData.userName(pwdLayout.userId)
     property bool currentPwdVisible: true
+    property string currentName
     Layout.fillWidth: true
     spacing: 0
     
@@ -269,12 +270,12 @@ ColumnLayout {
 
             let alertText = ""
             // pwcheck verifyPassword
-            alertText = dccData.checkPassword(pwdLayout.name, edit0.text)
+            alertText = dccData.checkPassword(pwdLayout.currentName, edit0.text)
             if (alertText.length > 0) {
                 edit0.showAlertText(alertText)
                 return false
             }
-            alertText = dccData.checkPassword(pwdLayout.name, edit1.text)
+            alertText = dccData.checkPassword(pwdLayout.currentName, edit1.text)
             if (alertText.length > 0) {
                 edit1.showAlertText(alertText)
                 return false
@@ -385,6 +386,14 @@ ColumnLayout {
                 }
                 
                 pwdItem.textChanged(text)
+            }
+
+            onEditingFinished: {
+                if (echoButtonVisible && pwdContainter.eidtItems[2] != rightItem) {
+                    if (text === pwdLayout.currentName && text.length > 0) {
+                        showAlertText(qsTr("Different from the username"))
+                    }
+                }
             }
 
             function showAlertText(text) {


### PR DESCRIPTION
Fix password error prompt issue

Log: Fix password error prompt issue
pms: BUG-314837

## Summary by Sourcery

Add validation to password input to show an error when the password matches the username

Bug Fixes:
- Show an alert when the password equals the username on edit completion

Enhancements:
- Introduce a currentName property in PasswordLayout
- Assign the username to currentName in CreateAccountDialog to enable the new validation