### PR TITLE
style: remove redundant textColor properties in DccWindow

### DIFF
--- a/qml/DccWindow.qml
+++ b/qml/DccWindow.qml
@@ -71,7 +71,6 @@ D.ApplicationWindow {
         autoHideOnFullscreen: true
         focus: true
         leftContent: D.ActionButton {
-            textColor: parent.textColor
             palette.windowText: D.ColorSelector.textColor
             anchors {
                 verticalCenter: parent.verticalCenter
@@ -128,7 +127,6 @@ D.ApplicationWindow {
             }
             D.ActionButton {
                 id: breakBut
-                textColor: parent.textColor
                 palette.windowText: D.ColorSelector.textColor
                 implicitHeight: 30
                 implicitWidth: 30


### PR DESCRIPTION
1. Removed duplicate textColor property assignments in ActionButton
components
2. The text color is already being set via palette.windowText using
ColorSelector
3. This eliminates redundant styling and follows DRY principles
4. No visual changes expected as the same color is applied through
palette

style: 移除 DccWindow 中冗余的 textColor 属性

1. 移除了 ActionButton 组件中重复的 textColor 属性赋值
2. 文本颜色已通过 ColorSelector 使用 palette.windowText 设置
3. 此修改消除了冗余样式并遵循 DRY 原则
4. 预计不会产生视觉变化，因为相同的颜色已通过 palette 应用

pms: BUG-323539

## Summary by Sourcery

Enhancements:
- Remove duplicate textColor properties from ActionButton components in DccWindow.qml