### PR TITLE
refactor: clean up QML properties and connections

### DIFF
--- a/qml/SecondPage.qml
+++ b/qml/SecondPage.qml
@@ -103,7 +103,6 @@ Item {
                     DccLabel {
                         Layout.fillWidth: true
                         text: model.display
-                        font: root.font
                     }
                     Rectangle {
                         Layout.alignment: Qt.AlignRight

--- a/src/plugin-deepinid/qml/deepinid.qml
+++ b/src/plugin-deepinid/qml/deepinid.qml
@@ -17,7 +17,8 @@ DccObject {
 
     page: Control {
         id: control
-        anchors.fill: parent
+        width: parent ? parent.width : 10
+        height: parent ? parent.height : 10
         contentItem: dccObj.children.length > 0 ? dccObj.children[0].getSectionItem(control) : null
     }
 

--- a/src/plugin-personalization/qml/ThemeSelectView.qml
+++ b/src/plugin-personalization/qml/ThemeSelectView.qml
@@ -34,7 +34,7 @@ ListView {
 
     Connections {
         target: dccData.globalThemeModel
-        onModelReset: {
+        function onModelReset() {
             listview.selectTheme = ""
         }
     }

--- a/src/plugin-personalization/qml/personalizationMain.qml
+++ b/src/plugin-personalization/qml/personalizationMain.qml
@@ -58,7 +58,7 @@ DccObject {
                         onClicked: {
                             themeSelectView.decrementCurrentIndex()
                         }
-                        background:{}
+                        background: null
                     }
                     D.IconButton {
                         flat: true
@@ -71,7 +71,7 @@ DccObject {
                         onClicked: {
                             themeSelectView.incrementCurrentIndex()
                         }
-                        background:{}
+                        background: null
                     }
                 }
                 ThemeSelectView {

--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -75,7 +75,6 @@ DccObject {
                         width: 16
                         height: 16
                     }
-                    property D.Palette textColor: parent.textColor
                     palette.windowText: D.ColorSelector.textColor
                     flat: !hovered
                     implicitWidth: 24

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -71,7 +71,6 @@ DccObject {
                         width: 16
                         height: 16
                     }
-                    property Palette textColor: parent.textColor
                     palette.windowText: ColorSelector.textColor
                     flat: !hovered
                     implicitWidth: 24


### PR DESCRIPTION
1. Removed redundant font property in SecondPage.qml DccLabel since it
inherits from root
2. Changed parent anchoring to explicit width/height in deepinid.qml for
better null safety
3. Updated signal connection syntax in ThemeSelectView.qml to use
function syntax
4. Simplified background properties in personalizationMain.qml by
setting to null
5. Removed duplicate textColor properties in sound plugin pages as they
were unused

refactor: 清理 QML 属性和连接

1. 移除 SecondPage.qml 中 DccLabel 冗余的 font 属性，因为它从 root 继承
2. 在 deepinid.qml 中将父级锚定改为显式宽高设置以提高空安全性
3. 在 ThemeSelectView.qml 中更新信号连接语法为函数语法
4. 在 personalizationMain.qml 中通过设为 null 简化背景属性
5. 移除声音插件页面中未使用的重复 textColor 属性

## Summary by Sourcery

Clean up QML code by removing redundant properties, improving null safety in anchors, standardizing signal connection syntax, and simplifying component backgrounds.

Enhancements:
- Remove redundant font property from DccLabel in SecondPage.qml
- Replace anchors.fill with explicit width and height checks in deepinid.qml for null safety
- Update Connections syntax to function style in ThemeSelectView.qml
- Simplify button backgrounds in personalizationMain.qml by setting background to null
- Remove unused duplicate textColor properties in MicrophonePage.qml and SpeakerPage.qml