### PR TITLE
fix: resolve audio feedback issue when adjusting volume from 0% to 100%

### DIFF
--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -112,7 +112,7 @@ DccObject {
                     to: 1
                     value: dccData.model().microphoneVolume
                     onPressedChanged: {
-                        if (!pressed && voiceTipsSlider1.value != dccData.model().microphoneVolume) {
+                        if (!pressed) {
                             dccData.worker().setSourceVolume(voiceTipsSlider1.value)
                         }
                     }

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -107,7 +107,7 @@ DccObject {
                     to: dccData.model().increaseVolume ? 1.5 : 1.0
                     stepSize: 0.01
                     onPressedChanged: {
-                        if (!pressed && voiceTipsSlider.value != dccData.model().speakerVolume) {
+                        if (!pressed) {
                             dccData.worker().setSinkVolume(voiceTipsSlider.value)
                         }
                     }
@@ -172,7 +172,7 @@ DccObject {
                     value: dccData.model().speakerBalance
 
                     onPressedChanged: {
-                        if (!pressed && balanceSlider.value != dccData.model().speakerBalance) {
+                        if (!pressed) {
                             dccData.worker().setSinkBalance(balanceSlider.value)
                         }
                     }


### PR DESCRIPTION
- Removed value comparison condition in onPressedChanged handlers to ensure audio feedback
- Fixed issue where volume adjustment from 0% to 100% had no corresponding audio output
- Streamlined volume change detection logic in MicrophonePage and SpeakerPage sliders

Log: resolve audio feedback issue when adjusting volume from 0% to 100%
pms: BUG-316597