### PR TITLE
fix: resolve keyboard layout addition failure

### DIFF
--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -331,7 +331,25 @@ void KeyboardWorker::setKeyboardEnabled(bool value)
 
 void KeyboardWorker::addUserLayout(const QString &value)
 {
-    m_keyboardDBusProxy->AddUserLayout(m_model->kbLayout().key(value));
+    // Use allLayout as the data source
+    const auto &layouts = m_model->allLayout();
+    // Find the layout key in the layout source
+    QString layoutKey = layouts.key(value);
+
+    // If not found, the value might already be a key, try to use it directly
+    if (layoutKey.isEmpty() && layouts.contains(value)) {
+        layoutKey = value;
+    }
+
+    // If we still don't have a valid key, log error and return
+    if (layoutKey.isEmpty()) {
+        qWarning() << "KeyboardWorker::addUserLayout: Could not find layout key for value:" << value;
+        qWarning() << "Available layout keys:" << layouts.keys();
+        return;
+    }
+
+    qDebug() << "KeyboardWorker::addUserLayout: Using layout key:" << layoutKey << "for value:" << value;
+    m_keyboardDBusProxy->AddUserLayout(layoutKey);
 }
 
 void KeyboardWorker::delUserLayout(const QString &value)


### PR DESCRIPTION
- Added debug logging to show available layout keys when layout lookup fails in addUserLayout function.

Log: resolve keyboard layout addition failure
pms: BUG-324431

## Summary by Sourcery

Improve the addUserLayout method to robustly resolve layout keys and emit diagnostic logs on failure.

Bug Fixes:
- Log a warning and list available layout keys when a layout key cannot be found to avoid silent failures

Enhancements:
- Search for layout keys using the full allLayout map and fall back to using the provided value if it matches a key
- Emit debug logs detailing the resolved layout key on successful lookup