### PR TITLE
fix: Worng state in power anagement

### DIFF
--- a/src/plugin-power/operation/powerinterface.cpp
+++ b/src/plugin-power/operation/powerinterface.cpp
@@ -23,15 +23,31 @@ PowerInterface::PowerInterface(QObject *parent)
     setPowerActionsVisible({m_powerLidClosedOperatorModel, m_batteryLidClosedOperatorModel}, 
         {POT_ShutDown, POT_ShowShutDownInter}, false);
 
+    setPowerActionsVisible(
+            {m_powerLidClosedOperatorModel, m_powerPressedOperatorModel, m_batteryLidClosedOperatorModel, m_batteryPressedOperatorModel},
+            {POT_Suspend}, m_model->canSuspend() && m_model->getSuspend() &&!isVirtualEnvironment());
+    setPowerActionsVisible(
+            {m_powerLidClosedOperatorModel, m_powerPressedOperatorModel, m_batteryLidClosedOperatorModel, m_batteryPressedOperatorModel},
+            {POT_Hibernate}, m_model->canHibernate() && m_model->getHibernate() &&!isVirtualEnvironment());
+    connect(m_model, &PowerModel::canHibernateChanged, this, [this](bool value){
+        setPowerActionsVisible(
+            {m_powerLidClosedOperatorModel, m_powerPressedOperatorModel, m_batteryLidClosedOperatorModel, m_batteryPressedOperatorModel},
+            {POT_Hibernate}, value && m_model->getHibernate() &&!isVirtualEnvironment());
+    });
+    connect(m_model, &PowerModel::canSuspendChanged, this, [this](bool value){
+        setPowerActionsVisible(
+            {m_powerLidClosedOperatorModel, m_powerPressedOperatorModel, m_batteryLidClosedOperatorModel, m_batteryPressedOperatorModel},
+            {POT_Suspend}, value && m_model->getSuspend() &&!isVirtualEnvironment());
+    });
     connect(m_model, &PowerModel::hibernateChanged, this, [this](bool value){
         setPowerActionsVisible(
             {m_powerLidClosedOperatorModel, m_powerPressedOperatorModel, m_batteryLidClosedOperatorModel, m_batteryPressedOperatorModel},
-            {POT_Hibernate}, value &&!isVirtualEnvironment());
+            {POT_Hibernate}, value && m_model->canHibernate() &&!isVirtualEnvironment());
     });
     connect(m_model, &PowerModel::suspendChanged, this, [this](bool value){
         setPowerActionsVisible(
             {m_powerLidClosedOperatorModel, m_powerPressedOperatorModel, m_batteryLidClosedOperatorModel, m_batteryPressedOperatorModel},
-            {POT_Suspend}, value &&!isVirtualEnvironment());
+            {POT_Suspend}, value && m_model->canSuspend() &&!isVirtualEnvironment());
     });
     connect(m_model, &PowerModel::shutdownChanged, this, [this](bool value){
         setPowerActionsVisible(

--- a/src/plugin-power/operation/powermodel.cpp
+++ b/src/plugin-power/operation/powermodel.cpp
@@ -291,7 +291,7 @@ void PowerModel::setCanSuspend(bool canSuspend)
     if (canSuspend != m_canSuspend) {
         m_canSuspend = canSuspend;
 
-        Q_EMIT suspendChanged(canSuspend);
+        Q_EMIT canSuspendChanged(canSuspend);
     }
 }
 

--- a/src/plugin-power/operation/powermodel.h
+++ b/src/plugin-power/operation/powermodel.h
@@ -229,7 +229,7 @@ public:
 
 Q_SIGNALS:
     void sleepLockChanged(const bool sleepLock);
-    void canSleepChanged(const bool canSleep);
+    void canSuspendChanged(const bool canSuspend);
     void screenBlackLockChanged(const bool screenBlackLock);
     void lidPresentChanged(const bool lidPresent);
     void sleepOnLidOnPowerCloseChanged(const bool sleepOnLidClose);

--- a/src/plugin-power/qml/BatteryPage.qml
+++ b/src/plugin-power/qml/BatteryPage.qml
@@ -122,7 +122,7 @@ DccObject {
         parentName: "power/onBattery"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment
+        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment && dccData.model.canSuspend
         page: DccGroupView {}
 
         DccObject {
@@ -268,7 +268,7 @@ DccObject {
         parentName: "power/onBattery"
         weight: 700
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
+        visible: dccData.platformName() !== "wayland" && (dccData.model.canSuspend || dccData.model.canHibernate)
         page: DccGroupView {}
 
         DccObject {

--- a/src/plugin-power/qml/PowerPage.qml
+++ b/src/plugin-power/qml/PowerPage.qml
@@ -123,7 +123,7 @@ DccObject {
         parentName: "power/onPower"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment
+        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment && dccData.model.canSuspend
         page: DccGroupView {}
 
         DccObject {


### PR DESCRIPTION
Optimize power management features and fix visibility conditions ﻿
Simplify suspend/hibernate checks by removing async QFutureWatchers and using direct DBus calls ﻿
Update power action visibility logic to properly check canSuspend/canHibernate ﻿
Fix QML visibility conditions for battery/power pages to account for suspend capability ﻿
Clean up power interface signal connections and moc includes ﻿
The changes improve performance by eliminating unnecessary async operations while maintaining the same functionality. Visibility conditions are now more accurate by checking both virtual environment status and suspend/hibernate capabilities.

pms: BUG-324589

## Summary by Sourcery

Optimize power management by replacing asynchronous suspend/hibernate checks with direct DBus calls and refining UI visibility logic for power actions

Bug Fixes:
- Update power action visibility to correctly check suspend/hibernate capabilities and virtual environment status
- Adjust QML BatteryPage and PowerPage visibility conditions to only show options when suspend or hibernate is supported

Enhancements:
- Replace QFutureWatcher-based suspend/hibernate queries with synchronous DBus calls to improve performance
- Streamline PowerInterface by cleaning up signal connections and removing redundant moc includes