### PR TITLE
fix: hide noise suppression setting when input device is bluetooth

### DIFF
--- a/src/plugin-sound/operation/soundmodel.cpp
+++ b/src/plugin-sound/operation/soundmodel.cpp
@@ -64,6 +64,7 @@ SoundModel::SoundModel(QObject *parent)
     , m_outPutCount(0)
     , m_audioMono(false)
     , m_showBluetoothMode(false)
+    , m_showInputBluetoothMode(false)
 {
     m_soundEffectMapBattery = {
         { tr("Boot up"), DDesktopServices::SSE_BootUp },
@@ -718,5 +719,18 @@ QString SoundModel::getListName(int index) const
 {
     Q_UNUSED(index)
     return QString();
+}
+
+bool SoundModel::showInputBluetoothMode() const
+{
+    return m_showInputBluetoothMode;
+}
+
+void SoundModel::setShowInputBluetoothMode(bool newShowInputBluetoothMode)
+{
+    if (m_showInputBluetoothMode == newShowInputBluetoothMode)
+        return;
+    m_showInputBluetoothMode = newShowInputBluetoothMode;
+    emit showInputBluetoothModeChanged();
 }
 

--- a/src/plugin-sound/operation/soundmodel.h
+++ b/src/plugin-sound/operation/soundmodel.h
@@ -51,6 +51,7 @@ class SoundModel : public QObject
     Q_PROPERTY(QStringList bluetoothModeOpts READ bluetoothAudioModeOpts NOTIFY bluetoothModeOptsChanged FINAL)
     Q_PROPERTY(QString currentBluetoothAudioMode READ currentBluetoothAudioMode NOTIFY bluetoothModeChanged FINAL)
     Q_PROPERTY(bool showBluetoothMode READ showBluetoothMode NOTIFY showBluetoothModeChanged FINAL)
+    Q_PROPERTY(bool showInputBluetoothMode READ showInputBluetoothMode NOTIFY showInputBluetoothModeChanged FINAL)
 
     Q_PROPERTY(bool outPutPortComboEnable READ outPutPortComboEnable NOTIFY outPutPortComboEnableChanged FINAL)
     Q_PROPERTY(bool inPutPortComboEnable READ inPutPortComboEnable NOTIFY inPutPortComboEnableChanged FINAL)
@@ -212,6 +213,9 @@ public:
     bool inPutPortComboEnable() const;
     void setInPutPortComboEnable(bool newInPutPortComboEnable);
 
+    bool showInputBluetoothMode() const;
+    void setShowInputBluetoothMode(bool newShowInputBluetoothMode);
+
 private:
 
 
@@ -275,6 +279,8 @@ Q_SIGNALS:
 
     void inPutPortComboEnableChanged();
 
+    void showInputBluetoothModeChanged();
+
 private:
     QString m_audioServer;     // 当前使用音频框架
     bool m_audioServerStatus{true};  // 设置音频时的状态
@@ -332,6 +338,7 @@ private:
 
     bool m_audioMono;
     bool m_showBluetoothMode;
+    bool m_showInputBluetoothMode;
 };
 
 #endif // DCC_SOUND_SOUNDMODEL_H

--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -394,8 +394,11 @@ void SoundWorker::cardsChanged(const QString &cards)
 
                 port->setIsActive(isActiveInputPort || isActiveOuputPort);
 
-                if (port->isActive()) {
+                if (isActiveOuputPort) {
                     m_model->setShowBluetoothMode(port->isBluetoothPort());
+                }
+                if (isActiveInputPort) {
+                    m_model->setShowInputBluetoothMode(port->isBluetoothPort());
                 }
                 if (!include) { m_model->addPort(port); }
 
@@ -515,6 +518,9 @@ void SoundWorker::updatePortActivity()
 
         if (isActiveOuputPort) {
             m_model->setShowBluetoothMode(port->isBluetoothPort());
+        }
+        if (isActiveInputPort) {
+            m_model->setShowInputBluetoothMode(port->isBluetoothPort());
         }
     }
     m_model->updateActiveComboIndex();

--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -183,6 +183,7 @@ DccObject {
             displayName: qsTr("Automatic Noise Suppression")
             weight: 30
             pageType: DccObject.Editor
+            visible: !dccData.model().showInputBluetoothMode
             page: Switch {
                 Layout.alignment: Qt.AlignRight | Qt.AlignTop
 


### PR DESCRIPTION
- Added showInputBluetoothMode property to SoundModel to track input bluetooth device status
- Updated port activity handling in SoundWorker to detect and set input bluetooth mode visibility
- Added visibility control in MicrophonePage to hide automatic noise suppression when input bluetooth mode is active

Log: hide noise suppression setting when input device is bluetooth
pms: BUG-299135