### PR TITLE
fix: Fixed Bluetooth device status not refreshing

### DIFF
--- a/src/plugin-bluetooth/operation/bluetoothdevicemodel.cpp
+++ b/src/plugin-bluetooth/operation/bluetoothdevicemodel.cpp
@@ -102,6 +102,7 @@ void BluetoothDeviceModel::reorderDevices()
     }
     
     if (connectedDevices.isEmpty() || disconnectedDevices.isEmpty()) {
+        updateAllData();
         return;
     }
     


### PR DESCRIPTION
Fixed Bluetooth device status not refreshing

Log: Fixed Bluetooth device status not refreshing
pms: BUG-324807

## Summary by Sourcery

Bug Fixes:
- Call updateAllData() in reorderDevices when connected or disconnected device list is empty to ensure status refresh