### PR TITLE
fix: Change the size of the hover background

### DIFF
--- a/src/dde-control-center/frame/plugin/DccItemBackground.qml
+++ b/src/dde-control-center/frame/plugin/DccItemBackground.qml
@@ -94,7 +94,7 @@ Item {
         active: (backgroundType & 0x01) || ((backgroundType & 0x02) && control.hovered)
         // active: backgroundType !== 0 // (backgroundType & 0xFF) && !(backgroundType & 0x08)
         anchors.topMargin: 0
-        anchors.bottomMargin: ((backgroundType & 0x02) && control.hovered) && !(control.corners & D.RoundRectangle.BottomCorner) ? 1 : 0
+        anchors.bottomMargin: 0
         sourceComponent: D.RoundRectangle {
             // 高亮时，hovered状态HighlightPanel有处理,无阴影时，hovered状态使用半透明
             color: ((backgroundType & 0x08) || (backgroundType & 0x02) === 0 || !control.hoverEnabled) ? root.D.ColorSelector.bgColor : root.D.ColorSelector.backgroundColor

--- a/src/plugin-defaultapp/qml/DetailItem.qml
+++ b/src/plugin-defaultapp/qml/DetailItem.qml
@@ -76,8 +76,8 @@ DccObject {
                     }
                     D.ActionButton {
                         Layout.alignment: Qt.AlignCenter
-                        implicitHeight: 30
-                        implicitWidth: 30
+                        implicitHeight: 22
+                        implicitWidth: 22
                         visible: !model.isDefault && model.canDelete && control.hovered
                         icon {
                             name: "dcc-delete"


### PR DESCRIPTION
Change the size of the hover background

pms: BUG-319257
pms: BUG-308353

## Summary by Sourcery

Fix hover background sizing by shrinking the delete action button and removing its bottom margin to correct visual alignment

Bug Fixes:
- Reduce the implicit size of the hover ActionButton from 30x30 to 22x22
- Remove the bottom margin on hovered backgrounds to eliminate extra padding