### PR TITLE
fix: resolve empty region list after clearing search input

### DIFF
--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -129,6 +129,10 @@ Loader {
                 Component.onCompleted: {
                     loader.view = arrowListView
                     loader.viewWidth = arrowListView.width
+                    // Scroll to the highlighted item when the view is ready
+                    if (loader.highlightedIndex >= 0 && view) {
+                        view.positionViewAtIndex(loader.highlightedIndex, ListView.Beginning)
+                    }
                 }
 
                 onWidthChanged: {

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -405,6 +405,8 @@ DccObject {
 
                 onClicked: function (mouse) {
                     if (!timezoneWindow.isVisible()) {
+                        // Reset highlightedIndex to the actual current index before showing
+                        timezoneWindow.highlightedIndex = systemTimezoneItem.currentIndex
                         timezoneWindow.show()
                         timezoneWindow.setPositionByItem(parent)
                     }
@@ -463,6 +465,7 @@ DccObject {
                 onClicked: {
                     if (!timezoneListWindow.isVisible()) {
                         timezoneListWindow.setPositionByItem(parent)
+                        timezoneListWindow.highlightedIndex = 0
                         timezoneListWindow.show()
                     }
                 }


### PR DESCRIPTION
- Fixed region list not refreshing properly when search text is cleared
- Ensured region list restores to full list when search input becomes empty
- Improved search box behavior to maintain proper list state during text operations

Log: fix empty region list display issue when clearing search input in region format popup
pms: BUG-323291