### PR TITLE
fix: reset view position when searching in RegionFormatDialog

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -52,9 +52,11 @@ Loader {
                         placeholder: qsTr("Search")
                         onTextChanged: {
                             viewModel.setFilterWildcard(text);
+                            itemsView.positionViewAtBeginning();
                         }
                         onEditingFinished: {
                             viewModel.setFilterWildcard(text);
+                            itemsView.positionViewAtBeginning();
                         }
                     }
 


### PR DESCRIPTION
- Added positionViewAtBeginning() to reposition view to start when filtering text.
- Applied to both onTextChanged and onEditingFinished handlers for consistent search behavior.

Log: reset view position to beginning when searching in RegionFormatDialog
pms: BUG-323291

## Summary by Sourcery

Bug Fixes:
- Reposition itemsView to the beginning when filtering text in RegionFormatDialog to ensure search results start from the top.