### PR TITLE
fix: resolve cancel operation in shortcut setting dialog

### DIFF
--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -23,8 +23,10 @@ D.DialogWindow {
     property alias cmdName: commandEdit.text
     property alias keySequence: edit.keys
     property alias accels: edit.accels
-    property string saveAccels: ""
     property alias conflitedText : conflictText.text
+    property string saveKeyName: ""
+    property string saveCmdName: ""
+    property string saveAccels: ""
 
     ColumnLayout {
         spacing: 10
@@ -137,7 +139,7 @@ D.DialogWindow {
                 text: qsTr("Cancel")
                 onClicked: {
                     if (ddialog.keyId.length > 0) {
-                        dccData.modifyCustomShortcut(ddialog.keyId, nameEdit.text, commandEdit.text, ddialog.saveAccels)
+                        dccData.modifyCustomShortcut(ddialog.keyId, ddialog.saveKeyName, ddialog.saveCmdName, ddialog.saveAccels)
                     }
                     ddialog.close()
                 }

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -229,7 +229,9 @@ DccObject {
                                     item.cmdName = model.command
                                     item.keySequence = model.keySequence
                                     item.accels = model.accels
-                                    item.saveAccels = accels
+                                    item.saveAccels = item.accels
+                                    item.saveKeyName = item.keyName
+                                    item.saveCmdName = item.cmdName
 
                                     item.show()
                                 }


### PR DESCRIPTION
- Added saveKeyName and saveCmdName properties to preserve original values
- Updated cancel button logic to restore original name and command instead of current edited values
- Ensure proper state restoration when user cancels shortcut modification

Log: fix cancel operation not properly restoring original shortcut settings
pms: BUG-325147

## Summary by Sourcery

Ensure the shortcut setting dialog correctly reverts to original values on cancel by saving and restoring key name, command, and accelerators.

Bug Fixes:
- Restore original shortcut settings when cancelling edits in the shortcut setting dialog

Enhancements:
- Add saveKeyName and saveCmdName properties to preserve the initial shortcut name and command