### PR TITLE
fix: resolve theme adaptation issues in RegionsChooserWindow dark mode

### DIFF
--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
+import QtQuick
 import QtQuick.Controls 2.0
 import QtQuick.Window
 import org.deepin.dtk 1.0
@@ -38,6 +38,7 @@ Loader {
         flags: Qt.Dialog
         // default color is white
         color: active ? DTK.palette.window : DTK.inactivePalette.window
+        palette: DTK.palette
 
         ColumnLayout {
             id: contentLayout


### PR DESCRIPTION
- Added palette property to Window component for proper theme color inheritance
- Updated QtQuick import to use latest version for better theme support
- Fixed text and arrow colors not adapting correctly in dark mode theme

Log: resolve theme adaptation issues in RegionsChooserWindow dark mode
pms: BUG-325209
pms: BUG-325215

## Summary by Sourcery

Resolve theme adaptation issues in RegionsChooserWindow dark mode by updating QtQuick import, adding palette inheritance, and ensuring text and arrow colors adapt correctly.

Bug Fixes:
- Fix text and arrow colors not adapting correctly in dark mode

Enhancements:
- Add palette property to Window component for theme color inheritance
- Update QtQuick import to the latest version for better theme support