### PR TITLE
fix: Modify search error issues

### DIFF
--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -596,7 +596,7 @@ void AccountsController::setPasswordHint(const QString &id, const QString &pwdHi
 int AccountsController::passwordAge(const QString &id) const
 {
     User *user = m_model->getUser(id);
-    qDebug() << "passwordAge" << user->passwordAge();
+    qDebug() << "passwordAge" << (user ? user->passwordAge() : -1);
     return user ? user->passwordAge() : -1;
 }
 

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -39,6 +39,7 @@ DccObject {
         name: "userAvatars"
         parentName: settings.papaName
         weight: 10
+        canSearch: settings.canSearch
         pageType: DccObject.Item
         page: Rectangle {
             id: item
@@ -242,6 +243,7 @@ DccObject {
         name: "acountInfosTitle"
         parentName: settings.papaName
         displayName: qsTr("Account Information")
+        canSearch: settings.canSearch
         weight: 18
         pageType: DccObject.Item
         page: Label {
@@ -257,8 +259,8 @@ DccObject {
     DccObject {
         name: settings.papaName + "acountInfos"
         parentName: settings.papaName
-        displayName: qsTr("Account Information")
         description: qsTr("Account name, account fullname, account type")
+        canSearch: settings.canSearch
         weight: 20
         pageType: DccObject.Item
         page: DccGroupView {}
@@ -267,6 +269,7 @@ DccObject {
             name: settings.papaName + "acountName"
             parentName: settings.papaName + "acountInfos"
             displayName: qsTr("Account name")
+            canSearch: settings.canSearch
             weight: 10
             pageType: DccObject.Editor
             page: Label {
@@ -277,6 +280,7 @@ DccObject {
             name: settings.papaName + "acountFullname"
             parentName: settings.papaName + "acountInfos"
             displayName: qsTr("Account fullname")
+            canSearch: settings.canSearch
             weight: 20
             pageType: DccObject.Editor
             page: RowLayout {
@@ -520,6 +524,7 @@ DccObject {
             name: settings.papaName + "acountType"
             parentName: settings.papaName + "acountInfos"
             displayName: qsTr("Account type")
+            canSearch: settings.canSearch
             weight: 30
             pageType: DccObject.Editor
             enabled: dccData.isDeleteAble(settings.userId)
@@ -548,6 +553,7 @@ DccObject {
         name: settings.papaName + "acountSettingsTitle"
         parentName: settings.papaName
         displayName: qsTr("Login settings")
+        canSearch: settings.canSearch
         weight: 28
         pageType: DccObject.Item
         visible: acountSettings.visible
@@ -565,8 +571,8 @@ DccObject {
         id: acountSettings
         name: settings.papaName + "acountSettings"
         parentName: settings.papaName
-        displayName: qsTr("Login Settings")
         description: qsTr("quick login, Auto login, login without password")
+        canSearch: settings.canSearch
         weight: 30
         pageType: DccObject.Item
         page: DccGroupView {}
@@ -577,6 +583,7 @@ DccObject {
             name: settings.papaName + "quickLogin"
             parentName: settings.papaName + "acountSettings"
             displayName: qsTr("Quickly load DDE with your login information")
+            canSearch: settings.canSearch
             weight: 20
             pageType: DccObject.Editor
             visible: dccData.isQuickLoginVisible
@@ -597,6 +604,7 @@ DccObject {
             name: settings.papaName + "autoLongin"
             parentName: settings.papaName + "acountSettings"
             displayName: qsTr("Auto login")
+            canSearch: settings.canSearch
             weight: 10
             pageType: DccObject.Editor
             visible: dccData.isAutoLoginVisable()
@@ -640,6 +648,7 @@ DccObject {
             name: settings.papaName + "noPassword"
             parentName: settings.papaName + "acountSettings"
             displayName: qsTr("Login without password")
+            canSearch: settings.canSearch
             weight: 30
             pageType: DccObject.Editor
             visible: dccData.isNoPassWordLoginVisable()
@@ -661,6 +670,7 @@ DccObject {
         name: settings.papaName + "loginMethodTitle"
         parentName: settings.papaName
         userId: settings.userId
+        canSearch: settings.canSearch
     }
 
     // 动态锁
@@ -702,6 +712,7 @@ DccObject {
         id: bottomButtons
         name: settings.papaName + "/bottomButtons"
         parentName: settings.papaName
+        canSearch: settings.canSearch
         weight: 0xFFFF
         pageType: DccObject.Item
         page: RowLayout {
@@ -764,6 +775,7 @@ DccObject {
         name: settings.papaName + "/groupSettings"
         parentName: bottomButtons.name
         displayName: qsTr("Account groups")
+        canSearch: settings.canSearch
         weight: 10
         pageType: DccObject.Menu
         page: ListView {

--- a/src/plugin-accounts/qml/LoginMethod.qml
+++ b/src/plugin-accounts/qml/LoginMethod.qml
@@ -22,6 +22,7 @@ DccTitleObject {
         name: loginMethodTitle.parentName + "loginMethod"
         parentName: loginMethodTitle.parentName
         description: qsTr("Password, wechat, biometric authentication, security key")
+        canSearch: loginMethodTitle.canSearch
         weight: 40
         pageType: DccObject.Item
         page: DccGroupView {}
@@ -40,6 +41,7 @@ DccTitleObject {
             name: loginMethodTitle.parentName + "loginMethodItem" + "password"
             parentName: loginMethodTitle.parentName + "loginMethod"
             displayName: qsTr("Password")
+            canSearch: loginMethodTitle.canSearch
             weight: 10 + 10
         }
 
@@ -47,6 +49,7 @@ DccTitleObject {
             name: loginMethodTitle.parentName + "PasswordLoginTitle"
             parentName: loginMethodTitle.parentName + "loginMethodItem" + "password"
             displayName: qsTr("Password")
+            canSearch: loginMethodTitle.canSearch
             weight: 12
             pageType: DccObject.Item
             page: RowLayout {
@@ -66,6 +69,7 @@ DccTitleObject {
             name: loginMethodTitle.parentName + "PasswordGroupView"
             parentName: loginMethodTitle.parentName + "loginMethodItem" + "password"
             description: qsTr("Password, wechat, biometric authentication, security key")
+            canSearch: loginMethodTitle.canSearch
             weight: 20
             pageType: DccObject.Item
             page: DccGroupView {}
@@ -74,6 +78,7 @@ DccTitleObject {
                 name: loginMethodTitle.parentName + "PasswordModify"
                 parentName: passwordGroupView.name
                 displayName: dccData.currentUserId() === loginMethodTitle.userId ? qsTr("Modify password") : qsTr("Reset password")
+                canSearch: loginMethodTitle.canSearch
                 backgroundType: DccObject.ClickStyle
                 weight: 12
                 enabled: dccData.currentUserId() === loginMethodTitle.userId || (dccData.curUserIsSysAdmin() && !dccData.isOnline(loginMethodTitle.userId))
@@ -109,6 +114,7 @@ DccTitleObject {
                 name: loginMethodTitle.parentName + "PasswordValidityDays" + "biometric"
                 parentName: passwordGroupView.name
                 displayName: qsTr("Validity days")
+                canSearch: loginMethodTitle.canSearch
                 weight: 12
                 pageType: DccObject.Editor
                 page: D.SpinBox {

--- a/src/plugin-accounts/qml/accountsMain.qml
+++ b/src/plugin-accounts/qml/accountsMain.qml
@@ -195,6 +195,7 @@ DccObject {
                 name: "otherAccountSettings"
                 parentName: "otherSettingsHolder"
                 papaName: name
+                canSearch: false
             }
         }
     }

--- a/src/plugin-personalization/qml/ScreenSaverPage.qml
+++ b/src/plugin-personalization/qml/ScreenSaverPage.qml
@@ -113,7 +113,7 @@ DccObject {
             page: DccGroupView { }
 
             DccObject {
-                name: "whenTheLidIsClosed"
+                name: "personalizedScreensaver"
                 parentName: "personalization/screenSaver/screenSaverStatusGroup/screenSaverSetGroup/screenSaverSetItemGroup"
                 displayName: qsTr("Personalized screensaver")
                 weight: 10
@@ -128,7 +128,7 @@ DccObject {
                 }
             }
             DccObject {
-                name: "whenTheLidIsClosed1"
+                name: "idleTime"
                 parentName: "personalization/screenSaver/screenSaverStatusGroup/screenSaverSetGroup/screenSaverSetItemGroup"
                 displayName: qsTr("idle time")
                 weight: 100
@@ -159,7 +159,7 @@ DccObject {
                 }
             }
             DccObject {
-                name: "whenTheLidIsClosed2"
+                name: "passwordRequired"
                 parentName: "personalization/screenSaver/screenSaverStatusGroup/screenSaverSetGroup/screenSaverSetItemGroup"
                 displayName: qsTr("Password required for recovery")
                 weight: 200

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -116,13 +116,12 @@ DccObject {
         DccObject {
             name: "wallpaperSetItemGroup"
             parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup"
-            displayName: qsTr("Window rounded corners")
             weight: 10
             pageType: DccObject.Item
             page: DccGroupView { }
 
             DccObject {
-                name: "whenTheLidIsClosed"
+                name: "wallpaperType"
                 parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup/wallpaperSetItemGroup"
                 displayName: {
                     let cutUrl = dccData.model.wallpaperMap[dccData.model.currentSelectScreen]
@@ -136,11 +135,12 @@ DccObject {
                         return qsTr("Customizable wallpapers")
                     }
                 }
+                canSearch: false
                 pageType: DccObject.Editor
                 weight: 10
             }
             DccObject {
-                name: "whenTheLidIsClosed"
+                name: "fillStyle"
                 parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup/wallpaperSetItemGroup"
                 displayName: qsTr("fill style")
                 visible: false
@@ -153,7 +153,7 @@ DccObject {
                 }
             }
             DccObject {
-                name: "whenTheLidIsClosed"
+                name: "automaticWallpaper"
                 parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup/wallpaperSetItemGroup"
                 displayName: qsTr("Automatic wallpaper change")
                 weight: 200
@@ -186,7 +186,7 @@ DccObject {
     }
 
     DccObject {
-        name: "screenAndSuspendTitle"
+        name: "myPictures"
         parentName: "personalization/wallpaper"
         displayName: qsTr("My pictures")
         weight: 400
@@ -220,7 +220,7 @@ DccObject {
     }
 
     DccObject {
-        name: "screenAndSuspendTitle"
+        name: "systemWallapers"
         parentName: "personalization/wallpaper"
         displayName: qsTr("System Wallapers")
         weight: 500
@@ -236,7 +236,7 @@ DccObject {
     }
 
     DccObject {
-        name: "screenAndSuspendTitle"
+        name: "liveWallpaper"
         parentName: "personalization/wallpaper"
         visible: false
         displayName: qsTr("Live Wallpaper")
@@ -249,7 +249,7 @@ DccObject {
     }
 
     DccObject {
-        name: "screenAndSuspendTitle"
+        name: "solidColor"
         parentName: "personalization/wallpaper"
         displayName: qsTr("Solid color wallpaper")
         weight: 600


### PR DESCRIPTION
Modify search error issues

pms: BUG-312791
pms: BUG-312797
pms: BUG-312705

## Summary by Sourcery

Rename duplicate QML DccObject name properties to unique identifiers to resolve conflicts and adjust related display and search settings

Bug Fixes:
- Fix duplicate DccObject name fields in wallpaper and screensaver pages by renaming them to unique identifiers

Enhancements:
- Remove redundant displayName from wallpaperSetItemGroup
- Add canSearch property to disable searching on the wallpaperType item