### PR TITLE
fix: resolve active color inconsistency in timezone menu popup

### DIFF
--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
+import QtQuick
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import QtQuick.Window
@@ -80,6 +80,7 @@ Loader {
         flags: Qt.Dialog
         // default color is white
         color: active ? DTK.palette.window : DTK.inactivePalette.window
+        palette: DTK.palette
 
         Component.onCompleted: {
             positionWindow()


### PR DESCRIPTION
- Updated QtQuick import to use latest version for better compatibility.
- Added palette: DTK.palette to Window component to ensure timezone menu uses system active colors consistently.

Log: resolve active color inconsistency in timezone menu popup
pms: BUG-323859

## Summary by Sourcery

Resolve active color inconsistency in the timezone menu popup by adding DTK.palette to the window component and updating the QtQuick import to the latest version.

Bug Fixes:
- Resolve active color inconsistency in timezone menu popup by applying the system palette to the popup window.

Enhancements:
- Update QtQuick import to use the latest version for improved compatibility.