### PR TITLE
fix: allow saving shortcuts with modifier-only keys

### DIFF
--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -27,6 +27,7 @@ D.DialogWindow {
     property string saveKeyName: ""
     property string saveCmdName: ""
     property string saveAccels: ""
+    property var saveKeys: [qsTr("None")]
 
     ColumnLayout {
         spacing: 10
@@ -170,7 +171,7 @@ D.DialogWindow {
         Connections {
             target: dccData
             function onRequestRestore() {
-                edit.keys = ddialog.keySequence
+                edit.keys = ddialog.saveKeys
                 conflictText.text = ""
             }
             function onRequestClear() {

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -228,6 +228,9 @@ DccObject {
                                     item.keyName = model.display
                                     item.cmdName = model.command
                                     item.keySequence = model.keySequence
+                                    if (model.keySequence.length > 0) {
+                                        item.saveKeys = model.keySequence
+                                    }
                                     item.accels = model.accels
                                     item.saveAccels = item.accels
                                     item.saveKeyName = item.keyName


### PR DESCRIPTION
- Added saveKeys property to preserve original key sequence for restore functionality
- Updated restore logic to use saved keys instead of current keySequence
- Enables saving custom shortcuts that contain only modifier or non-modifier keys

Log: allow saving shortcuts with modifier-only keys
pms: BUG-325131

## Summary by Sourcery

Preserve original key sequences for shortcuts to support saving and restoring modifier-only key combinations.

Bug Fixes:
- Allow saving shortcuts that consist only of modifier or non-modifier keys by retaining their exact key sequence

Enhancements:
- Introduce saveKeys property in ShortcutSettingDialog and Shortcuts to store the original key sequence
- Update restore logic to use saveKeys for reverting to the saved key sequence