### PR TITLE
feat: adjust notification combo box width

### DIFF
--- a/src/plugin-notification/qml/notificationMain.qml
+++ b/src/plugin-notification/qml/notificationMain.qml
@@ -94,6 +94,7 @@ DccObject {
         backgroundType: DccObject.Normal
         pageType: DccObject.Editor
         page: D.ComboBox {
+            implicitWidth: 120
             model: ["1", "2", "3"]
             flat: true
             currentIndex: dccData.sysItemModel.bubbleCount - 1


### PR DESCRIPTION
1. Added implicitWidth property to notification combo box
2. Set fixed width of 120 pixels for better UI consistency
3. Prevents dynamic resizing when switching between different options
4. Improves visual alignment in the notification settings panel

feat: 调整通知组合框宽度

1. 为通知组合框添加 implicitWidth 属性
2. 设置固定宽度为120像素以提高UI一致性
3. 防止在不同选项间切换时动态调整大小
4. 改善通知设置面板中的视觉对齐效果

pms: BUG-323947

## Summary by Sourcery

Enhancements:
- Add implicitWidth property on the notification combo box and set it to 120 pixels for UI consistency and alignment