### PR TITLE
refactor: remove redundant textColor property in NativeInfoPage

### DIFF
--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -108,7 +108,6 @@ DccObject {
                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
 
                     palette.windowText: ColorSelector.textColor
-                    property Palette textColor: parent.textColor
 
                     background: Rectangle {
                         property Palette pressedColor: Palette {


### PR DESCRIPTION
1. Removed the redundant textColor property from the palette
configuration
2. The property was unnecessary since palette.windowText already handles
text coloring
3. Simplifies the code by removing duplicate color handling
4. Maintains same visual appearance while reducing complexity

refactor: 移除 NativeInfoPage 中冗余的 textColor 属性

1. 从调色板配置中移除了冗余的 textColor 属性
2. 该属性是多余的，因为 palette.windowText 已经处理了文本着色
3. 通过移除重复的颜色处理简化了代码
4. 在减少复杂性的同时保持了相同的视觉效果

## Summary by Sourcery

Enhancements:
- Remove redundant textColor property from NativeInfoPage and rely solely on palette.windowText for text coloring