### PR TITLE
fix: show shortcut keys in edit mode

### DIFF
--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -70,7 +70,6 @@ Control {
                 Repeater {
                     model: control.keys
                     P.KeySequenceLabel {
-                        visible: !control.showEditButtons
                         Layout.alignment: Qt.AlignRight
                         text: modelData
                     }


### PR DESCRIPTION
- Removed 'visible: !control.showEditButtons' property from P.KeySequenceLabel to fix issue where custom shortcut keys were hidden when edit buttons were shown.

Log: fix custom keyboard shortcuts not displaying in edit mode
pms: BUG-293223

## Summary by Sourcery

Bug Fixes:
- Remove `visible: !control.showEditButtons` from `KeySequenceLabel` to ensure custom shortcuts display when edit buttons are shown