### PR TITLE
fix: remove unnecessary trim in Bluetooth device name validation

### DIFF
--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -166,7 +166,7 @@ DccObject{
                 }
 
                 function updateAlias() {
-                    if (nameEdit.text.trim() === "") {
+                    if (nameEdit.text === "") {
                         nameEdit.text = myDeviceName.text
                     } else {
                         dccData.work().setAdapterAlias(model.id, nameEdit.text)


### PR DESCRIPTION
The change removes the .trim() call when validating Bluetooth device names in the alias update function. The original implementation was unnecessarily trimming whitespace from the input before checking if it was empty. The simpler check for empty string is sufficient since leading/trailing whitespace in device names is actually valid and should be preserved.

This modification ensures that users can set device names containing whitespace characters exactly as they intend, without any automatic trimming that might alter their desired naming format.

fix: 移除蓝牙设备名称验证中不必要的trim操作

该变更移除了在别名更新函数中对蓝牙设备名称验证时的.trim()调用。原始实现
在检查输入是否为空之前不必要地修剪了空格。更简单的空字符串检查已经足够，
因为设备名称中的前导/尾随空格实际上是有效的，应该保留。

此修改确保用户可以按照他们的意图设置包含空格字符的设备名称，而不会因自动
修剪而改变他们想要的命名格式。

PMS: BUG-326145

## Summary by Sourcery

Bug Fixes:
- Eliminate trimming of nameEdit.text when checking for empty input, allowing Bluetooth device names to retain whitespace