### PR TITLE
style: adjust datetime plugin UI elements

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -129,7 +129,6 @@ DccObject {
                             implicitHeight: 36
                             anchors {
                                 right: itemDelegate.right
-                                rightMargin: 10
                                 top: itemDelegate.top
                                 topMargin: (itemDelegate.height - removeButton.height) / 2
                             }

--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -79,7 +79,7 @@ Loader {
         // ensure show in center of mainwindow
         flags: Qt.Dialog
         // default color is white
-        color: active ? DTK.palette.window : DTK.inactivePalette.window
+        color: DTK.palette.window
         palette: DTK.palette
 
         Component.onCompleted: {

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -426,9 +426,9 @@ DccObject {
             spacing: 10
             Button {
                 id: addButton
-                icon.name: "add"
-                implicitHeight: 32
-                implicitWidth: 32
+                text: qsTr("Add")
+                implicitHeight: 30
+                implicitWidth: 60
 
                 SearchableListViewPopup {
                     id: timezoneListWindow


### PR DESCRIPTION
1. Removed rightMargin from removeButton in LangAndFormat.qml for better alignment
2. Simplified window color logic in SearchableListViewPopup.qml by removing active state condition
3. Changed addButton in TimeAndDate.qml from icon to text button with adjusted dimensions for better usability

Log: Changed timezone add button from icon to text label

Influence:
1. Verify remove button alignment in language and format settings
2. Check popup window colors in different states
3. Test timezone addition functionality with new text button

style: 调整日期时间插件UI元素

1. 移除LangAndFormat.qml中removeButton的rightMargin以实现更好对齐
2. 简化SearchableListViewPopup.qml中的窗口颜色逻辑，移除活动状态条件
3. 将TimeAndDate.qml中的addButton从图标按钮改为文本按钮并调整尺寸以提高 可用性

Log: 将时区添加按钮从图标改为文本标签

Influence:
1. 验证语言和格式设置中删除按钮的对齐情况
2. 检查不同状态下弹出窗口的颜色显示
3. 测试使用新文本按钮的时区添加功能

PMS: BUG-323905 BUG-278357

## Summary by Sourcery

Adjust datetime plugin UI by improving button alignment, simplifying popup color logic, and replacing the timezone add icon with a labeled text button

Enhancements:
- Remove right margin from the remove button in language settings for better alignment
- Simplify popup window color logic by dropping the active-state condition
- Convert the timezone add button from an icon to a text button and adjust its size for improved usability