### PR TITLE
fix: update double click speed slider labels

### DIFF
--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -129,7 +129,7 @@ DccObject {
                     }
                     D.TipsSlider {
                         id: doubleClickSlider
-                        readonly property var tips: [qsTr("Slow"), (""), (""), (""), (""), (""), qsTr("Fast")]
+                        readonly property var tips: [qsTr("Short"), (""), (""), (""), (""), (""), qsTr("Long")]
                         Layout.alignment: Qt.AlignCenter
                         Layout.margins: 10
                         Layout.fillWidth: true


### PR DESCRIPTION
Changed the double click speed slider labels from "Slow/Fast" to "Short/ Long" to better represent the actual functionality being adjusted (double click interval duration rather than speed).

The previous labels "Slow/Fast" were misleading since the slider actually controls the time interval between clicks that registers as a double click. "Short/Long" more accurately describes the time duration being adjusted.

Log: Changed double click speed slider labels from "Slow/Fast" to "Short/Long"

Influence:
1. Verify the slider still functions correctly with the new labels
2. Check that the tooltips and accessibility descriptions are updated accordingly
3. Test double click registration with various slider positions

fix: 更新双击速度滑块标签

将双击速度滑块的标签从"慢/快"改为"短/长"，以更准确地表示实际调整的功能
（双击间隔时间而非速度）。

之前的"慢/快"标签容易造成误解，因为滑块实际上是控制被视为双击的点击间隔
时间。"短/长"能更准确地描述所调整的时间长度。

Log: 将双击速度滑块标签从"慢/快"改为"短/长"

Influence:
1. 验证滑块在更新标签后仍能正常工作
2. 检查工具提示和无障碍描述是否相应更新
3. 测试不同滑块位置下的双击注册功能

PMS: BUG-313331

## Summary by Sourcery

Bug Fixes:
- Change slider labels from “Slow/Fast” to “Short/Long” and update related tooltips and accessibility descriptions