### PR TITLE
fix: adjust avatar dialog layout and dimensions

### DIFF
--- a/src/plugin-accounts/qml/AvatarSettingsDialog.qml
+++ b/src/plugin-accounts/qml/AvatarSettingsDialog.qml
@@ -16,7 +16,7 @@ D.DialogWindow {
     id: dialog
     property string userId: dccData.currentUserId()
     property string currentAvatar: dccData.avatar()
-    width: 630
+    width: 640
     minimumWidth: width
     minimumHeight: height
     maximumWidth: minimumWidth
@@ -64,7 +64,6 @@ D.DialogWindow {
         // enableInWindowBlendBlur: true
         icon.name: dialog.icon
     }
-
     RowLayout {
         width: dialog.width
         Rectangle {
@@ -188,10 +187,12 @@ D.DialogWindow {
         ColumnLayout {
             Layout.fillWidth: true
             Layout.fillHeight: true
-
+            
             CustomAvatarEmpatyArea {
                 id: customEmptyAvatar
                 visible: needShow()
+                Layout.alignment: Qt.AlignHCenter
+                Layout.rightMargin: 10
                 onIconDropped: function (url){
                     dialog.currentAvatar = url
                     needShow()
@@ -220,7 +221,7 @@ D.DialogWindow {
                 implicitHeight: 360
                 visible: !customEmptyAvatar.visible
                 Layout.fillWidth: true
-                Layout.alignment: Qt.AlignTop
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
                 contentHeight: layout.childrenRect.height
 
                 ColumnLayout {
@@ -299,7 +300,7 @@ D.DialogWindow {
                 Layout.bottomMargin: 10
                 Layout.topMargin: 20
                 Layout.leftMargin: 30
-                Layout.rightMargin: 60
+                Layout.rightMargin: 40
 
                 Button {
                     Layout.fillWidth: true


### PR DESCRIPTION
1. Increased dialog width from 630 to 640 for better content fit
2. Removed unnecessary empty line in code structure
3. Added horizontal center alignment and right margin to empty avatar area
4. Adjusted avatar preview alignment to center horizontally while keeping top alignment
5. Reduced right margin of button area from 60 to 40 for better spacing balance

Log: Improved layout and spacing in avatar settings dialog

Influence:
1. Verify dialog displays correctly at new width
2. Check empty avatar area alignment and margins
3. Test avatar preview positioning
4. Confirm button area spacing looks balanced
5. Test all layout changes with different avatar states

fix: 调整头像对话框布局和尺寸

1. 将对话框宽度从630增加到640以更好适应内容
2. 移除代码中不必要的空行
3. 为空白头像区域添加水平居中对齐和右边距
4. 调整头像预览对齐方式为水平居中同时保持顶部对齐
5. 将按钮区域右边距从60减少到40以获得更好的间距平衡

Log: 优化了头像设置对话框的布局和间距

Influence:
1. 验证对话框在新宽度下正确显示
2. 检查空白头像区域的对齐和边距
3. 测试头像预览的定位
4. 确认按钮区域间距看起来平衡
5. 使用不同头像状态测试所有布局更改

PMS: BUG-292621

## Summary by Sourcery

Adjust avatar settings dialog layout and spacing

Enhancements:
- Increase dialog width from 630 to 640 for better content fit
- Center-align empty avatar area horizontally and add a right margin
- Center-align avatar preview horizontally while retaining top alignment
- Reduce button area right margin from 60 to 40 for improved balance

Chores:
- Remove an unnecessary empty line in the QML file