### PR TITLE
fix: unsupported relocation error on arm64

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.1.40) unstable; urgency=medium
+
+  * fix: unsupported relocation error on arm64
+
+ -- Wang Zichong <wangzichong@deepin.org>  Fri, 01 Aug 2025 11:08:00 +0800
+
 dde-control-center (6.1.39) unstable; urgency=medium
 
   * chore: remove upper-level datetime_*.ts resources

--- a/src/shared-utils/dcclocale.cpp
+++ b/src/shared-utils/dcclocale.cpp
@@ -5,6 +5,7 @@
 #include "dcclocale.h"
 
 #include <QCoreApplication>
+#include <QGlobalStatic>
 #include <QLocale>
 #include <memory>
 
@@ -15,11 +16,18 @@ using namespace Qt::Literals::StringLiterals;
 
 namespace {
     // Cache LocaleDisplayNames instance
+    struct DisplayNamesHolder {
+        DisplayNamesHolder() 
+            : displayNames(icu::LocaleDisplayNames::createInstance(
+                icu::Locale::getDefault(), ULDN_DIALECT_NAMES)) {}
+        
+        std::unique_ptr<icu::LocaleDisplayNames> displayNames;
+    };
+    
+    Q_GLOBAL_STATIC(DisplayNamesHolder, globalDisplayNames);
+    
     icu::LocaleDisplayNames* getDisplayNames() {
-        static std::unique_ptr<icu::LocaleDisplayNames> displayNames(
-            icu::LocaleDisplayNames::createInstance(icu::Locale::getDefault(), ULDN_DIALECT_NAMES)
-        );
-        return displayNames.get();
+        return globalDisplayNames()->displayNames.get();
     }
 
     icu::UnicodeString fromQString(const QString& qstr) {


### PR DESCRIPTION
Switch to use Q_GLOBAL_STATIC to avoid relocation on CMake object library.

Log:

## Summary by Sourcery

Bug Fixes:
- Replace static unique_ptr with Q_GLOBAL_STATIC for ICU LocaleDisplayNames caching to fix unsupported relocation on arm64.