### PR TITLE
fix: Created successfully with the same username and password

### DIFF
--- a/src/plugin-accounts/qml/CreateAccountDialog.qml
+++ b/src/plugin-accounts/qml/CreateAccountDialog.qml
@@ -58,6 +58,16 @@ D.DialogWindow {
             pwdLayout.maxLabelWidth = Math.ceil(finalWidth)
         }
         
+        function checkUserNamePasswordMatch() {
+            var userName = namesContainter.eidtItems[0].text
+            var password = pwdLayout.getPwdInfo()["pwd"]
+            if (userName === password && userName.length > 0) {
+                pwdLayout.showUserNameMatchPasswordAlert()
+                return false
+            }
+            return true
+        }
+        
         Connections {
             target: pwdLayout
             function onLabelWidthCalculated() {
@@ -326,6 +336,9 @@ D.DialogWindow {
                         return
 
                     if (!pwdLayout.checkPassword())
+                        return
+
+                    if (!mainLayout.checkUserNamePasswordMatch())
                         return
 
                     var info = pwdLayout.getPwdInfo()

--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -78,6 +78,12 @@ ColumnLayout {
         return pwdContainter.checkPassword()
     }
 
+    function showUserNameMatchPasswordAlert() {
+        if (pwdContainter && pwdContainter.eidtItems && pwdContainter.eidtItems[0]) {
+            pwdContainter.eidtItems[0].showAlertText(qsTr("Different from the username"))
+        }
+    }
+
     function playErrorSound() {
         dccData.playSystemSound(14)
     }


### PR DESCRIPTION
Adds username/password match validation

Adds a check to prevent the username from being the same as the password during account creation. This enhances security by preventing users from setting easily guessable passwords.

添加用户名/密码匹配验证
添加一个检查，以防止在创建帐户期间用户名与密码相同。
这通过防止用户设置容易猜测的密码来增强安全性。
pms: BUG-314837

## Summary by Sourcery

Prevent users from creating accounts with identical usernames and passwords by adding validation and an alert in the account creation dialog.

Bug Fixes:
- Block account creation when the username and password are the same.

Enhancements:
- Show an inline alert prompting users to choose a password different from the username.