### PR TITLE
fix: improve gesture action data handling

### DIFF
--- a/src/plugin-mouse/operation/gesturemodel.cpp
+++ b/src/plugin-mouse/operation/gesturemodel.cpp
@@ -65,7 +65,7 @@ QVariant GestureModel::data(const QModelIndex &index, int role) const
         case ActionsIndexRole:
             return getGestureActionIndex(data);
         case ActionListRole:
-            return getGestureActiocNames(data);
+            return getGestureActionNames(data);
         default:
             break;
     }
@@ -109,11 +109,14 @@ QString GestureModel::getGesturesIconPath(GestureData *data) const
     return  QString("trackpad_gesture_%1_%2").arg(data->fingersNum()).arg(direction);
 }
 
-QStringList GestureModel::getGestureActiocNames(GestureData *data) const
+QVariantList GestureModel::getGestureActionNames(GestureData *data) const
 {
-    QStringList gestureActionNames;
+    QVariantList gestureActionNames;
     for (auto data : data->actionMaps()) {
-        gestureActionNames.append(data.second);
+        QVariantMap map;
+        map["actionText"] = data.second;
+        map["actionValue"] = data.first;
+        gestureActionNames.append(map);
     }
 
     return gestureActionNames;

--- a/src/plugin-mouse/operation/gesturemodel.h
+++ b/src/plugin-mouse/operation/gesturemodel.h
@@ -33,7 +33,7 @@ public:
 
     QString getGesturesDec(GestureData *data) const;
     QString getGesturesIconPath(GestureData *data) const;
-    QStringList getGestureActiocNames(GestureData *data) const;
+    QVariantList getGestureActionNames(GestureData *data) const;
     int getGestureActionIndex(GestureData *data) const;
 
     // Add data:

--- a/src/plugin-mouse/qml/GestureGroup.qml
+++ b/src/plugin-mouse/qml/GestureGroup.qml
@@ -43,16 +43,20 @@ Rectangle {
 
                 property var comboMoel: model.actionListRole
                 property int comboIndex: model.actionsIndexRole
+                property var comboItem: null
                 content: D.ComboBox {
                     id: combo
                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                     model: comboMoel
+                    textRole: "actionText"
+                    valueRole: "actionValue"
                     currentIndex: comboIndex
                     editable: false
                     flat: true
-                    onCurrentTextChanged: {
-                        root.comboIndexChanged(index, combo.currentText)
+                    onCurrentValueChanged: {
+                        root.comboIndexChanged(index, combo.currentValue)
                     }
+                    Component.onCompleted: comboItem = this
                 }
                 background: DccItemBackground {
                     backgroundType: DccObject.Normal
@@ -61,7 +65,7 @@ Rectangle {
 
                 onHoveredChanged: {
                     if (hovered) {
-                       root.hoveredChanged(index, itemCtl.content.currentText)
+                        root.hoveredChanged(index, comboItem.currentValue)
                     }
                 }
 

--- a/src/plugin-mouse/qml/Touchpad.qml
+++ b/src/plugin-mouse/qml/Touchpad.qml
@@ -338,6 +338,7 @@ DccObject {
 
             onComboIndexChanged: function (index, actionDec){
                 dccData.setGestures(3, index, actionDec)
+                dccData.updateFigerGestureAni(3,index, actionDec)
             }
 
             onHoveredChanged: function (index, actionDec) {


### PR DESCRIPTION
1. Changed return type from QStringList to QVariantList in getGestureActionNames to include both action text and value
2. Fixed typo in method name from getGestureActiocNames to getGestureActionNames
3. Updated QML components to use new data structure with textRole and valueRole
4. Modified signal types to properly handle action values instead of text
5. Added gesture animation update when action changes in Touchpad.qml

Log: Improved gesture action selection with better data structure and fixed animation updates

Influence:
1. Verify all gesture actions display correctly in the UI
2. Test action selection and ensure proper values are passed
3. Check gesture animations update when actions are changed
4. Verify hover state still works correctly with new implementation

refactor: 改进手势动作数据处理

1. 将getGestureActionNames的返回类型从QStringList改为QVariantList以包含 动作文本和值
2. 修复方法名拼写错误，从getGestureActiocNames改为getGestureActionNames
3. 更新QML组件使用新的数据结构，支持textRole和valueRole
4. 修改信号类型以正确处理动作值而非文本
5. 在Touchpad.qml中添加动作变更时的动画更新

Log: 改进了手势动作选择的数据结构并修复了动画更新问题

Influence:
1. 验证所有手势动作在UI中正确显示
2. 测试动作选择功能并确保传递正确的值
3. 检查动作变更时手势动画是否正确更新
4. 验证悬停状态在新实现下仍能正常工作

PMS: BUG-311913