### PR TITLE
fix: round margin values to prevent subpixel blurring

### DIFF
--- a/src/dde-control-center/frame/plugin/DccUtils.js
+++ b/src/dde-control-center/frame/plugin/DccUtils.js
@@ -16,10 +16,10 @@ function copyFont(srcFont, propertys) {
 
 function getMargin(w) {
     if (w > 1300) {
-        return (w - 1200) / 2
+        return Math.round((w - 1200) / 2)
     }
     if (w >= 600) {
         return 50
     }
-    return (w - 500) / 2
+    return Math.round((w - 500) / 2)
 }


### PR DESCRIPTION
The getMargin function now uses Math.round() to ensure integer pixel
values for margins. This fixes an issue where fractional pixel values
(subpixels) were causing icon blurring in the control center interface.
The change affects all window width calculations, particularly for
widths above 1300px and below 600px where margins were previously
calculated with decimal values.

Log: Fixed icon blurring issues caused by subpixel margins

Influence:
1. Test control center layout at various window widths (especially
around breakpoints)
2. Verify icon rendering clarity at all supported resolutions
3. Check margin calculations for different window sizes
4. Ensure no layout shifts occur due to rounding

fix: 四舍五入边距值防止亚像素模糊

getMargin 函数现在使用 Math.round() 确保边距为整数像素值。这修复了之前由
于小数像素值(亚像素)导致控制中心界面图标模糊的问题。该修改影响所有窗口宽
度计算，特别是宽度超过1300px和低于600px时边距计算会产生小数的情况。

Log: 修复了亚像素边距导致的图标模糊问题

Influence:
1. 在不同窗口宽度下测试控制中心布局(特别是临界点附近)
2. 验证所有支持分辨率下的图标显示清晰度
3. 检查不同窗口大小下的边距计算
4. 确保四舍五入不会导致布局偏移

PMS: BUG-327609

## Summary by Sourcery

Bug Fixes:
- Use Math.round for getMargin calculations to ensure integer margins and fix icon blurring