### PR TITLE
chore: bump version to 6.1.42

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+dde-control-center (6.1.42) unstable; urgency=medium
+
+  * fix: improve bluetooth mode selection stability (#2564)
+  * i18n: Updates for project Deepin Desktop Environment (#2558)
+  * fix: round margin values to prevent subpixel blurring
+
+ -- wujiangyu <wujiangyu@uniontech.com>  Tue, 12 Aug 2025 10:38:51 +0800
+
 dde-control-center (6.1.41) unstable; urgency=medium
 
   * fix: improve gesture action data handling


### PR DESCRIPTION
update changelog to 6.1.42

## Summary by Sourcery

Chores:
- Update debian/changelog entry for version 6.1.42