### PR TITLE
fix: improve Bluetooth UI state handling during power toggle

### DIFF
--- a/src/plugin-bluetooth/qml/Adapters.qml
+++ b/src/plugin-bluetooth/qml/Adapters.qml
@@ -7,6 +7,19 @@ import org.deepin.dcc 1.0
 import QtQuick.Layouts 1.15
 
 DccObject{
+    property bool isUserClosingBluetooth: false  // 跟踪用户是否正在关闭蓝牙
+    
+    // 监听蓝牙状态变化，当真正开启时重置隐藏状态
+    Connections {
+        target: model
+        function onPoweredChanged(poweredState, discoveringState) {
+            if (model.powered && isUserClosingBluetooth) {
+                // 蓝牙已真正开启，重置隐藏状态
+                isUserClosingBluetooth = false;
+            }
+        }
+    }
+    
     DccObject {
         name: "blueToothCtl" + model.name
         parentName: "blueToothAdapters" + model.name + index
@@ -16,7 +29,17 @@ DccObject{
             spacing: 0
             isGroup: false
         }
-        BluetoothCtl{}
+        BluetoothCtl{
+            hideWhenUserClosing: isUserClosingBluetooth
+            onUserClickedClose: {
+                // 用户点击关闭时立即隐藏
+                isUserClosingBluetooth = true
+            }
+            onUserClickedOpen: {
+                // 用户点击开启时显示
+                isUserClosingBluetooth = false
+            }
+        }
     }
 
     DccObject {
@@ -24,6 +47,7 @@ DccObject{
         parentName: "blueToothAdapters" + model.name+ index
         weight: 30
         pageType: DccObject.Item
+        visible: model.powered && !isUserClosingBluetooth
         page: DccGroupView {
             spacing: 0
             isGroup: false
@@ -37,11 +61,14 @@ DccObject{
         parentName: "blueToothAdapters" + model.name+ index
         weight: 40
         pageType: DccObject.Item
+        visible: model.powered && !isUserClosingBluetooth
         page: DccGroupView {
             spacing: 0
             isGroup: false
         }
 
-        OtherDevice{}       
+        OtherDevice{
+            hideWhenUserClosing: isUserClosingBluetooth
+        }
     }
 }

--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -10,6 +10,10 @@ import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DS
 
 DccObject{
+    signal userClickedClose()
+    signal userClickedOpen()
+    property bool hideWhenUserClosing: false  // 接收来自父组件的隐藏状态
+    
     DccObject {
         name: "blueToothSwitch"
         parentName: "blueToothCtl" + model.name
@@ -229,6 +233,16 @@ DccObject{
                 onClicked: {
                     if (enabled) {
                         isSwitching = true;
+                        
+                        // 立即发送信号通知父组件
+                        if (!checked) {
+                            // 用户点击关闭蓝牙
+                            userClickedClose();
+                        } else {
+                            // 用户点击开启蓝牙
+                            userClickedOpen();
+                        }
+                        
                         dccData.work().setAdapterPowered(model.id, checked);
                     }
                 }
@@ -243,7 +257,7 @@ DccObject{
         icon: "audio"
         pageType: DccObject.Item
         weight: 20
-        visible: !dccData.model().airplaneEnable && model.powered
+        visible: !dccData.model().airplaneEnable && model.powered && !hideWhenUserClosing
 
         page: RowLayout {
             CheckBox {

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -10,6 +10,7 @@ import org.deepin.dtk 1.0
 DccObject{
     property bool refreshEnable: true
     property bool lastPoweredState: false  // 记录上次蓝牙开关状态
+    property bool hideWhenUserClosing: false  // 接收来自父组件的隐藏状态
 
     Connections {
         target: DccApp
@@ -78,7 +79,7 @@ DccObject{
         parentName: "otherDevice" + model.name
         pageType: DccObject.Item
         weight: 20
-        visible: model.powered
+        visible: model.powered && !hideWhenUserClosing
 
         page: RowLayout {
             CheckBox {


### PR DESCRIPTION
1. Added isUserClosingBluetooth property to track user-initiated power state changes
2. Implemented immediate UI feedback when user toggles Bluetooth power
3. Added visibility control for dependent components during power transitions
4. Introduced signal-based communication between components for state synchronization

Log: Improved Bluetooth UI responsiveness during power toggle operations

Influence:
1. Test Bluetooth power toggle from UI - verify immediate visual feedback
2. Verify all dependent components (devices, controls) hide/show correctly
3. Test state persistence after power toggle
4. Verify no UI flickering during power state transitions

fix: 改进蓝牙开关时的UI状态处理

1. 添加isUserClosingBluetooth属性跟踪用户发起的电源状态变更
2. 实现用户切换蓝牙电源时的即时UI反馈
3. 为电源切换期间的相关组件添加可见性控制
4. 引入基于信号的组件间通信以实现状态同步

Log: 改进蓝牙开关操作时的UI响应速度

Influence:
1. 测试从UI切换蓝牙电源 - 验证即时视觉反馈
2. 验证所有相关组件(设备、控件)正确隐藏/显示
3. 测试电源切换后的状态持久性
4. 验证电源状态切换期间无UI闪烁

PMS: BUG-283835

## Summary by Sourcery

Improve Bluetooth UI responsiveness during power toggles by tracking user-initiated state changes, providing immediate feedback, and synchronizing component visibility to eliminate flicker

Bug Fixes:
- Reset UI hide state when Bluetooth power is actually enabled to restore component visibility
- Prevent UI flickering by hiding dependent components during user-initiated power toggles

Enhancements:
- Add isUserClosingBluetooth property to track user-initiated Bluetooth power changes
- Introduce userClickedClose/open signals for immediate feedback and inter-component synchronization
- Control visibility of Bluetooth controls and device lists during power transitions to reflect user actions preemptively