### PR TITLE
fix: adjust notification UI alignment

### DIFF
--- a/src/plugin-notification/qml/notificationMain.qml
+++ b/src/plugin-notification/qml/notificationMain.qml
@@ -33,6 +33,10 @@ DccObject {
             weight: 10
             pageType: DccObject.Editor
             page: D.Switch {
+                anchors {
+                    left: parent.left
+                    leftMargin: 10
+                }
                 checked: dccData.sysItemModel.disturbMode
                 onCheckedChanged: {
                     if (dccData.sysItemModel.disturbMode !== checked) {
@@ -49,7 +53,12 @@ DccObject {
             weight: 20
             pageType: DccObject.Item
             visible: dccData.sysItemModel.disturbMode
-            page: TimeRange {}
+            page: TimeRange {
+                anchors {
+                    left: parent.left
+                    leftMargin: 10
+                }
+            }
         }
         DccObject {
             name: "enableDoNotDisturbLock"
@@ -60,6 +69,10 @@ DccObject {
             pageType: DccObject.Item
             visible: dccData.sysItemModel.disturbMode
             page: RowLayout {
+                anchors {
+                    left: parent.left
+                    leftMargin: 10
+                }
                 D.CheckBox {
                     id: lockScreenCheckBox
                     implicitHeight: implicitContentHeight + 30


### PR DESCRIPTION
1. Added left margin and alignment to notification UI components
2. Modified Switch, TimeRange and CheckBox elements to have consistent
left margins
3. Ensured proper visual alignment across all notification settings

Log: Fixed notification UI alignment issues

Influence:
1. Verify all notification settings are properly aligned to the left
2. Check that margins are consistent across different notification
components
3. Test UI responsiveness at different screen sizes
4. Ensure no visual elements are cut off or misaligned

fix: 调整通知界面对齐问题

1. 为通知界面组件添加左边距和对齐方式
2. 修改Switch、TimeRange和CheckBox元素使其具有一致的左边距
3. 确保所有通知设置项视觉对齐一致

Log: 修复通知界面对齐问题

Influence:
1. 验证所有通知设置项是否正确左对齐
2. 检查不同通知组件的边距是否一致
3. 在不同屏幕尺寸下测试界面响应性
4. 确保没有视觉元素被截断或错位

pms: BUG-308687

## Summary by Sourcery

Bug Fixes:
- Align Switch, TimeRange, and CheckBox elements with a consistent 10px left margin in notification settings