### PR TITLE
style: adjust window effect page layout spacing

### DIFF
--- a/src/plugin-personalization/qml/WindowEffectPage.qml
+++ b/src/plugin-personalization/qml/WindowEffectPage.qml
@@ -73,7 +73,7 @@ DccObject {
                             width: 112
                             height: 104
                             Item {
-                                Layout.preferredHeight: 77
+                                Layout.preferredHeight: 78
                                 Layout.fillWidth: true
                                 Rectangle {
                                     anchors.fill: parent
@@ -85,7 +85,7 @@ DccObject {
                                 }
                                 Rectangle {
                                     anchors.fill: parent
-                                    anchors.margins: 4
+                                    anchors.margins: 3
                                     color: Qt.rgba(0, 0, 0, 0.05)
                                     radius: 7
                                     Control {


### PR DESCRIPTION
1. Changed Layout.preferredHeight from 77 to 78 for better visual balance
2. Reduced Rectangle margins from 4 to 3 pixels to improve element spacing
3. Maintains same overall design while optimizing visual proportions

style: 调整窗口效果页面布局间距

1. 将 Layout.preferredHeight 从 77 改为 78 以获得更好的视觉平衡
2. 将 Rectangle 边距从 4 像素减少到 3 像素以改善元素间距
3. 保持相同整体设计的同时优化视觉比例

PMS: BUG-324021

## Summary by Sourcery

Adjust window effect page layout spacing for improved visual proportions

Enhancements:
- Increase Layout.preferredHeight from 77 to 78 for better visual balance
- Decrease Rectangle anchors.margins from 4px to 3px to refine element spacing