### PR TITLE
feat: enhance privacy plugin UI and functionality

### DIFF
--- a/src/plugin-privacy/qml/Camera.qml
+++ b/src/plugin-privacy/qml/Camera.qml
@@ -39,6 +39,7 @@ DccObject {
                 displayName: model.name
                 pageType: DccObject.Editor
                 canSearch: false
+                backgroundType: DccObject.Hover
                 page: D.Switch {
                     checked: model.cameraPermission
                     onCheckedChanged: {

--- a/src/plugin-privacy/qml/FileAndFolder.qml
+++ b/src/plugin-privacy/qml/FileAndFolder.qml
@@ -35,18 +35,69 @@ DccObject {
                 id: privacyFolderItem
                 name: "plugin" + model.name
                 property real iconSize: 16
-                property bool isExpaned: false
+                property bool isExpanded: false
                 property var dataModel: model
                 parentName: "privacy/filefolder/filefolderViewGroup"
                 weight: 10 + index * 10
                 pageType: DccObject.Item
                 visible: !model.noDisplay
                 canSearch: false
+                backgroundType: DccObject.Hover
 
                 Connections {
                     target: parentItem
                     function onClicked() {
-                        privacyFolderItem.isExpaned = !privacyFolderItem.isExpaned
+                        privacyFolderItem.isExpanded = !privacyFolderItem.isExpanded
+                    }
+                }
+
+                DccRepeater {
+                    id: rep
+                    property var itemIndex: index
+                    model: [
+                        { name: qsTr("Documents"), checked: privacyFolderItem.dataModel.documentPermission, premission: ApplicationItem.DocumentFoldersPermission},
+                        { name: qsTr("Desktop"), checked: privacyFolderItem.dataModel.desktopPermission, premission: ApplicationItem.DesktopFoldersPermission},
+                        { name: qsTr("Pictures"), checked: privacyFolderItem.dataModel.picturePermission, premission: ApplicationItem.PictureFoldersPermission},
+                        { name: qsTr("Videos"), checked: privacyFolderItem.dataModel.videoPermission, premission: ApplicationItem.VideoFoldersPermission},
+                        { name: qsTr("Music"), checked: privacyFolderItem.dataModel.musicPermission, premission: ApplicationItem.MusicFoldersPermission},
+                        { name: qsTr("Downloads"), checked: privacyFolderItem.dataModel.downloadPermission, premission: ApplicationItem.DownloadFoldersPermission}
+                    ]
+                    delegate: DccObject {
+                        parentName: "privacy/filefolder/filefolderViewGroup"
+                        weight: privacyFolderItem.weight + 1
+                        canSearch: false
+                        visible: privacyFolderItem.isExpanded
+                        displayName: modelData.name
+                        pageType: DccObject.Item
+                        backgroundType: DccObject.Hover
+                        page: RowLayout {
+                            spacing: 2
+
+                            Item {
+                                Layout.preferredHeight: DS.Style.itemDelegate.height
+                                Layout.preferredWidth: 34
+                            }
+
+                            DccLabel {
+                                text: String('"%1" ').arg(modelData.name)
+                                color: D.DTK.platformTheme.activeColor
+                            }
+                            DccLabel {
+                                Layout.fillWidth: true
+                                text: qsTr("folder")
+                            }
+                            D.Switch {
+                                Layout.alignment: Qt.AlignRight
+                                Layout.rightMargin: 10
+                                checked: modelData.checked
+
+                                onCheckedChanged: {
+                                    if (checked != modelData.checked) {
+                                        dccData.worker.setPremissionEnabled(rep.itemIndex, modelData.premission, checked)
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -67,7 +118,7 @@ DccObject {
                         }
                         Control {
                             id: control
-                            rotation: privacyFolderItem.isExpaned ? 180 : 0
+                            rotation: privacyFolderItem.isExpanded ? 180 : 0
                             Behavior on rotation {
                                 NumberAnimation {
                                     duration: 200
@@ -81,68 +132,6 @@ DccObject {
                             }
                         }
                         
-                    }
-
-                    Item {
-                        Layout.fillWidth: true
-                        implicitHeight: coLayout.implicitHeight
-                        Behavior on implicitHeight {
-                            NumberAnimation {
-                                duration: 300
-                                easing.type: Easing.OutQuart
-                            }
-                        }
-
-                        ColumnLayout {
-                            id: coLayout
-                            anchors.fill: parent
-                            Repeater {
-                                id: rep
-                                property var itemIndex: index
-
-                                model: privacyFolderItem.isExpaned ? [
-                                    { name: qsTr("Documents"), checked: privacyFolderItem.dataModel.documentPermission, premission: ApplicationItem.DocumentFoldersPermission},
-                                    { name: qsTr("Desktop"), checked: privacyFolderItem.dataModel.desktopPermission, premission: ApplicationItem.DesktopFoldersPermission},
-                                    { name: qsTr("Pictures"), checked: privacyFolderItem.dataModel.picturePermission, premission: ApplicationItem.PictureFoldersPermission},
-                                    { name: qsTr("Videos"), checked: privacyFolderItem.dataModel.videoPermission, premission: ApplicationItem.VideoFoldersPermission},
-                                    { name: qsTr("Music"), checked: privacyFolderItem.dataModel.musicPermission, premission: ApplicationItem.MusicFoldersPermission},
-                                    { name: qsTr("Downloads"), checked: privacyFolderItem.dataModel.downloadPermission, premission: ApplicationItem.DownloadFoldersPermission}
-                                    ] : []
-                                
-
-                                delegate: D.ItemDelegate {
-                                    Layout.fillWidth: true
-                                    cascadeSelected: true
-                                    checkable: false
-                                    contentFlow: true
-                                    corners: getCornersForBackground(index, rep.model.count)
-                                    content: RowLayout {
-                                        spacing: 2
-                                        DccLabel {
-                                            text: String('"%1" ').arg(modelData.name)
-                                            color: D.DTK.platformTheme.activeColor
-                                        }
-                                        DccLabel {
-                                            Layout.fillWidth: true
-                                            text: qsTr("folder")
-                                        }
-                                        D.Switch {
-                                            Layout.alignment: Qt.AlignRight
-                                            checked: modelData.checked
-
-                                            onCheckedChanged: {
-                                                if (checked != modelData.checked) {
-                                                    dccData.worker.setPremissionEnabled(rep.itemIndex, modelData.premission, checked)
-                                                }
-                                            }
-                                        }
-                                    }
-                                    background: DccItemBackground {
-                                        separatorVisible: true
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
             }

--- a/src/plugin-privacy/qml/privacy.qml
+++ b/src/plugin-privacy/qml/privacy.qml
@@ -11,6 +11,6 @@ DccObject {
     displayName: qsTr("Privacy and Security")
     description: qsTr("Camera, folder permissions")
     icon: "privacy"
-    weight: 70
+    weight: 80
     visible: typeof D.SysInfo !== 'undefined' && DccApp.productType() === D.SysInfo.Uos
 }


### PR DESCRIPTION
1. Added hover background type to Camera and FileAndFolder components for better visual feedback
2. Refactored FileAndFolder.qml to use DccRepeater instead of regular Repeater for consistent styling
3. Improved folder permission layout with proper spacing and alignment
4. Added right margin to switches for better visual balance
5. Simplified the folder permission section structure while maintaining all functionality

feat: 增强隐私插件UI和功能

1. 为Camera和FileAndFolder组件添加悬停背景类型以提供更好的视觉反馈
2. 重构FileAndFolder.qml使用DccRepeater替代常规Repeater以获得一致的样式
3. 改进文件夹权限布局，增加适当的间距和对齐
4. 为开关添加右边距以获得更好的视觉平衡
5. 简化文件夹权限部分结构同时保留所有功能

PMS: BUG-323995
PMS: BUG-311323
PMS: BUG-303411
PMG: BUG-303167

## Summary by Sourcery

Enhance the privacy plugin UI by adding hover backgrounds to items, refactoring the folder-permission list for consistent styling, improving layout spacing and alignment, and adjusting the plugin’s menu ordering.

Enhancements:
- Add hover backgroundType to Camera and FileAndFolder items for better visual feedback
- Refactor FileAndFolder.qml to use DccRepeater delegates, simplifying folder-permission structure and styling
- Improve folder permission layout with consistent spacing and a right margin on switches
- Adjust plugin weight from 70 to 80 to update menu ordering