### PR TITLE
fix: update building warnings.

### DIFF
--- a/src/shared-utils/dcclocale.cpp
+++ b/src/shared-utils/dcclocale.cpp
@@ -30,7 +30,7 @@ namespace {
         return globalDisplayNames()->displayNames.get();
     }
 
-    icu::UnicodeString fromQString(const QString& qstr) {
+    [[maybe_unused]] icu::UnicodeString fromQString(const QString& qstr) {
         return icu::UnicodeString(qstr.utf16(), qstr.length());
     }
     


### PR DESCRIPTION
as title.

Logs:

## Summary by Sourcery

Bug Fixes:
- Add [[maybe_unused]] attribute to fromQString in dcclocale.cpp to prevent unused function warnings