### PR TITLE
fix: resolve missing corner radius in format list items

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -194,7 +194,7 @@ Loader {
                                 id: background
                                 backgroundType: DccObject.Normal
                                 separatorVisible: true
-                                radius: 8
+                                radius: 8 + bgMargins
                             }
                         }
                     }


### PR DESCRIPTION
- Fixed corner radius calculation to compensate for background margins
- Changed radius from fixed value to dynamic calculation (8 + bgMargins)
- Ensures format list items display proper rounded corners instead of square corners

Log: fix missing corner radius in format list items
pms: BUG-325229

## Summary by Sourcery

Bug Fixes:
- Fix corner radius calculation by adding background margins to the radius value in the RegionFormatDialog component.