### PR TITLE
fix: resolve delete button hover effect issues in DefaultApp DetailItem

### DIFF
--- a/src/plugin-defaultapp/qml/DetailItem.qml
+++ b/src/plugin-defaultapp/qml/DetailItem.qml
@@ -61,6 +61,8 @@ DccObject {
                 id: control
                 leftPadding: 10
                 rightPadding: 8
+                topPadding: 0
+                bottomPadding: 0
                 icon.name: dccObj.icon
                 text: dccObj.displayName
                 checked: false
@@ -74,10 +76,10 @@ DccObject {
                         Layout.alignment: Qt.AlignCenter
                         visible: model.isDefault
                     }
-                    D.ActionButton {
+                    D.IconButton {
                         Layout.alignment: Qt.AlignCenter
-                        implicitHeight: 22
-                        implicitWidth: 22
+                        implicitHeight: 30
+                        implicitWidth: 30
                         visible: !model.isDefault && model.canDelete && control.hovered
                         icon {
                             name: "dcc-delete"


### PR DESCRIPTION
- Replaced D.ActionButton with D.IconButton to fix hover interaction
- Increased button size from 22x22 to 30x30 pixels for proper hover area
- Added topPadding and bottomPadding set to 0 for better button alignment
- Ensures delete button hover effect displays correctly when mouse over

Log: fix delete button hover effect in default application settings
pms: BUG-327429

## Summary by Sourcery

Fix delete button hover interaction in the DefaultApp DetailItem by switching to IconButton, enlarging its hit area, and adjusting padding for correct alignment.

Bug Fixes:
- Restore delete button hover state in the detail item when the mouse is over the button

Enhancements:
- Replace D.ActionButton with D.IconButton for the delete action
- Increase delete button implicit size from 22x22 to 30x30 to enlarge the hover area
- Set top and bottom padding to 0 on the control for proper button alignment