### PR TITLE
fix: resolve bluetooth device more button style issues

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -6,6 +6,7 @@ import QtQuick.Layouts 1.15
 
 import org.deepin.dtk 1.0 as D
 import org.deepin.dcc 1.0
+import org.deepin.dtk.style 1.0 as DS
 import QtQuick.Window 2.15
 import Qt.labs.platform
 
@@ -190,20 +191,38 @@ Rectangle {
                                 }
                             }
 
-                            D.IconButton {
+                            D.ActionButton {
                                 id: moreBtn
+                                palette.windowText: D.ColorSelector.textColor
                                 visible: showMoreBtn
                                 Layout.alignment: Qt.AlignRight
                                 icon.name: "bluetooth_option"
-                                icon.width: 20
-                                icon.height: 20
+                                icon.width: 16
+                                icon.height: 16
 
-                                implicitHeight: 24
-                                implicitWidth: 24
+                                implicitHeight: 30
+                                implicitWidth: 30
 
                                 flat: !hovered
 
                                 property bool menuShown: false
+
+                                background: Rectangle {
+                                    property D.Palette pressedColor: D.Palette {
+                                        normal: Qt.rgba(0, 0, 0, 0.2)
+                                        normalDark: Qt.rgba(1, 1, 1, 0.25)
+                                    }
+                                    property D.Palette hoveredColor: D.Palette {
+                                        normal: Qt.rgba(0, 0, 0, 0.1)
+                                        normalDark: Qt.rgba(1, 1, 1, 0.1)
+                                    }
+                                    radius: DS.Style.control.radius
+                                    color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                                    border {
+                                        color: parent.palette.highlight
+                                        width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                    }
+                                }
 
                                 D.Menu {
                                     id: contextMenu


### PR DESCRIPTION
- Replaced D.IconButton with D.ActionButton to fix incorrect button styling
- Added custom background with proper hover and pressed state colors
- Implemented DTK style import for consistent styling framework
- Adjusted button and icon dimensions for proper visual appearance
- Added palette configuration to ensure correct text color display

Log: fix bluetooth device more button style issues
pms: BUG-310077

## Summary by Sourcery

Fix styling issues for the Bluetooth device list “more” button by switching to ActionButton, importing the DTK style module, and adding a custom background with proper hover, pressed, and focus states.

Enhancements:
- Replace IconButton with ActionButton and import org.deepin.dtk.style for consistent DTK styling
- Add custom background Rectangle with hover, pressed, and focus border states
- Adjust icon and button dimensions for proper visual appearance
- Configure palette properties to ensure correct text and border highlight colors