### PR TITLE
fix: correct double click speed slider direction

### DIFF
--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -129,15 +129,15 @@ DccObject {
                     }
                     D.TipsSlider {
                         id: doubleClickSlider
-                        readonly property var tips: [qsTr("Short"), (""), (""), (""), (""), (""), qsTr("Long")]
+                        readonly property var tips: [qsTr("Slow"), (""), (""), (""), (""), (""), qsTr("Fast")]
                         Layout.alignment: Qt.AlignCenter
                         Layout.margins: 10
                         Layout.fillWidth: true
                         tickDirection: D.TipsSlider.TickDirection.Back
                         slider.handleType: Slider.HandleType.ArrowBottom
                         slider.value: dccData.doubleSpeed
-                        slider.from: 6
-                        slider.to: 0
+                        slider.from: 0
+                        slider.to: 6
                         slider.live: true
                         slider.stepSize: 1
                         slider.snapMode: Slider.SnapAlways


### PR DESCRIPTION
Changed the double click speed slider from decreasing to increasing direction to match user expectations and standard UI patterns. The slider now goes from 0 (Slow) to 6 (Fast) instead of 6 to 0. Also updated the tooltip labels from "Short/Long" to "Slow/Fast" to better describe the speed adjustment functionality.

Log: Fixed double click speed slider direction and improved tooltip labels

Influence:
1. Test double click speed slider functionality
2. Verify slider moves from left (Slow) to right (Fast)
3. Check tooltip labels display correctly as "Slow" and "Fast"
4. Test slider value changes affect double click speed appropriately
5. Verify slider snaps to integer positions correctly

fix: 修正双击速度滑块方向

将双击速度滑块从递减方向改为递增方向，以符合用户期望和标准UI模式。滑块现
在从0（慢）到6（快），而不是从6到0。同时将工具提示标签从"短/长"改为"慢/
快"，以更好地描述速度调整功能。

Log: 修复双击速度滑块方向并改进工具提示标签

Influence:
1. 测试双击速度滑块功能
2. 验证滑块从左（慢）向右（快）移动
3. 检查工具提示标签正确显示为"慢"和"快"
4. 测试滑块值变化是否正确影响双击速度
5. 验证滑块正确吸附到整数位置

PMS: BUG-328881