### PR TITLE
fix: Fixed user group list tab focus failure

### DIFF
--- a/src/plugin-accounts/operation/accountlistmodel.cpp
+++ b/src/plugin-accounts/operation/accountlistmodel.cpp
@@ -99,6 +99,7 @@ GroupListModel::GroupListModel(const QString &id, QObject *parent)
             beginInsertRows(QModelIndex(), index, index);
             m_groups << "";
             endInsertRows();
+            Q_EMIT groupsUpdated();
         });
         connect(controller, &AccountsController::requestClearEmptyGroup, this, [this, controller](const QString &userId) {
             if (userId != m_userId)


### PR DESCRIPTION
Fixed user group list tab focus failure

Log: Fixed user group list tab focus failure
pms: bug-311343

## Summary by Sourcery

Fix focus handling in the user group list view by adding custom QML focus control logic and ensure model updates notify observers.

Bug Fixes:
- Restore keyboard and tab focus behavior in the user group list when switching tabs, editing, and adding new groups.

Enhancements:
- Introduce QML flags (blockInitialFocus, suppressAutoFocusFirstOnFocus, focusNewlyCreatedItem) with handlers to manage initial focus suppression and focusing of newly created items.
- Add keyboard navigation (Tab, Up/Down arrows) and focusPolicy controls for group editing and action buttons to prevent unwanted focus shifts.

Chores:
- Emit groupsUpdated signal in GroupListModel after inserting a new group row to notify observers.