### PR TITLE
fix: resolve language display order issues in language name formatting

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -105,16 +105,44 @@ DccObject {
                         icon.name: dccObj.icon
                         checkable: false
 
-                        Label {
-                            id: langName
-                            text: dccObj.displayName
-                            elide: Text.ElideRight
-                            font: DTK.fontManager.t6
+                        Loader {
+                            id: langNameLoader
+                            property string text: dccObj.displayName
+                            property bool shouldSplit: text.split("-").length === 2
                             anchors {
                                 left: itemDelegate.left
                                 leftMargin: 12
                                 top: itemDelegate.top
-                                topMargin: (itemDelegate.height - langName.height) / 2
+                                topMargin: (itemDelegate.height - height) / 2
+                            }
+                            sourceComponent: shouldSplit ? splitComponent : singleComponent
+
+                            Component {
+                                id: singleComponent
+                                Label {
+                                    text: langNameLoader.text
+                                    elide: Text.ElideRight
+                                    font: DTK.fontManager.t6
+                                }
+                            }
+
+                            Component {
+                                id: splitComponent
+                                RowLayout {
+                                    spacing: 0
+                                    Label {
+                                        text: langNameLoader.text.split("-")[0] || ""
+                                        font: DTK.fontManager.t6
+                                    }
+                                    Label {
+                                        text: "-"
+                                        font: DTK.fontManager.t6
+                                    }
+                                    Label {
+                                        text: langNameLoader.text.split("-")[1] || ""
+                                        font: DTK.fontManager.t6
+                                    }
+                                }
                             }
                         }
 


### PR DESCRIPTION
- Replaced single Label with Loader to handle proper language component ordering
- Added conditional logic to detect and split hyphenated language codes correctly
- Implemented splitComponent with RowLayout to maintain proper sequence of language parts
- Fixed display order for language-region codes (e.g., "zh-CN") to show components in correct order
- Ensured consistent text positioning and layout for both single and compound language names

Log: fix language display order issues in language and format settings
pms: BUG-311277

## Summary by Sourcery

Use a Loader to dynamically choose between single or split label components for language names, ensuring proper ordering and alignment of hyphenated language codes.

Bug Fixes:
- Correct display order for hyphenated language-region codes by splitting and sequencing their parts
- Fix vertical centering of language name text within the delegate

Enhancements:
- Replace static Label with a Loader that selects between singleComponent and splitComponent based on the presence of a hyphen
- Implement splitComponent using RowLayout to maintain proper sequence of language parts