### PR TITLE
style: adjust busy indicator size and positioning

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -174,16 +174,16 @@ DccObject {
                             active: itemDelegate.isCurrentLang && !dccObj.enabled 
                                 && dccData.langState & langAndFormat.localeStateSetLang
                             sourceComponent: BusyIndicator {
-                                running: true
-                                implicitWidth: 36
-                                implicitHeight: 36
+                                running: visible
+                                implicitWidth: 20
+                                implicitHeight: 20
                             }
                             onLoaded: {
                                 item.parent = itemDelegate
                                 item.anchors.right = itemDelegate.right
                                 item.anchors.rightMargin = 10
                                 item.anchors.top = itemDelegate.top
-                                item.anchors.topMargin = (itemDelegate.height - removeButton.height) / 2
+                                item.anchors.topMargin = (itemDelegate.height - implicitHeight) / 2
                             }
                         }
 
@@ -364,9 +364,10 @@ DccObject {
                 visible: regionAndFormat.localeGenRunning
                 Layout.rightMargin: 10
                 BusyIndicator {
-                    running: true
-                    implicitWidth: 36
-                    implicitHeight: 36
+                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                    running: visible
+                    implicitWidth: 20
+                    implicitHeight: 20
                 }
             }
 


### PR DESCRIPTION
1. Changed BusyIndicator implicitWidth and implicitHeight from 36 to 20 for better visual proportion
2. Modified running property to use 'visible' instead of 'true' for proper state management
3. Added Layout.alignment to center the busy indicator vertically and align it to the right
4. Updated anchors.topMargin calculation to use implicitHeight instead of removeButton.height for proper centering
5. These changes improve UI consistency and visual alignment in the language and format settings

style: 调整忙碌指示器大小和定位

1. 将 BusyIndicator 的 implicitWidth 和 implicitHeight 从 36 改为 20，以 获得更好的视觉比例
2. 将 running 属性改为使用 'visible' 而不是 'true'，以进行正确的状态管理
3. 添加 Layout.alignment 以垂直居中并将忙碌指示器右对齐
4. 更新 anchors.topMargin 计算以使用 implicitHeight 而不是 removeButton.height，实现正确居中
5. 这些更改提高了语言和格式设置中的 UI 一致性和视觉对齐

PMS: STORY-39187

## Summary by Sourcery

Adjust busy indicator dimensions and positioning in the language and format settings for improved UI consistency and alignment.

Enhancements:
- Reduce busy indicator size to 20x20 for better visual proportion
- Bind running property to visible state for proper state management
- Add Layout.alignment to center vertically and right-align the busy indicator
- Update topMargin calculation to use implicitHeight for correct vertical centering