### PR TITLE
chore: bump version to 6.1.44

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,30 @@
+dde-control-center (6.1.44) unstable; urgency=medium
+
+  * style: adjust busy indicator size and positioning
+  * Fix: Modify search list style
+  * fix: Fixed the launch menu display issue
+  * fix: resolve language display order issues in language name
+    formatting
+  * fix: Fixed user group list tab focus failure
+  * [dde-control-center] Updates for project Deepin Desktop Environment
+    (#2591)
+  * Fix: Default display on the primary screen
+  * i18n: Updates for project Deepin Desktop Environment (#2575)
+  * fix: add system shortcut name conflict detection
+  * fix: correct double click speed slider direction (#2588)
+  * fix: resolve bluetooth device more button style issues
+  * fix: Fix the password box display abnormally
+  * fix: resolve delete button hover effect issues in DefaultApp
+    DetailItem
+  * fix: resolve missing corner radius in format list items
+  * fix: adjust DccEditorItem height calculation
+  * fix: update building warnings.
+  * style: update DccLabel font style
+  * feat: enhance privacy plugin UI and functionality
+  * refactor: simplify theme selection UI components
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 21 Aug 2025 19:47:51 +0800
+
 dde-control-center (6.1.43) unstable; urgency=medium
 
   * fix: update region format config flags


### PR DESCRIPTION
update changelog to 6.1.44

## Summary by Sourcery

Chores:
- Update debian/changelog to reflect version 6.1.44