### PR TITLE
fix: resolve text truncation issue in ShortcutSettingDialog

### DIFF
--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -140,7 +140,7 @@ D.DialogWindow {
             id: conflictText
             Layout.rightMargin: 20
             Layout.fillWidth: true
-            elide: Text.ElideRight
+            wrapMode: Text.WordWrap
             clip: true
             font: D.DTK.fontManager.t6
             visible: text.length > 0
@@ -148,7 +148,7 @@ D.DialogWindow {
 
         RowLayout {
             Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-            Layout.topMargin: 20
+            Layout.topMargin: 0
             spacing: 10
             Button {
                 Layout.bottomMargin: 14


### PR DESCRIPTION
- Changed conflictText from elide to wrapMode to display full text instead of ellipsis
- Updated font size from t to t6 for consistency
- Reduced button row top margin for better layout

Log: resolve text truncation issue in shortcut conflict messages
pms: BUG-308925

## Summary by Sourcery

Prevent shortcut conflict messages from being truncated by enabling word wrap, standardize font size, and adjust dialog layout spacing.

Bug Fixes:
- Replace text elision with word wrapping to display full conflict messages instead of ellipses.

Enhancements:
- Update conflict text font from t to t6 for visual consistency.
- Reduce the button row's top margin to improve dialog layout.