### PR TITLE
fix: align combo label to right

### DIFF
--- a/src/plugin-datetime/qml/ComboLabel.qml
+++ b/src/plugin-datetime/qml/ComboLabel.qml
@@ -3,6 +3,7 @@
 
 import QtQuick
 import QtQuick.Controls 2.0
+import QtQuick.Layouts 1.15
 
 Item {
     id: item
@@ -13,30 +14,33 @@ Item {
     implicitWidth: item.comboModel.length > 1 ? 280 : 80
     signal comboBoxActivated(int index)
 
-    ComboBox {
-        id: comboBox
-        visible: item.comboModel.length > 1
-        flat: true
-        implicitWidth: 280
-        model: item.comboModel
-        currentIndex: comboCurrentIndex
-        hoverEnabled: true
-        onActivated: function (index) {
-            item.comboBoxActivated(index)
+    RowLayout {
+        anchors.fill: parent
+        
+        Item {
+            Layout.fillWidth: true
         }
-        anchors {
-            verticalCenter: parent.verticalCenter
+        
+        ComboBox {
+            id: comboBox
+            visible: item.comboModel.length > 1
+            flat: true
+            implicitWidth: 280
+            model: item.comboModel
+            currentIndex: comboCurrentIndex
+            hoverEnabled: true
+            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+            onActivated: function (index) {
+                item.comboBoxActivated(index)
+            }
         }
-    }
 
-    Label {
-        id: label
-        visible: item.comboModel.length === 1
-        text: item.comboModel[0]
-        anchors {
-            verticalCenter: parent.verticalCenter
-            right: parent.right
-            rightMargin: 10
+        Label {
+            id: label
+            visible: item.comboModel.length === 1
+            text: item.comboModel[0]
+            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+            Layout.rightMargin: 10
         }
     }
 }


### PR DESCRIPTION
Changed ComboLabel layout from absolute positioning to RowLayout for better alignment
Added QtQuick.Layouts import and restructured the component to use Layout properties
ComboBox and Label now use Layout.alignment with Qt.AlignRight | Qt.AlignVCenter
Removed manual anchor positioning in favor of layout management This ensures consistent right alignment and better visual consistency

Log: Improved alignment of combo box labels in datetime settings

Influence:
1. Verify combo boxes are properly right-aligned in datetime settings
2. Test with both single item (Label) and multiple items (ComboBox) scenarios
3. Check layout responsiveness at different screen sizes
4. Verify hover effects and interaction still work correctly
5. Test with different language text lengths to ensure proper alignment

style: 调整组合标签右对齐

将 ComboLabel 布局从绝对定位改为 RowLayout 以实现更好的对齐
添加了 QtQuick.Layouts 导入并使用布局属性重构组件
ComboBox 和 Label 现在使用 Layout.alignment 并设置右对齐和垂直居中 移除了手动锚点定位，改用布局管理
这确保了统一的右对齐和更好的视觉一致性

Log: 改进了日期时间设置中组合框标签的对齐方式

Influence:
1. 验证日期时间设置中的组合框是否正确右对齐
2. 测试单选项（标签）和多选项（组合框）场景
3. 检查不同屏幕尺寸下的布局响应性
4. 验证悬停效果和交互是否仍然正常工作
5. 测试不同语言文本长度以确保正确对齐

PMS: BUG-330415