### PR TITLE
fix: prevent audio effect output when toggling mono audio setting

### DIFF
--- a/src/plugin-sound/operation/sounddbusproxy.cpp
+++ b/src/plugin-sound/operation/sounddbusproxy.cpp
@@ -355,6 +355,6 @@ void SoundDBusProxy::setAudioMono(bool audioMono)
         }
         Q_EMIT AudioMonoChanged(this->audioMono());
         watcher->deleteLater();
-        SetBalanceSink(oldBalance,true);
+        SetBalanceSink(oldBalance,false);
     });
 }


### PR DESCRIPTION
- Changed SetBalanceSink second parameter from true to false in setAudioMono callback to avoid triggering unwanted audio effect when switching mono audio on/off.

Log: fix unwanted audio effect when toggling mono audio setting
pms: BUG-327153

## Summary by Sourcery

Bug Fixes:
- Change SetBalanceSink call to use false for the second parameter to avoid triggering audio effects when switching mono audio on/off