### PR TITLE
fix: correct DBus interface usage in SetTimezone method

### DIFF
--- a/src/plugin-datetime/operation/datetimedbusproxy.cpp
+++ b/src/plugin-datetime/operation/datetimedbusproxy.cpp
@@ -200,7 +200,7 @@ bool DatetimeDBusProxy::GetZoneInfo(const QString &zone, QObject *receiver, cons
 // System Timedate
 void DatetimeDBusProxy::SetTimezone(const QString &timezone, const QString &message)
 {
-    m_systemtimedatedInter->asyncCall(QStringLiteral("SetTimezone"), timezone, message);
+    m_timedateInter->asyncCall(QStringLiteral("SetTimezone"), timezone);
 }
 
 void DatetimeDBusProxy::SetNTPServer(const QString &server, const QString &message)


### PR DESCRIPTION
- Changed m_systemtimedatedInter to m_timedateInter for consistency with other timedate operations
- Removed unused message parameter from asyncCall to match the correct interface signature
- Ensures proper timezone setting functionality through unified DBus interface

Log: fix timezone setting functionality in datetime plugin
pms: BUG-314939

## Summary by Sourcery

Bug Fixes:
- Use m_timedateInter instead of m_systemtimedatedInter in SetTimezone and drop the extraneous message argument to match the DBus interface signature