### PR TITLE
fix: standardize font sizes for Wacom plugin menu item titles

### DIFF
--- a/src/plugin-wacom/qml/wacomMain.qml
+++ b/src/plugin-wacom/qml/wacomMain.qml
@@ -21,7 +21,9 @@ DccObject {
             Label {
                 height: contentHeight
                 Layout.leftMargin: 10
-                font: D.DTK.fontManager.t4
+                font.family: D.DTK.fontManager.t5.family
+                font.bold: true
+                font.pixelSize: D.DTK.fontManager.t5.pixelSize
                 text: dccObj.displayName
             }
         }
@@ -56,7 +58,7 @@ DccObject {
             Label {
                 id: speedText
                 Layout.topMargin: 10
-                font: D.DTK.fontManager.t7
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
                 Layout.leftMargin: 10
             }


### PR DESCRIPTION
- Update wacom title label font from t4 to t5 with bold styling for consistency
- Change pressure sensitivity label font from t7 to t6 to match standard sizing
- Ensure uniform font appearance across all third-level menu items in Wacom settings
- Replace direct font assignment with explicit font properties for better control

Log: standardize font sizes for Wacom plugin menu item titles
pms: BUG-293177

## Summary by Sourcery

Standardize font sizes and styling for Wacom plugin menu item titles by upgrading to the correct font levels and using explicit font properties for consistent appearance.

Bug Fixes:
- Update Wacom menu item titles to use t5 bold styling and pressure sensitivity labels to t6 for consistent sizing

Enhancements:
- Replace direct font assignments with explicit font.family, font.bold, and font.pixelSize properties for better control