### PR TITLE
refactor: standardize shortcut key identifiers naming convention

### DIFF
--- a/src/plugin-datetime/operation/keyboard/shortcutmodel.cpp
+++ b/src/plugin-datetime/operation/keyboard/shortcutmodel.cpp
@@ -15,49 +15,53 @@
 #include <QGuiApplication>
 
 QStringList systemFilter = {"terminal",
-                            "terminal-quake",
-                            "global-search",
+                            "terminalQuake",
+                            "globalSearch",
                             "screenshot",
-                            "screenshot-delayed",
-                            "screenshot-fullscreen",
-                            "screenshot-window",
-                            "screenshot-scroll",
-                            "screenshot-ocr",
-                            "deepin-screen-recorder",
-                            "switch-group",
-                            "switch-group-backward",
-                            "preview-workspace",
+                            "screenshotDelayed",
+                            "screenshotFullscreen",
+                            "screenshotWindow",
+                            "screenshotScroll",
+                            "screenshotOcr",
+                            "deepinScreenRecorder",
+                            "switchGroup",
+                            "switchGroupBackward",
+                            "previewWorkspace",
                             "launcher",
-                            "switch-applications",
-                            "switch-applications-backward",
-                            "show-desktop",
-                            "file-manager",
-                            "lock-screen",
+                            "switchApplications",
+                            "switchApplicationsBackward",
+                            "showDesktop",
+                            "fileManager",
+                            "lockScreen",
                             "logout",
-                            "wm-switcher",
-                            "system-monitor",
-                            "color-picker",
-                            "clipboard"};
-
-const QStringList &windowFilter = {"maximize",
-                                   "unmaximize",
-                                   "minimize",
-                                   "begin-move",
-                                   "begin-resize",
-                                   "close",
-                                   "toggle-to-left",
-                                   "toggle-to-right"
+                            "wmSwitcher",
+                            "systemMonitor",
+                            "colorPicker",
+                            "clipboard",
+                            "switchMonitors"
 };
 
-const QStringList &workspaceFilter = {"switch-to-workspace-left",
-                                      "switch-to-workspace-right",
-                                      "move-to-workspace-left",
-                                      "move-to-workspace-right"};
+const QStringList &windowFilter = {"maximize",
+                                    "unmaximize",
+                                    "minimize",
+                                    "beginMove",
+                                    "beginResize",
+                                    "close",
+                                    "toggleToLeft",
+                                    "toggleToRight"
+};
 
-const QStringList &assistiveToolsFilter = {"ai-assistant",
-                                           "text-to-speech",
-                                           "speech-to-text",
-                                           "translation"};
+const QStringList &workspaceFilter = {"switchToWorkspaceLeft",
+                                        "switchToWorkspaceRight",
+                                        "moveToWorkspaceLeft",
+                                        "moveToWorkspaceRight"};
+
+const QStringList &assistiveToolsFilter = {"textToSpeech",
+                                        "speechToText",
+                                        "translation",
+                                            "viewZoomIn",
+                                            "viewZoomOut",
+                                            "viewActualSize"};
 
 using namespace dccV25;
 DCORE_USE_NAMESPACE

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -16,53 +16,53 @@
 #include <DPinyin>
 
 QStringList systemFilter = {"terminal",
-                            "terminal-quake",
-                            "global-search",
+                            "terminalQuake",
+                            "globalSearch",
                             "screenshot",
-                            "screenshot-delayed",
-                            "screenshot-fullscreen",
-                            "screenshot-window",
-                            "screenshot-scroll",
-                            "screenshot-ocr",
-                            "deepin-screen-recorder",
-                            "switch-group",
-                            "switch-group-backward",
-                            "preview-workspace",
+                            "screenshotDelayed",
+                            "screenshotFullscreen",
+                            "screenshotWindow",
+                            "screenshotScroll",
+                            "screenshotOcr",
+                            "deepinScreenRecorder",
+                            "switchGroup",
+                            "switchGroupBackward",
+                            "previewWorkspace",
                             "launcher",
-                            "switch-applications",
-                            "switch-applications-backward",
-                            "show-desktop",
-                            "file-manager",
-                            "lock-screen",
+                            "switchApplications",
+                            "switchApplicationsBackward",
+                            "showDesktop",
+                            "fileManager",
+                            "lockScreen",
                             "logout",
-                            "wm-switcher",
-                            "system-monitor",
-                            "color-picker",
+                            "wmSwitcher",
+                            "systemMonitor",
+                            "colorPicker",
                             "clipboard",
-                            "switch-monitors"
+                            "switchMonitors"
 };
 
 const QStringList &windowFilter = {"maximize",
                                    "unmaximize",
                                    "minimize",
-                                   "begin-move",
-                                   "begin-resize",
+                                   "beginMove",
+                                   "beginResize",
                                    "close",
-                                   "toggle-to-left",
-                                   "toggle-to-right"
+                                   "toggleToLeft",
+                                   "toggleToRight"
 };
 
-const QStringList &workspaceFilter = {"switch-to-workspace-left",
-                                      "switch-to-workspace-right",
-                                      "move-to-workspace-left",
-                                      "move-to-workspace-right"};
+const QStringList &workspaceFilter = {"switchToWorkspaceLeft",
+                                      "switchToWorkspaceRight",
+                                      "moveToWorkspaceLeft",
+                                      "moveToWorkspaceRight"};
 
-const QStringList &assistiveToolsFilter = {"text-to-speech",
-                                           "speech-to-text",
+const QStringList &assistiveToolsFilter = {"textToSpeech",
+                                           "speechToText",
                                            "translation",
-                                            "view-zoom-in",
-                                            "view-zoom-out",
-                                            "view-actual-size"};
+                                            "viewZoomIn",
+                                            "viewZoomOut",
+                                            "viewActualSize"};
 
 // from dquickrectangle_p.h
 #define NoneCorner 0x0


### PR DESCRIPTION
Changed all shortcut key identifiers from kebab-case to camelCase for consistency across the codebase
Updated systemFilter, windowFilter, workspaceFilter, and assistiveToolsFilter lists in both datetime and keyboard plugins Added missing switchMonitors entry to systemFilter and removed ai- assistant from assistiveToolsFilter
This improves code maintainability and follows Qt naming conventions for string identifiers

refactor: 标准化快捷键标识符命名约定

将所有快捷键标识符从短横线命名法改为驼峰命名法，保持代码库一致性
更新了日期时间和键盘插件中的 systemFilter、windowFilter、workspaceFilter 和 assistiveToolsFilter 列表
向 systemFilter 添加了缺失的 switchMonitors 条目，并从
assistiveToolsFilter 中移除了 ai-assistant
这提高了代码可维护性并遵循 Qt 字符串标识符的命名约定

pms: TASK-374909

## Summary by Sourcery

Standardize shortcut key identifiers naming to camelCase across datetime and keyboard plugins and align filter lists accordingly

Enhancements:
- Convert all shortcut identifiers from kebab-case to camelCase in datetime and keyboard plugins
- Update systemFilter, windowFilter, workspaceFilter, and assistiveToolsFilter lists with renamed identifiers
- Add missing switchMonitors entry to systemFilter
- Remove ai-assistant from assistiveToolsFilter and add viewZoomIn, viewZoomOut, and viewActualSize entries