### PR TITLE
style: adjust font size and left margin in multiple QML files

### DIFF
--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -54,9 +54,9 @@ DccObject {
             Label {
                 id: speedText
                 Layout.topMargin: 10
-                font: D.DTK.fontManager.t7
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
-                Layout.leftMargin: 10
+                Layout.leftMargin: 14
             }
             D.TipsSlider {
                 id: scrollSlider
@@ -139,8 +139,8 @@ DccObject {
                     Label {
                         id: doubleClickText
                         Layout.topMargin: 10
-                        Layout.leftMargin: 10
-                        font: D.DTK.fontManager.t7
+                        Layout.leftMargin: 14
+                        font: D.DTK.fontManager.t6
                         text: dccObj.displayName
                     }
                     D.TipsSlider {

--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -38,9 +38,9 @@ DccObject {
             Label {
                 id: speedText
                 Layout.topMargin: 10
-                font: D.DTK.fontManager.t7
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
-                Layout.leftMargin: 10
+                Layout.leftMargin: 14
             }
             D.TipsSlider {
                 id: scrollSlider
@@ -123,8 +123,8 @@ DccObject {
                     Label {
                         id: doubleClickText
                         Layout.topMargin: 10
-                        Layout.leftMargin: 10
-                        font: D.DTK.fontManager.t7
+                        Layout.leftMargin: 14
+                        font: D.DTK.fontManager.t6
                         text: dccObj.displayName
                     }
                     D.TipsSlider {

--- a/src/plugin-mouse/qml/Mouse.qml
+++ b/src/plugin-mouse/qml/Mouse.qml
@@ -36,9 +36,9 @@ DccObject {
             Label {
                 id: speedText
                 Layout.topMargin: 10
-                font: D.DTK.fontManager.t7
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
-                Layout.leftMargin: 10
+                Layout.leftMargin: 14
             }
             D.TipsSlider {
                 id: scrollSlider
@@ -105,9 +105,9 @@ DccObject {
                     enabled: false
                     id: doubleClickText
                     Layout.topMargin: 10
-                    font: D.DTK.fontManager.t7
+                    font: D.DTK.fontManager.t6
                     text: dccObj.displayName
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                 }
                 D.TipsSlider {
                     id: doubleClickSlider

--- a/src/plugin-mouse/qml/Touchpad.qml
+++ b/src/plugin-mouse/qml/Touchpad.qml
@@ -72,10 +72,9 @@ DccObject {
         page: ColumnLayout {
             Label {
                 id: speedText
-
                 Layout.topMargin: 10
-                Layout.leftMargin: 10
-                font: D.DTK.fontManager.t7
+                Layout.leftMargin: 14
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
             }
 

--- a/src/plugin-personalization/qml/FontSizePage.qml
+++ b/src/plugin-personalization/qml/FontSizePage.qml
@@ -21,9 +21,9 @@ DccObject {
             Layout.fillHeight: true
             Label {
                 Layout.topMargin: 10
-                font: D.DTK.fontManager.t7
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
-                Layout.leftMargin: 10
+                Layout.leftMargin: 14
             }
             D.TipsSlider {
                 id: fontSizeSlider

--- a/src/plugin-personalization/qml/WindowEffectPage.qml
+++ b/src/plugin-personalization/qml/WindowEffectPage.qml
@@ -54,7 +54,7 @@ DccObject {
                     Layout.topMargin: 10
                     font: D.DTK.fontManager.t7
                     text: dccObj.displayName
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                 }
 
                 Flow {
@@ -162,9 +162,9 @@ DccObject {
             Layout.fillHeight: true
             Label {
                 Layout.topMargin: 10
-                font: D.DTK.fontManager.t7
+                font: D.DTK.fontManager.t6
                 text: dccObj.displayName
-                Layout.leftMargin: 10
+                Layout.leftMargin: 14
             }
 
             D.TipsSlider {

--- a/src/plugin-power/qml/BatteryPage.qml
+++ b/src/plugin-power/qml/BatteryPage.qml
@@ -35,7 +35,7 @@ DccObject {
                 Layout.fillHeight: true
 
                 RowLayout {
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
                     Label {
@@ -85,7 +85,7 @@ DccObject {
                 Layout.fillHeight: true
 
                 RowLayout {
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
                     Label {
@@ -135,7 +135,7 @@ DccObject {
                 Layout.fillHeight: true
 
                 RowLayout {
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
                     Label {

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -105,7 +105,7 @@ DccObject {
             Layout.fillHeight: true
             Label {
                 Layout.topMargin: 10
-                Layout.leftMargin: 15
+                Layout.leftMargin: 14
                 font: D.DTK.fontManager.t6
                 text: dccObj.displayName
             }

--- a/src/plugin-power/qml/PowerPage.qml
+++ b/src/plugin-power/qml/PowerPage.qml
@@ -35,7 +35,7 @@ DccObject {
                 Layout.fillHeight: true
 
                 RowLayout {
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
                     Label {
@@ -86,7 +86,7 @@ DccObject {
                 Layout.fillHeight: true
                 
                 RowLayout {
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
                     Label {
@@ -136,7 +136,7 @@ DccObject {
                 Layout.fillHeight: true
                 
                 RowLayout {
-                    Layout.leftMargin: 10
+                    Layout.leftMargin: 14
                     Layout.rightMargin: 10
                     Layout.topMargin: 10
                     Label {

--- a/src/plugin-wacom/qml/wacomMain.qml
+++ b/src/plugin-wacom/qml/wacomMain.qml
@@ -60,7 +60,7 @@ DccObject {
                 Layout.topMargin: 10
                 font: D.DTK.fontManager.t6
                 text: dccObj.displayName
-                Layout.leftMargin: 10
+                Layout.leftMargin: 14
             }
             D.TipsSlider {
                 id: scrollSlider


### PR DESCRIPTION
Changed font size from t7 to t6 for consistency across multiple label components in keyboard, mouse, personalization, power, and wacom plugins Adjusted left margin from 10/15 to 14 pixels to standardize spacing and improve visual alignment
These changes ensure uniform typography and layout consistency throughout the application interface

style: 调整多个 QML 文件中的字体大小和左边距

将键盘、鼠标、个性化、电源和数位板插件中多个标签组件的字体大小从 t7 调整
为 t6 以保持一致性
将左边距从 10/15 像素调整为 14 像素以标准化间距并改善视觉对齐
这些更改确保了整个应用程序界面的统一排版和布局一致性

pms: BUG-310875

## Summary by Sourcery

Standardize label typography and layout spacing across various QML plugins

Enhancements:
- Reduce label font size from t7 to t6 across keyboard, mouse, personalization, power, and wacom plugins
- Adjust label left margins to 14px in multiple QML files for consistent spacing and alignment