### PR TITLE
fix: Supplement referral dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,6 +50,7 @@ Depends:
  qml6-module-qtquick-effects,
  libdtk6declarative,
  netselect,
+Recommends: uos-license-content,
 Conflicts: dde-control-center-dock
 Replaces: dde-control-center-dock
 Description: New control center for Deepin Desktop Environment,


### PR DESCRIPTION
Supplement referral dependencies

Log: Supplement referral dependencies
pms: BUG-331387

## Summary by Sourcery

Bug Fixes:
- Add additional referral dependencies to debian/control to ensure required packages are declared