### PR TITLE
fix: show remove button when locale generation is running

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -149,7 +149,8 @@ DccObject {
                         IconButton {
                             id: removeButton
                             visible: (itemDelegate.isCurrentLang && dccObj.enabled) ||
-                                     languageListTiltle.isEditing
+                                     languageListTiltle.isEditing ||
+                                     (itemDelegate.isCurrentLang && regionAndFormat.localeGenRunning)
                             icon.name: itemDelegate.isCurrentLang ? "item_checked" : "list_delete"
                             icon.width: 16
                             icon.height: 16


### PR DESCRIPTION
- Added visibility condition for removeButton when regionAndFormat.localeGenRunning is true
- Ensures proper UI state during locale generation process in language list

Log: fix remove button visibility during locale generation in language settings
pms: BUG-331185

## Summary by Sourcery

Bug Fixes:
- Show remove button when locale generation is running for the current language in the language settings UI.