### PR TITLE
fix: add missing number separators for international locales

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -124,7 +124,7 @@ static inline QString escapSpace(const QString &space)
 static inline QString normalizeSpace(const QString &value)
 {
     QString ret = " ";
-    QStringList numberKeepList{ QString("."), QString(","), QString("'"), QString("٬")};
+    QStringList numberKeepList{ QString("."), QString(","), QString("'"), QString("٬"), QString("’"), QString("ወ"), QString("،")};
     if (numberKeepList.contains(value)) {
         ret = value;
     } else {


### PR DESCRIPTION
- Added apostrophe ('), Ethiopian separator (ወ), and Arabic comma (،) to numberKeepList
- Ensures proper handling of number formatting across different regional locales
- Prevents incorrect space normalization for valid numeric separators

Log: add missing number separators for international locales
pms: BUG-331143