### PR TITLE
fix: adjust ComboBox width in datetime plugin for better layout

### DIFF
--- a/src/plugin-datetime/qml/ComboLabel.qml
+++ b/src/plugin-datetime/qml/ComboLabel.qml
@@ -25,7 +25,7 @@ Item {
             id: comboBox
             visible: item.comboModel.length > 1
             flat: true
-            implicitWidth: 280
+            implicitWidth: 220
             model: item.comboModel
             currentIndex: comboCurrentIndex
             hoverEnabled: true


### PR DESCRIPTION
- Reduced ComboBox implicitWidth from 280 to 220 pixels to improve component spacing and visual balance in the datetime settings interface.

Log: adjust ComboBox width in datetime plugin for better layout
pms: BUG-331281

## Summary by Sourcery

Bug Fixes:
- Adjust ComboBox implicitWidth from 280 to 220 pixels in the datetime settings interface to enhance component spacing and visual balance