### PR TITLE
fix: use ClickStyle instead of magic number

### DIFF
--- a/src/dde-control-center/frame/plugin/DccGroupView.qml
+++ b/src/dde-control-center/frame/plugin/DccGroupView.qml
@@ -37,7 +37,7 @@ Rectangle {
                         topInset: root.isGroup ? 0 : 5
                         bottomInset: root.isGroup ? 0 : 5
                         separatorVisible: root.isGroup
-                        backgroundType: model.item.backgroundType | 3
+                        backgroundType: model.item.backgroundType | DccObject.ClickStyle
                         Layout.fillWidth: true
                         corners: root.isGroup ? getCornersForBackground(index, repeater.count) : D.RoundRectangle.TopLeftCorner | D.RoundRectangle.TopRightCorner | D.RoundRectangle.BottomLeftCorner | D.RoundRectangle.BottomRightCorner
                     }
@@ -70,7 +70,7 @@ Rectangle {
                         topInset: root.isGroup ? 0 : 5
                         bottomInset: root.isGroup ? 0 : 5
                         separatorVisible: root.isGroup
-                        backgroundType: model.item.backgroundType | 3
+                        backgroundType: model.item.backgroundType | DccObject.ClickStyle
                         Layout.fillWidth: true
                         corners: root.isGroup ? getCornersForBackground(index, repeater.count) : D.RoundRectangle.TopLeftCorner | D.RoundRectangle.TopRightCorner | D.RoundRectangle.BottomLeftCorner | D.RoundRectangle.BottomRightCorner
                     }

--- a/src/dde-control-center/frame/plugin/DccItemBackground.qml
+++ b/src/dde-control-center/frame/plugin/DccItemBackground.qml
@@ -39,6 +39,9 @@ Item {
         normal: Qt.rgba(0, 0, 0, 0.05)
         normalDark: Qt.rgba(1, 1, 1, 0.05)
     }
+
+    D.ColorSelector.pressed: control.pressed && backgroundType & DccObject.Clickable
+
     // 阴影
     Loader {
         id: shadow

--- a/src/plugin-privacy/qml/FileAndFolder.qml
+++ b/src/plugin-privacy/qml/FileAndFolder.qml
@@ -42,7 +42,7 @@ DccObject {
                 pageType: DccObject.Item
                 visible: !model.noDisplay
                 canSearch: false
-                backgroundType: DccObject.Hover
+                backgroundType: DccObject.ClickStyle
 
                 Connections {
                     target: parentItem


### PR DESCRIPTION
Changed backgroundType assignment from hardcoded value 3 to DccObject.ClickStyle constant for better code readability and maintainability
Added pressed color selector for clickable items to provide visual feedback when pressed
Updated FileAndFolder.qml to use ClickStyle instead of Hover for consistent styling

fix: 使用 ClickStyle 替代魔术数字

将 backgroundType 赋值从硬编码值 3 改为使用 DccObject.ClickStyle 常量， 提高代码可读性和可维护性
为可点击项添加按下颜色选择器，在按下时提供视觉反馈
更新 FileAndFolder.qml 使用 ClickStyle 替代 Hover 以实现一致的样式

## Summary by Sourcery

Use DccObject.ClickStyle constant for backgroundType assignments, introduce pressed-state color feedback for clickable items, and align FileAndFolder.qml with the new ClickStyle styling

Enhancements:
- Replace hardcoded backgroundType value 3 with DccObject.ClickStyle constant
- Add pressed color selector in DccItemBackground.qml for click feedback
- Standardize FileAndFolder.qml styling by using ClickStyle instead of Hover