### PR TITLE
fix: adjust notification settings checkbox layout

### DIFF
--- a/src/plugin-notification/qml/notificationMain.qml
+++ b/src/plugin-notification/qml/notificationMain.qml
@@ -238,14 +238,16 @@ DccObject {
                             displayName: qsTr("Show message preview")
                             pageType: DccObject.Item
                             weight: 10
-                            page: D.CheckBox {
-                                Layout.rightMargin: 10
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                text: dccObj.displayName
-                                checked: model.EnablePreview
-                                onCheckedChanged: {
-                                    if (model.EnablePreview !== checked) {
-                                        model.EnablePreview = checked
+                            page: RowLayout {
+                                D.CheckBox {
+                                    implicitHeight: 40
+                                    Layout.leftMargin: 14
+                                    text: dccObj.displayName
+                                    checked: model.EnablePreview
+                                    onCheckedChanged: {
+                                        if (model.EnablePreview !== checked) {
+                                            model.EnablePreview = checked
+                                        }
                                     }
                                 }
                             }
@@ -256,14 +258,16 @@ DccObject {
                             displayName: qsTr("Play a sound")
                             pageType: DccObject.Item
                             weight: 20
-                            page: D.CheckBox {
-                                Layout.rightMargin: 10
-                                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                                text: dccObj.displayName
-                                checked: model.EnableSound
-                                onCheckedChanged: {
-                                    if (model.EnableSound !== checked) {
-                                        model.EnableSound = checked
+                            page: RowLayout {
+                                D.CheckBox {
+                                    implicitHeight: 40
+                                    Layout.leftMargin: 14
+                                    text: dccObj.displayName
+                                    checked: model.EnableSound
+                                    onCheckedChanged: {
+                                        if (model.EnableSound !== checked) {
+                                            model.EnableSound = checked
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
The checkboxes for "Show message preview" and "Play a sound" options in notification settings were previously aligned to the right with margin. This change wraps them in RowLayout containers with proper left margin and height settings to improve visual consistency and alignment within the settings interface. The functionality remains unchanged - only the layout and styling have been adjusted for better UI presentation.

Influence:
1. Verify that both checkboxes still function correctly (toggling enables/disables the respective settings)
2. Check visual alignment and spacing in notification settings
3. Ensure text labels remain properly displayed
4. Confirm that layout changes work across different screen sizes
5. Test that the settings persist after toggling and application restart

fix: 调整通知设置复选框布局

通知设置中的"显示消息预览"和"播放声音"选项复选框之前右对齐并带有边距。此
更改将它们包装在RowLayout容器中，具有适当的左边距和高度设置，以提高设置
界面中的视觉一致性和对齐效果。功能保持不变 - 仅调整了布局和样式以获得更
好的UI呈现。

Influence:
1. 验证两个复选框是否仍能正常工作（切换启用/禁用相应设置）
2. 检查通知设置中的视觉对齐和间距
3. 确保文本标签正确显示
4. 确认布局更改在不同屏幕尺寸下正常工作
5. 测试切换设置后设置能够持久保存并在应用重启后生效

PMS: BUG-331579