### PR TITLE
fix: fix gesture group item corner and separator styling

### DIFF
--- a/src/plugin-mouse/qml/GestureGroup.qml
+++ b/src/plugin-mouse/qml/GestureGroup.qml
@@ -40,6 +40,9 @@ Rectangle {
                 text: model.descriptionRole
                 icon.name: model.iconRole
                 hoverEnabled: true
+                
+                // 使用框架标准函数动态设置corners
+                corners: getCornersForBackground(index, repeater.count)
 
                 property var comboMoel: model.actionListRole
                 property int comboIndex: model.actionsIndexRole
@@ -58,9 +61,10 @@ Rectangle {
                     }
                     Component.onCompleted: comboItem = this
                 }
+                
                 background: DccItemBackground {
                     backgroundType: DccObject.Hover
-                    separatorVisible: true
+                    separatorVisible: index < (repeater.count - 1)  // 动态条件：最后一行不显示分割线
                 }
 
                 onHoveredChanged: {


### PR DESCRIPTION
Fixed corner rounding and separator visibility issues in GestureGroup items. Previously all items had the same styling regardless of their position in the list. Now items dynamically adjust their corner rounding based on position: first item gets top corners, last item gets bottom corners, single item gets all corners, and middle items get no corners. Also fixed separator visibility to only show between items, not after the last item.

Log: Improved visual styling of gesture group items with proper corner rounding and separator placement

Influence:
1. Test gesture group with single item to verify all corners are rounded
2. Test with multiple items to verify top item has top corners, bottom item has bottom corners
3. Verify middle items have no rounded corners
4. Check that separators only appear between items, not after the last item
5. Test hover effects maintain proper styling
6. Verify visual consistency across different gesture group sizes

fix: 修复手势组项目圆角和分隔线样式问题

修复了GestureGroup项目中圆角和分隔线可见性的问题。之前所有项目无论其在
列表中的位置如何都具有相同的样式。现在项目根据位置动态调整圆角：第一个项
目获得顶部圆角，最后一个项目获得底部圆角，单个项目获得所有圆角，中间项目
无圆角。同时修复了分隔线可见性，使其仅在项目之间显示，不在最后一个项目后
显示。

Log: 改进了手势组项目的视觉样式，具有正确的圆角和分隔线放置

Influence:
1. 测试单个项目的手势组，验证所有圆角是否正确
2. 测试多个项目，验证顶部项目有顶部圆角，底部项目有底部圆角
3. 验证中间项目没有圆角
4. 检查分隔线是否仅在项目之间显示，不在最后一个项目后显示
5. 测试悬停效果是否保持正确的样式
6. 验证不同大小手势组的视觉一致性

PMS: BUG-331611

## Summary by Sourcery

Implement dynamic styling for gesture group items to adjust corner rounding based on their position and to show separators only between items

Bug Fixes:
- Fix uniform corner rounding and separator visibility in GestureGroup items

Enhancements:
- Apply dynamic corner rounding based on item position (first, last, single, middle)
- Limit separator display to between items, hiding after the last item