### PR TITLE
fix: Fix the plaintext password to be copied

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,7 +48,7 @@ Depends:
  qml6-module-qt-labs-qmlmodels,
  qml6-module-qtquick-dialogs,
  qml6-module-qtquick-effects,
- libdtk6declarative,
+ libdtk6declarative(>= 6.0.41.5),
  netselect,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock

--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -384,6 +384,8 @@ ColumnLayout {
             topPadding: 0
             bottomPadding: 0
             font: D.DTK.fontManager.t7
+            canCopy: false
+            canCut: false
             Layout.fillWidth: true
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
             verticalAlignment: TextInput.AlignVCenter

--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -466,6 +466,8 @@ DccObject {
                             Layout.preferredWidth: parent.width
                             height: 30
                             showAlert: false
+                            canCopy: false
+                            canCut: false
 
                             Timer {
                                 id: newPasswordAlertTimer
@@ -534,6 +536,8 @@ DccObject {
                             Layout.preferredWidth: parent.width
                             placeholderText: qsTr("Required")
                             height: 30
+                            canCopy: false
+                            canCut: false
 
                             Timer {
                                 id: repeatPasswordAlertTimer


### PR DESCRIPTION
Fix the plaintext password to be copied

Log: Fix the plaintext password to be copied
pms: BUG-312183

## Summary by Sourcery

Disable copy and cut actions on password fields to prevent copying plaintext passwords in the UI.

Bug Fixes:
- Disable canCopy and canCut on new and repeat password inputs in BootPage.qml upon component completion
- Disable canCopy and canCut on password inputs in PasswordLayout.qml upon component completion