### PR TITLE
fix: fix combobox layout issues in sound settings

### DIFF
--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -202,7 +202,7 @@ DccObject {
             displayName: qsTr("Input Device")
             weight: 40
             pageType: DccObject.Editor
-            page: ComboBox {
+            page: D.ComboBox {
                 id: control
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: 10
@@ -254,7 +254,7 @@ DccObject {
                         }
 
                         Layout.fillWidth: true
-                        Layout.fillHeight: true
+                        implicitHeight: fm.height
                         Layout.rightMargin: DS.Style.comboBox.spacing
                         text: getDisplayText()
 

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -232,6 +232,7 @@ DccObject {
                 currentIndex: dccData.model().outPutPortComboIndex
                 model: dccData.model().soundOutputDeviceModel()
                 enabled: dccData.model().outPutPortComboEnable
+                implicitWidth: 300
 
                 contentItem: RowLayout {
                     spacing: DS.Style.comboBox.spacing
@@ -274,7 +275,7 @@ DccObject {
                         }
 
                         Layout.fillWidth: true
-                        Layout.fillHeight: true
+                        implicitHeight: fm.height
                         Layout.rightMargin: DS.Style.comboBox.spacing
                         text: getDisplayText()
 


### PR DESCRIPTION
Fixed layout issues in Microphone and Speaker pages by:
1. Replacing ComboBox with D.ComboBox in MicrophonePage for consistency
2. Setting implicitHeight to font metrics height instead of Layout.fillHeight to prevent excessive height
3. Adding implicitWidth of 300 to SpeakerPage combobox to ensure proper width

These changes ensure consistent styling and proper layout behavior for combobox controls in sound settings.

Log: Fixed layout issues with combobox controls in sound settings

Influence:
1. Verify comboboxes display correctly in both Microphone and Speaker settings
2. Check that combobox height is appropriate and consistent
3. Test that SpeakerPage combobox has sufficient width
4. Verify all combobox functionality remains intact
5. Test with different screen resolutions and font sizes

fix: 修复声音设置中组合框布局问题

修复了麦克风和扬声器页面中的布局问题：
1. 在 MicrophonePage 中将 ComboBox 替换为 D.ComboBox 以保持一致性
2. 将 implicitHeight 设置为字体度量高度而不是 Layout.fillHeight 以防止高 度过大
3. 为 SpeakerPage 组合框添加 300 的 implicitWidth 以确保适当的宽度

这些更改确保了声音设置中组合框控件的一致样式和正确的布局行为。

Log: 修复了声音设置中组合框控件的布局问题

Influence:
1. 验证麦克风和扬声器设置中的组合框显示正确
2. 检查组合框高度是否合适且一致
3. 测试 SpeakerPage 组合框是否有足够的宽度
4. 验证所有组合框功能保持完整
5. 在不同屏幕分辨率和字体大小下进行测试

PMS: BUG-331917

## Summary by Sourcery

Fix layout issues for combobox controls in sound settings by standardizing component usage and sizing across Microphone and Speaker pages

Bug Fixes:
- Replace ComboBox with D.ComboBox in MicrophonePage for consistent styling
- Set implicitHeight of combobox items to font metric height to avoid excessive height

Enhancements:
- Add implicitWidth of 300 to SpeakerPage combobox to ensure adequate width