### PR TITLE
chore: bump version to 6.1.47

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.1.47) unstable; urgency=medium
+
+  * Release 6.1.47
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Thu, 04 Sep 2025 21:50:06 +0800
+
 dde-control-center (6.1.46) unstable; urgency=medium
 
   * chore: update color extractor icon binary


### PR DESCRIPTION
update changelog to 6.1.47