### PR TITLE
fix: add previousServerAddress recovery mechanism in datetime plugin

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -172,6 +172,7 @@ DatetimeModel::DatetimeModel(QObject *parent)
     : QObject(parent)
     , m_ntp(true)
     , m_bUse24HourType(true)
+    , m_previousServerAddress("")
     , m_work(new DatetimeWorker(this, this))
 {
     connect(this, &DatetimeModel::ntpChanged, m_work, &DatetimeWorker::setNTP);
@@ -233,6 +234,16 @@ DatetimeModel::DatetimeModel(QObject *parent)
     timer->start();
 
     qmlRegisterType<dccV25::ZoneInfoModel>("ZoneInfoModel", 1, 0, "ZoneInfoModel");
+}
+
+DatetimeModel::~DatetimeModel()
+{
+    bool isCustomizeMode = !m_NtpServerList.contains(m_strNtpServerAddress);
+    if (isCustomizeMode && m_strNtpServerAddress.isEmpty() && !m_previousServerAddress.isEmpty()) {
+        if (m_work) {
+            m_work->setNtpServer(m_previousServerAddress);
+        }
+    }
 }
 
 void DatetimeModel::setNTP(bool ntp)
@@ -948,6 +959,14 @@ void DatetimeModel::setNtpServerAddress(const QString &ntpServer)
     if (m_strNtpServerAddress != ntpServer) {
         m_strNtpServerAddress = ntpServer;
         Q_EMIT NTPServerChanged(ntpServer);
+    }
+}
+
+void DatetimeModel::setPreviousServerAddress(const QString &address)
+{
+    if (m_previousServerAddress != address) {
+        m_previousServerAddress = address;
+        Q_EMIT previousServerAddressChanged(address);
     }
 }
 

--- a/src/plugin-datetime/operation/datetimemodel.h
+++ b/src/plugin-datetime/operation/datetimemodel.h
@@ -23,6 +23,7 @@ class DatetimeModel : public QObject
     Q_PROPERTY(bool ntpEnabled READ nTP WRITE setNTP NOTIFY ntpChanged FINAL)
     Q_PROPERTY(bool use24HourFormat READ use24HourFormat WRITE set24HourFormat NOTIFY hourTypeChanged FINAL)
     Q_PROPERTY(QString ntpServerAddress READ ntpServerAddress WRITE setNtpServerAddress NOTIFY NTPServerChanged FINAL)
+    Q_PROPERTY(QString previousServerAddress READ previousServerAddress WRITE setPreviousServerAddress NOTIFY previousServerAddressChanged FINAL)
     Q_PROPERTY(QStringList ntpServerList READ ntpServerList WRITE setNTPServerList NOTIFY NTPServerListChanged FINAL)
     Q_PROPERTY(QString timeZoneDispalyName READ timeZoneDispalyName NOTIFY currentSystemTimeZoneChanged)
     Q_PROPERTY(int currentTimeZoneIndex READ currentTimeZoneIndex NOTIFY currentSystemTimeZoneChanged)
@@ -77,6 +78,7 @@ public:
     };
 
     explicit DatetimeModel(QObject *parent = nullptr);
+    ~DatetimeModel();
 
     inline bool nTP() const { return m_ntp; }
     void setNTP(bool ntp);
@@ -100,6 +102,9 @@ public:
 
     inline QString ntpServerAddress() const { return m_strNtpServerAddress; }
     void setNtpServerAddress(const QString &ntpServer);
+
+    inline QString previousServerAddress() const { return m_previousServerAddress; }
+    void setPreviousServerAddress(const QString &address);
 
     inline QStringList ntpServerList() const { return m_NtpServerList; }
     void setNTPServerList(const QStringList &list);
@@ -176,6 +181,7 @@ Q_SIGNALS:
     void NTPServerChanged(QString server);
     void NTPServerListChanged(QStringList list);
     void NTPServerNotChanged(QString server);
+    void previousServerAddressChanged(const QString &address);
     void timeZoneChanged(QString value);
     void localeNameChanged(const QString &localeName);
     void countryChanged(const QString &country);
@@ -255,6 +261,7 @@ private:
     ZoneInfo m_currentTimeZone;
     ZoneInfo m_currentSystemTimeZone;
     QString m_strNtpServerAddress;
+    QString m_previousServerAddress;
     QStringList m_NtpServerList;
     QString m_timeZones;
     QString m_country;

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -118,9 +118,14 @@ DccObject {
                         dateAndTimeSettings.showCustom = (index < 0)
                         if (index < 0)
                             dateAndTimeSettings.customAddr = dccData.ntpServerAddress
+                        if (dccData.ntpServerAddress.length > 0)
+                            dccData.previousServerAddress = dccData.ntpServerAddress
                         return index < 0 ? serverList.length - 1 : index
                     }
                     onActivated: function (index) {
+                        if (dccData.ntpServerAddress.length > 0)
+                            dccData.previousServerAddress = dccData.ntpServerAddress
+
                         dateAndTimeSettings.showCustom = (serverList[index] === qsTr("Customize"))
                         if (dateAndTimeSettings.showCustom) {
                             dccData.ntpServerAddress = dateAndTimeSettings.customAddr
@@ -177,6 +182,9 @@ DccObject {
                 if (dateAndTimeSettings.showCustom &&
                         dateAndTimeSettings.customAddr.length === 0) {
                     dateAndTimeSettings.showCustom = false
+                    if (dccData.previousServerAddress.length > 0) {
+                        dccData.ntpServerAddress = dccData.previousServerAddress
+                    }
                 }
             }
         }


### PR DESCRIPTION
- Add previousServerAddress property to DatetimeModel with Q_PROPERTY binding
- Implement setPreviousServerAddress method for QML to update the stored address
- Add destructor logic to restore previousServerAddress when customize mode is empty
- Update QML to manage previousServerAddress through C++ property binding
- Remove redundant serverList variable in onDeactive handler

Log: add automatic server address recovery when custom NTP server field is left empty
pms: BUG-331663