### PR TITLE
fix: resolve incorrect corner display on hover in default app list

### DIFF
--- a/src/plugin-defaultapp/qml/DetailItem.qml
+++ b/src/plugin-defaultapp/qml/DetailItem.qml
@@ -15,6 +15,18 @@ DccObject {
     id: root
     property CategoryModel categoryModel: null
     property bool canDelete: false
+
+    // Function to get appropriate corners for list items based on position
+    function getCornersForBackground(index, count) {
+        if (count <= 1 || index === count - 1) {
+            // Single item or last item: only bottom corners
+            return D.RoundRectangle.BottomLeftCorner | D.RoundRectangle.BottomRightCorner
+        } else {
+            // All other items: no corners (container already provides top corners)
+            return 0
+        }
+    }
+
     page: DccRightView {
         isGroup: true
     }
@@ -69,7 +81,12 @@ DccObject {
                 hoverEnabled: true
                 cascadeSelected: false
                 checkable: false
+                corners: root.getCornersForBackground(index, categoryModel.rowCount())
                 onClicked: categoryModel.setDefaultApp(model.id)
+                background: DccItemBackground {
+                    separatorVisible: true
+                    backgroundType: DccObject.ClickStyle
+                }
                 content: RowLayout {
                     width: 38
                     DccCheckIcon {


### PR DESCRIPTION
- Added getCornersForBackground function to control corner visibility based on item position
- Fixed hover effects showing corners on all sides instead of position-appropriate corners
- Only last item displays bottom corners, other items show no corners during hover
- Added proper DccItemBackground to ensure correct hover styling

Log: Fixed default application list hover effects displaying unwanted corners on all sides
pms: BUG-331533

## Summary by Sourcery

Resolve incorrect corner display on hover in the default application list by calculating corner visibility per item and using the correct background component for styling

Bug Fixes:
- Fix hover corner rendering in default app list items to only show bottom corners for the last item

Enhancements:
- Add getCornersForBackground helper to determine appropriate corners based on item position
- Apply DccItemBackground for proper hover styling and separators