### PR TITLE
fix: center-align verification switch in boot menu settings

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -370,6 +370,7 @@ DccObject {
                     id: verificationSwitch
 
                     rightPadding: 7
+                    bottomPadding: 5
                     checked: dccData.mode().grubEditAuthEnabled
                     onCheckedChanged: {
                         if (checked && !dccData.mode().grubEditAuthEnabled) {


### PR DESCRIPTION
- Added bottomPadding: 5 to verificationSwitch for proper vertical alignment with adjacent elements.

Log: fix verification switch alignment issue in boot menu settings
pms: BUG-329087

## Summary by Sourcery

Bug Fixes:
- Add bottomPadding to verification switch for proper center alignment in BootPage.qml