### PR TITLE
fix: Fix the biometric authentication refresh not being timely.

### DIFF
--- a/src/plugin-authentication/operation/charamangerworker.cpp
+++ b/src/plugin-authentication/operation/charamangerworker.cpp
@@ -243,6 +243,9 @@ void CharaMangerWorker::refreshDriverInfo()
 {
     auto driverInfo = m_charaMangerInter->driverInfo();
     predefineDriverInfo(driverInfo);
+    
+    auto defaultDevice = m_charaMangerInter->defaultDevice();
+    refreshFingerDriverStatus(defaultDevice);
 }
 
 void CharaMangerWorker::entollStart(const QString &driverName, const int &charaType, const QString &charaName)
@@ -411,4 +414,20 @@ void CharaMangerWorker::renameFingerItem(const QString &userName, const QString 
 {
     m_charaMangerInter->RenameFinger(userName, finger, newName);
     refreshFingerEnrollList(userName);
+}
+
+void CharaMangerWorker::refreshFingerDriverStatus(const QString &defaultDevice)
+{
+    bool isFingerValid = !defaultDevice.isEmpty();
+    m_model->setFingerVaild(isFingerValid);
+    
+    if (isFingerValid) {
+        struct passwd *pws;
+        QString userId;
+        pws = getpwuid(getuid());
+        userId = QString(pws->pw_name);
+        refreshFingerEnrollList(userId);
+    } else {
+        m_model->setThumbsList(QStringList());
+    }
 }

--- a/src/plugin-authentication/operation/charamangerworker.h
+++ b/src/plugin-authentication/operation/charamangerworker.h
@@ -81,6 +81,7 @@ public Q_SLOTS:
     void stopFingerEnroll(const QString& userName);
     void deleteFingerItem(const QString& userName, const QString& finger);
     void renameFingerItem(const QString& userName, const QString& finger, const QString& newName);
+    void refreshFingerDriverStatus(const QString &defaultDevice);
 
 private:
     CharaMangerModel *m_model;


### PR DESCRIPTION
Fix the biometric authentication refresh not being timely.

Log: Fix the biometric authentication refresh not being timely.
pms: BUG-332419

## Summary by Sourcery

Improve biometric authentication refresh to update driver status and fingerprint enrollment list immediately.

Bug Fixes:
- Invoke refreshFingerDriverStatus after retrieving the default device to ensure timely update of biometric status
- Implement refreshFingerDriverStatus slot to validate device, update model state, and refresh or clear fingerprint enrollment list