### PR TITLE
fix: adapt datetime plugin dialogs for 20pt font size display

### DIFF
--- a/src/plugin-datetime/qml/LangsChooserDialog.qml
+++ b/src/plugin-datetime/qml/LangsChooserDialog.qml
@@ -228,6 +228,7 @@ Loader {
                     id: cancelButton
                     Layout.fillWidth: true
                     Layout.bottomMargin: 6
+                    font: DTK.fontManager.t6
                     implicitHeight: Math.max(30, cancelButtonFontMetrics.height + (DS.Style.control.padding - DS.Style.control.borderWidth) * 2) // Minimum 30px, adaptive based on font
                     text: qsTr("Cancel")
                     onClicked: {
@@ -243,6 +244,7 @@ Loader {
                     id: addButton
                     Layout.fillWidth: true
                     Layout.bottomMargin: 6
+                    font: DTK.fontManager.t6
                     implicitHeight: Math.max(30, addButtonFontMetrics.height + (DS.Style.control.padding - DS.Style.control.borderWidth) * 2) // Minimum 30px, adaptive based on font
                     text: qsTr("Add")
                     enabled: itemsView.checkedLang.length > 0

--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -24,11 +24,9 @@ Loader {
     sourceComponent: DialogWindow {
         id: ddialog
         width: 738
-        height: 636
         minimumWidth: width
-        minimumHeight: height
+        minimumHeight: 636
         maximumWidth: minimumWidth
-        maximumHeight: minimumHeight
         icon: "preferences-system"
         modality: Qt.WindowModal
         ColumnLayout {
@@ -36,7 +34,9 @@ Loader {
             width: parent.width
             Label {
                 Layout.alignment: Qt.AlignHCenter
+                font.family: DTK.fontManager.t5.family
                 font.bold: true
+                font.pixelSize: DTK.fontManager.t5.pixelSize
                 text: qsTr("Regional format")
             }
 
@@ -50,6 +50,7 @@ Loader {
                         Layout.leftMargin: 10
                         Layout.rightMargin: 10
                         placeholder: qsTr("Search")
+                        font: DTK.fontManager.t6
                         onTextChanged: {
                             viewModel.setFilterWildcard(text);
                             itemsView.positionViewAtBeginning();
@@ -94,6 +95,7 @@ Loader {
                             id: checkDelegate
                             implicitWidth: itemsView.width
                             text: model.display
+                            font: DTK.fontManager.t6
                             checked: (itemsView.selectedLangKey === model.langKey &&
                                      itemsView.selectedLocaleKey === model.localeKey) ||
                                     (itemsView.selectedLangKey === "" && index === itemsView.currentIndex)
@@ -140,6 +142,7 @@ Loader {
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop | Qt.H
                         Layout.bottomMargin: 20
                         text: qsTr("Default formats")
+                        font: DTK.fontManager.t6
                     }
 
                     Repeater {
@@ -170,6 +173,7 @@ Loader {
                             topPadding: topInset
                             bottomPadding: bottomInset
                             contentFlow: true
+                            font: DTK.fontManager.t6
                             corners: getCornersForBackground(index, repeater.count)
                             content: RowLayout {
                                 ColumnLayout {
@@ -206,17 +210,18 @@ Loader {
 
             RowLayout {
                 Layout.alignment: Qt.AlignHCenter
+                Layout.bottomMargin: 6
                 spacing: 10
                 Button {
-                    Layout.bottomMargin: 10
+                    font: DTK.fontManager.t6
                     text: qsTr("Cancel")
                     onClicked: {
                         ddialog.close()
                     }
                 }
                 Button {
-                    Layout.bottomMargin: 10
                     text: qsTr("Save")
+                    font: DTK.fontManager.t6
                     enabled: itemsView.checkedLang.length > 0
                     onClicked: {
                         regionFormatLoader.selectedRegion(itemsView.checkedLocale, itemsView.checkedLang)


### PR DESCRIPTION
- Added DTK.fontManager font properties to all text components in datetime dialogs
- Removed fixed height constraints in RegionFormatDialog to enable automatic sizing
- Implemented dynamic width calculation in RegionsChooserWindow based on text metrics
- Updated button layouts with proper font scaling and adjusted bottom margins
- Fixed LangsChooserDialog button font properties for consistent scaling

Log: fix datetime dialogs not properly adapting to 20pt font size settings
pms: BUG-330913

## Summary by Sourcery

Adapt datetime plugin dialogs to respect custom 20pt font sizes by applying dynamic font properties and removing rigid sizing constraints

Bug Fixes:
- Fix datetime dialogs not adapting to 20pt font size settings

Enhancements:
- Apply DTK.fontManager font settings to all text components and buttons in datetime dialogs
- Remove fixed height constraints in RegionFormatDialog and introduce dynamic width calculation in RegionsChooserWindow using TextMetrics
- Adjust dialog layouts and bottom margins for proper spacing at larger font sizes