### PR TITLE
fix: resolve scrollbar unable to reach bottom in region list

### DIFF
--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -169,9 +169,29 @@ Loader {
 
                     onPositionChanged: {
                         if (pressed) {
-                            itemsView.view.contentY = position * (itemsView.view.contentHeight - itemsView.view.height)
+                            Qt.callLater(function() {
+                                if (!itemsView.view) return
+                                var maxY = itemsView.view.contentHeight - itemsView.view.height
+                                if (maxY <= 0) return
+
+                                position = Math.max(0, Math.min(position, 1))
+                                size = Math.max(0, Math.min(size, 1))
+
+                                var normalized = size < 1 ? position / (1 - size) : 0
+                                var newY = Math.max(0, Math.min(normalized * maxY, maxY))
+
+                                // Snap to edges (30px = ~item height)
+                                if (newY <= 30) {
+                                    itemsView.view.positionViewAtBeginning()
+                                } else if (maxY - newY <= 30) {
+                                    itemsView.view.positionViewAtEnd()
+                                } else {
+                                    itemsView.view.contentY = newY
+                                }
+                            })
                         }
                     }
+
                 }
             }
         }


### PR DESCRIPTION
- Fix scrollbar dragging cannot reach the bottom of region list
- Use Qt.callLater() to defer scroll calculation and prevent race conditions
- Add boundary check to handle edge cases when content height is insufficient
- Implement position normalization with proper size ratio calculation
- Add 30px edge snapping for better user experience at list boundaries

Log: fix scrollbar dragging issue that prevented users from reaching bottom items in region selection list
pms: BUG-333055

## Summary by Sourcery

Fix scrollbar dragging issue in the region selection list by deferring scroll calculations, adding boundary checks, normalizing position, and snapping to list edges.

Bug Fixes:
- Ensure scrollbar dragging can reach bottom items in the region list

Enhancements:
- Defer scroll position updates using Qt.callLater to prevent race conditions
- Add boundary checks for cases where content height is insufficient
- Normalize scrollbar position based on content size ratio
- Implement 30px edge snapping at the top and bottom of the list