### PR TITLE
fix: add timeout dialog for X11 rotation changes

### DIFF
--- a/src/plugin-display/qml/displayMain.qml
+++ b/src/plugin-display/qml/displayMain.qml
@@ -757,6 +757,11 @@ DccObject {
                 onActivated: {
                     if (screen.rotate !== currentValue) {
                         screen.rotate = currentValue
+                        if (dccData.isX11) {
+                            timeoutDialog.createObject(this, {
+                                                           "screen": getQtScreen(root.screen)
+                                                       }).show()
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Added timeout dialog confirmation for display rotation changes on X11 environments to prevent accidental rotation changes from being applied immediately. This provides users with a cancellation opportunity before the rotation takes effect, improving the user experience and preventing unintended display orientation changes.

Log: Added confirmation dialog for display rotation changes on X11

Influence:
1. Test display rotation on X11 environment - should show confirmation dialog
2. Verify dialog allows cancellation of rotation changes
3. Test rotation changes proceed normally when confirmed
4. Verify no dialog appears on non-X11 environments
5. Test rotation functionality remains unchanged for Wayland sessions

fix: 为X11旋转变化添加超时确认对话框

在X11环境下为显示旋转变化添加了超时确认对话框，防止意外的旋转变化立即生
效。这为用户提供了在旋转生效前的取消机会，改善了用户体验并防止意外的显示
方向变化。

Log: 在X11环境下为显示旋转变化添加确认对话框

Influence:
1. 测试X11环境下的显示旋转功能 - 应显示确认对话框
2. 验证对话框允许取消旋转变化
3. 测试确认后旋转变化正常进行
4. 验证非X11环境下不显示对话框
5. 测试Wayland会话的旋转功能保持不变

PMS: BUG-292697

## Summary by Sourcery

Add a timed confirmation dialog for display rotation changes in X11 sessions to prevent accidental orientation shifts and allow cancellation before applying changes, without affecting non-X11 or Wayland workflows.

New Features:
- Show a timeout confirmation dialog before applying display rotations on X11 environments

Enhancements:
- Keep rotation behavior unchanged for non-X11 and Wayland sessions