### PR TITLE
fix: typo mistake of "Wallpapers"

### DIFF
--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -220,7 +220,7 @@ DccObject {
     DccObject {
         name: "systemWallapers"
         parentName: "personalization/wallpaper"
-        displayName: qsTr("System Wallapers")
+        displayName: qsTr("System Wallpapers")
         weight: 500
         backgroundType: DccObject.Normal
         pageType: DccObject.Item


### PR DESCRIPTION
Correct a typo mistake of "Wallpapers".

## Summary by Sourcery

Bug Fixes:
- Correct spelling of "System Wallpapers" in WallpaperPage.qml