### PR TITLE
fix: adjust title bar left margin

### DIFF
--- a/qml/DccWindow.qml
+++ b/qml/DccWindow.qml
@@ -71,7 +71,7 @@ D.ApplicationWindow {
             palette.windowText: D.ColorSelector.textColor
             anchors {
                 verticalCenter: parent.verticalCenter
-                leftMargin: 30
+                leftMargin: 20
                 left: parent.left
             }
             implicitHeight: 30


### PR DESCRIPTION
Changed the left margin of the title bar from 30 to 20 pixels to improve visual alignment and spacing consistency with other UI elements. This adjustment provides better balance in the window layout and enhances the overall aesthetic appearance of the application interface.

Influence:
1. Verify the title bar text alignment in the window
2. Check that all UI elements maintain proper spacing
3. Test window resizing behavior with the new margin
4. Ensure no text clipping occurs with the reduced margin

fix: 调整标题栏左边距

将标题栏的左边距从30像素改为20像素，以改善视觉对齐效果并与其他UI元素保持
间距一致性。此调整使窗口布局更加平衡，提升了应用程序界面的整体美观性。

Influence:
1. 验证窗口中标题栏文本的对齐情况
2. 检查所有UI元素是否保持适当的间距
3. 测试新边距下的窗口调整大小行为
4. 确保减少边距后不会出现文本裁剪问题

PMS: BUG-332339

## Summary by Sourcery

Bug Fixes:
- Change title bar left margin from 30px to 20px in DccWindow.qml to enhance layout balance and prevent text clipping