### PR TITLE
refactor: simplify gesture action mapping logic

### DIFF
--- a/src/plugin-mouse/operation/gesturedata.cpp
+++ b/src/plugin-mouse/operation/gesturedata.cpp
@@ -90,17 +90,6 @@ void GestureData::addActiosPair(const QPair<QString, QString> &actionPair)
     m_actionMaps.append(actionPair);
 }
 
-QString GestureData::getActionFromActionDec(QString actionDec)
-{
-    for (auto item : m_actionMaps) {
-        if (item.second == actionDec) {
-            return item.first;
-        }
-    }
-
-    return QString();
-}
-
 GestureData::GestureData(QObject *parent)
     : QObject(parent)
 {

--- a/src/plugin-mouse/operation/mousemodel.cpp
+++ b/src/plugin-mouse/operation/mousemodel.cpp
@@ -287,7 +287,7 @@ GestureModel *MouseModel::fourFigerGestureModel() const
     return m_fourFigerGestureModel;
 }
 
-void MouseModel::setGestures(int fingerNum, int index, QString acitonDec)
+void MouseModel::setGestures(int fingerNum, int index, QString actionName)
 {
     GestureModel *gestureModel = NULL;
     if (fingerNum == 4) {
@@ -300,7 +300,6 @@ void MouseModel::setGestures(int fingerNum, int index, QString acitonDec)
 
     GestureData *data = gestureModel->getGestureData(index);
     if (data) {
-        QString actionName = data->getActionFromActionDec(acitonDec);
         qDebug() << " setGestures action name : " << actionName << data->actionName();
         if (actionName == data->actionName())
             return;

--- a/src/plugin-mouse/operation/mousemodel.h
+++ b/src/plugin-mouse/operation/mousemodel.h
@@ -102,7 +102,7 @@ public:
 
     Q_INVOKABLE GestureModel *fourFigerGestureModel() const;
 
-    Q_INVOKABLE void setGestures(int fingerNum, int index, QString acitonDec);
+    Q_INVOKABLE void setGestures(int fingerNum, int index, QString actionName);
     Q_INVOKABLE void updateFigerGestureAni(int fingerNum, int index, QString acitonDec);
 
     QString getGestureFingerAniPath() const;


### PR DESCRIPTION
Removed the getActionFromActionDec method from GestureData class as it was no longer needed
Modified MouseModel::setGestures to accept actionName directly instead of action description
This change eliminates the unnecessary conversion from action description to action name
The method now directly uses the provided actionName parameter without lookup
Simplifies the code and improves performance by removing redundant mapping operations

refactor: 简化手势动作映射逻辑

移除了GestureData类中不再需要的getActionFromActionDec方法
修改MouseModel::setGestures方法直接接受actionName参数而非动作描述
此更改消除了从动作描述到动作名称的不必要转换
该方法现在直接使用提供的actionName参数而无需查找
简化了代码并通过移除冗余的映射操作提高了性能

pms: BUG-333717

## Summary by Sourcery

Refactor gesture action mapping logic to remove redundant lookup and streamline gesture configuration

Enhancements:
- Remove unused getActionFromActionDec method from GestureData
- Update MouseModel::setGestures signature to accept actionName directly instead of action description, eliminating extra mapping step