### PR TITLE
fix: hide current keyboard layouts from add layout dialog

### DIFF
--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -563,19 +563,11 @@ void KeyboardWorker::onPinyin()
         QStringList letterFirstList;
         if (letterFirst.isLower() || letterFirst.isUpper()) {
             letterFirstList << QString(letterFirst);
-            if (currentLayouts.contains(key)) {
-                md.setPinyin(" " + title);
-            } else {
-                md.setPinyin(title);
-            }
+            md.setPinyin(title);
         } else {
             QDBusMessage message = dbus_pinyin.call("Query", title);
             letterFirstList = message.arguments()[0].toStringList();
-            if (currentLayouts.contains(key)) {
-                md.setPinyin(" " + letterFirstList.at(0));
-            } else {
-                md.setPinyin(letterFirstList.at(0));
-            }
+            md.setPinyin(letterFirstList.at(0));
         }
         append(md);
     }

--- a/src/plugin-keyboard/operation/layoutsmodel.cpp
+++ b/src/plugin-keyboard/operation/layoutsmodel.cpp
@@ -41,7 +41,7 @@ QVariant LayoutsModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole:
         return data.text();
     case SearchedTextRole:
-        return (data.pinyin().at(0) == ' ' ? data.pinyin().mid(1) : data.pinyin()) + data.key() + data.text();
+        return data.pinyin() + data.key() + data.text();
     case IdRole:
         return data.key();
     case SectionRole:


### PR DESCRIPTION
- Removed space-based marking logic in KeyboardWorker::onPinyin() for current layouts
- Simplified SearchedTextRole processing in LayoutsModel by removing space trimming
- Prevents duplicate keyboard layouts from appearing in the add layout selection

Log: fix duplicate keyboard layouts showing in add layout dialog
pms: BUG-332569