### PR TITLE
feat: add configurable device management visibility

### DIFF
--- a/misc/configs/org.deepin.dde.control-center.sound.json
+++ b/misc/configs/org.deepin.dde.control-center.sound.json
@@ -1,0 +1,17 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "showDeviceManager": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "Whether to display device management",
+            "name[zh_CN]": "是否显示设备管理",
+            "description": "Whether to display device management, mainly to enable automatic port switching for use",
+            "description[zh_CN]": "是否显示设备管理，主要是开启端口自动切换使用",
+            "permissions": "readwrite",
+            "visibility": "public"
+        }
+    }
+}

--- a/src/plugin-sound/qml/soundMain.qml
+++ b/src/plugin-sound/qml/soundMain.qml
@@ -65,8 +65,14 @@ DccObject {
         displayName: qsTr("Devices Management")
         description: qsTr("Enable/disable audio devices")
         icon: "equipment_management"
-        visible: dccData.model().inPutPortCount !== 0 || dccData.model().outPutCount !== 0
+        visible: (dccData.model().inPutPortCount !== 0 || dccData.model().outPutCount !== 0) && config.showDeviceManager
         weight: 50
         SoundDevicemanagesPage {}
+
+        D.Config {
+            id: config
+            name: "org.deepin.dde.control-center.sound"
+            property bool showDeviceManager: true
+        }
     }
 }


### PR DESCRIPTION
Added configuration support for device management module visibility in sound settings
1. Created new configuration file org.deepin.dde.control- center.sound.json with showDeviceManager setting
2. Modified soundMain.qml to read configuration value and conditionally show device management
3. Added D.Config component to access the configuration properties
4. The setting allows controlling whether device management section should be displayed
5. Provides both English and Chinese translations for configuration metadata

feat: 添加可配置的设备管理可见性

在声音设置中添加设备管理模块可见性的配置支持
1. 创建新的配置文件 org.deepin.dde.control-center.sound.json，包含 showDeviceManager 设置
2. 修改 soundMain.qml 以读取配置值并条件性显示设备管理
3. 添加 D.Config 组件来访问配置属性
4. 该设置允许控制是否显示设备管理部分
5. 提供配置元数据的英文和中文翻译

pms: TASK-381277

## Summary by Sourcery

Add a configuration file and integrate it into the sound settings UI to conditionally display the device management section based on the showDeviceManager setting

New Features:
- Allow toggling the device management section visibility in sound settings via configuration

Enhancements:
- Introduce D.Config component in soundMain.qml to load configuration properties

Documentation:
- Provide English and Chinese translations for the new configuration metadata