### PR TITLE
fix: update iris enrollment UI and max limit

### DIFF
--- a/src/plugin-authentication/qml/AddIrisDialog.qml
+++ b/src/plugin-authentication/qml/AddIrisDialog.qml
@@ -252,7 +252,7 @@ D.DialogWindow {
 
                 RowLayout {
                     id: successBtnLayout
-                    visible: dccData.enrollIrisTips.addStage === CharaMangerModel.Success
+                    visible: dccData.irisController.addStage === CharaMangerModel.Success
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
                     Layout.bottomMargin: 0

--- a/src/plugin-authentication/qml/authenticationMain.qml
+++ b/src/plugin-authentication/qml/authenticationMain.qml
@@ -47,7 +47,7 @@ DccObject {
                 authIcon: "user_biometric_iris",
                 authType: CharaMangerModel.Type_Iris,
                 available: dccData.model.irisDriverVaild,
-                max: 10
+                max: 5
             }
         ]
         property var listDatas: [dccData.model.facesList, dccData.model.thumbsList, dccData.model.irisList]
@@ -296,36 +296,36 @@ DccObject {
                                 break;
                             }
                         }
+                    }
+                }
+            }
 
-                        Loader {
-                            id: addFaceDialogLoader
-                            active: false
-                            sourceComponent: AddFaceinfoDialog {
-                                onClosing: function (close) {
-                                    addFaceDialogLoader.active = false;
-                                }
-                            }
-                        }
+            Loader {
+                id: addFaceDialogLoader
+                active: false
+                sourceComponent: AddFaceinfoDialog {
+                    onClosing: function (close) {
+                        addFaceDialogLoader.active = false;
+                    }
+                }
+            }
 
-                        Loader {
-                            id: addFingerDialogLoader
-                            active: false
-                            sourceComponent: AddFingerDialog {
-                                onClosing: function (close) {
-                                    addFingerDialogLoader.active = false;
-                                }
-                            }
-                        }
+            Loader {
+                id: addFingerDialogLoader
+                active: false
+                sourceComponent: AddFingerDialog {
+                    onClosing: function (close) {
+                        addFingerDialogLoader.active = false;
+                    }
+                }
+            }
 
-                        Loader {
-                            id: addIrisDialogLoader
-                            active: false
-                            sourceComponent: AddIrisDialog {
-                                onClosing: function (close) {
-                                    addIrisDialogLoader.active = false;
-                                }
-                            }
-                        }
+            Loader {
+                id: addIrisDialogLoader
+                active: false
+                sourceComponent: AddIrisDialog {
+                    onClosing: function (close) {
+                        addIrisDialogLoader.active = false;
                     }
                 }
             }


### PR DESCRIPTION
1. Changed visibility condition for success button from dccData.enrollIrisTips.addStage to dccData.irisController.addStage to fix incorrect property reference
2. Reduced maximum iris enrollment limit from 10 to 5 to match system capabilities
3. Fixed dialog loader indentation and structure to ensure proper component loading behavior

fix: 更新虹膜注册UI和最大限制

1. 将成功按钮的可见性条件从 dccData.enrollIrisTips.addStage 改为 dccData.irisController.addStage 以修复错误的属性引用
2. 将最大虹膜注册限制从10减少到5以匹配系统能力
3. 修复对话框加载器的缩进和结构以确保正确的组件加载行为

pms: BUG-334387
pms: BUG-334385