### PR TITLE
style: update font styles in control center

### DIFF
--- a/src/dde-control-center/frame/plugin/DccItem.qml
+++ b/src/dde-control-center/frame/plugin/DccItem.qml
@@ -20,6 +20,7 @@ D.ItemDelegate {
     bottomPadding: bottomInset
     implicitHeight: contentItem.implicitHeight + topPadding + bottomPadding
     padding: 0
+    font: D.DTK.fontManager.t6
 
     contentItem: model.item.getSectionItem(this)
     background: DccItemBackground {

--- a/src/plugin-personalization/qml/WindowEffectPage.qml
+++ b/src/plugin-personalization/qml/WindowEffectPage.qml
@@ -52,7 +52,6 @@ DccObject {
                 Label {
                     id: speedText
                     Layout.topMargin: 10
-                    font: D.DTK.fontManager.t7
                     text: dccObj.displayName
                     Layout.leftMargin: 14
                 }


### PR DESCRIPTION
Changed DccItem.qml to use t6 font from DTK fontManager for consistent typography
Removed explicit font assignment from WindowEffectPage.qml to use default font settings
These changes ensure better visual consistency across the control center interface

style: 更新控制中心字体样式

修改 DccItem.qml 使用 DTK fontManager 的 t6 字体以保持排版一致性
移除 WindowEffectPage.qml 中的显式字体设置以使用默认字体配置
这些更改确保控制中心界面具有更好的视觉一致性

pms: BUG-310875