### PR TITLE
fix: remove background from default app items

### DIFF
--- a/src/plugin-defaultapp/qml/DetailItem.qml
+++ b/src/plugin-defaultapp/qml/DetailItem.qml
@@ -16,16 +16,6 @@ DccObject {
     property CategoryModel categoryModel: null
     property bool canDelete: false
 
-    // Function to get appropriate corners for list items based on position
-    function getCornersForBackground(index, count) {
-        if (count <= 1 || index === count - 1) {
-            // Single item or last item: only bottom corners
-            return D.RoundRectangle.BottomLeftCorner | D.RoundRectangle.BottomRightCorner
-        } else {
-            // All other items: no corners (container already provides top corners)
-            return 0
-        }
-    }
 
     page: DccRightView {
         isGroup: true
@@ -81,12 +71,9 @@ DccObject {
                 hoverEnabled: true
                 cascadeSelected: false
                 checkable: false
-                corners: root.getCornersForBackground(index, categoryModel.rowCount())
                 onClicked: categoryModel.setDefaultApp(model.id)
-                background: DccItemBackground {
-                    separatorVisible: true
-                    backgroundType: DccObject.ClickStyle
-                }
+                background: null
+                implicitHeight: 48
                 content: RowLayout {
                     width: 38
                     DccCheckIcon {


### PR DESCRIPTION
Removed the DccItemBackground from DetailItem.qml and set implicitHeight to 48 to fix visual issues with the default application selection interface. The background was causing rendering problems and visual inconsistencies in the item display. Setting background to null eliminates the unwanted visual elements while maintaining proper item sizing with explicit height.

Influence:
1. Verify default application selection items display correctly without background artifacts
2. Test clicking functionality still works properly
3. Check item height consistency across different screen sizes
4. Verify visual alignment with other interface elements

fix: 移除默认应用项目的背景

从 DetailItem.qml 中移除了 DccItemBackground 并将隐式高度设置为 48，以 修复默认应用选择界面的视觉问题。背景导致了项目显示的渲染问题和视觉不一致
性。将背景设置为 null 可以消除不需要的视觉元素，同时通过明确的高度设置保
持正确的项目尺寸。

Influence:
1. 验证默认应用选择项目在没有背景伪影的情况下正确显示
2. 测试点击功能是否仍然正常工作
3. 检查不同屏幕尺寸下的项目高度一致性
4. 验证与其他界面元素的视觉对齐

PMS: BUG-334465

## Summary by Sourcery

Remove the DccItemBackground from default app selection items to eliminate rendering artifacts and set an implicit height of 48 for consistent sizing

Bug Fixes:
- Remove default background in DetailItem.qml to fix visual inconsistencies
- Set implicitHeight to 48 for proper item sizing