### PR TITLE
fix: connect license state change signal

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfoproxy.cpp
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.cpp
@@ -89,6 +89,13 @@ CommonInfoProxy::CommonInfoProxy(QObject *parent)
         SIGNAL(BackgroundChanged())
     );
 
+    QDBusConnection::systemBus().connect(
+        LicenseService,
+        LicensePath,
+        LicenseInterface,
+        "LicenseStateChange",
+        this, SLOT(onLicenseStateChanged()));
+
     m_isACLController =  isACLActivatable();
     if (m_isACLController) {
         qInfo(dcCommonLog) << "DeveloperMode uses ACL service to work.";
@@ -327,4 +334,10 @@ void CommonInfoProxy::onACLError(quint32 exitCode)
             << exitCode << ", errorCode" << errorCode;
         Q_EMIT developModeError("1001");
     }
+}
+
+void CommonInfoProxy::onLicenseStateChanged()
+{
+    const auto state = AuthorizationState();
+    Q_EMIT AuthorizationStateChanged(state);
 }

--- a/src/plugin-commoninfo/operation/commoninfoproxy.h
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.h
@@ -96,6 +96,7 @@ Q_SIGNALS: // SIGNALS
 private Q_SLOTS:
     void onDeepinIdError(const int code, const QString &msg);
     void onACLError(quint32 exitCode);
+    void onLicenseStateChanged();
 
 private:
     DDBusInterface *m_grubInter;


### PR DESCRIPTION
Added D-Bus connection to listen for license state changes from the
license service. This ensures the system can immediately respond when
the license state changes after activation, fixing the issue where the
system didn't respond promptly after activation.

The fix connects to the LicenseStateChange signal from the license
service and emits AuthorizationStateChanged signal with the current
state when triggered, ensuring UI components can update in real-time.

Log: Fixed system activation response delay issue

Influence:
1. Test system activation process and verify immediate response
2. Check if AuthorizationStateChanged signal is properly emitted on
license changes
3. Verify UI updates correctly when license state changes
4. Test with different license states (active, expired, invalid)

fix: 连接许可证状态变更信号

添加了D-Bus连接来监听许可证服务的许可证状态变更。这确保系统在激活后许可
证状态发生变化时能够立即响应，修复了系统激活后未及时响应的问题。

该修复连接到许可证服务的LicenseStateChange信号，并在触发时发射
AuthorizationStateChanged信号及当前状态，确保UI组件能够实时更新。

Log: 修复系统激活后响应延迟问题

Influence:
1. 测试系统激活过程并验证即时响应
2. 检查许可证变更时AuthorizationStateChanged信号是否正确发射
3. 验证许可证状态变更时UI是否正确更新
4. 测试不同许可证状态（激活、过期、无效）下的表现

## Summary by Sourcery

Connect to the license service’s LicenseStateChange D-Bus signal and emit AuthorizationStateChanged with the current state to fix delayed activation response and enable real-time UI updates on license state changes

Bug Fixes:
- Connect to LicenseStateChange signal to resolve delayed system activation response

Enhancements:
- Emit AuthorizationStateChanged on license state changes for immediate UI component updates