### PR TITLE
fix: resolve onboard icon display in privacy FileAndFolder

### DIFF
--- a/src/plugin-privacy/qml/FileAndFolder.qml
+++ b/src/plugin-privacy/qml/FileAndFolder.qml
@@ -109,6 +109,8 @@ DccObject {
                         D.DciIcon {
                             sourceSize: Qt.size(DS.Style.itemDelegate.iconSize, DS.Style.itemDelegate.iconSize)
                             name: model.iconName
+                            theme: D.DTK.themeType
+                            palette: parent ? D.DTK.makeIconPalette(parent.palette) : D.DTK.makeIconPalette(D.DTK.palette)
                         }
                         DccLabel {
                             text: model.name
@@ -128,7 +130,7 @@ DccObject {
                                 name: "arrow_ordinary_down"
                                 sourceSize: Qt.size(12, 12)
                                 theme: D.DTK.themeType
-                                palette: D.DTK.makeIconPalette(control.palette)
+                                palette: parent ? D.DTK.makeIconPalette(parent.palette) : D.DTK.makeIconPalette(control.palette)
                             }
                         }
                         


### PR DESCRIPTION
- Added theme and palette properties to DciIcon for proper icon rendering
- Fixed null-safe palette binding to ensure onboard icons display correctly

Log: fix onboard icon display issues in privacy and security file folder settings
pms: BUG-331063
pms: BUG-331507

## Summary by Sourcery

Add explicit theme and palette bindings to DciIcon in FileAndFolder.qml to ensure onboard icons render correctly in privacy and security file folder settings

Bug Fixes:
- Implement null-safe palette binding to prevent missing icons in FileAndFolder view

Enhancements:
- Add theme and palette properties to DciIcon for proper icon rendering