### PR TITLE
refactor: replace libdpkg API with dpkg-query command

### DIFF
--- a/src/plugin-privacy/CMakeLists.txt
+++ b/src/plugin-privacy/CMakeLists.txt
@@ -3,9 +3,6 @@ set(LIB_NAME privacy)
 find_package(DDEShell REQUIRED)
 find_package(PolkitQt6-1 REQUIRED)
 
-pkg_check_modules(LIBDPKG REQUIRED libdpkg)
-include_directories(${DPKG_INCLUDE_DIRS})
-
 file(GLOB_RECURSE Privacy_SRCS
     "operation/*.cpp"
     "operation/*.hpp"
@@ -30,7 +27,6 @@ set(Privacy_Libraries
     ${QT_NS}::Concurrent
     Dde::Shell
     PolkitQt6-1::Agent
-    dpkg
 )
 
 target_include_directories(${LIB_NAME} PUBLIC

--- a/src/plugin-privacy/operation/privacysecuritydataproxy.h
+++ b/src/plugin-privacy/operation/privacysecuritydataproxy.h
@@ -71,11 +71,8 @@ private Q_SLOTS:
     void onSetEntityFinished(QDBusPendingCallWatcher *w);
     void onGetPolicyFinished(QDBusPendingCallWatcher *w);
     void onSetPolicyFinished(QDBusPendingCallWatcher *w);
-    void initModstatdb();
-    void shutdownModstatdb();
 
 private:
-    bool m_initModstatdb; // dpkg 初始化标志
     bool m_serviceExists;
     Dtk::Core::DConfig *m_dconfig;
 };


### PR DESCRIPTION
1. Removed libdpkg dependency from CMakeLists.txt and library links
2. Replaced complex libdpkg API calls with simple dpkg-query command execution
3. Simplified getExecutable() method by reading package file list directly
4. Removed modstatdb initialization and shutdown logic
5. Improved code readability and reduced maintenance complexity

The change was necessary because the libdpkg API was overly complex for the simple task of finding package files. Using dpkg-query command is more straightforward and reduces the risk of memory leaks or database locking issues. The new implementation reads package file lists directly from /var/lib/dpkg/info/ which is simpler and more reliable.

refactor: 使用 dpkg-query 命令替换 libdpkg API

1. 从 CMakeLists.txt 和库链接中移除 libdpkg 依赖
2. 使用简单的 dpkg-query 命令执行替换复杂的 libdpkg API 调用
3. 通过直接读取包文件列表简化 getExecutable() 方法
4. 移除 modstatdb 初始化和关闭逻辑
5. 提高代码可读性并降低维护复杂度

此变更是必要的，因为 libdpkg API 对于查找包文件这一简单任务过于复杂。使
用 dpkg-query 命令更直接，并减少了内存泄漏或数据库锁定问题的风险。新实现
直接从 /var/lib/dpkg/info/ 读取包文件列表，更简单可靠。

## Summary by Sourcery

Refactor package file lookup to use dpkg-query instead of the libdpkg API, removing unnecessary dependencies and simplifying internal logic

Enhancements:
- Replace libdpkg API calls with QProcess invocation of dpkg-query
- Simplify getExecutable() to parse package ownership and scan /var/lib/dpkg/info/*.list files directly
- Remove modstatdb initialization, shutdown logic and fsys-based queries
- Eliminate libdpkg dependency from CMakeLists.txt and linking configuration