### PR TITLE
fix: update week start day format on locale change

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -579,6 +579,8 @@ void DatetimeModel::setCurrentLocaleAndLangRegion(const QString &localeName, con
     RegionFormat regionFormat = RegionProxy::regionFormat(locale);
     // case FirstDayOfWeek:
     m_work->setConfigValue(firstDayOfWeek_key, regionFormat.firstDayOfWeekFormat);
+    m_work->setWeekStartDayFormat(regionFormat.firstDayOfWeekFormat < 1 ? 0 : regionFormat.firstDayOfWeekFormat - 1);
+    setFirstDayOfWeek(regionFormat.firstDayOfWeekFormat);
     // case ShortDate:
     m_work->setConfigValue(shortDateFormat_key, regionFormat.shortDateFormat);
     // case LongDate:


### PR DESCRIPTION
- Added missing setWeekStartDayFormat() and setFirstDayOfWeek() calls
- Fixes week start day not syncing with locale changes in datetime settings

Log: Fixed week start day display issue when changing locale
pms: BUG-330411

## Summary by Sourcery

Fix week start day display issue by updating week start day settings when the locale changes

Bug Fixes:
- Add missing setWeekStartDayFormat call to align week start day format with locale settings
- Invoke setFirstDayOfWeek to synchronize the first day of the week with locale updates