### PR TITLE
fix: disable hover effect on language delete button

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -161,6 +161,7 @@ DccObject {
                             icon.height: 16
                             implicitWidth: 36
                             implicitHeight: 36
+                            hoverEnabled: false
                             anchors {
                                 right: itemDelegate.right
                                 top: itemDelegate.top


### PR DESCRIPTION
- Set hoverEnabled: false to prevent unwanted hover background
- Fixes visual issue in dark mode where button shows extra background circle

Log: fix language delete button hover background issue
pms: BUG-335543

## Summary by Sourcery

Bug Fixes:
- Disable hover effect on language delete button to prevent unwanted hover background