### PR TITLE
fix: Fix the issue of the edit button not being horizontal

### DIFF
--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -107,8 +107,7 @@ DccObject{
                     ToolButton {
                         id: editBtn
                         anchors.left: nameDetail.right
-                        anchors.top: nameDetail.top
-                        anchors.topMargin: 2
+                        anchors.verticalCenter: nameDetail.verticalCenter
                         font: DTK.fontManager.t10
                         text: qsTr("Edit")
                         background: null


### PR DESCRIPTION
Fix the issue of the edit button not being horizontal

Log: Fix the issue of the edit button not being horizontal
pms: BUG-304933

## Summary by Sourcery

Bug Fixes:
- Align the edit button vertically with the nameDetail element to ensure horizontal positioning