### PR TITLE
fix: Fix the /home image background that cannot be set

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfowork.h
+++ b/src/plugin-commoninfo/operation/commoninfowork.h
@@ -78,6 +78,7 @@ private:
     bool m_scaleIsSetting;
     QDBusInterface *m_debugConfigInter;
     QDBusInterface *m_inter;
+    QString m_tmpBackgroundPath;
 };
 
 


### PR DESCRIPTION
Fix the /home image background that cannot be set

Log: Fix the /home image background that cannot be set
pms: BUG-315803

## Summary by Sourcery

Fix inability to set the /home background image by copying the selected image into a writable temporary directory and applying it from there, with cleanup of previous temporary files.

Bug Fixes:
- Resolve failure to set the /home background by using a temporary copy of the image when applying it.
- Clear temporary background path on load failure or after applying new image.

Enhancements:
- Create a dedicated /tmp/dcc-grub-backgrounds directory and generate unique filenames based on timestamp for background copies.
- Remove the temporary backgrounds directory recursively before loading a new background to avoid stale files.