### PR TITLE
chore: bump version to 6.1.50

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.1.50) unstable; urgency=medium
+
+  * fix: Fix the issue of the edit button not being horizontal
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 26 Sep 2025 13:11:56 +0800
+
 dde-control-center (6.1.49) unstable; urgency=medium
 
   * fix: disable hover effect on language delete button


### PR DESCRIPTION
update changelog to 6.1.50

## Summary by Sourcery

Chores:
- Bump project version to 6.1.50 and update Debian changelog accordingly