### PR TITLE
fix: add missing scrollbars in timezone selection dialogs

### DIFF
--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -119,6 +119,7 @@ Loader {
                     maxVisibleItems: 12
                     view.model: viewModel
                     view.currentIndex: loader.currentIndex
+                    view.ScrollBar.vertical: verticalScrollBar
 
                     ButtonGroup {
                         id: regionGroup
@@ -156,6 +157,7 @@ Loader {
                 }
 
                 ScrollBar {
+                    id: verticalScrollBar
                     anchors.top: parent.top
                     anchors.bottom: parent.bottom
                     anchors.right: parent.right
@@ -166,32 +168,6 @@ Loader {
                     position: itemsView.view.visibleArea.yPosition
                     size: itemsView.view.visibleArea.heightRatio
                     active: hovered || pressed || itemsView.view.moving || itemsView.view.flicking
-
-                    onPositionChanged: {
-                        if (pressed) {
-                            Qt.callLater(function() {
-                                if (!itemsView.view) return
-                                var maxY = itemsView.view.contentHeight - itemsView.view.height
-                                if (maxY <= 0) return
-
-                                position = Math.max(0, Math.min(position, 1))
-                                size = Math.max(0, Math.min(size, 1))
-
-                                var normalized = size < 1 ? position / (1 - size) : 0
-                                var newY = Math.max(0, Math.min(normalized * maxY, maxY))
-
-                                // Snap to edges (30px = ~item height)
-                                if (newY <= 30) {
-                                    itemsView.view.positionViewAtBeginning()
-                                } else if (maxY - newY <= 30) {
-                                    itemsView.view.positionViewAtEnd()
-                                } else {
-                                    itemsView.view.contentY = newY
-                                }
-                            })
-                        }
-                    }
-
                 }
             }
         }

--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -208,6 +208,7 @@ Loader {
                     highlightFollowsCurrentItem: true
                     focus: true
                     activeFocusOnTab: true
+                    ScrollBar.vertical: verticalScrollBar
                     
                     // 根据内容确定是否需要交互（模仿ArrowListView逻辑）
                     interactive: loader.delegateModel.count > loader.maxVisibleItems
@@ -287,6 +288,20 @@ Loader {
                     enabled: !listView.atYEnd
                     focusPolicy: Qt.NoFocus
                     activeFocusOnTab: false
+                }
+
+                ScrollBar {
+                    id: verticalScrollBar
+                    anchors.top: parent.top
+                    anchors.bottom: parent.bottom
+                    anchors.right: parent.right
+                    anchors.rightMargin: -6
+                    implicitWidth: 10
+                    orientation: Qt.Vertical
+
+                    position: listView.visibleArea.yPosition
+                    size: listView.visibleArea.heightRatio
+                    active: hovered || pressed || listView.moving || listView.flicking
                 }
             }
 


### PR DESCRIPTION
- Added ScrollBar component to RegionsChooserWindow.qml for timezone region selection
- Added ScrollBar component to SearchableListViewPopup.qml for timezone list navigation
- Removed complex custom scroll handling logic in favor of standard Qt ScrollBar implementation
- Fixed user experience issue where long timezone lists were difficult to navigate without visible scrollbars

Log: add missing scrollbars in timezone selection dialogs
pms: BUG-333151