### PR TITLE
fix: adjust time range input opacity based on enabled state

### DIFF
--- a/src/dde-control-center/frame/plugin/DccTimeRange.qml
+++ b/src/dde-control-center/frame/plugin/DccTimeRange.qml
@@ -67,6 +67,7 @@ D.SpinBox {
     contentItem: RowLayout {
         property string text: hourInput.text + ":" + minuteInput.text
         spacing: 0
+        opacity: enabled ? 1 : 0.4
         TextInput {
             id: hourInput
             Layout.preferredWidth: 20


### PR DESCRIPTION
Added opacity control to the time range input component to visually indicate disabled state. When the input is disabled, the opacity is reduced to 0.4 to provide clear visual feedback to users about the component's availability.

Log: Time range input now shows reduced opacity when disabled for better visual indication

Influence:
1. Test time range input in enabled state - should have full opacity (1.0)
2. Test time range input in disabled state - should have reduced opacity (0.4)
3. Verify the opacity change doesn't affect input functionality
4. Check visual consistency with other disabled controls in the interface

fix: 根据启用状态调整时间范围输入框的不透明度

为时间范围输入组件添加了不透明度控制，以视觉方式指示禁用状态。当输入框被
禁用时，不透明度降低至0.4，为用户提供关于组件可用性的清晰视觉反馈。

Log: 时间范围输入框在禁用时显示降低的不透明度，提供更好的视觉指示

Influence:
1. 测试启用状态下的时间范围输入框 - 应具有完全不透明度（1.0）
2. 测试禁用状态下的时间范围输入框 - 应具有降低的不透明度（0.4）
3. 验证不透明度变化不影响输入功能
4. 检查与界面中其他禁用控件的视觉一致性

## Summary by Sourcery

Bug Fixes:
- Reduce time range input opacity to 0.4 when disabled for clearer visual feedback.