### PR TITLE
refactor: optimize image loading and thumbnail generation

### DIFF
--- a/src/dde-control-center/frame/dccimageprovider.h
+++ b/src/dde-control-center/frame/dccimageprovider.h
@@ -17,6 +17,7 @@ class DccImageProvider : public QQuickAsyncImageProvider
     Q_OBJECT
 public:
     explicit DccImageProvider();
+    ~DccImageProvider();
 
     QImage *cacheImage(const QString &id, const QSize &thumbnailSize);
     QImage *cacheImage(const QString &id, const QSize &thumbnailSize, CacheImageResponse *response, const QSize &requestedSize);

--- a/src/plugin-authentication/operation/charamangermodel.cpp
+++ b/src/plugin-authentication/operation/charamangermodel.cpp
@@ -350,7 +350,6 @@ void CharaMangerModel::onEnrollIrisStatusChanged(int code, const QString &msg)
 void CharaMangerModel::onRefreshEnrollDate(const int &charaType)
 {
     if (charaType & FACE_CHARA) {
-        qWarning()<< "=======2" << this->facesList();
         Q_EMIT facesListChanged(this->facesList());
     }
 

--- a/src/plugin-personalization/operation/model/wallpapermodel.cpp
+++ b/src/plugin-personalization/operation/model/wallpapermodel.cpp
@@ -83,9 +83,6 @@ bool WallpaperModel::setData(const QModelIndex &index, const QVariant &value, in
             Q_EMIT dataChanged(index, index, {role});
 
         }
-    } else if (role == Item_Thumbnail_Role) {
-        items[index.row()]->thumbnail = value.toString();
-        Q_EMIT dataChanged(index, index, {role});
     }
 
     return QAbstractItemModel::setData(index, value, role);
@@ -176,16 +173,6 @@ void WallpaperModel::updateSelected(const QStringList &selectedLists)
         setData(cutIndex, 
             selectedLists.contains(data(cutIndex, Item_Url_Role).toString()), 
             Item_Selected_Role);
-    }
-}
-
-void WallpaperModel::setThumbnail(WallpaperItemPtr item, const QString &thumbnail)
-{
-    for (int i = 0; i < items.size(); ++i) {
-        if (items[i].get() == item.get()) {
-            setData(index(i, 0), thumbnail, Item_Thumbnail_Role);
-            break;
-        }
     }
 }
 

--- a/src/plugin-personalization/operation/model/wallpapermodel.h
+++ b/src/plugin-personalization/operation/model/wallpapermodel.h
@@ -114,7 +114,6 @@ public:
     QModelIndex itemIndex(WallpaperItemPtr item) const;
     void resetData(const QList<WallpaperItemPtr> &list);
     void updateSelected(const QStringList &selectedLists);
-    void setThumbnail(WallpaperItemPtr item, const QString &thumbnail);
 protected:
     QHash<int, QByteArray> roleNames() const override;
 private:

--- a/src/plugin-personalization/operation/screensaverprovider.cpp
+++ b/src/plugin-personalization/operation/screensaverprovider.cpp
@@ -61,11 +61,12 @@ void ScreensaverWorker::list()
         items.append(temp);
 
         QString coverPath = m_proxy->GetScreenSaverCover(name);
+        const QString &thumbnail = QUrl::fromLocalFile(coverPath).toString();
         temp->url = name;
         temp->configurable = configurable.contains(name);
         temp->deleteAble = false;
         temp->picPath = coverPath;
-        temp->thumbnail = generateThumbnail(coverPath, QSize(THUMBNAIL_ICON_WIDTH, THUMBNAIL_ICON_HEIGHT));
+        temp->thumbnail = thumbnail;
 
         imgs.insert(name, coverPath);
     }

--- a/src/plugin-personalization/operation/utils.hpp
+++ b/src/plugin-personalization/operation/utils.hpp
@@ -83,33 +83,4 @@ inline static QString currentUserName()
     return cutName;
 }
 
-inline static QString ImageToBase64(const QImage &image) {
-    QByteArray byteArray;
-    
-    QBuffer buffer(&byteArray);
-    buffer.open(QIODevice::WriteOnly);
-    
-    image.save(&buffer, "PNG");
-    
-    return QString("%1,%2").arg("data:image/png;base64").arg(byteArray.toBase64());
-}
-
-inline static QString generateThumbnail(const QImage &image, const QSize &size)
-{
-    QPixmap pix = QPixmap::fromImage(image.scaled(size, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation));
-    const QRect r(QPoint(0, 0), size);
-
-    if (pix.width() > size.width() || pix.height() > size.height())
-        pix = pix.copy(QRect(pix.rect().center() - r.center(), size));
-
-    return ImageToBase64(pix.toImage());
-}
-
-inline static QString generateThumbnail(const QString &path, const QSize &size)
-{
-    QImage image(path);
-
-    return generateThumbnail(image, size);
-}
-
 #endif // UTILS_H

--- a/src/plugin-personalization/operation/wallpaperprovider.h
+++ b/src/plugin-personalization/operation/wallpaperprovider.h
@@ -7,9 +7,7 @@
 
 #include <QObject>
 #include <QPixmap>
-#include <QMutex>
 #include <QHash>
-#include <atomic>
 
 #include "operation/personalizationdbusproxy.h"
 #include "personalizationmodel.h"
@@ -38,7 +36,6 @@ public:
 signals:
     void pushBackground(const QList<WallpaperItemPtr> &items, WallpaperType type = WallpaperType::Wallpaper_Sys);
     void pushOneBackground(const WallpaperItemPtr items, WallpaperType type = WallpaperType::Wallpaper_Sys);
-    void thumbnailFinished(WallpaperItemPtr item, const WallpaperType type, const QString &thumbnail);
     void listFinished();
 public slots:
     void startListBackground(WallpaperType type = WallpaperType::Wallpaper_all);
@@ -48,7 +45,6 @@ private:
 private:
     PersonalizationDBusProxy *m_proxy = nullptr;
     std::atomic_bool m_running = false;
-    static QHash<QString, QString> g_thumbnailMap;
 };
 
 class WallpaperProvider : public QObject

--- a/src/plugin-personalization/qml/WallpaperSelectView.qml
+++ b/src/plugin-personalization/qml/WallpaperSelectView.qml
@@ -197,7 +197,7 @@ ColumnLayout {
                         anchors.centerIn : parent
                         width: 2
                         height: 2
-                        source: model.thumbnail
+                        source: "image://DccImage/" + model.thumbnail
                         fillMode: Image.Stretch
                         asynchronous: true
                     }
@@ -208,7 +208,7 @@ ColumnLayout {
                         width: root.imageRectW
                         height: root.imageRectH
                         sourceSize: Qt.size(width, height)
-                        source: model.thumbnail
+                        source: "image://DccImage/" + model.thumbnail
                         mipmap: true
                         visible: false
                         fillMode: Image.PreserveAspectCrop


### PR DESCRIPTION
1. Replace manual QImage pointer management with safer QPointer and move semantics
2. Add thread-safe image response handling using Qt::QueuedConnection
3. Remove custom thumbnail generation in favor of DccImageProvider QML engine integration
4. Clean up unused code and debug output
5. Add proper destructor for thread pool cleanup
6. Simplify wallpaper item creation by using DccImageProvider directly

Log: Improved wallpaper and screensaver thumbnail loading performance

Influence:
1. Test wallpaper and screensaver thumbnail display in personalization module
2. Verify image loading performance with various image sizes
3. Check for memory leaks during image loading and switching
4. Test concurrent image requests handling
5. Verify thumbnail scaling and aspect ratio preservation
6. Test application stability during image provider operations

refactor: 优化图像加载和缩略图生成

1. 使用更安全的 QPointer 和移动语义替换手动 QImage 指针管理
2. 使用 Qt::QueuedConnection 添加线程安全的图像响应处理
3. 移除自定义缩略图生成，改用 DccImageProvider QML 引擎集成
4. 清理未使用的代码和调试输出
5. 添加适当的析构函数用于线程池清理
6. 通过直接使用 DccImageProvider 简化壁纸项创建

Log: 提升壁纸和屏保缩略图加载性能

Influence:
1. 测试个性化模块中的壁纸和屏保缩略图显示
2. 验证不同尺寸图像加载的性能表现
3. 检查图像加载和切换过程中的内存泄漏
4. 测试并发图像请求处理能力
5. 验证缩略图缩放和宽高比保持
6. 测试图像提供程序操作期间的应用程序稳定性

## Summary by Sourcery

Refactor image loading and thumbnail generation to leverage the QML DccImageProvider for improved performance, thread safety, and memory management while removing redundant and unused code.

Enhancements:
- Integrate DccImageProvider for thumbnail handling and remove custom thumbnail generation logic
- Use Qt::QueuedConnection in CacheImageResponse to deliver images on the correct thread
- Adopt QPointer and move semantics in ImageTask to manage QImage lifetimes safely
- Simplify wallpaper and screensaver providers to reference thumbnails via "image://DccImage/" URLs
- Add DccImageProvider destructor to ensure thread pool is properly cleaned up

Chores:
- Remove unused utility functions (generateThumbnail, ImageToBase64) and debug output
- Clean up obsolete signals, slots, model methods, and static thumbnail map