### PR TITLE
fix: preserve hostname validation alert when input loses focus

### DIFF
--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -157,13 +157,16 @@ DccObject {
                             showAlert = false
                         }
                     }
-                    
-                    onActiveFocusChanged: {
-                        if (!activeFocus && showAlert) {
-                            showAlert = false
+
+                    Connections {
+                        target: DccApp
+                        function onActiveObjectChanged(object) {
+                            if (hostNameEdit.showAlert) {
+                                hostNameEdit.showAlert = false
+                            }
                         }
                     }
-                    
+
                     onTextChanged: {
                         if (showAlert)
                             showAlert = false


### PR DESCRIPTION
- Replaced onActiveFocusChanged with Connections targeting DccApp.onActiveObjectChanged to prevent premature alert dismissal
- Fixed issue where invalid character warnings would disappear when user clicked outside hostname input field
- Ensured validation alerts persist until user navigates to different page, improving error visibility

Log: Fixed hostname input validation to properly display error messages when focus changes, helping users identify invalid characters
pms: BUG-335539

## Summary by Sourcery

Fix hostname input validation alert dismissal by replacing focus-based logic with a global app event so alerts persist until navigating away

Bug Fixes:
- Prevent hostname validation alerts from disappearing when the hostname field loses focus
- Ensure validation alerts are only cleared on global active object change rather than local focus change

Enhancements:
- Use Connections to DccApp.onActiveObjectChanged instead of onActiveFocusChanged for alert handling