### PR TITLE
refactor: optimize wallpaper settings layout structure

### DIFF
--- a/src/dde-control-center/frame/plugin/DccEditorItem.qml
+++ b/src/dde-control-center/frame/plugin/DccEditorItem.qml
@@ -15,6 +15,8 @@ D.ItemDelegate {
     property real iconRadius: model.item.iconRadius ? model.item.iconRadius : 0
     property real iconSize: model.item.iconSize ? model.item.iconSize : 0
     property real leftPaddingSize: model.item.leftPaddingSize ? model.item.leftPaddingSize : 10
+    property real rightItemTopMargin: 5
+    property real rightItemBottomMargin: 5
 
     implicitHeight: Math.max(model.item.description.length !== 0 ? 48 : 40, implicitContentHeight) + topInset + bottomInset
     backgroundVisible: false
@@ -64,8 +66,8 @@ D.ItemDelegate {
         }
         Control {
             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-            Layout.topMargin: 5
-            Layout.bottomMargin: 5
+            Layout.topMargin: root.rightItemTopMargin
+            Layout.bottomMargin: root.rightItemBottomMargin
             enabled: model.item.enabledToApp
             opacity: enabled ? 1 : 0.4
             contentItem: rightItem ? rightItem : model.item.getSectionItem(this)

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -111,73 +111,83 @@ DccObject {
         parentName: "personalization/wallpaper/wallpaperStatusGroup"
         weight: 300
         pageType: DccObject.Item
-        page: DccGroupView { isGroup: false }
+        page: DccGroupView {
+            Layout.alignment: Qt.AlignTop
+        }
 
         DccObject {
-            name: "wallpaperSetItemGroup"
+            name: "wallpaperType"
             parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup"
+            displayName: {
+                let cutUrl = dccData.model.wallpaperMap[dccData.model.currentSelectScreen]
+                if (dccData.model.customWallpaperModel.hasWallpaper(cutUrl)) {
+                    return qsTr("My pictures")
+                } else if (dccData.model.sysWallpaperModel.hasWallpaper(cutUrl)) {
+                    return qsTr("System Wallpaper")
+                } else if (dccData.model.solidWallpaperModel.hasWallpaper(cutUrl)) {
+                    return qsTr("Solid color wallpaper")
+                } else {
+                    return qsTr("Customizable wallpapers")
+                }
+            }
+            canSearch: false
+            pageType: DccObject.Editor
             weight: 10
-            pageType: DccObject.Item
-            page: DccGroupView { }
+            onParentItemChanged: {
+                if (parentItem)
+                    parentItem.implicitHeight = 36
+            }
+        }
+        DccObject {
+            name: "fillStyle"
+            parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup"
+            displayName: qsTr("fill style")
+            visible: false
+            weight: 100
+            pageType: DccObject.Editor
+            page: D.ComboBox {
+                flat: true
+                model: ["adapt"]
+            }
 
-            DccObject {
-                name: "wallpaperType"
-                parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup/wallpaperSetItemGroup"
-                displayName: {
-                    let cutUrl = dccData.model.wallpaperMap[dccData.model.currentSelectScreen]
-                    if (dccData.model.customWallpaperModel.hasWallpaper(cutUrl)) {
-                        return qsTr("My pictures")
-                    } else if (dccData.model.sysWallpaperModel.hasWallpaper(cutUrl)) {
-                        return qsTr("System Wallpaper")
-                    } else if (dccData.model.solidWallpaperModel.hasWallpaper(cutUrl)) {
-                        return qsTr("Solid color wallpaper")
-                    } else {
-                        return qsTr("Customizable wallpapers")
+            onParentItemChanged: {
+                if (parentItem)
+                    parentItem.implicitHeight = 36
+            }
+        }
+        DccObject {
+            name: "automaticWallpaper"
+            parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup"
+            displayName: qsTr("Automatic wallpaper change")
+            weight: 200
+            pageType: DccObject.Editor
+            page: CustomComboBox {
+                flat: true
+                textRole: "text"
+                currentIndex: indexByValue(dccData.model.wallpaperSlideShowMap[dccData.model.currentSelectScreen])
+                model: ListModel {
+                    ListElement { text: qsTr("never"); value: "" }
+                    ListElement { text: qsTr("30 second"); value: "30" }
+                    ListElement { text: qsTr("1 minute"); value: "60" }
+                    ListElement { text: qsTr("5 minute"); value: "300" }
+                    ListElement { text: qsTr("10 minute"); value: "600" }
+                    ListElement { text: qsTr("15 minute"); value: "900" }
+                    ListElement { text: qsTr("30 minute"); value: "1800" }
+                    ListElement { text: qsTr("1 hour"); value: "3600" }
+                    ListElement { text: qsTr("login"); value: "login" }
+                    ListElement { text: qsTr("wake up"); value: "wakeup" }
+                }
+                onCurrentIndexChanged: {
+                    if (indexByValue(dccData.model.wallpaperSlideShowMap[dccData.model.currentSelectScreen]) !== currentIndex) {
+                        dccData.worker.setWallpaperSlideShow(dccData.model.currentSelectScreen, model.get(currentIndex).value)
                     }
                 }
-                canSearch: false
-                pageType: DccObject.Editor
-                weight: 10
             }
-            DccObject {
-                name: "fillStyle"
-                parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup/wallpaperSetItemGroup"
-                displayName: qsTr("fill style")
-                visible: false
-                weight: 100
-                pageType: DccObject.Editor
-                page: D.ComboBox {
-                    flat: true
-                    model: ["adapt"]
-                }
-            }
-            DccObject {
-                name: "automaticWallpaper"
-                parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup/wallpaperSetItemGroup"
-                displayName: qsTr("Automatic wallpaper change")
-                weight: 200
-                pageType: DccObject.Editor
-                page: CustomComboBox {
-                    flat: true
-                    textRole: "text"
-                    currentIndex: indexByValue(dccData.model.wallpaperSlideShowMap[dccData.model.currentSelectScreen])
-                    model: ListModel {
-                        ListElement { text: qsTr("never"); value: "" }
-                        ListElement { text: qsTr("30 second"); value: "30" }
-                        ListElement { text: qsTr("1 minute"); value: "60" }
-                        ListElement { text: qsTr("5 minute"); value: "300" }
-                        ListElement { text: qsTr("10 minute"); value: "600" }
-                        ListElement { text: qsTr("15 minute"); value: "900" }
-                        ListElement { text: qsTr("30 minute"); value: "1800" }
-                        ListElement { text: qsTr("1 hour"); value: "3600" }
-                        ListElement { text: qsTr("login"); value: "login" }
-                        ListElement { text: qsTr("wake up"); value: "wakeup" }
-                    }
-                    onCurrentIndexChanged: {
-                        if (indexByValue(dccData.model.wallpaperSlideShowMap[dccData.model.currentSelectScreen]) !== currentIndex) {
-                            dccData.worker.setWallpaperSlideShow(dccData.model.currentSelectScreen, model.get(currentIndex).value)
-                        }
-                    }
+            onParentItemChanged: {
+                if (parentItem) {
+                    parentItem.implicitHeight = 36
+                    parentItem.rightItemTopMargin = 0
+                    parentItem.rightItemBottomMargin = 0
                 }
             }
         }


### PR DESCRIPTION
1. Extract right item margin properties to root level for better reusability
2. Remove unnecessary nested group wrapper for wallpaper settings items
3. Move wallpaper type, fill style, and automatic wallpaper directly under wallpaperSetGroup
4. Add implicit height and margin adjustments for consistent item spacing
5. Set Layout.alignment for wallpaperSetGroup to align top
6. Add parentItemChanged handlers to control item heights and margins

The changes simplify the QML structure by flattening the hierarchy and making margin properties configurable. This improves maintainability and allows for more precise control over item spacing and layout. The automatic wallpaper item now has custom top and bottom margins set to 0 for better visual alignment.

Log: Improved wallpaper settings layout with better spacing control

Influence:
1. Verify wallpaper settings page displays correctly with all options
2. Check that wallpaper type detection works for different wallpaper sources
3. Test automatic wallpaper change functionality with different intervals
4. Verify fill style combobox appears when visible property is enabled
5. Check layout alignment and spacing consistency
6. Test parent item height adjustments work properly

refactor: 优化壁纸设置布局结构

1. 将右侧项边距属性提取到根级别以提高可重用性
2. 移除壁纸设置项中不必要的嵌套组包装器
3. 将壁纸类型、填充样式和自动壁纸直接移至 wallpaperSetGroup 下
4. 添加隐式高度和边距调整以确保一致的项间距
5. 为 wallpaperSetGroup 设置顶部对齐的布局对齐方式
6. 添加 parentItemChanged 处理程序以控制项高度和边距

这些更改通过扁平化层次结构并使边距属性可配置来简化 QML 结构。这提高了可
维护性，并允许更精确地控制项间距和布局。自动壁纸项现在设置了自定义的顶部
和底部边距为 0，以实现更好的视觉对齐。

Log: 改进了壁纸设置布局，提供更好的间距控制

Influence:
1. 验证壁纸设置页面正确显示所有选项
2. 检查壁纸类型检测是否适用于不同的壁纸源
3. 测试不同时间间隔的自动壁纸更换功能
4. 验证当 visible 属性启用时填充样式组合框是否正确显示
5. 检查布局对齐和间距的一致性
6. 测试父项高度调整是否正常工作

pms: BUG-317947

## Summary by Sourcery

Refactor wallpaper settings layout by flattening the item hierarchy, centralizing margin properties, and adding implicit sizing and alignment adjustments to improve spacing control.

Enhancements:
- Extract rightItem top and bottom margin properties to DccEditorItem for reusable spacing configuration
- Remove nested group wrapper and move wallpaper type, fill style, and automatic wallpaper items directly under wallpaperSetGroup
- Set wallpaperSetGroup Layout.alignment to top and add implicitHeight adjustments for consistent item spacing
- Add parentItemChanged handlers to adjust item heights and margins, including zero top/bottom margins for automatic wallpaper item