### PR TITLE
fix: update time format display when system timezone is modified

### DIFF
--- a/src/plugin-datetime/operation/datetimeworker.cpp
+++ b/src/plugin-datetime/operation/datetimeworker.cpp
@@ -46,6 +46,8 @@ DatetimeWorker::DatetimeWorker(DatetimeModel *model, QObject *parent)
                 break;
             }
         }
+
+        Q_EMIT m_model->currentFormatChanged(DatetimeModel::LongTime);
     });
 
     connect(m_timedateInter, &DatetimeDBusProxy::NTPServerChanged, m_model, &DatetimeModel::setNtpServerAddress);


### PR DESCRIPTION
- Added currentFormatChanged(LongTime) signal emission in timezone change handler
- Ensures time format display is immediately updated when system timezone is modified
- Resolves issue where time format was not refreshed until control center restart
- Triggers format display refresh to maintain consistency after timezone changes

Log: Fixed time format not updating immediately when system timezone is modified
pms: BUG-335709