### PR TITLE
Fix: Abnormal interface display when clicking any hotkey

### DIFF
--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -15,6 +15,10 @@ D.ApplicationWindow {
     property string appLicense: "GPL-3.0-or-later"
     property real currentIndex: 1
     property var sidebarPage: null
+    // 在全局快捷键抓取期间临时保持窗口激活外观
+    property bool forceActiveAppearance: false
+    // 本次抓取期间是否还需要尝试一次重新激活
+    property bool pendingReactivation: false
 
     minimumWidth: 520
     minimumHeight: 400
@@ -23,6 +27,16 @@ D.ApplicationWindow {
     modality: Qt.ApplicationModal
     color: "transparent"
     D.DWindow.enabled: true
+    onActiveChanged: if (!active && forceActiveAppearance && pendingReactivation) {
+        pendingReactivation = false
+        requestActivateTimer.start()
+    }
+    Timer {
+        id: requestActivateTimer
+        interval: 1
+        repeat: false
+        onTriggered: if (mainWindow.forceActiveAppearance) mainWindow.requestActivate()
+    }
 
     D.StyledBehindWindowBlur {
         anchors.fill: parent

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -135,6 +135,13 @@ D.DialogWindow {
             }
             onRequestKeys: {
                 keys = [];
+                var win = DccApp.mainWindow()
+                if (win) {
+                    if (win.forceActiveAppearance !== undefined)
+                        win.forceActiveAppearance = true
+                    if (win.pendingReactivation !== undefined)
+                        win.pendingReactivation = true
+                }
                 dccData.updateKey(ddialog.keyId, 1);
             }
         }
@@ -192,9 +199,15 @@ D.DialogWindow {
         Connections {
             target: dccData
             function onRequestRestore() {
+                var win = DccApp.mainWindow()
+                if (win) {
+                    if (win.forceActiveAppearance !== undefined)
+                        win.forceActiveAppearance = false
+                    if (win.pendingReactivation !== undefined)
+                        win.pendingReactivation = false
+                }
                 edit.keys = ddialog.saveKeys;
                 conflictText.text = "";
-                // 重置名称验证状态
                 if (nameEdit.text.trim().length > 0) {
                     ddialog.nameExists = dccData.isShortcutNameExists(nameEdit.text.trim(), ddialog.keyId);
                 } else {
@@ -205,11 +218,25 @@ D.DialogWindow {
                 onRequestRestore();
             }
             function onKeyConflicted(oldAccels, newAccels) {
-                edit.accels = newAccels; // 冲突也可以覆盖
+                var win = DccApp.mainWindow()
+                if (win) {
+                    if (win.forceActiveAppearance !== undefined)
+                        win.forceActiveAppearance = false
+                    if (win.pendingReactivation !== undefined)
+                        win.pendingReactivation = false
+                }
+                edit.accels = newAccels;
                 var actionText = ddialog.keyId.length > 0 ? qsTr("click Save to make this shortcut key effective") : qsTr("click Add to make this shortcut key effective");
                 conflictText.text = dccData.conflictText + ", " + actionText;
             }
             function onKeyDone(accels) {
+                var win = DccApp.mainWindow()
+                if (win) {
+                    if (win.forceActiveAppearance !== undefined)
+                        win.forceActiveAppearance = false
+                    if (win.pendingReactivation !== undefined)
+                        win.pendingReactivation = false
+                }
                 edit.keys = dccData.formatKeys(accels);
                 edit.accels = accels;
                 conflictText.text = "";

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -170,6 +170,13 @@ DccObject {
                                 }
 
                                 edit.keys = ""
+                                var win = DccApp.mainWindow()
+                                if (win) {
+                                    if (win.forceActiveAppearance !== undefined)
+                                        win.forceActiveAppearance = true
+                                    if (win.pendingReactivation !== undefined)
+                                        win.pendingReactivation = true
+                                }
                                 dccData.updateKey(model.id, model.type)
                                 shortcutView.editItem = edit
                                 shortcutView.conflictText = conflictText
@@ -179,12 +186,10 @@ DccObject {
                                 dialogloader.active = true
                             }
                             onRequestDeleteKeys: {
-                                console.log("onRequestDeleteKeys", model.id)
                                 dccData.deleteCustomShortcut(model.id)
                             }
 
                             function modifyShortcut(accels) {
-                                console.log("modifyShortcut", model.id, accels, model.type)
                                 if (accels.length > 0)
                                     dccData.modifyShortcut(model.id, accels, model.type)
                             }
@@ -327,18 +332,46 @@ DccObject {
                 Connections {
                     target: dccData
                     function onRequestRestore() {
+                        var win = DccApp.mainWindow()
+                        if (win) {
+                            if (win.forceActiveAppearance !== undefined)
+                                win.forceActiveAppearance = false
+                            if (win.pendingReactivation !== undefined)
+                                win.pendingReactivation = false
+                        }
                         shortcutView.restoreShortcutView()
                     }
                     function onRequestClear() {
+                        var win = DccApp.mainWindow()
+                        if (win) {
+                            if (win.forceActiveAppearance !== undefined)
+                                win.forceActiveAppearance = false
+                            if (win.pendingReactivation !== undefined)
+                                win.pendingReactivation = false
+                        }
                         shortcutView.editItem.clearShortcut()
                     }
                     function onKeyConflicted(oldAccels, newAccels) {
+                        var win = DccApp.mainWindow()
+                        if (win) {
+                            if (win.forceActiveAppearance !== undefined)
+                                win.forceActiveAppearance = false
+                            if (win.pendingReactivation !== undefined)
+                                win.pendingReactivation = false
+                        }
                         if (shortcutView.conflictText)
                             shortcutView.conflictText.visible = true
 
                         shortcutSettingsBody.conflictAccels = newAccels
                     }
                     function onKeyDone(accels) {
+                        var win = DccApp.mainWindow()
+                        if (win) {
+                            if (win.forceActiveAppearance !== undefined)
+                                win.forceActiveAppearance = false
+                            if (win.pendingReactivation !== undefined)
+                                win.pendingReactivation = false
+                        }
                         if (!shortcutView.editItem)
                             return
                         shortcutView.editItem.focus = false


### PR DESCRIPTION
Log: When editing hotkeys, forceActiveAppearance is used to keep the Control Center main window “active” during global key capture, preventing the window from briefly turning gray due to focus loss.

pms: bug-303139

## Summary by Sourcery

Keep the Control Center window visually active while capturing global shortcut keys to prevent abnormal interface appearance during hotkey editing.

Bug Fixes:
- Prevent the Control Center main window from briefly appearing inactive or grayed out when editing or capturing hotkeys.

Enhancements:
- Introduce a forceActiveAppearance flag on the main window and wire shortcut editing views to toggle it during global key capture.