### PR TITLE
fix(ui): optimize TipsSlider layout margins to prevent text clipping

### DIFF
--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -55,8 +55,8 @@ DccObject {
 
                 property real leftTextWidth: 10
                 property real rightTextWidth: 10
-                property real dynamicLeftMargin: Math.max(10, leftTextWidth / 2)
-                property real dynamicRightMargin: Math.max(10, rightTextWidth / 2)
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
 
                 Layout.preferredHeight: 90
                 Layout.alignment: Qt.AlignCenter
@@ -167,8 +167,8 @@ DccObject {
                             // 动态计算左右边距
                             property real leftTextWidth: 0
                             property real rightTextWidth: 0
-                            property real dynamicLeftMargin: Math.max(10, leftTextWidth / 2 + 5)
-                            property real dynamicRightMargin: Math.max(10, rightTextWidth / 2 + 5)
+                            property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                            property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
 
                             Layout.preferredHeight: 90
                             Layout.alignment: Qt.AlignCenter

--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -42,13 +42,36 @@ DccObject {
             D.TipsSlider {
                 id: scrollSlider
                 readonly property var tips: [("1"), ("2"), ("3"), ("4"), ("5"), ("6"), ("7"), ("8"), ("9"), ("10")]
+
+                property real leftTextWidth: 0
+                property real rightTextWidth: 0
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                Layout.preferredHeight: 90
                 Layout.alignment: Qt.AlignCenter
-                Layout.leftMargin: 10
-                Layout.rightMargin: 10
-                Layout.topMargin: 2
+                Layout.leftMargin: dynamicLeftMargin
+                Layout.rightMargin: dynamicRightMargin
+                Layout.topMargin: 10
                 Layout.bottomMargin: 10
                 Layout.fillWidth: true
-                slider.height: 30
+
+                TextMetrics {
+                    id: scrollLeftTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[0]
+                    Component.onCompleted: {
+                        scrollSlider.leftTextWidth = width
+                    }
+                }
+                TextMetrics {
+                    id: scrollRightTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[scrollSlider.tips.length - 1]
+                    Component.onCompleted: {
+                        scrollSlider.rightTextWidth = width
+                    }
+                }
                 tickDirection: D.TipsSlider.TickDirection.Back
                 slider.handleType: Slider.HandleType.ArrowBottom
                 slider.value: dccData.scrollSpeed
@@ -131,13 +154,36 @@ DccObject {
                     D.TipsSlider {
                         id: doubleClickSlider
                         readonly property var tips: [qsTr("Slow"), (""), (""), (""), (""), (""), qsTr("Fast")]
+
+                        property real leftTextWidth: 0
+                        property real rightTextWidth: 0
+                        property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                        property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                        Layout.preferredHeight: 90
                         Layout.alignment: Qt.AlignCenter
-                        Layout.leftMargin: 10
-                        Layout.rightMargin: 10
-                        Layout.topMargin: 2
+                        Layout.leftMargin: dynamicLeftMargin
+                        Layout.rightMargin: dynamicRightMargin
+                        Layout.topMargin: 10
                         Layout.bottomMargin: 10
                         Layout.fillWidth: true
-                        slider.height: 30
+
+                        TextMetrics {
+                            id: doubleClickLeftTextMetrics
+                            font: doubleClickSlider.slider.font
+                            text: doubleClickSlider.tips[0]
+                            Component.onCompleted: {
+                                doubleClickSlider.leftTextWidth = width
+                            }
+                        }
+                        TextMetrics {
+                            id: doubleClickRightTextMetrics
+                            font: doubleClickSlider.slider.font
+                            text: doubleClickSlider.tips[doubleClickSlider.tips.length - 1]
+                            Component.onCompleted: {
+                                doubleClickSlider.rightTextWidth = width
+                            }
+                        }
                         tickDirection: D.TipsSlider.TickDirection.Back
                         slider.handleType: Slider.HandleType.ArrowBottom
                         slider.value: dccData.doubleSpeed

--- a/src/plugin-mouse/qml/MousePage.qml
+++ b/src/plugin-mouse/qml/MousePage.qml
@@ -33,10 +33,36 @@ DccObject {
             D.TipsSlider {
                 id: scrollSlider
                 readonly property var tips: [qsTr("Slow"), (""), (""), (""), (""), (""), qsTr("Fast")]
+
+                property real leftTextWidth: 0
+                property real rightTextWidth: 0
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
                 Layout.preferredHeight: 100
                 Layout.alignment: Qt.AlignCenter
-                Layout.margins: 10
+                Layout.leftMargin: dynamicLeftMargin
+                Layout.rightMargin: dynamicRightMargin
+                Layout.topMargin: 10
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
+
+                TextMetrics {
+                    id: scrollLeftTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[0]
+                    Component.onCompleted: {
+                        scrollSlider.leftTextWidth = width
+                    }
+                }
+                TextMetrics {
+                    id: scrollRightTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[scrollSlider.tips.length - 1]
+                    Component.onCompleted: {
+                        scrollSlider.rightTextWidth = width
+                    }
+                }
                 tickDirection: D.TipsSlider.TickDirection.Back
                 slider.handleType: Slider.HandleType.ArrowBottom
                 slider.value: dccData.mouseMoveSpeed
@@ -262,3 +288,4 @@ DccObject {
         }
     }
 }
+

--- a/src/plugin-mouse/qml/Touchpad.qml
+++ b/src/plugin-mouse/qml/Touchpad.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.0
 import QtQuick.Controls 2.0
@@ -94,10 +94,35 @@ DccObject {
 
                 readonly property var tips: [qsTr("Slow"), (""), (""), (""), (""), (""), qsTr("Fast")]
 
+                property real leftTextWidth: 0
+                property real rightTextWidth: 0
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
                 Layout.preferredHeight: 90
                 Layout.alignment: Qt.AlignCenter
-                Layout.margins: 10
+                Layout.leftMargin: dynamicLeftMargin
+                Layout.rightMargin: dynamicRightMargin
+                Layout.topMargin: 10
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
+
+                TextMetrics {
+                    id: scrollLeftTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[0]
+                    Component.onCompleted: {
+                        scrollSlider.leftTextWidth = width
+                    }
+                }
+                TextMetrics {
+                    id: scrollRightTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[scrollSlider.tips.length - 1]
+                    Component.onCompleted: {
+                        scrollSlider.rightTextWidth = width
+                    }
+                }
                 tickDirection: D.TipsSlider.TickDirection.Back
                 slider.handleType: Slider.HandleType.ArrowBottom
                 slider.value: dccData.tpadMoveSpeed

--- a/src/plugin-personalization/qml/FontSizePage.qml
+++ b/src/plugin-personalization/qml/FontSizePage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
@@ -28,10 +28,36 @@ DccObject {
             D.TipsSlider {
                 id: fontSizeSlider
                 readonly property var fontSizeModel: [11, 12, 13, 14, 15, 16, 18, 20]
+
+                property real leftTextWidth: 0
+                property real rightTextWidth: 0
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
                 Layout.preferredHeight: 90
                 Layout.alignment: Qt.AlignCenter
-                Layout.margins: 10
+                Layout.leftMargin: dynamicLeftMargin
+                Layout.rightMargin: dynamicRightMargin
+                Layout.topMargin: 10
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
+
+                TextMetrics {
+                    id: fontSizeLeftTextMetrics
+                    font: fontSizeSlider.slider.font
+                    text: String(fontSizeSlider.fontSizeModel[0])
+                    Component.onCompleted: {
+                        fontSizeSlider.leftTextWidth = width
+                    }
+                }
+                TextMetrics {
+                    id: fontSizeRightTextMetrics
+                    font: fontSizeSlider.slider.font
+                    text: String(fontSizeSlider.fontSizeModel[fontSizeSlider.fontSizeModel.length - 1])
+                    Component.onCompleted: {
+                        fontSizeSlider.rightTextWidth = width
+                    }
+                }
                 tickDirection: D.TipsSlider.TickDirection.Back
                 slider.handleType: Slider.HandleType.ArrowBottom
                 slider.from: 0

--- a/src/plugin-power/qml/BatteryPage.qml
+++ b/src/plugin-power/qml/BatteryPage.qml
@@ -54,10 +54,34 @@ DccObject {
                 CustomTipsSlider {
                     id: offMonitorSlider
                     dataMap: dccData.model.batteryScreenBlackDelayModel
-                    Layout.preferredHeight: 80
+
+                    property real leftTextWidth: 0
+                    property real rightTextWidth: 0
+                    property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                    property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                    Layout.preferredHeight: 90
                     Layout.alignment: Qt.AlignCenter
-                    Layout.margins: 10
+                    Layout.leftMargin: dynamicLeftMargin
+                    Layout.rightMargin: dynamicRightMargin
+                    Layout.topMargin: 10
+                    Layout.bottomMargin: 10
                     Layout.fillWidth: true
+
+                    TextMetrics {
+                        font: offMonitorSlider.slider.font
+                        text: offMonitorSlider.dataMap[0].text
+                        Component.onCompleted: {
+                            offMonitorSlider.leftTextWidth = width
+                        }
+                    }
+                    TextMetrics {
+                        font: offMonitorSlider.slider.font
+                        text: offMonitorSlider.dataMap[offMonitorSlider.dataMap.length - 1].text
+                        Component.onCompleted: {
+                            offMonitorSlider.rightTextWidth = width
+                        }
+                    }
                     slider.value: dccData.indexByValueOnMap(dataMap, dccData.model.screenBlackDelayOnBattery)
                     slider.onValueChanged: {
                         dccData.worker.setScreenBlackDelayOnBattery(dataMap[slider.value].value)
@@ -104,10 +128,34 @@ DccObject {
                 CustomTipsSlider {
                     id: lockScreenSlider
                     dataMap: dccData.model.batteryLockDelayModel
-                    Layout.preferredHeight: 80
+
+                    property real leftTextWidth: 0
+                    property real rightTextWidth: 0
+                    property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                    property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                    Layout.preferredHeight: 90
                     Layout.alignment: Qt.AlignCenter
-                    Layout.margins: 10
+                    Layout.leftMargin: dynamicLeftMargin
+                    Layout.rightMargin: dynamicRightMargin
+                    Layout.topMargin: 10
+                    Layout.bottomMargin: 10
                     Layout.fillWidth: true
+
+                    TextMetrics {
+                        font: lockScreenSlider.slider.font
+                        text: lockScreenSlider.dataMap[0].text
+                        Component.onCompleted: {
+                            lockScreenSlider.leftTextWidth = width
+                        }
+                    }
+                    TextMetrics {
+                        font: lockScreenSlider.slider.font
+                        text: lockScreenSlider.dataMap[lockScreenSlider.dataMap.length - 1].text
+                        Component.onCompleted: {
+                            lockScreenSlider.rightTextWidth = width
+                        }
+                    }
                     slider.value: dccData.indexByValueOnMap(dataMap, dccData.model.batteryLockScreenDelay)
                     slider.onValueChanged: {
                         dccData.worker.setLockScreenDelayOnBattery(dataMap[slider.value].value)
@@ -154,10 +202,34 @@ DccObject {
                 CustomTipsSlider {
                     id: suspendsSlider
                     dataMap: dccData.model.batterySleepDelayModel
-                    Layout.preferredHeight: 80
+
+                    property real leftTextWidth: 0
+                    property real rightTextWidth: 0
+                    property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                    property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                    Layout.preferredHeight: 90
                     Layout.alignment: Qt.AlignCenter
-                    Layout.margins: 10
+                    Layout.leftMargin: dynamicLeftMargin
+                    Layout.rightMargin: dynamicRightMargin
+                    Layout.topMargin: 10
+                    Layout.bottomMargin: 10
                     Layout.fillWidth: true
+
+                    TextMetrics {
+                        font: suspendsSlider.slider.font
+                        text: suspendsSlider.dataMap[0].text
+                        Component.onCompleted: {
+                            suspendsSlider.leftTextWidth = width
+                        }
+                    }
+                    TextMetrics {
+                        font: suspendsSlider.slider.font
+                        text: suspendsSlider.dataMap[suspendsSlider.dataMap.length - 1].text
+                        Component.onCompleted: {
+                            suspendsSlider.rightTextWidth = width
+                        }
+                    }
                     slider.value: dccData.indexByValueOnMap(dataMap, dccData.model.sleepDelayOnBattery)
                     slider.onValueChanged: {
                         dccData.worker.setSleepDelayOnBattery(dataMap[slider.value].value)

--- a/src/plugin-power/qml/CustomTipsSlider.qml
+++ b/src/plugin-power/qml/CustomTipsSlider.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -113,10 +113,37 @@ DccObject {
             D.TipsSlider {
                 id: scrollSlider
                 readonly property var tips: [("10%"), ("20%"), ("30%"), ("40%")]
-                Layout.preferredHeight: 80
+
+                property real leftTextWidth: 0
+                property real rightTextWidth: 0
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                Layout.preferredHeight: 90
                 Layout.alignment: Qt.AlignCenter
-                Layout.margins: 10
+                Layout.leftMargin: dynamicLeftMargin
+                Layout.rightMargin: dynamicRightMargin
+                Layout.topMargin: 10
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
+
+                TextMetrics {
+                    id: scrollLeftTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[0]
+                    Component.onCompleted: {
+                        scrollSlider.leftTextWidth = width
+                    }
+                }
+                TextMetrics {
+                    id: scrollRightTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[scrollSlider.tips.length - 1]
+                    Component.onCompleted: {
+                        scrollSlider.rightTextWidth = width
+                    }
+                }
+
                 slider.handleType: Slider.HandleType.ArrowBottom
                 slider.from: 10
                 slider.to: ticks.length * 10

--- a/src/plugin-power/qml/PowerPage.qml
+++ b/src/plugin-power/qml/PowerPage.qml
@@ -55,10 +55,34 @@ DccObject {
                 CustomTipsSlider {
                     id: offMonitorSlider
                     dataMap: dccData.model.linePowerScreenBlackDelayModel
-                    Layout.preferredHeight: 80
+
+                    property real leftTextWidth: 0
+                    property real rightTextWidth: 0
+                    property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                    property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                    Layout.preferredHeight: 90
                     Layout.alignment: Qt.AlignCenter
-                    Layout.margins: 10
+                    Layout.leftMargin: dynamicLeftMargin
+                    Layout.rightMargin: dynamicRightMargin
+                    Layout.topMargin: 10
+                    Layout.bottomMargin: 10
                     Layout.fillWidth: true
+
+                    TextMetrics {
+                        font: offMonitorSlider.slider.font
+                        text: offMonitorSlider.dataMap[0].text
+                        Component.onCompleted: {
+                            offMonitorSlider.leftTextWidth = width
+                        }
+                    }
+                    TextMetrics {
+                        font: offMonitorSlider.slider.font
+                        text: offMonitorSlider.dataMap[offMonitorSlider.dataMap.length - 1].text
+                        Component.onCompleted: {
+                            offMonitorSlider.rightTextWidth = width
+                        }
+                    }
                     slider.value: dccData.indexByValueOnMap(dataMap, dccData.model.screenBlackDelayOnPower)
                     slider.onValueChanged: {
                         dccData.worker.setScreenBlackDelayOnPower(dataMap[slider.value].value)
@@ -105,10 +129,34 @@ DccObject {
                 CustomTipsSlider {
                     id: lockScreenSlider
                     dataMap: dccData.model.linePowerLockDelayModel
-                    Layout.preferredHeight: 80
+
+                    property real leftTextWidth: 0
+                    property real rightTextWidth: 0
+                    property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                    property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                    Layout.preferredHeight: 90
                     Layout.alignment: Qt.AlignCenter
-                    Layout.margins: 10
+                    Layout.leftMargin: dynamicLeftMargin
+                    Layout.rightMargin: dynamicRightMargin
+                    Layout.topMargin: 10
+                    Layout.bottomMargin: 10
                     Layout.fillWidth: true
+
+                    TextMetrics {
+                        font: lockScreenSlider.slider.font
+                        text: lockScreenSlider.dataMap[0].text
+                        Component.onCompleted: {
+                            lockScreenSlider.leftTextWidth = width
+                        }
+                    }
+                    TextMetrics {
+                        font: lockScreenSlider.slider.font
+                        text: lockScreenSlider.dataMap[lockScreenSlider.dataMap.length - 1].text
+                        Component.onCompleted: {
+                            lockScreenSlider.rightTextWidth = width
+                        }
+                    }
                     slider.value: dccData.indexByValueOnMap(dataMap, dccData.model.powerLockScreenDelay)
                     slider.onValueChanged: {
                         dccData.worker.setLockScreenDelayOnPower(dataMap[slider.value].value)
@@ -155,10 +203,34 @@ DccObject {
                 CustomTipsSlider {
                     id: suspendsSlider
                     dataMap: dccData.model.linePowerSleepDelayModel
-                    Layout.preferredHeight: 80
+
+                    property real leftTextWidth: 0
+                    property real rightTextWidth: 0
+                    property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                    property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
+                    Layout.preferredHeight: 90
                     Layout.alignment: Qt.AlignCenter
-                    Layout.margins: 10
+                    Layout.leftMargin: dynamicLeftMargin
+                    Layout.rightMargin: dynamicRightMargin
+                    Layout.topMargin: 10
+                    Layout.bottomMargin: 10
                     Layout.fillWidth: true
+
+                    TextMetrics {
+                        font: suspendsSlider.slider.font
+                        text: suspendsSlider.dataMap[0].text
+                        Component.onCompleted: {
+                            suspendsSlider.leftTextWidth = width
+                        }
+                    }
+                    TextMetrics {
+                        font: suspendsSlider.slider.font
+                        text: suspendsSlider.dataMap[suspendsSlider.dataMap.length - 1].text
+                        Component.onCompleted: {
+                            suspendsSlider.rightTextWidth = width
+                        }
+                    }
                     slider.value: dccData.indexByValueOnMap(dataMap, dccData.model.sleepDelayOnPower)
                     slider.onValueChanged: {
                         dccData.worker.setSleepDelayOnPower(dataMap[slider.value].value)

--- a/src/plugin-wacom/qml/WacomMain.qml
+++ b/src/plugin-wacom/qml/WacomMain.qml
@@ -65,10 +65,37 @@ DccObject {
             D.TipsSlider {
                 id: scrollSlider
                 readonly property var tips: [qsTr("Light"), (""), (""), (""), (""), (""), qsTr("Heavy")]
+
+                property real leftTextWidth: 0
+                property real rightTextWidth: 0
+                property real dynamicLeftMargin: Math.max(16, leftTextWidth / 2 + 5)
+                property real dynamicRightMargin: Math.max(16, rightTextWidth / 2 + 5)
+
                 Layout.preferredHeight: 90
                 Layout.alignment: Qt.AlignCenter
-                Layout.margins: 10
+                Layout.leftMargin: dynamicLeftMargin
+                Layout.rightMargin: dynamicRightMargin
+                Layout.topMargin: 10
+                Layout.bottomMargin: 10
                 Layout.fillWidth: true
+
+                TextMetrics {
+                    id: scrollLeftTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[0]
+                    Component.onCompleted: {
+                        scrollSlider.leftTextWidth = width
+                    }
+                }
+                TextMetrics {
+                    id: scrollRightTextMetrics
+                    font: scrollSlider.slider.font
+                    text: scrollSlider.tips[scrollSlider.tips.length - 1]
+                    Component.onCompleted: {
+                        scrollSlider.rightTextWidth = width
+                    }
+                }
+
                 tickDirection: D.TipsSlider.TickDirection.Back
                 slider.handleType: Slider.HandleType.ArrowBottom
                 slider.value: dccData.EraserPressureSensitive


### PR DESCRIPTION
Add TextMetrics to dynamically calculate left/right margins based on text width, ensuring tips are fully visible without being clipped.

添加TextMetrics动态计算左右边距，确保提示文本完整显示不被裁剪。

Log: 修复TipsSlider文本裁剪问题
PMS: BUG-305223
Influence: 优化后所有TipsSlider组件的提示文本都能完整显示，提升用户体验。