### PR TITLE
fix(core): resolve GC crashes and race conditions in object management

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -838,6 +838,8 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     if (triggeredObj->pageType() == DccObject::MenuEditor && !triggeredObj->getChildren().isEmpty()) {
         triggeredObj = triggeredObj->getChildren().first();
     }
+
+    m_batchUpdating = true;
     DccObject *tmpObj = triggeredObj;
     tmpObj->setCurrentObject(nullptr);
     tmpObj->active(QString());
@@ -851,6 +853,7 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
         tmpObj = tmpObjParent;
     }
     if (!tmpObj) {
+        m_batchUpdating = false;
         return;
     }
     modules.append(tmpObj);
@@ -882,6 +885,8 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     // 更新当前对象
     m_currentObjects = modules;
     m_triggeredObjects = triggeredObjs;
+    m_batchUpdating = false;
+
     Q_EMIT triggeredObjectsChanged(m_triggeredObjects);
     if (auto *lastObj = m_currentObjects.last(); lastObj != m_activeObject) {
         m_activeObject = lastObj;

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -6,6 +6,8 @@
 #include "dccapp.h"
 #include "dccobject.h"
 
+#include <atomic>
+
 #include <DConfig>
 #include <DSysInfo>
 
@@ -51,6 +53,8 @@ public:
     inline const QVector<DccObject *> &currentObjects() const override { return m_currentObjects; }
 
     inline const QVector<DccObject *> &triggeredObjects() const override { return m_triggeredObjects; }
+
+    inline bool isBatchUpdating() const { return m_batchUpdating; }
 
     Q_INVOKABLE DccApp::UosEdition uosEdition() const;
     Q_INVOKABLE Dtk::Core::DSysInfo::ProductType productType() const;
@@ -145,6 +149,7 @@ private:
     QDBusMessage m_showMessage;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
+    std::atomic<bool> m_batchUpdating{false};  // 批量更新标志，防止 GC 崩溃，支持线程安全访问
 };
 } // namespace dccV25
 #endif // DCCMANAGER_H

--- a/src/dde-control-center/plugin/DccLoader.qml
+++ b/src/dde-control-center/plugin/DccLoader.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
 
@@ -7,10 +7,17 @@ Loader {
     property Item dccObjItem: null
 
     function updateDccObjItem() {
-        if (dccObj) {
+        if (dccObj && dccObjItem) {
             dccObj.parentItem = dccObjItem
         }
     }
+
+    Component.onDestruction: {
+        if (dccObj && dccObj.parentItem === dccObjItem) {
+            dccObj.parentItem = null
+        }
+    }
+
     enabled: dccObj && dccObj.enabledToApp
     // asynchronous: true
     sourceComponent: dccObj ? dccObj.page : null

--- a/src/dde-control-center/plugin/dccapp.h
+++ b/src/dde-control-center/plugin/dccapp.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DCCAPP_H
@@ -61,6 +61,9 @@ public:
     virtual int sidebarWidth() const;
     virtual void setSidebarWidth(int width);
     virtual void setAnimationMode(AnimationMode mode);
+
+    // 批量更新标志，用于防止页面切换时的 GC 崩溃
+    virtual bool isBatchUpdating() const { return false; }
 
 public Q_SLOTS:
     virtual DccObject *object(const QString &name);

--- a/src/dde-control-center/plugin/dccobject.cpp
+++ b/src/dde-control-center/plugin/dccobject.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccobject.h"
 
+#include "dccapp.h"
 #include "dccobject_p.h"
 
 #include <QLoggingCategory>
@@ -44,7 +45,7 @@ DccObject::Private::~Private()
         m_page->deleteLater();
         m_page = nullptr;
     }
-    if (m_parent) {
+    if (m_parent && m_parent->p_ptr) {
         m_parent->p_ptr->removeChild(q_ptr);
     }
     while (!m_children.isEmpty()) {
@@ -176,7 +177,7 @@ const QVector<DccObject *> &DccObject::Private::getChildren() const
 
 int DccObject::Private::getIndex() const
 {
-    return m_parent ? m_parent->p_ptr->getChildren().indexOf(q_ptr) : -1;
+    return (m_parent && m_parent->p_ptr) ? m_parent->p_ptr->getChildren().indexOf(q_ptr) : -1;
 }
 
 DccObject *DccObject::Private::getChild(int childPos) const
@@ -289,7 +290,7 @@ void DccObject::setWeight(quint32 weight)
 {
     if (p_ptr->m_weight != weight) {
         p_ptr->m_weight = weight;
-        if (p_ptr->m_parent) {
+        if (p_ptr->m_parent && p_ptr->m_parent->p_ptr) {
             p_ptr->m_parent->p_ptr->updatePos(this);
         }
         Q_EMIT weightChanged(p_ptr->m_weight);
@@ -428,11 +429,16 @@ DccObject *DccObject::currentObject()
 void DccObject::setCurrentObject(DccObject *obj)
 {
     if (p_ptr->m_currentObject != obj) {
-        if (p_ptr->m_currentObject) {
-            Q_EMIT p_ptr->m_currentObject->deactive();
-        }
+        DccObject *oldObject = p_ptr->m_currentObject;
         p_ptr->m_currentObject = obj;
-        Q_EMIT currentObjectChanged(p_ptr->m_currentObject);
+
+        DccApp *app = DccApp::instance();
+        if (!app || !app->isBatchUpdating()) {
+            if (oldObject) {
+                Q_EMIT oldObject->deactive();
+            }
+            Q_EMIT currentObjectChanged(p_ptr->m_currentObject);
+        }
     }
 }
 

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -166,18 +166,22 @@ void LoadPluginTask::doLoadSo()
                     break;
                 }
                 dataObj = factory->create();
-                if (dataObj && dataObj->parent()) {
-                    dataObj->setParent(nullptr);
-                }
                 soObj = factory->dccObject();
-                if (soObj && soObj->parent()) {
-                    soObj->setParent(nullptr);
-                }
             } while (false);
         }
     } else {
         Q_EMIT m_pManager->updatePluginStatus(m_data, DataErr, "File does not exist:" + soPath);
     }
+
+    // Check if manager is being deleted before assigning objects
+    if (m_pManager->isDeleting()) {
+        if (dataObj)
+            delete dataObj;
+        if (soObj)
+            delete soObj;
+        return;
+    }
+
     if (dataObj) {
         m_data->data = dataObj;
     }
@@ -410,7 +414,7 @@ void PluginManager::loadModule(PluginData *plugin)
     }
     QQmlComponent *component = new QQmlComponent(m_manager->engine(), m_manager->engine());
     component->setProperty("PluginData", QVariant::fromValue(plugin));
-    connect(component, &QQmlComponent::statusChanged, this, &PluginManager::moduleLoading);
+    connect(component, &QQmlComponent::statusChanged, this, &PluginManager::moduleLoading, Qt::QueuedConnection);
     switch (plugin->version()) {
     case T_V1_0: {
         const QString qmlPath = plugin->path + "/" + plugin->name + ".qml";
@@ -438,7 +442,8 @@ void PluginManager::loadMain(PluginData *plugin)
     }
     QQmlComponent *component = new QQmlComponent(m_manager->engine(), m_manager->engine());
     component->setProperty("PluginData", QVariant::fromValue(plugin));
-    connect(component, &QQmlComponent::statusChanged, this, &PluginManager::mainLoading);
+    // 使用 Qt::QueuedConnection 确保槽函数在主线程执行，避免多线程竞态条件
+    connect(component, &QQmlComponent::statusChanged, this, &PluginManager::mainLoading, Qt::QueuedConnection);
     switch (plugin->version()) {
     case T_V1_0: {
         const QString qmlPath = plugin->path + "/" + ((plugin->type & T_ShortMain) ? "main.qml" : plugin->name + "Main.qml");
@@ -458,6 +463,7 @@ void PluginManager::loadMain(PluginData *plugin)
 void PluginManager::createModule(QQmlComponent *component)
 {
     if (isDeleting()) {
+        component->deleteLater();
         return;
     }
     PluginData *plugin = component->property("PluginData").value<PluginData *>();
@@ -559,6 +565,8 @@ void PluginManager::moduleLoading()
     QQmlComponent *component = qobject_cast<QQmlComponent *>(sender());
     if (!component || component->status() == QQmlComponent::Loading)
         return;
+    // 断开信号连接，防止重复触发
+    disconnect(component, &QQmlComponent::statusChanged, this, &PluginManager::moduleLoading);
     createModule(component);
 }
 
@@ -567,6 +575,8 @@ void PluginManager::mainLoading()
     QQmlComponent *component = qobject_cast<QQmlComponent *>(sender());
     if (!component || component->status() == QQmlComponent::Loading)
         return;
+    // 断开信号连接，防止重复触发
+    disconnect(component, &QQmlComponent::statusChanged, this, &PluginManager::mainLoading);
     createMain(component);
 }
 

--- a/src/plugin-commoninfo/qml/DevelopModePage.qml
+++ b/src/plugin-commoninfo/qml/DevelopModePage.qml
@@ -168,7 +168,7 @@ DccObject {
                                         return
                                     }
                                     developDlg.currentStackIndex = 0;
-                                    stackView.replace(page1Component);
+                                    stackView.replace(page1Component, StackView.Immediate);
                                 }
                             }
 
@@ -182,7 +182,7 @@ DccObject {
                                     }
 
                                     developDlg.currentStackIndex = 1;
-                                    stackView.replace(page2Component);
+                                    stackView.replace(page2Component, StackView.Immediate);
                                 }
                             }
                         }


### PR DESCRIPTION
Add batch update flag to prevent GC crashes during page transitions. Fix null pointer checks in destructors and use queued connections for thread-safe signal handling. Add proper resource cleanup in QML loaders.

添加批量更新标志防止页面切换时GC崩溃。修复析构函数中的空指针检查,
使用队列连接确保线程安全的信号处理。在QML加载器中添加适当的资源清理。

Log: 修复GC崩溃和竞态条件问题
PMS: BUG-335919
Influence: 修复页面切换时因对象生命周期管理不当导致的崩溃问题,提升系统稳定性。

## Summary by Sourcery

Improve object lifecycle and page transition handling to prevent crashes and race conditions in the control center.

Bug Fixes:
- Guard plugin loading against manager destruction and clean up created objects safely.
- Ensure parent-child relationships in DccObject are accessed only when internal pointers are valid to avoid null dereferences.
- Prevent re-entrant or multi-threaded issues by using queued connections for QQmlComponent status signals and disconnecting after handling.
- Avoid GC-related crashes during page transitions by batching current-object updates and deferring activation/deactivation signals.
- Ensure QML-loaded items are detached from their container on destruction to avoid dangling references.

Enhancements:
- Introduce a batch update flag in DccManager/DccApp to coordinate safe multi-step page updates.
- Make StackView page replacements immediate in the develop mode page to keep navigation state consistent.