### PR TITLE
fix: Change the QML creation method to asynchronous creation.

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -76,7 +76,7 @@ DccManager::DccManager(QObject *parent)
     QJSEngine::setObjectOwnership(m_noParentObjects, QQmlEngine::CppOwnership);
 
     initConfig();
-    connect(m_plugins, &PluginManager::addObject, this, &DccManager::addObject, Qt::QueuedConnection);
+    connect(m_plugins, &PluginManager::addObject, this, &DccManager::addObject);
     connect(m_plugins, &PluginManager::loadAllFinished, this, &DccManager::tryShow, Qt::QueuedConnection);
     m_showTimer = new QTimer(this);
     connect(m_showTimer, &QTimer::timeout, this, &DccManager::tryShow);
@@ -468,20 +468,25 @@ void DccManager::initConfig()
     connect(m_dconfig, &DConfig::valueChanged, this, &DccManager::updateModuleConfig);
 }
 
-bool DccManager::contains(const QSet<QString> &urls, const DccObject *obj)
+bool DccManager::containsByName(const QSet<QString> &urls, const QString &name)
 {
     for (auto &&url : urls) {
         if (url.contains("*")) {
-            if (isMatch(url, obj)) {
+            if (isMatchByName(url, name)) {
                 return true;
             }
         } else {
-            if (isEqual(url, obj)) {
+            if (isEqualByName(url, name)) {
                 return true;
             }
         }
     }
     return false;
+}
+
+bool DccManager::contains(const QSet<QString> &urls, const DccObject *obj)
+{
+    return containsByName(urls, obj->parentName() + "/" + obj->name());
 }
 
 QStringList DccManager::splitUrl(const QString &url, QString &targetName)
@@ -777,7 +782,7 @@ void DccManager::clearShowParam()
 
 void DccManager::tryShow()
 {
-    if (m_showUrl.isEmpty() && !m_activeObject) {
+    if (m_showUrl.isEmpty() && m_showTimer) {
         clearShowParam();
         showPage(m_root, QString());
         return;
@@ -801,6 +806,9 @@ void DccManager::tryShow()
             QDBusConnection::sessionBus().send(m_showMessage.createErrorReply(QDBusError::InvalidArgs, QString("not found url:") + m_showUrl));
         }
         clearShowParam();
+        if (!m_activeObject) {
+            showPage(m_root, QString());
+        }
     }
 }
 
@@ -1098,9 +1106,9 @@ void DccManager::clearData()
 
     qCDebug(dccLog()) << "delete clearData hide:" << m_hideObjects->getChildren().size() << "noAdd:" << m_noAddObjects->getChildren().size() << "noParent" << m_noParentObjects->getChildren().size();
     QVector<DccObject *> deleteObjects;
-    deleteObjects.append(m_hideObjects);
-    deleteObjects.append(m_noAddObjects);
     deleteObjects.append(m_noParentObjects);
+    deleteObjects.append(m_noAddObjects);
+    deleteObjects.append(m_hideObjects);
     while (!deleteObjects.isEmpty()) {
         auto obj = deleteObjects.takeFirst();
         QVector<DccObject *> children = obj->getChildren();

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -59,6 +59,13 @@ public:
 
     inline const QSet<QString> &hideModule() const { return m_hideModule; }
 
+    static bool isMatchByName(const QString &url, const QString &name);
+    static bool isMatch(const QString &url, const DccObject *obj);
+    static bool isEqualByName(const QString &url, const QString &name);
+    static bool isEqual(const QString &url, const DccObject *obj);
+    static bool containsByName(const QSet<QString> &urls, const QString &name);
+    static bool contains(const QSet<QString> &urls, const DccObject *obj);
+
 public Q_SLOTS:
     DccObject *object(const QString &name) override;
     void addObject(DccObject *obj) override;
@@ -89,12 +96,7 @@ Q_SIGNALS:
 
 private:
     void initConfig();
-    bool contains(const QSet<QString> &urls, const DccObject *obj);
     QStringList splitUrl(const QString &url, QString &targetName);
-    bool isMatchByName(const QString &url, const QString &name);
-    bool isMatch(const QString &url, const DccObject *obj);
-    bool isEqualByName(const QString &url, const QString &name);
-    bool isEqual(const QString &url, const DccObject *obj);
     DccObject *findObject(const QString &url);
     QVector<DccObject *> findObjects(const QString &url, bool one = false);
     const DccObject *findParent(const DccObject *obj);

--- a/src/dde-control-center/plugin/dccimageprovider.cpp
+++ b/src/dde-control-center/plugin/dccimageprovider.cpp
@@ -3,8 +3,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccimageprovider.h"
 
-#include <QMutexLocker>
 #include <QMetaObject>
+#include <QThread>
+#include <QThreadPool>
+#include <QUrl>
 
 namespace dccV25 {
 // 4x of 84x54 => 336x216, used as a high-res base thumbnail size
@@ -12,160 +14,192 @@ const QSize THUMBNAIL_ICON_SIZE(336, 216);
 // Separator for cache key to include size information
 const QString CACHE_KEY_SIZE_SEPARATOR = "::SIZE::";
 
+static QSize resolveSize(const QSize &size)
+{
+    return (size.isValid() && size.width() > 0 && size.height() > 0)
+               ? size
+               : THUMBNAIL_ICON_SIZE;
+}
+
+// ---------------------------------------------------------------------------
+// CacheImageResponse – pure QML response container, no loading logic.
+// ---------------------------------------------------------------------------
 class CacheImageResponse : public QQuickImageResponse
 {
+    Q_OBJECT
 public:
-    CacheImageResponse(const QString &id, const QSize &requestedSize, DccImageProvider *provider)
-        : QQuickImageResponse()
-    {
-        QImage *img = provider->cacheImage(id, requestedSize, this, requestedSize);
-        if (img) {
-            // Image is already scaled to the proper size, no need to rescale here.
-            setImage(*img, QSize());
-        }
-    }
+    CacheImageResponse() = default;
 
-    QQuickTextureFactory *textureFactory() const override { return QQuickTextureFactory::textureFactoryForImage(m_image); }
+    void setImage(const QImage &image) { m_image = image; }
+    void emitFinished() { Q_EMIT finished(); }
 
-    void setImage(const QImage &image, const QSize &requestedSize)
+    QQuickTextureFactory *textureFactory() const override
     {
-        QMetaObject::invokeMethod(this, [this, image, requestedSize]() {
-            m_image = requestedSize.isValid() ? image.scaled(requestedSize) : image;
-            Q_EMIT finished();
-        }, Qt::QueuedConnection);
+        return QQuickTextureFactory::textureFactoryForImage(m_image);
     }
 
 private:
     QImage m_image;
 };
 
-class ImageTask : public QRunnable
+// ---------------------------------------------------------------------------
+// ImageTask – async image loader, runs on thread pool.
+// ---------------------------------------------------------------------------
+class ImageTask : public QObject, public QRunnable
 {
+    Q_OBJECT
+
+Q_SIGNALS:
+    void imageLoaded(const QString &cacheKey, const QImage &image);
+
 public:
-    explicit ImageTask(const QString &cacheKey, const QSize &thumbnailSize, DccImageProvider *provider, CacheImageResponse *response, const QSize &requestedSize)
-        : QRunnable()
-        , m_cacheKey(cacheKey)
-        , m_size(thumbnailSize.isValid() ? thumbnailSize : THUMBNAIL_ICON_SIZE)
+    ImageTask(const QString &id, const QSize &requestedSize, const QString &cacheKey)
+        : m_id(id)
         , m_requestedSize(requestedSize)
-        , m_provider(provider)
-        , m_response(response)
+        , m_cacheKey(cacheKey)
     {
-        // Extract original image path from cache key
-        int sepIndex = m_cacheKey.indexOf(CACHE_KEY_SIZE_SEPARATOR);
-        if (sepIndex > 0) {
-            m_id = m_cacheKey.left(sepIndex);
-        } else {
-            m_id = m_cacheKey;
-        }
+        setAutoDelete(false);
     }
 
-protected:
-    void run() override;
+    void run() override
+    {
+        QUrl url(m_id);
+        const QString scheme = url.scheme().toLower();
+        QString path;
+        if (scheme == "qrc")
+            path = ":" + url.path();
+        else if (scheme == "file" || url.isLocalFile())
+            path = url.toLocalFile();
+        else
+            path = url.toString();
 
-protected:
+        QImage img;
+        if (!img.load(path)) {
+            Q_EMIT imageLoaded(m_cacheKey, QImage());
+            return;
+        }
+
+        img = img.scaled(m_requestedSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+        if (img.width() > m_requestedSize.width() || img.height() > m_requestedSize.height()) {
+            const QRect dest(QPoint(0, 0), m_requestedSize);
+            const QRect src(img.rect().center() - dest.center(), m_requestedSize);
+            img = img.copy(src);
+        }
+
+        Q_EMIT imageLoaded(m_cacheKey, img);
+    }
+
+private:
     QString m_id;
-    QString m_cacheKey;  // Cache key including size information
-    QSize m_size;
     QSize m_requestedSize;
-    QPointer<DccImageProvider> m_provider;
-    QPointer<CacheImageResponse> m_response;
+    QString m_cacheKey;
 };
 
-void ImageTask::run()
-{
-    QImage originalImage;
-    QUrl url(m_id);
-    QString scheme = url.scheme().toLower();
-
-    QString path;
-    if (scheme == "qrc") {
-        path = ":" + url.path();
-    }
-    else if (scheme == "file" || url.isLocalFile()) {
-        path = url.toLocalFile();
-    }
-    else {
-        path = url.toString();
-    }
-
-    if (originalImage.load(path)) {
-        QSize targetSize = m_requestedSize.isValid() ? m_requestedSize : m_size;
-        if (!targetSize.isValid()) {
-            targetSize = THUMBNAIL_ICON_SIZE;
-        }
-
-        QImage img = originalImage.scaled(targetSize,
-                                          Qt::KeepAspectRatioByExpanding,
-                                          Qt::SmoothTransformation);
-        if (img.width() > targetSize.width() || img.height() > targetSize.height()) {
-            const QRect r(QPoint(0, 0), targetSize);
-            const QRect srcRect(img.rect().center() - r.center(), targetSize);
-            img = img.copy(srcRect);
-        }
-
-        if (m_provider && m_response) {
-            QImage *heapImage = new QImage(std::move(img));
-            if (m_provider->insert(m_cacheKey, heapImage)) {
-                // Image already at target size, no further scaling needed.
-                m_response->setImage(*heapImage, QSize());
-            } else {
-                delete heapImage;
-            }
-        }
-    }
-}
+// ---------------------------------------------------------------------------
+// DccImageProvider
+// ---------------------------------------------------------------------------
 
 DccImageProvider::DccImageProvider()
     : QQuickAsyncImageProvider()
     , m_cache(80)
-    , m_threadPool(new QThreadPool(this))
 {
 }
 
 DccImageProvider::~DccImageProvider()
 {
-    if (m_threadPool) {
-        m_threadPool->waitForDone();
-    }
 }
 
-QImage *DccImageProvider::cacheImage(const QString &id, const QSize &thumbnailSize)
+// static
+QString DccImageProvider::makeCacheKey(const QString &id, const QSize &size)
 {
-    return cacheImage(id, thumbnailSize, new CacheImageResponse(id, QSize(), this), QSize());
+    const QSize s = resolveSize(size);
+    return QString("%1%2%3x%4").arg(id, CACHE_KEY_SIZE_SEPARATOR).arg(s.width()).arg(s.height());
 }
 
-QImage *DccImageProvider::cacheImage(const QString &id, const QSize &thumbnailSize, CacheImageResponse *response, const QSize &requestedSize)
+void DccImageProvider::submitTask(const QString &id, const QSize &resolvedSize,
+                                  const QString &cacheKey, CacheImageResponse *response)
 {
-    QMutexLocker<QMutex> locker(&m_mutex);
+    Q_ASSERT(thread() == QThread::currentThread());
 
-    // Use size as part of cache key to avoid different size images interfering with each other
-    QString cacheKey = id;
-
-    // Determine the size to use for cache key
-    QSize cacheSize = requestedSize.isValid() ? requestedSize : thumbnailSize;
-    if (!cacheSize.isValid() || cacheSize.width() <= 0 || cacheSize.height() <= 0) {
-        cacheSize = THUMBNAIL_ICON_SIZE;
+    if (m_pendingResponses.contains(cacheKey)) {
+        // Task already in flight – just register this response for notification
+        if (response)
+            m_pendingResponses.insert(cacheKey, response);
+        return;
     }
 
-    // Add size to cache key
-    cacheKey = QString("%1%2%3x%4").arg(id).arg(CACHE_KEY_SIZE_SEPARATOR).arg(cacheSize.width()).arg(cacheSize.height());
+    // Insert the response pointer, or an empty QPointer as an in-flight marker.
+    m_pendingResponses.insert(cacheKey, QPointer<CacheImageResponse>(response));
 
-    if (m_cache.contains(cacheKey)) {
-        return m_cache.object(cacheKey);
-    }
-    m_threadPool->start(new ImageTask(cacheKey, thumbnailSize, this, response, requestedSize));
-    return nullptr;
+    auto task = new ImageTask(id, resolvedSize, cacheKey);
+    connect(task, &ImageTask::imageLoaded, this, &DccImageProvider::onImageLoaded, Qt::QueuedConnection);
+    connect(task, &ImageTask::imageLoaded, task, &QObject::deleteLater, Qt::QueuedConnection);
+    QThreadPool::globalInstance()->start(task);
+}
+
+void DccImageProvider::cacheImage(const QString &id, const QSize &thumbnailSize)
+{
+    const QString cacheKey = makeCacheKey(id, thumbnailSize);
+    const QSize resolved = resolveSize(thumbnailSize);
+
+    const auto work = [this, id, resolved, cacheKey]() {
+        if (m_cache.object(cacheKey))
+            return;
+        submitTask(id, resolved, cacheKey, nullptr);
+    };
+
+    QMetaObject::invokeMethod(this, work);
 }
 
 QQuickImageResponse *DccImageProvider::requestImageResponse(const QString &id, const QSize &requestedSize)
 {
-    return new CacheImageResponse(id, requestedSize, this);
+    const QString cacheKey = makeCacheKey(id, requestedSize);
+    const QSize resolved = resolveSize(requestedSize);
+    auto response = new CacheImageResponse();
+    response->moveToThread(thread());
+    QPointer<CacheImageResponse> guardedResponse(response);
+
+    const auto work = [this, guardedResponse, id, resolved, cacheKey]() {
+        if (!guardedResponse)
+            return;
+
+        if (const QImage *cached = m_cache.object(cacheKey)) {
+            // Cache hit: set image and emit finished asynchronously on the provider thread.
+            guardedResponse->setImage(*cached);
+            guardedResponse->emitFinished();
+        } else {
+            // Cache miss: submit a loading task. The response will be notified when loading is done.
+            submitTask(id, resolved, cacheKey, guardedResponse);
+        }
+    };
+
+    QMetaObject::invokeMethod(this, work);
+
+    return response;
 }
 
-bool DccImageProvider::insert(const QString &id, QImage *img)
+void DccImageProvider::onImageLoaded(const QString &cacheKey, const QImage &image)
 {
-    QMutexLocker<QMutex> locker(&m_mutex);
-    return m_cache.insert(id, img);
+    Q_ASSERT(thread() == QThread::currentThread());
+
+    if (!image.isNull())
+        m_cache.insert(cacheKey, new QImage(image));
+
+    if (!m_pendingResponses.contains(cacheKey))
+        return;
+
+    const auto responses = m_pendingResponses.values(cacheKey);
+    m_pendingResponses.remove(cacheKey);
+
+    for (const auto &resp : responses) {
+        if (resp) {
+            if (!image.isNull())
+                resp->setImage(image);
+            resp->emitFinished();
+        }
+    }
 }
 
 } // namespace dccV25
+
+#include "dccimageprovider.moc"

--- a/src/dde-control-center/plugin/dccimageprovider.h
+++ b/src/dde-control-center/plugin/dccimageprovider.h
@@ -1,13 +1,14 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DCCIMAGEPROVIDER_H
 #define DCCIMAGEPROVIDER_H
 #include <QCache>
-#include <QMutex>
+#include <QImage>
+#include <QMultiMap>
 #include <QObject>
+#include <QPointer>
 #include <QQuickAsyncImageProvider>
-#include <QThreadPool>
 
 namespace dccV25 {
 class CacheImageResponse;
@@ -17,18 +18,21 @@ class DccImageProvider : public QQuickAsyncImageProvider
     Q_OBJECT
 public:
     explicit DccImageProvider();
-    ~DccImageProvider();
+    ~DccImageProvider() override;
 
-    QImage *cacheImage(const QString &id, const QSize &thumbnailSize);
-    QImage *cacheImage(const QString &id, const QSize &thumbnailSize, CacheImageResponse *response, const QSize &requestedSize);
-    bool insert(const QString &id, QImage *img);
-
+    void cacheImage(const QString &id, const QSize &thumbnailSize);
     QQuickImageResponse *requestImageResponse(const QString &id, const QSize &requestedSize) override;
 
+private Q_SLOTS:
+    void onImageLoaded(const QString &cacheKey, const QImage &image);
+    
 private:
+    static QString makeCacheKey(const QString &id, const QSize &size);
+    void submitTask(const QString &id, const QSize &resolvedSize, const QString &cacheKey,
+                    CacheImageResponse *response);
+
     QCache<QString, QImage> m_cache;
-    QThreadPool *m_threadPool;
-    QMutex m_mutex;
+    QMultiMap<QString, QPointer<CacheImageResponse>> m_pendingResponses;
 };
 } // namespace dccV25
 #endif // DCCIMAGEPROVIDER_H

--- a/src/dde-control-center/plugin/dccobject.cpp
+++ b/src/dde-control-center/plugin/dccobject.cpp
@@ -25,6 +25,7 @@ DccObject::Private::Private(DccObject *obj)
     , m_pageType(Menu)
     , m_weight(-1)
     , m_flags(0)
+    , m_componentComplete(false)
     , q_ptr(obj)
     , m_parent(nullptr)
     , m_currentObject(nullptr)
@@ -331,15 +332,23 @@ void DccObject::setIcon(const QString &icon)
 {
     if (p_ptr->m_icon != icon) {
         p_ptr->m_icon = icon;
-        if (!icon.isEmpty()) {
-            QQmlContext *context = qmlContext(this);
-            p_ptr->m_iconSource = context ? context->resolvedUrl(icon) : icon;
-        } else {
-            p_ptr->m_iconSource.clear();
-        }
         Q_EMIT iconChanged(p_ptr->m_icon);
-        Q_EMIT iconSourceChanged(p_ptr->m_iconSource);
+        // 只在组件完成后才解析 URL
+        if (p_ptr->m_componentComplete) {
+            updateIconSource();
+        }
     }
+}
+
+void DccObject::updateIconSource()
+{
+    if (!p_ptr->m_icon.isEmpty()) {
+        QQmlContext *context = qmlContext(this);
+        p_ptr->m_iconSource = context ? context->resolvedUrl(p_ptr->m_icon) : p_ptr->m_icon;
+    } else {
+        p_ptr->m_iconSource.clear();
+    }
+    Q_EMIT iconSourceChanged(p_ptr->m_iconSource);
 }
 
 QUrl DccObject::iconSource() const
@@ -486,6 +495,18 @@ QQmlListProperty<QObject> DccObject::data()
 const QVector<DccObject *> &DccObject::getChildren() const
 {
     return p_ptr->getChildren();
+}
+
+void DccObject::classBegin()
+{
+}
+
+void DccObject::componentComplete()
+{
+    p_ptr->m_componentComplete = true;
+    if (!p_ptr->m_icon.isEmpty()) {
+        updateIconSource();
+    }
 }
 
 } // namespace dccV25

--- a/src/dde-control-center/plugin/dccobject.cpp
+++ b/src/dde-control-center/plugin/dccobject.cpp
@@ -31,26 +31,24 @@ DccObject::Private::Private(DccObject *obj)
     , m_currentObject(nullptr)
     , m_page(nullptr)
     , m_parentItem(nullptr)
+    , m_pParent(nullptr)
 {
 }
 
 DccObject::Private::~Private()
 {
-    if (m_page && (!m_page->parent() || m_page->parent() == q_ptr)) {
-        // Use deleteLater() to avoid dangling QObjectWrapper references in QML's
-        // JS engine. Synchronous delete can cause crashes when GC runs during
-        // StackView page transitions and tries to mark already-freed objects.
-        if (m_page->parent() == q_ptr)
-            m_page->setParent(nullptr);
-        m_page->deleteLater();
-        m_page = nullptr;
+    if (m_pParent) {
+        m_pParent->removeObject(q_ptr);
     }
+    clearObject();
+    m_page = nullptr;
     if (m_parent) {
         m_parent->p_ptr->removeChild(q_ptr);
     }
+
     while (!m_children.isEmpty()) {
-        DccObject *child = m_children.first();
-        removeChild(0);
+        DccObject *child = m_children.last();
+        removeChild(m_children.size() - 1);
         if (child->parent() == q_ptr) {
             // Detach from parent to prevent ~QObject() from doing a synchronous
             // delete, then defer destruction so QML's GC can safely process any
@@ -194,13 +192,16 @@ void DccObject::Private::addObject(DccObject *child)
 {
     if (child && !m_objects.contains(child)) {
         m_objects.append(child);
+        child->p_ptr->m_pParent = this;
         Q_EMIT q_ptr->addObject(child);
     }
 }
 
 void DccObject::Private::removeObject(DccObject *child)
 {
-    if (child && m_objects.removeOne(child)) {
+    if (child) {
+        child->p_ptr->m_pParent = nullptr;
+        m_objects.removeOne(child);
         Q_EMIT q_ptr->removeObject(child);
     }
 }
@@ -208,6 +209,7 @@ void DccObject::Private::removeObject(DccObject *child)
 void DccObject::Private::clearObject()
 {
     for (auto obj : m_objects) {
+        obj->p_ptr->m_pParent = nullptr;
         Q_EMIT q_ptr->removeObject(obj);
     }
     m_objects.clear();
@@ -497,9 +499,7 @@ const QVector<DccObject *> &DccObject::getChildren() const
     return p_ptr->getChildren();
 }
 
-void DccObject::classBegin()
-{
-}
+void DccObject::classBegin() { }
 
 void DccObject::componentComplete()
 {

--- a/src/dde-control-center/plugin/dccobject.h
+++ b/src/dde-control-center/plugin/dccobject.h
@@ -7,12 +7,15 @@
 #include <QObject>
 #include <QQmlComponent>
 #include <QQmlListProperty>
+#include <QQmlParserStatus>
 #include <QQuickItem>
 
 namespace dccV25 {
-class DccObject : public QObject
+class DccModel;
+class DccObject : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
     QML_ELEMENT
 public:
     Q_PROPERTY(QString name READ name WRITE setName NOTIFY nameChanged)
@@ -118,6 +121,11 @@ public:
     QQmlListProperty<QObject> data();
     const QVector<DccObject *> &getChildren() const;
 
+    // QQmlParserStatus interface
+    void classBegin() override;
+    void componentComplete() override;
+
+
     class Private;
 
 Q_SIGNALS:
@@ -162,6 +170,9 @@ Q_SIGNALS:
 
 protected:
     DccObject::Private *p_ptr;
+
+private:
+    void updateIconSource();
 };
 } // namespace dccV25
 #endif // DCCOBJECT_H

--- a/src/dde-control-center/plugin/dccobject_p.h
+++ b/src/dde-control-center/plugin/dccobject_p.h
@@ -70,6 +70,7 @@ protected:
     quint8 m_pageType;
     quint16 m_weight;
     quint32 m_flags;
+    bool m_componentComplete;
 
     DccObject *q_ptr;    // q指针
     DccObject *m_parent; // 父项

--- a/src/dde-control-center/plugin/dccobject_p.h
+++ b/src/dde-control-center/plugin/dccobject_p.h
@@ -80,6 +80,7 @@ protected:
     QObjectList m_data;              // data属性，为qml能加子项
     QPointer<QQmlComponent> m_page;
     QPointer<QQuickItem> m_parentItem; // Item父项
+    DccObject::Private *m_pParent;     // m_objects对应的父项 private parent
 
     QString m_parentName;
     QString m_displayName;

--- a/src/dde-control-center/plugin/dccrepeater.cpp
+++ b/src/dde-control-center/plugin/dccrepeater.cpp
@@ -34,7 +34,7 @@ public:
 
         for (int i = 0; i < itemCount; i++) {
             if (i >= deletables.size() || !deletables.at(i))
-                model->object(i, QQmlIncubator::AsynchronousIfNested);
+                model->object(i, QQmlIncubator::Asynchronous);
         }
     }
 
@@ -185,6 +185,8 @@ void DccRepeater::createdItem(int index, QObject *item)
 {
     DccObject *dccObj = qmlobject_cast<DccObject *>(item);
     if (dccObj) {
+        Q_D(const DccRepeater);
+        d->model->object(index);
         dccObj->setParent(this);
         p_ptr->addObject(dccObj);
         Q_EMIT objAdded(index, item);

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -75,6 +75,7 @@ struct PluginData
     QString name;
     QString path;
     uint type;
+    DccFactory *factory;
 
     DccObject *module;
     DccObject *mainObj;
@@ -87,6 +88,7 @@ struct PluginData
         : name(_name)
         , path(_path)
         , type(T_Unknown)
+        , factory(nullptr)
         , module(nullptr)
         , mainObj(nullptr)
         , soObj(nullptr)
@@ -111,7 +113,7 @@ public:
 
 protected:
     void run() override;
-    void doLoadSo();
+    void createData();
 
 protected:
     PluginManager *m_pManager;
@@ -121,62 +123,33 @@ protected:
 void LoadPluginTask::run()
 {
     m_data->thread = QThread::currentThread();
-    doLoadSo();
+    createData();
     m_data->thread = nullptr;
 }
 
-void LoadPluginTask::doLoadSo()
+void LoadPluginTask::createData()
 {
-    Q_EMIT m_pManager->updatePluginStatus(m_data, DataBegin, "load plugin begin");
-    // {main.qml}
-    const QString soPath = m_data->path + "/" + m_data->name + ".so";
+    Q_EMIT m_pManager->updatePluginStatus(m_data, DataBegin, "create data begin");
     QElapsedTimer timer;
     timer.start();
     QObject *dataObj = nullptr;
     DccObject *soObj = nullptr;
-    if (QFile::exists(soPath)) {
-        if (m_pManager->isDeleting()) {
-            return;
-        }
-        QPluginLoader loader(soPath);
-        Q_EMIT m_pManager->updatePluginStatus(m_data, DataLoad, QString());
-        loader.load();
-        if (m_pManager->isDeleting()) {
-            return;
-        }
-        if (!loader.isLoaded()) {
-            Q_EMIT m_pManager->updatePluginStatus(m_data, DataErr, "Load the plugin failed." + loader.errorString());
-        } else {
-            const auto &meta = loader.metaData();
-            do {
-                const auto iid = meta["IID"].toString();
-                if (iid.isEmpty() || iid != QString(qobject_interface_iid<DccFactory *>())) {
-                    Q_EMIT m_pManager->updatePluginStatus(m_data, DataErr, "Error iid:" + iid);
-                    break;
-                }
-
-                if (!loader.instance()) {
-                    Q_EMIT m_pManager->updatePluginStatus(m_data, DataErr, "instance() failed." + loader.errorString());
-                    break;
-                }
-                DccFactory *factory = qobject_cast<DccFactory *>(loader.instance());
-                if (!factory) {
-                    Q_EMIT m_pManager->updatePluginStatus(m_data, DataErr, "The plugin isn't a DccFactory." + soPath);
-                    loader.unload();
-                    break;
-                }
-                dataObj = factory->create();
-                if (dataObj && dataObj->parent()) {
-                    dataObj->setParent(nullptr);
-                }
-                soObj = factory->dccObject();
-                if (soObj && soObj->parent()) {
-                    soObj->setParent(nullptr);
-                }
-            } while (false);
-        }
+    if (m_pManager->isDeleting()) {
+        return;
+    }
+    if (!m_data->factory) {
+        Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data skipped");
+        return;
     } else {
-        Q_EMIT m_pManager->updatePluginStatus(m_data, DataErr, "File does not exist:" + soPath);
+        Q_EMIT m_pManager->updatePluginStatus(m_data, DataLoad, QString());
+        dataObj = m_data->factory->create();
+        if (dataObj && dataObj->parent()) {
+            dataObj->setParent(nullptr);
+        }
+        soObj = m_data->factory->dccObject();
+        if (soObj && soObj->parent()) {
+            soObj->setParent(nullptr);
+        }
     }
     if (dataObj) {
         m_data->data = dataObj;
@@ -192,7 +165,7 @@ void LoadPluginTask::doLoadSo()
         m_data->soObj->moveToThread(m_pManager->thread());
         m_data->soObj->setParent(m_pManager->parent());
     }
-    Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": load plugin finished. elapsed time :" + QString::number(timer.elapsed()));
+    Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data finished. elapsed time :" + QString::number(timer.elapsed()));
 }
 
 PluginManager::PluginManager(DccManager *parent)
@@ -224,6 +197,7 @@ PluginManager::~PluginManager()
             delete data->data;
             data->data = nullptr;
         }
+        data->factory = nullptr;
         delete data;
     }
     m_plugins.clear();
@@ -305,6 +279,49 @@ bool PluginManager::updatePluginType(PluginData *plugin)
     return false;
 }
 
+bool PluginManager::preparePluginFactory(PluginData *plugin)
+{
+    if (!plugin || plugin->factory) {
+        return plugin && plugin->factory;
+    }
+
+    const QString soPath = plugin->path + "/" + plugin->name + ".so";
+    if (!QFile::exists(soPath)) {
+        return true;
+    }
+
+    QPluginLoader loader(soPath);
+    if (!loader.load()) {
+        qCWarning(dccLog()) << plugin->name << ": prepare factory load failed" << loader.errorString();
+        return false;
+    }
+
+    const auto &meta = loader.metaData();
+    const auto iid = meta["IID"].toString();
+    if (iid.isEmpty() || iid != QString(qobject_interface_iid<DccFactory *>())) {
+        qCWarning(dccLog()) << plugin->name << ": prepare factory iid error" << iid;
+        loader.unload();
+        return false;
+    }
+
+    QObject *instance = loader.instance();
+    if (!instance) {
+        qCWarning(dccLog()) << plugin->name << ": prepare factory instance failed" << loader.errorString();
+        loader.unload();
+        return false;
+    }
+
+    DccFactory *factory = qobject_cast<DccFactory *>(instance);
+    if (!factory) {
+        qCWarning(dccLog()) << plugin->name << ": prepare factory cast failed";
+        loader.unload();
+        return false;
+    }
+
+    plugin->factory = factory;
+    return true;
+}
+
 QThreadPool *PluginManager::threadPool()
 {
     if (!m_threadPool) {
@@ -341,6 +358,10 @@ void PluginManager::loadPlugin(PluginData *plugin)
             threadPool()->start(new LoadPluginTask(plugin, this));
         }
     } else if ((plugin->status & (MetaDataEnd | ModuleLoad)) == MetaDataEnd) {
+        if (!preparePluginFactory(plugin)) {
+            Q_EMIT updatePluginStatus(plugin, DataErr | PluginEnd, ": factory preparation failed, plugin skipped");
+            return;
+        }
         DccManager::installTranslator(plugin->name);
         loadModule(plugin);
     } else {

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -174,10 +174,12 @@ PluginManager::PluginManager(DccManager *parent)
     , m_rootModule(nullptr)
     , m_threadPool(nullptr)
     , m_isDeleting(false)
+    , m_modulePhaseFinished(false)
 {
     qRegisterMetaType<PluginData>("PluginData");
     connect(this, &PluginManager::pluginEndStatusChanged, this, &PluginManager::loadPlugin);
     connect(this, &PluginManager::updatePluginStatus, this, &PluginManager::onUpdatePluginStatus);
+    connect(this, &PluginManager::modulePhaseFinished, this, &PluginManager::onModulePhaseFinished);
     connect(m_manager, &DccManager::hideModuleChanged, this, &PluginManager::onHideModuleChanged);
 }
 
@@ -322,6 +324,18 @@ bool PluginManager::preparePluginFactory(PluginData *plugin)
     return true;
 }
 
+bool PluginManager::allModulesFinished() const
+{
+    for (auto &&plugin : m_plugins) {
+        uint status = plugin->status;
+        bool moduleFinished = (status & ModuleEnd) || (status & ModuleErr) || (status & PluginEnd);
+        if (!moduleFinished) {
+            return false;
+        }
+    }
+    return !m_plugins.isEmpty();
+}
+
 QThreadPool *PluginManager::threadPool()
 {
     if (!m_threadPool) {
@@ -346,16 +360,12 @@ void PluginManager::loadPlugin(PluginData *plugin)
     } else if ((plugin->status & (DataEnd | MainObjLoad)) == DataEnd) {
         loadMain(plugin);
     } else if ((plugin->status & (ModuleEnd | DataBegin)) == ModuleEnd) {
-        if (plugin->module) {
-            disconnect(plugin->module, nullptr, this, nullptr);
-            if (plugin->module->isVisibleToApp()) {
-                threadPool()->start(new LoadPluginTask(plugin, this));
-            } else {
-                connect(plugin->module, &DccObject::visibleToAppChanged, this, &PluginManager::onVisibleToAppChanged);
-                Q_EMIT updatePluginStatus(plugin, PluginEnd, QString());
-            }
-        } else {
-            threadPool()->start(new LoadPluginTask(plugin, this));
+        if (!m_modulePhaseFinished && allModulesFinished()) {
+            Q_EMIT modulePhaseFinished();
+            return;
+        }
+        if (m_modulePhaseFinished) {
+            loadPluginData(plugin);
         }
     } else if ((plugin->status & (MetaDataEnd | ModuleLoad)) == MetaDataEnd) {
         if (!preparePluginFactory(plugin)) {
@@ -445,6 +455,24 @@ void PluginManager::loadModule(PluginData *plugin)
         Q_EMIT updatePluginStatus(plugin, ModuleLoad, ": load module " + typeName);
         component->loadFromModule(plugin->name, typeName, QQmlComponent::Asynchronous);
     } break;
+    }
+}
+
+void PluginManager::loadPluginData(PluginData *plugin)
+{
+    if (isDeleting()) {
+        return;
+    }
+    if (plugin->module) {
+        disconnect(plugin->module, nullptr, this, nullptr);
+        if (plugin->module->isVisibleToApp()) {
+            threadPool()->start(new LoadPluginTask(plugin, this));
+        } else {
+            connect(plugin->module, &DccObject::visibleToAppChanged, this, &PluginManager::onVisibleToAppChanged);
+            Q_EMIT updatePluginStatus(plugin, PluginEnd, QString());
+        }
+    } else {
+        threadPool()->start(new LoadPluginTask(plugin, this));
     }
 }
 
@@ -589,6 +617,19 @@ void PluginManager::mainLoading()
     if (!component || component->status() == QQmlComponent::Loading)
         return;
     createMain(component);
+}
+
+void PluginManager::onModulePhaseFinished()
+{
+    if (isDeleting()) {
+        return;
+    }
+    m_modulePhaseFinished = true;
+    for (auto &&plugin : m_plugins) {
+        if (plugin->status & ModuleEnd) {
+            loadPlugin(plugin);
+        }
+    }
 }
 
 void PluginManager::onHideModuleChanged(const QSet<QString> &hideModule)

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -19,6 +19,7 @@
 #include <QQmlComponent>
 #include <QQmlContext>
 #include <QQmlFile>
+#include <QQmlIncubator>
 #include <QRunnable>
 #include <QSet>
 #include <QSettings>
@@ -101,6 +102,93 @@ struct PluginData
     inline uint version() { return type & T_V_MASK; }
 };
 
+static void doLoadSo(PluginData *plugin, PluginManager *pManager)
+{
+    const QString soPath = plugin->path + "/" + plugin->name + ".so";
+    QElapsedTimer timer;
+    timer.start();
+    if (QFile::exists(soPath)) {
+        if (pManager->isDeleting()) {
+            return;
+        }
+        QPluginLoader loader(soPath);
+        Q_EMIT pManager->updatePluginStatus(plugin, DataLoad, QString());
+        loader.load();
+        if (pManager->isDeleting()) {
+            return;
+        }
+        if (!loader.isLoaded()) {
+            Q_EMIT pManager->updatePluginStatus(plugin, DataErr, "Load the plugin failed." + loader.errorString());
+        } else {
+            const auto &meta = loader.metaData();
+            do {
+                const auto iid = meta["IID"].toString();
+                if (iid.isEmpty() || iid != QString(qobject_interface_iid<DccFactory *>())) {
+                    Q_EMIT pManager->updatePluginStatus(plugin, DataErr, "Error iid:" + iid);
+                    break;
+                }
+
+                if (!loader.instance()) {
+                    Q_EMIT pManager->updatePluginStatus(plugin, DataErr, "instance() failed." + loader.errorString());
+                    break;
+                }
+                DccFactory *factory = qobject_cast<DccFactory *>(loader.instance());
+                if (!factory) {
+                    Q_EMIT pManager->updatePluginStatus(plugin, DataErr, "The plugin isn't a DccFactory." + soPath);
+                    loader.unload();
+                    break;
+                }
+                plugin->factory = factory;
+            } while (false);
+        }
+    }
+    Q_EMIT pManager->updatePluginStatus(plugin, DataLoad, ": Load the plugin. elapsed time :" + QString::number(timer.elapsed()));
+}
+
+static void doCreateDccObject(PluginData *plugin, PluginManager * /*pManager*/)
+{
+    if (plugin->factory) {
+        QObject *obj = plugin->factory->dccObject();
+        DccObject *soObj = dynamic_cast<DccObject *>(obj);
+        if (soObj) {
+            plugin->soObj = soObj;
+        } else if (obj) {
+            obj->deleteLater();
+        }
+    }
+}
+
+static void doCreateData(PluginData *plugin, PluginManager *pManager)
+{
+    Q_EMIT pManager->updatePluginStatus(plugin, DataBegin, "create data begin");
+    QElapsedTimer timer;
+    timer.start();
+    QObject *dataObj = nullptr;
+    if (pManager->isDeleting()) {
+        return;
+    }
+    if (!plugin->factory) {
+        Q_EMIT pManager->updatePluginStatus(plugin, DataEnd, ": create data skipped");
+        return;
+    } else {
+        Q_EMIT pManager->updatePluginStatus(plugin, DataLoad, QString());
+        dataObj = plugin->factory->create();
+        if (dataObj && dataObj->parent()) {
+            dataObj->setParent(nullptr);
+        }
+    }
+    if (dataObj) {
+        plugin->data = dataObj;
+    }
+    if (plugin->data) {
+        plugin->data->moveToThread(pManager->thread());
+    }
+    if (plugin->factory) {
+        plugin->factory->moveToThread(pManager->thread());
+    }
+    Q_EMIT pManager->updatePluginStatus(plugin, DataEnd, ": create data finished. elapsed time :" + QString::number(timer.elapsed()));
+}
+
 class LoadPluginTask : public QRunnable
 {
 public:
@@ -123,56 +211,67 @@ protected:
 void LoadPluginTask::run()
 {
     m_data->thread = QThread::currentThread();
-    createData();
+    doCreateData(m_data, m_pManager);
     m_data->thread = nullptr;
 }
 
-void LoadPluginTask::createData()
+class DccIncubator : public QQmlIncubator
 {
-    Q_EMIT m_pManager->updatePluginStatus(m_data, DataBegin, "create data begin");
-    QElapsedTimer timer;
-    timer.start();
-    QObject *dataObj = nullptr;
-    DccObject *soObj = nullptr;
-    if (m_pManager->isDeleting()) {
-        return;
+public:
+    DccIncubator(PluginManager *pManager, PluginData *data, QQmlComponent *component, QQmlContext *context)
+        : QQmlIncubator(Asynchronous)
+        , m_pManager(pManager)
+        , m_data(data)
+        , m_component(component)
+        , m_context(context)
+    {
     }
-    if (!m_data->factory) {
-        Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data skipped");
-        return;
-    } else {
-        Q_EMIT m_pManager->updatePluginStatus(m_data, DataLoad, QString());
-        dataObj = m_data->factory->create();
-        if (dataObj && dataObj->parent()) {
-            dataObj->setParent(nullptr);
+
+protected:
+    // 当对象孵化（创建）完成时调用
+    void setInitialState(QObject *object) override
+    {
+        // 这里可以做一些初始化设置，但通常建议在 statusChanged 中处理
+        QQmlIncubator::setInitialState(object);
+    }
+
+    void statusChanged(Status status) override
+    {
+        switch (status) {
+        case Ready: {
+            QObject *obj = object();
+            if (obj) {
+                m_context->setParent(obj);
+                obj->setParent(m_data->module ? m_data->module : nullptr);
+                m_data->mainObj = qobject_cast<DccObject *>(obj);
+                Q_EMIT m_pManager->updatePluginStatus(m_data, MainObjEnd, ": create main finished");
+            } else {
+                m_context->deleteLater();
+                Q_EMIT m_pManager->updatePluginStatus(m_data, MainObjErr | MainObjEnd, " component create main object is null:" + m_component->errorString());
+            }
+        } break;
+        case Error: {
+            Q_EMIT m_pManager->updatePluginStatus(m_data, MainObjErr | MainObjEnd, " component create main object error:" + m_component->errorString());
+        } break;
+        default:
+            return;
+            break;
         }
-        soObj = m_data->factory->dccObject();
-        if (soObj && soObj->parent()) {
-            soObj->setParent(nullptr);
-        }
+        m_component->deleteLater();
+        delete this;
     }
-    if (dataObj) {
-        m_data->data = dataObj;
-    }
-    if (soObj) {
-        m_data->soObj = soObj;
-    }
-    if (m_data->data) {
-        m_data->data->moveToThread(m_pManager->thread());
-        m_data->data->setParent(m_pManager->parent());
-    }
-    if (m_data->soObj) {
-        m_data->soObj->moveToThread(m_pManager->thread());
-        m_data->soObj->setParent(m_pManager->parent());
-    }
-    Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data finished. elapsed time :" + QString::number(timer.elapsed()));
-}
+
+private:
+    PluginManager *m_pManager;
+    PluginData *m_data;
+    QQmlComponent *m_component;
+    QQmlContext *m_context;
+};
 
 PluginManager::PluginManager(DccManager *parent)
     : QObject(parent)
     , m_manager(parent)
     , m_rootModule(nullptr)
-    , m_threadPool(nullptr)
     , m_isDeleting(false)
     , m_modulePhaseFinished(false)
 {
@@ -338,10 +437,7 @@ bool PluginManager::allModulesFinished() const
 
 QThreadPool *PluginManager::threadPool()
 {
-    if (!m_threadPool) {
-        m_threadPool = new QThreadPool(this);
-    }
-    return m_threadPool;
+    return QThreadPool::globalInstance();
 }
 
 void PluginManager::loadPlugin(PluginData *plugin)
@@ -358,14 +454,26 @@ void PluginManager::loadPlugin(PluginData *plugin)
         addMainObject(plugin);
         Q_EMIT updatePluginStatus(plugin, PluginEnd, QString());
     } else if ((plugin->status & (DataEnd | MainObjLoad)) == DataEnd) {
+        if (plugin->data) {
+            plugin->data->setParent(this);
+            QJSEngine::setObjectOwnership(plugin->data, QQmlEngine::CppOwnership);
+        }
         loadMain(plugin);
     } else if ((plugin->status & (ModuleEnd | DataBegin)) == ModuleEnd) {
-        if (!m_modulePhaseFinished && allModulesFinished()) {
-            Q_EMIT modulePhaseFinished();
-            return;
-        }
-        if (m_modulePhaseFinished) {
-            loadPluginData(plugin);
+        if (plugin->module) {
+            disconnect(plugin->module, nullptr, this, nullptr);
+            if (plugin->module->isVisibleToApp()) {
+                doLoadSo(plugin, this);
+                doCreateDccObject(plugin, this);
+                threadPool()->start(new LoadPluginTask(plugin, this));
+            } else {
+                connect(plugin->module, &DccObject::visibleToAppChanged, this, &PluginManager::onVisibleToAppChanged);
+                Q_EMIT updatePluginStatus(plugin, PluginEnd, QString());
+            }
+        } else {
+            doLoadSo(plugin, this);
+            doCreateDccObject(plugin, this);
+            threadPool()->start(new LoadPluginTask(plugin, this));
         }
     } else if ((plugin->status & (MetaDataEnd | ModuleLoad)) == MetaDataEnd) {
         if (!preparePluginFactory(plugin)) {
@@ -402,7 +510,7 @@ void PluginManager::loadMetaData(PluginData *plugin)
         return;
     }
     updatePluginType(plugin);
-    if (m_manager->hideModule().contains(plugin->name)) {
+    if (DccManager::containsByName(m_manager->hideModule(), plugin->name)) {
         // 跳过隐藏的模块,需要动态加载回来
         Q_EMIT updatePluginStatus(plugin, PluginEnd | MetaDataEnd, QString());
         return;
@@ -542,17 +650,10 @@ void PluginManager::createMain(QQmlComponent *component)
     Q_EMIT updatePluginStatus(plugin, MainObjCreate, "create main");
     switch (component->status()) {
     case QQmlComponent::Ready: {
-        QQmlContext *context = new QQmlContext(component->engine());
+        QQmlContext *context = new QQmlContext(component->engine(), component->engine());
         context->setContextProperties({ { "dccData", QVariant::fromValue(plugin->data) }, { "dccModule", QVariant::fromValue(plugin->module) } });
-        QObject *object = component->create(context);
-        component->deleteLater();
-        if (!object) {
-            Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object is null:" + component->errorString());
-            return;
-        }
-        object->setParent(plugin->module ? plugin->module : m_rootModule);
-        plugin->mainObj = qobject_cast<DccObject *>(object);
-        Q_EMIT updatePluginStatus(plugin, MainObjEnd, ": create main finished");
+        DccIncubator *incubator = new DccIncubator(this, plugin, component, context);
+        component->create(*incubator, context, nullptr);
     } break;
     case QQmlComponent::Error: {
         Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object error:" + component->errorString());
@@ -594,13 +695,13 @@ void PluginManager::addMainObject(PluginData *plugin)
     } else {
         Q_EMIT updatePluginStatus(plugin, MainObjErr, "The plugin isn't main DccObject");
     }
-    Q_EMIT updatePluginStatus(plugin, MainObjEnd | PluginEnd, "add main object finished");
     if (plugin->mainObj) {
         Q_EMIT addObject(plugin->mainObj);
     }
     if (plugin->soObj) {
         Q_EMIT addObject(plugin->soObj);
     }
+    Q_EMIT updatePluginStatus(plugin, MainObjEnd | PluginEnd, "add main object finished");
 }
 
 void PluginManager::moduleLoading()
@@ -702,23 +803,7 @@ void PluginManager::loadModules(DccObject *root, bool async, const QStringList &
     }
 }
 
-void PluginManager::cancelLoad()
-{
-    if (m_threadPool) {
-        m_threadPool->clear();
-        // 等待所有正在运行的任务完成,避免析构时的竞态条件
-        m_threadPool->waitForDone();
-        for (auto &&plugin : m_plugins) {
-            if (plugin->thread) {
-                qCWarning(dccLog()) << plugin->name << ": status" << QString::number(plugin->status, 16) << "thread exit timeout";
-            }
-        }
-        qCWarning(dccLog()) << "delete threadPool";
-        delete m_threadPool;
-        qCWarning(dccLog()) << "delete threadPool finish";
-        m_threadPool = nullptr;
-    }
-}
+void PluginManager::cancelLoad() { }
 
 bool PluginManager::loadFinished() const
 {

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
@@ -8,7 +8,6 @@
 #include <QStringList>
 #include <QVector>
 
-class QPluginLoader;
 class QQmlComponent;
 class QThreadPool;
 
@@ -42,6 +41,7 @@ Q_SIGNALS:
 private:
     bool compareVersion(const QString &targetVersion, const QString &baseVersion);
     bool updatePluginType(PluginData *plugin);
+    bool preparePluginFactory(PluginData *plugin);
     QThreadPool *threadPool();
 
 private Q_SLOTS:

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -34,6 +34,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void addObject(DccObject *obj);
     void loadAllFinished();
+    void modulePhaseFinished();
 
     void pluginEndStatusChanged(PluginData *plugin);
     void updatePluginStatus(PluginData *plugin, uint status, const QString &log);
@@ -42,12 +43,14 @@ private:
     bool compareVersion(const QString &targetVersion, const QString &baseVersion);
     bool updatePluginType(PluginData *plugin);
     bool preparePluginFactory(PluginData *plugin);
+    bool allModulesFinished() const;
     QThreadPool *threadPool();
 
 private Q_SLOTS:
     void loadPlugin(PluginData *plugin);
     void loadMetaData(PluginData *plugin);
     void loadModule(PluginData *plugin);
+    void loadPluginData(PluginData *plugin);
     void loadMain(PluginData *plugin);
     void createModule(QQmlComponent *component);
     void createMain(QQmlComponent *component);
@@ -56,6 +59,7 @@ private Q_SLOTS:
     void moduleLoading();
     void mainLoading();
 
+    void onModulePhaseFinished();
     void onHideModuleChanged(const QSet<QString> &hideModule);
     void onVisibleToAppChanged(bool visibleToApp);
     void onUpdatePluginStatus(PluginData *plugin, uint status, const QString &log);
@@ -66,6 +70,7 @@ private:
     DccObject *m_rootModule;       // root module from MainWindow
     QThreadPool *m_threadPool;
     bool m_isDeleting;
+    bool m_modulePhaseFinished;
     QQmlEngine *m_engine;
 };
 

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -68,7 +68,6 @@ private:
     DccManager *m_manager;
     QList<PluginData *> m_plugins; // cache for other plugin
     DccObject *m_rootModule;       // root module from MainWindow
-    QThreadPool *m_threadPool;
     bool m_isDeleting;
     bool m_modulePhaseFinished;
     QQmlEngine *m_engine;


### PR DESCRIPTION
Change the QML creation method to asynchronous creation.

## Summary by Sourcery

Switch plugin QML loading to use asynchronous incubation and adjust plugin lifecycle management accordingly.

Bug Fixes:
- Prevent crashes and dangling references by decoupling DccObject ownership and cleaning up parent-child links more safely.
- Ensure hidden modules are correctly detected by name and excluded based on configuration.
- Fix navigation and startup behavior when no specific URL is requested by always showing the root page if nothing is active.

Enhancements:
- Load plugin shared libraries, Dcc objects, and plugin data in clearer dedicated helpers and on the global thread pool.
- Use QQmlIncubator with asynchronous creation for main QML components and repeater items to avoid blocking the UI and nested sync creation issues.
- Simplify plugin cancellation logic and rely on the global QThreadPool instead of a per-manager pool.
- Refine DccObject hierarchy bookkeeping so objects correctly inform their private parents on add/remove and destruction.
- Adjust plugin object ownership and signal connections in DccManager to better align with the new async loading behavior.