### PR TITLE
feat: improve DccRepeater parent object assignment

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -197,7 +197,7 @@ void DccManager::addObject(DccObject *obj)
         DccObject *o = objs.takeFirst();
         if (!o->name().isEmpty()) {
             m_objMap[o->name()].append(o);
-            connect(o, &DccObject::destroyed, this, &DccManager::onDccObjectDestroyed, Qt::UniqueConnection);
+            connect(o, &DccObject::objectDestroyed, this, &DccManager::onDccObjectDestroyed, Qt::UniqueConnection);
         }
         connect(o, &DccObject::addObject, this, &DccManager::addObject);
         connect(o, &DccObject::removeObject, this, qOverload<DccObject *>(&DccManager::removeObject));
@@ -398,16 +398,12 @@ QString DccManager::GetAllModule()
     return QString();
 }
 
-void DccManager::onDccObjectDestroyed()
+void DccManager::onDccObjectDestroyed(DccObject *obj)
 {
     if (m_plugins->isDeleting()) {
         return;
     }
-    QObject *o = sender();
-    if (!o) {
-        return;
-    }
-    const QString &name = o->objectName();
+    const QString &name = obj->name();
     if (name.isEmpty()) {
         return;
     }
@@ -415,7 +411,7 @@ void DccManager::onDccObjectDestroyed()
     if (it == m_objMap.end()) {
         return;
     }
-    it->removeOne(o);
+    it->removeOne(obj);
     if (it->isEmpty()) {
         m_objMap.erase(it);
     }

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -81,7 +81,7 @@ public Q_SLOTS:
     bool stop(const QString &json);
     bool action(const QString &json);
     QString GetAllModule();
-    void onDccObjectDestroyed();
+    void onDccObjectDestroyed(DccObject *obj);
 
 Q_SIGNALS:
     void activeItemChanged(QQuickItem *item, bool isIndicatorShown);

--- a/src/dde-control-center/plugin/dccobject.cpp
+++ b/src/dde-control-center/plugin/dccobject.cpp
@@ -194,6 +194,10 @@ void DccObject::Private::addObject(DccObject *child)
 {
     if (child && !m_objects.contains(child)) {
         m_objects.append(child);
+        connect(child, &DccObject::objectDestroyed, q_ptr, [this](DccObject *obj) {
+            m_objects.removeOne(obj);
+            Q_EMIT q_ptr->removeObject(obj);
+        });
         Q_EMIT q_ptr->addObject(child);
     }
 }
@@ -254,6 +258,7 @@ DccObject::DccObject(QObject *parent)
 
 DccObject::~DccObject()
 {
+    Q_EMIT objectDestroyed(this);
     delete p_ptr;
 }
 
@@ -497,9 +502,7 @@ const QVector<DccObject *> &DccObject::getChildren() const
     return p_ptr->getChildren();
 }
 
-void DccObject::classBegin()
-{
-}
+void DccObject::classBegin() { }
 
 void DccObject::componentComplete()
 {

--- a/src/dde-control-center/plugin/dccobject.h
+++ b/src/dde-control-center/plugin/dccobject.h
@@ -167,6 +167,7 @@ Q_SIGNALS:
 
     void addObject(DccObject *obj);
     void removeObject(DccObject *obj);
+    void objectDestroyed(DccObject *obj);
 
 protected:
     DccObject::Private *p_ptr;

--- a/src/dde-control-center/plugin/dccrepeater.cpp
+++ b/src/dde-control-center/plugin/dccrepeater.cpp
@@ -185,8 +185,16 @@ void DccRepeater::createdItem(int index, QObject *item)
 {
     DccObject *dccObj = qmlobject_cast<DccObject *>(item);
     if (dccObj) {
-        dccObj->setParent(this);
-        p_ptr->addObject(dccObj);
+        DccObject *targetParent = this;
+        for (QObject *pQObj = this; pQObj; pQObj = pQObj->parent()) {
+            DccObject *pObj = qmlobject_cast<DccObject *>(pQObj);
+            if (pObj && !pObj->name().isEmpty()) {
+                targetParent = pObj;
+                break;
+            }
+        }
+        dccObj->setParent(targetParent);
+        DccObject::Private::FromObject(targetParent)->addObject(dccObj);
         Q_EMIT objAdded(index, item);
     }
 }


### PR DESCRIPTION
1. Modified the createdItem method in DccRepeater to search for a suitable DccObject parent in the object hierarchy
2. Instead of always setting the current instance as parent, now traverses parent chain to find a named DccObject
3. When a named DccObject parent is found, sets the new item as its child and adds to its internal object list
4. Falls back to original behavior (current instance as parent) if no suitable parent is found
5. This improves object hierarchy management and parent-child relationships in the control center plugin system

Influence:
1. Test creation of DccRepeater items with various parent hierarchies
2. Verify that items are correctly parented to named DccObject ancestors when available
3. Test fallback behavior when no named DccObject parent exists in hierarchy
4. Verify object addition signals are still emitted correctly
5. Test with complex nested object structures to ensure proper parent assignment

feat: 改进 DccRepeater 父对象分配逻辑

1. 修改 DccRepeater 中的 createdItem 方法，在对象层次结构中搜索合适的 DccObject 父对象
2. 不再总是将当前实例设为父对象，而是遍历父链查找具有名称的 DccObject
3. 当找到具有名称的 DccObject 父对象时，将新项目设为其子项并添加到其内部 对象列表
4. 如果未找到合适的父对象，则回退到原始行为（将当前实例作为父对象）
5. 这改进了控制中心插件系统中的对象层次结构管理和父子关系

Influence:
1. 测试具有不同父层次结构的 DccRepeater 项目创建
2. 验证当存在命名 DccObject 祖先时，项目是否正确地父级化
3. 测试当层次结构中不存在命名 DccObject 父对象时的回退行为
4. 验证对象添加信号是否仍正确发出
5. 使用复杂的嵌套对象结构进行测试，确保正确的父级分配

## Summary by Sourcery

Enhancements:
- Adjust DccRepeater createdItem logic to traverse the QObject parent chain and parent new DccObject items to the nearest named DccObject ancestor when available, falling back to the repeater itself otherwise.