### PR TITLE
fix(datetime): add real-time display for timezone information

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -58,7 +58,10 @@ static QString getDescription(const ZoneInfo &zoneInfo)
         description = DatetimeModel::tr("%1 hours later than local").arg(QString::number(-timeDelta, 'f', decimalNumber));
     }
 
-    return QString("%1, %2").arg(dateLiteral).arg(description);
+    QDateTime targetTime = localTime.addSecs(static_cast<qint64>(timeDelta * 3600));
+    QString timeText = targetTime.toString("HH:mm");
+
+    return QString("%1, %2, %3").arg(dateLiteral).arg(description).arg(timeText);
 }
 
 static QString getDisplayText(const ZoneInfo &zoneInfo)
@@ -340,6 +343,19 @@ QAbstractListModel *DatetimeModel::userTimezoneModel()
         auto indexBegin = m_userTimezoneModel->index(0);
         auto indexEnd = m_userTimezoneModel->index(m_userTimeZones.count() - 1);
         Q_EMIT m_userTimezoneModel->dataChanged(indexBegin, indexEnd);
+    });
+    connect(this, &DatetimeModel::currentTimeChanged, m_userTimezoneModel, [this]() {
+        static int lastMinute = -1;
+        int curMinute = QTime::currentTime().minute();
+        if (curMinute == lastMinute)
+            return;
+        lastMinute = curMinute;
+
+        if (!m_userTimeZones.isEmpty()) {
+            auto indexBegin = m_userTimezoneModel->index(0);
+            auto indexEnd = m_userTimezoneModel->index(m_userTimeZones.count() - 1);
+            Q_EMIT m_userTimezoneModel->dataChanged(indexBegin, indexEnd);
+        }
     });
 
     return m_userTimezoneModel;


### PR DESCRIPTION
Add current time display (HH:mm format) to timezone description and implement minute-level updates for user timezone model data.

为时区信息添加实时时间显示，并实现每分钟更新用户时区模型数据。

Log: 添加时区实时时间显示功能
PMS: BUG-353159
Influence: 用户在查看时区信息时可以看到实时时间，提升用户体验。

## Summary by Sourcery

Display real-time local time for each timezone entry and refresh user timezone data at minute granularity.

New Features:
- Show the current time (HH:mm) alongside each timezone description in the datetime plugin UI.

Bug Fixes:
- Ensure user timezone information reflects up-to-date current time when viewing timezone data.

Enhancements:
- Trigger minute-level updates of the user timezone model when the current time changes to keep displayed times in sync.
- Simplify Chinese and Chinese regional translations for timezone offset descriptions to more concise phrasing.