### PR TITLE
fix(authentication): fix biometric edit/delete button hover style

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
@@ -267,24 +267,34 @@ DccObject {
                         Item {
                             Layout.fillWidth: true
                         }
-                        D.ToolButton {
+                        D.ActionButton {
                             id: editButton
                             visible: hoverHandler.hovered
                             icon.name: "dcc_edit"
                             background: Rectangle {
-                                color: "transparent"
+                                radius: DS.Style.control.radius
+                                color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                                border {
+                                    color: parent.palette.highlight
+                                    width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                }
                             }
                             onClicked: {
                                 textInputItem.readOnly = false;
                                 textInputItem.focus = true;
                             }
                         }
-                        D.ToolButton {
+                        D.ActionButton {
                             id: deleteButton
                             visible: hoverHandler.hovered
                             icon.name: "dcc_delete"
                             background: Rectangle {
-                                color: "transparent"
+                                radius: DS.Style.control.radius
+                                color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                                border {
+                                    color: parent.palette.highlight
+                                    width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                }
                             }
                             onClicked: {
                                 layout.requestDelete(modelData);


### PR DESCRIPTION
Replace D.ToolButton with D.ActionButton for biometric edit and delete buttons, adding proper DTk hover/pressed background effects.

将生物认证的编辑和删除按钮从D.ToolButton替换为D.ActionButton，
添加DTk标准的hover/pressed背景效果。

Log: 修复生物认证编辑/删除按钮hover样式缺失
PMS: BUG-317521
Influence: 生物认证的编辑和删除按钮hover时现在显示正确的方形背景效果。