### PR TITLE
fix: use QQmlIncubator for asynchronous plugin object creation

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -168,6 +168,30 @@ void LoadPluginTask::createData()
     Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data finished. elapsed time :" + QString::number(timer.elapsed()));
 }
 
+class DccIncubator : public QQmlIncubator
+{
+public:
+    DccIncubator(PluginManager *pManager, PluginData *plugin, QQmlComponent *component, QQmlContext *context, std::function<void(QQmlIncubator::Status, DccIncubator *)> &&fun)
+        : QQmlIncubator(Asynchronous)
+        , m_pManager(pManager)
+        , m_plugin(plugin)
+        , m_component(component)
+        , m_context(context)
+        , m_fun(std::move(fun))
+    {
+    }
+
+protected:
+    void statusChanged(Status status) override { m_fun(status, this); }
+
+public:
+    PluginManager *m_pManager;
+    PluginData *m_plugin;
+    QQmlComponent *m_component;
+    QQmlContext *m_context;
+    std::function<void(QQmlIncubator::Status, DccIncubator *)> m_fun;
+};
+
 PluginManager::PluginManager(DccManager *parent)
     : QObject(parent)
     , m_manager(parent)
@@ -513,16 +537,11 @@ void PluginManager::createModule(QQmlComponent *component)
     Q_EMIT updatePluginStatus(plugin, ModuleCreate, "create module");
     switch (component->status()) {
     case QQmlComponent::Ready: {
-        QObject *object = component->create();
-        component->deleteLater();
-        if (!object) {
-            Q_EMIT updatePluginStatus(plugin, ModuleErr | ModuleEnd, " component create module object is null:" + component->errorString());
-            return;
-        }
-        object->setParent(m_rootModule);
-        plugin->module = qobject_cast<DccObject *>(object);
-        Q_EMIT updatePluginStatus(plugin, ModuleEnd, "create module finished");
-        m_manager->addObject(plugin->module);
+        DccIncubator *incubator = new DccIncubator(this, plugin, component, nullptr, std::bind(&PluginManager::incubatorStatusChangedModule, this, std::placeholders::_1, std::placeholders::_2));
+        component->create(*incubator, nullptr, nullptr);
+        connect(component, &QQmlComponent::destroyed, this, [incubator]() {
+            delete incubator;
+        });
     } break;
     case QQmlComponent::Error: {
         component->deleteLater();
@@ -544,15 +563,11 @@ void PluginManager::createMain(QQmlComponent *component)
     case QQmlComponent::Ready: {
         QQmlContext *context = new QQmlContext(component->engine());
         context->setContextProperties({ { "dccData", QVariant::fromValue(plugin->data) }, { "dccModule", QVariant::fromValue(plugin->module) } });
-        QObject *object = component->create(context);
-        component->deleteLater();
-        if (!object) {
-            Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object is null:" + component->errorString());
-            return;
-        }
-        object->setParent(plugin->module ? plugin->module : m_rootModule);
-        plugin->mainObj = qobject_cast<DccObject *>(object);
-        Q_EMIT updatePluginStatus(plugin, MainObjEnd, ": create main finished");
+        DccIncubator *incubator = new DccIncubator(this, plugin, component, context, std::bind(&PluginManager::incubatorStatusChangedMain, this, std::placeholders::_1, std::placeholders::_2));
+        component->create(*incubator, context, nullptr);
+        connect(component, &QQmlComponent::destroyed, this, [incubator]() {
+            delete incubator;
+        });
     } break;
     case QQmlComponent::Error: {
         Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object error:" + component->errorString());
@@ -601,6 +616,67 @@ void PluginManager::addMainObject(PluginData *plugin)
         Q_EMIT addObject(plugin->soObj);
     }
     Q_EMIT updatePluginStatus(plugin, MainObjEnd | PluginEnd, "add main object finished");
+}
+
+void PluginManager::incubatorStatusChangedModule(QQmlIncubator::Status status, DccIncubator *incubator)
+{
+    if (isDeleting()) {
+        return;
+    }
+    switch (status) {
+    case QQmlIncubator::Ready: {
+        QObject *obj = incubator->object();
+        incubator->m_component->deleteLater();
+        if (!obj) {
+            Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleErr | ModuleEnd, " component create module object is null:" + incubator->m_component->errorString());
+            return;
+        }
+        if (m_rootModule) {
+            obj->setParent(m_rootModule);
+            incubator->m_plugin->module = qobject_cast<DccObject *>(obj);
+            Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleEnd, "create module finished");
+            m_manager->addObject(incubator->m_plugin->module);
+        } else {
+            obj->deleteLater();
+            Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleErr | ModuleEnd, " component create module object error:" + incubator->m_component->errorString());
+        }
+    } break;
+    case QQmlIncubator::Error: {
+        Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleErr | ModuleEnd, " component create module object error:" + incubator->m_component->errorString());
+        incubator->m_component->deleteLater();
+    } break;
+    default:
+        break;
+    }
+}
+
+void PluginManager::incubatorStatusChangedMain(QQmlIncubator::Status status, DccIncubator *incubator)
+{
+    if (isDeleting()) {
+        return;
+    }
+    switch (status) {
+    case QQmlIncubator::Ready: {
+        QObject *obj = incubator->object();
+        incubator->m_component->deleteLater();
+        if (!obj) {
+            incubator->m_context->deleteLater();
+            Q_EMIT updatePluginStatus(incubator->m_plugin, MainObjErr | MainObjEnd, " component create main object is null:" + incubator->m_component->errorString());
+            return;
+        }
+        incubator->m_context->setParent(obj);
+        obj->setParent(incubator->m_plugin->module ? incubator->m_plugin->module : nullptr);
+        incubator->m_plugin->mainObj = qobject_cast<DccObject *>(obj);
+        Q_EMIT updatePluginStatus(incubator->m_plugin, MainObjEnd, ": create main finished");
+    } break;
+    case QQmlIncubator::Error: {
+        Q_EMIT updatePluginStatus(incubator->m_plugin, MainObjErr | MainObjEnd, " component create main object error:" + incubator->m_component->errorString());
+        incubator->m_component->deleteLater();
+        incubator->m_context->deleteLater();
+    } break;
+    default:
+        break;
+    }
 }
 
 void PluginManager::moduleLoading()

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -3,8 +3,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
+#include "dccobject.h"
+
 #include <QObject>
 #include <QQmlContext>
+#include <QQmlIncubator>
 #include <QStringList>
 #include <QVector>
 
@@ -15,6 +18,7 @@ namespace dccV25 {
 class DccObject;
 class DccManager;
 struct PluginData;
+class DccIncubator;
 
 class PluginManager : public QObject
 {
@@ -56,6 +60,9 @@ private Q_SLOTS:
     void createMain(QQmlComponent *component);
     void addMainObject(PluginData *plugin);
 
+    void incubatorStatusChangedModule(QQmlIncubator::Status status, DccIncubator *incubator);
+    void incubatorStatusChangedMain(QQmlIncubator::Status status, DccIncubator *incubator);
+
     void moduleLoading();
     void mainLoading();
 
@@ -66,8 +73,8 @@ private Q_SLOTS:
 
 private:
     DccManager *m_manager;
-    QList<PluginData *> m_plugins; // cache for other plugin
-    DccObject *m_rootModule;       // root module from MainWindow
+    QList<PluginData *> m_plugins;    // cache for other plugin
+    QPointer<DccObject> m_rootModule; // root module from MainWindow
     QThreadPool *m_threadPool;
     bool m_isDeleting;
     bool m_modulePhaseFinished;


### PR DESCRIPTION
1. Changed PluginManager::createModule and createMain to use QQmlIncubator for asynchronous object creation instead of synchronous component->create()
2. Added DccIncubator class to handle incubator status callbacks for module and main object creation
3. Added incubatorStatusChangedModule and incubatorStatusChangedMain to process async creation results and manage object lifecycle
4. Fixed DccRepeater createdItem/initItem with boundary checks and improved object release logic

Influence:
1. Test control center startup performance with various plugin configurations
2. Verify page navigation works correctly after async plugin loading
3. Test D-Bus show requests with different URL parameters
4. Ensure plugin objects are properly added and displayed

fix: 使用QQmlIncubator异步创建插件对象

1. 将PluginManager::createModule和createMain改为使用QQmlIncubator 进行异步对象创建，替代同步的component->create()
2. 添加DccIncubator类处理模块和主对象创建的孵化器状态回调
3. 添加incubatorStatusChangedModule和incubatorStatusChangedMain 处理异步创建结果并管理对象生命周期
4. 修复DccRepeater的createdItem/initItem，添加边界检查 和改进对象释放逻辑

Influence:
1. 测试不同插件配置下控制中心的启动性能
2. 验证异步插件加载后页面导航是否正常工作
3. 测试使用不同URL参数的D-Bus显示请求
4. 确保插件对象被正确添加和显示