### PR TITLE
fix: optimize page visibility management in DccWindow

### DIFF
--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -250,12 +250,15 @@ D.ApplicationWindow {
                     mode: D.DTK.NormalState
                     theme: D.DTK.themeType
                 }
+                visible: stackView.currentIndex === DccWindow.PageIndex.LoadIndex
             }
             HomePage {
                 id: homePage
+                visible: stackView.currentIndex === DccWindow.PageIndex.HomeIndex
             }
             SecondPage {
                 id: secondPage
+                visible: stackView.currentIndex === DccWindow.PageIndex.SecondIndex
                 Component.onCompleted: mainWindow.sidebarPage = this
             }
             Connections {


### PR DESCRIPTION
1. Add explicit visibility bindings to all three main pages (loading page, home page, and second page)
2. Bind each page's visibility to its corresponding stackView.currentIndex to ensure only the active page is rendered
3. Prevent unnecessary rendering and potential performance issues from inactive pages remaining visible in the background
4. Improve memory usage and rendering efficiency by properly managing page lifecycle

Log: Optimized page switching performance and fixed potential visual glitches

Influence:
1. Test page switching between loading, home, and second pages for smooth transitions
2. Verify no visual artifacts or overlapping content during page navigation
3. Check memory usage remains stable during repeated page switches
4. Test rapid navigation between pages to ensure visibility states update correctly
5. Verify sidebar functionality remains intact on the second page
6. Test application startup to ensure loading page displays correctly before home page appears

fix: 优化 DccWindow 中的页面可见性管理

1. 为三个主要页面（加载页面、主页和二级页面）添加显式的可见性绑定
2. 将每个页面的可见性绑定到对应的 stackView.currentIndex，确保只有活动页 面被渲染
3. 防止非活动页面在后台保持可见导致的渲染问题和潜在性能问题
4. 通过正确管理页面生命周期来改善内存使用和渲染效率

Log: 优化页面切换性能，修复潜在的视觉异常问题

Influence:
1. 测试加载页面、主页和二级页面之间的切换，确保过渡流畅
2. 验证页面导航期间无视觉伪影或内容重叠现象
3. 检查重复页面切换时内存使用保持稳定
4. 测试快速页面导航，确保可见性状态正确更新
5. 验证二级页面上的侧边栏功能保持正常
6. 测试应用启动流程，确保加载页面在主页出现前正确显示

Fixes: #353225