### PR TITLE
fix: Fix secondary screen highlight display anomaly in 90° and 270° rotation

### DIFF
--- a/src/plugin-accounts/qml/CreateAccountDialog.qml
+++ b/src/plugin-accounts/qml/CreateAccountDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
@@ -22,8 +22,40 @@ D.DialogWindow {
     icon: "preferences-system"
     modality: Qt.WindowModal
     title: qsTr("Create a new account")
-
+    color: "transparent"
     signal accepted()
+
+    header: D.DialogTitleBar {
+        icon.name: dialog.icon
+    }
+
+    Rectangle {
+        // 覆盖整个窗口，包括 DialogWindow 的边距
+        x: -DS.Style.dialogWindow.contentHMargin
+        y: -DS.Style.dialogWindow.titleBarHeight
+        width: dialog.width + DS.Style.dialogWindow.contentHMargin * 2
+        height: dialog.height + DS.Style.dialogWindow.titleBarHeight
+        color: "transparent"
+        parent: dialog.contentItem
+        z: -1
+        D.StyledBehindWindowBlur {
+            anchors.fill: parent
+            blendColor: {
+                if (valid) {
+                    return DS.Style.control.selectColor(
+                        dialog ? dialog.palette.window : undefined,
+                        Qt.rgba(1, 1, 1, 0.8),
+                        Qt.rgba(0.06, 0.06, 0.06, 0.8)
+                    )
+                }
+                return DS.Style.control.selectColor(
+                    undefined,
+                    DS.Style.behindWindowBlur.lightNoBlurColor,
+                    DS.Style.behindWindowBlur.darkNoBlurColor
+                )
+            }
+        }
+    }
 
     ColumnLayout {
         id: mainLayout

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -11,7 +11,13 @@ import org.deepin.dcc 1.0
 DccObject {
     id: root
     property var screen: dccData.virtualScreens[0]
+    property string lastScreenName: ""
     property var activeDialogs: []
+    Component.onCompleted: {
+        if (screen && screen.name) {
+            lastScreenName = screen.name
+        }
+    }
     property var scaleModelConst: [{
             "text": qsTr("100%"),
             "value": 1.0
@@ -94,13 +100,19 @@ DccObject {
         return model.length - 1
     }
     function getQtScreen(screen) {
-        for (var s of Qt.application.screens) {
-            if (s.virtualX === screen.x && s.virtualY === screen.y && (Math.abs(s.width * s.devicePixelRatio - screen.currentResolution.width) < 1) && (Math.abs(s.height * s.devicePixelRatio - screen.currentResolution.height) < 1)) {
-                return s
-            }
+    for (var s of Qt.application.screens) {
+        var isRotated = (screen.rotate === 2 || screen.rotate === 8)
+        var targetW = isRotated ? screen.currentResolution.height : screen.currentResolution.width
+        var targetH = isRotated ? screen.currentResolution.width : screen.currentResolution.height
+
+        if (s.virtualX === screen.x && s.virtualY === screen.y
+            && Math.abs(s.width * s.devicePixelRatio - targetW) < 1
+            && Math.abs(s.height * s.devicePixelRatio - targetH) < 1) {
+            return s
         }
-        return null
     }
+    return null
+}
     function getControlCenterScreen() {
         var mainWindow = DccApp.mainWindow()
         if (mainWindow && mainWindow.screen) {
@@ -133,8 +145,18 @@ DccObject {
     Connections {
         target: dccData
         function onVirtualScreensChanged() {
-            if (!dccData.virtualScreens.includes(screen)) {
-                screen = dccData.virtualScreens[0]
+            var found = false
+            if (lastScreenName !== "") {
+                for (var i = 0; i < dccData.virtualScreens.length; i++) {
+                    if (dccData.virtualScreens[i].name === lastScreenName) {
+                        root.screen = dccData.virtualScreens[i]
+                        found = true
+                        break
+                    }
+                }
+            }
+            if (!found) {
+                root.screen = dccData.virtualScreens[0]
             }
             closeInvalidDialogs()
         }
@@ -222,10 +244,10 @@ DccObject {
                     delegate: ScreenItem {
                         z: selected ? 2 : 1
                         screen: model.modelData
+                        selected: root.screen === screen && screen.rotate !== undefined
                         translationX: monitorsGround.translationX
                         translationY: monitorsGround.translationY
                         scale: monitorsGround.scale
-                        selected: root.screen === screen
                         onPressed: monitorRepeater.pressedItem(this)
                         onPositionChanged: monitorRepeater.positionChangedItem(this)
                         onReleased: monitorRepeater.releasedItem(this)
@@ -243,6 +265,7 @@ DccObject {
                     function pressedItem(item) {
                         hasMove = false
                         root.screen = item.screen
+                        root.lastScreenName = item.screen.name
                         if (dccData.isX11) {
                             indicator.createObject(this, {
                                                        "screen": getQtScreen(item.screen)
@@ -535,6 +558,7 @@ DccObject {
             onScreenClicked: function (screen) {
                 if (screen && screen !== root.screen) {
                     root.screen = screen
+                    root.lastScreenName = screen.name  // 用户主动选择时更新 lastScreenName
                     if (dccData.isX11) {
                         indicator.createObject(this, {
                                                    "screen": getQtScreen(root.screen)

--- a/src/plugin-display/qml/ScreenItem.qml
+++ b/src/plugin-display/qml/ScreenItem.qml
@@ -105,21 +105,22 @@ Item {
         sourceSize: Qt.size(root.homeIconSize, root.homeIconSize)
     }
     Loader {
-        x: offset
-        y: offset
-        z: 2
-        width: root.width - offset
-        height: root.height - offset
-        active: root.selected
-        sourceComponent: Rectangle {
-            anchors.fill: parent
-            radius: root.radius + 1
-            color: "transparent"
-            border.color: this.palette.highlight
-            border.width: 2
-            smooth: true
-        }
+    x: offset
+    y: offset
+    z: 2
+    width: root.width - offset
+    height: root.height - offset
+    active: root.selected
+    visible: root.selected
+    sourceComponent: Rectangle {
+        anchors.fill: parent
+        radius: root.radius + 1
+        color: "transparent"
+        border.color: this.palette.highlight
+        border.width: 2
+        smooth: true
     }
+}
     MouseArea {
         z: 2
         anchors.fill: parent

--- a/src/plugin-display/qml/ScreenTab.qml
+++ b/src/plugin-display/qml/ScreenTab.qml
@@ -17,7 +17,11 @@ Item {
         Repeater {
             id: repeater
             delegate: Rectangle {
-                property bool isSelect: model.modelData === screen
+                property bool isSelect: {
+                    var modelName = model.modelData ? model.modelData.name : "null"
+                    var screenName = screen ? screen.name : "null"
+                    return model.modelData && screen ? model.modelData.name === screen.name : false
+                }
                 property alias hovered: mouseArea.containsMouse
                 implicitWidth: nameLabel.implicitWidth + 20
                 implicitHeight: 30


### PR DESCRIPTION
## Summary by Sourcery

Fix display configuration UI to correctly track and highlight the selected screen, especially when screens are rotated 90° or 270°, and when the virtual screen list changes.

Bug Fixes:
- Correct screen matching logic to account for swapped width and height when a screen is rotated 90° or 270°.
- Ensure the selected screen highlight and preview remain in sync after screen rotation and virtual screen list updates.
- Fix tab selection logic to rely on screen names instead of direct object equality, avoiding incorrect selection after screen objects change.

Enhancements:
- Persist the last selected screen by name so the selection can be restored when the virtual screen list changes.