### PR TITLE
fix: prevent control center from not closing properly

### DIFF
--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "controlcenterdbusadaptor.h"
@@ -91,6 +91,7 @@ int main(int argc, char *argv[])
 #else
     app->setApplicationVersion("6.0");
 #endif
+    app->setQuitOnLastWindowClosed(false);
 
     refreshQmlCache(app->applicationVersion());
 
@@ -172,6 +173,10 @@ int main(int argc, char *argv[])
     dccV25::DccManager *dccManager = new dccV25::DccManager(app);
     dccManager->init();
     QQmlApplicationEngine *engine = dccManager->engine();
+    // connect quit signal to qApp->exit, to make sure the app can quit when the main window is closed
+    QObject::connect(engine, &QQmlApplicationEngine::quit, app, [] {
+        qApp->exit();
+    });
     engine->loadFromModule("org.deepin.dcc", "DccWindow");
     QList<QObject *> objs = engine->rootObjects();
     for (auto &&obj : objs) {

--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -28,6 +28,12 @@ D.ApplicationWindow {
     flags: Qt.Window | Qt.WindowCloseButtonHint | Qt.WindowTitleHint | Qt.WindowMinimizeButtonHint | Qt.WindowMaximizeButtonHint
     color: "transparent"
     D.DWindow.enabled: true
+    onClosing: {
+        Qt.callLater(function () {
+            console.info("DccWindow closed")
+            Qt.quit()
+        })
+    }
     MouseArea {
         anchors.fill: parent
         enabled: false


### PR DESCRIPTION
1. Added `quitOnLastWindowClosed: false` to prevent automatic quit
behavior
2. Added explicit `onClosing` handler to ensure proper application
termination
3. Used `Qt.callLater` to schedule quit after window closing completes
4. Added debug logging for window close events

Log: Fixed issue where control center would occasionally not exit when
clicking close button

Influence:
1. Test clicking close button ensures control center application exits
completely
2. Verify no lingering processes remain after closing
3. Test multiple rapid open/close cycles to ensure stability
4. Check that all windows properly close and application terminates
5. Verify no memory leaks or resource retention after closing

fix: 修复控制中心点击关闭按钮偶现不退出问题

1. 添加 `quitOnLastWindowClosed: false` 防止自动退出行为
2. 添加显式的 `onClosing` 处理程序确保应用程序正确终止
3. 使用 `Qt.callLater` 在窗口关闭完成后调度退出操作
4. 添加窗口关闭事件的调试日志

Log: 修复控制中心点击关闭按钮偶现不退出问题

Influence:
1. 测试点击关闭按钮确保控制中心应用程序完全退出
2. 验证关闭后没有残留进程
3. 测试多次快速打开/关闭循环以确保稳定性
4. 检查所有窗口正确关闭且应用程序终止
5. 验证关闭后没有内存泄漏或资源残留

PMS: BUG-357065

## Summary by Sourcery

Bug Fixes:
- Fix intermittent issue where the control center process would remain running after closing the main window.