### PR TITLE
fix(display): use screen dimensions instead of currentResolution for …

### DIFF
--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -95,7 +95,7 @@ DccObject {
     }
     function getQtScreen(screen) {
         for (var s of Qt.application.screens) {
-            if (s.virtualX === screen.x && s.virtualY === screen.y && (Math.abs(s.width * s.devicePixelRatio - screen.currentResolution.width) < 1) && (Math.abs(s.height * s.devicePixelRatio - screen.currentResolution.height) < 1)) {
+            if (s.virtualX === screen.x && s.virtualY === screen.y && (Math.abs(s.width * s.devicePixelRatio - screen.width) < 1) && (Math.abs(s.height * s.devicePixelRatio - screen.height) < 1)) {
                 return s
             }
         }


### PR DESCRIPTION
…Qt screen matching

1. Replace screen.currentResolution.width/height with screen.width/height in getQtScreen function

Log: Fix screen matching by using correct dimension properties

fix(display): 使用屏幕尺寸属性替代 currentResolution 进行 Qt 屏幕匹配

1. 在 getQtScreen 函数中使用 screen.width/height 替代 screen.currentResolution.width/height

Log: 修复屏幕匹配逻辑，使用正确的尺寸属性
PMS: BUG-355449