### PR TITLE
fix: Optimize the typesetting layout of open-source software declarations

### DIFF
--- a/src/plugin-systeminfo/operation/qrc/gpl/gpl-3.0-en_US-body.txt
+++ b/src/plugin-systeminfo/operation/qrc/gpl/gpl-3.0-en_US-body.txt
@@ -2,6580 +2,4989 @@ The notice provides license information of respective open source software conta
 
 Open Source Software Licensed under the GPL-3.0-or-later:
 1、source package:accountsservice 23.13.9-2
-package:
-accountsservice
+package: accountsservice
 
 2、source package:cifs-utils 6.9.orig
-package:
-cifs-utils
+package: cifs-utils
 
 3、source package:coreutils 9.1-1
-package:
-coreutils
+package: coreutils
 
 4、source package:dosfstools 4.2-1
-package:
-dosfstools
+package: dosfstools
 
 5、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 6、source package:fonts-wqy-microhei 0.2.0-beta-3.1
-package:
-fonts-wqy-microhei
+package: fonts-wqy-microhei
 
 7、source package:gawk 5.0.1+dfsg.orig
-package:
-gawk
+package: gawk
 
 8、source package:gettext 0.21.1
-package:
-gettext
+package: gettext
 
 9、source package:gettext-base 0.19.8.1-9_s390x
-package:
-gettext-base
+package: gettext-base
 
 10、source package:gnupg 2.2.19-3_all
-package:
-gnupg
+package: gnupg
 
 11、source package:golang-gir-gobject-2.0-dev 2.2.0-1
-package:
-golang-gir-gobject-2.0-dev
+package: golang-gir-gobject-2.0-dev
 
 12、source package:gpgv 2.2.20-1~bpo9+1_s390x
-package:
-gpgv
+package: gpgv
 
 13、source package:grub-common 2.06-9
-package:
-grub-common
+package: grub-common
 
 14、source package:grub2-common 2.04~rc1-3_ppc64el
-package:
-grub2-common
+package: grub2-common
 
 15、source package:grub2-theme-vimix c7ab3ce
-package:
-grub2-theme-vimix
+package: grub2-theme-vimix
 
 16、source package:guvcview 2.0.2
-package:
-guvcview
+package: guvcview
 
 17、source package:hello 2.9-2_kfreebsd-i386
-package:
-hello
+package: hello
 
 18、source package:libparted-dev 3.3-4_s390x
-package:
-libparted-dev
+package: libparted-dev
 
 19、source package:libparted-fs-resize0 3.3-4_s390x
-package:
-libparted-fs-resize0
+package: libparted-fs-resize0
 
 20、source package:live-boot 5.0~a5-2
-package:
-live-boot
+package: live-boot
 
 21、source package:live-boot-initramfs-tools 4.0.2-1_all
-package:
-live-boot-initramfs-tools
+package: live-boot-initramfs-tools
 
 22、source package:live-config 5.20190519_all
-package:
-live-config
+package: live-config
 
 23、source package:live-config-systemd 5.20190519_all
-package:
-live-config-systemd
+package: live-config-systemd
 
 24、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 25、source package:parted 3.6-3
-package:
-parted
+package: parted
 
 26、source package:patchelf 0.9.orig
-package:
-patchelf
+package: patchelf
 
 27、source package:pkg-kde-tools 0.9.5
-package:
-pkg-kde-tools
+package: pkg-kde-tools
 
 28、source package:python3-samba 4.12.5+dfsg-3_s390x
-package:
-python3-samba
+package: python3-samba
 
 29、source package:qtchooser 66.orig
-package:
-qtchooser
+package: qtchooser
 
 30、source package:qtremoteobjects v5.11.0-rc2
-package:
-qtremoteobjects
+package: qtremoteobjects
 
 31、source package:redshift 1.9.1-4_s390x
-package:
-redshift
+package: redshift
 
 32、source package:rsync 3.2.7-1~bpo11+1
-package:
-rsync
+package: rsync
 
 33、source package:rsyslog 8.9.0-3
-package:
-rsyslog
+package: rsyslog
 
 34、source package:samba 4.9.5+dfsg-5_mips64el
-package:
-samba
+package: samba
 
 35、source package:samba-common-bin 4.9.5+dfsg-5_s390x
-package:
-samba-common-bin
+package: samba-common-bin
 
 36、source package:samba-dsdb-modules 4.9.5+dfsg-5_s390x
-package:
-samba-dsdb-modules
+package: samba-dsdb-modules
 
 37、source package:samba-vfs-modules 4.9.5+dfsg-5_s390x
-package:
-samba-vfs-modules
+package: samba-vfs-modules
 
 38、source package:sed 4.9-1
-package:
-sed
+package: sed
 
 39、source package:smbclient 4.9.5+dfsg-5_s390x
-package:
-smbclient
+package: smbclient
 
 40、source package:startdde 6.0.6
-package:
-startdde
+package: startdde
 
 41、source package:viper v1.3.2
-package:
-viper
+package: viper
 
 
 Open Source Software Licensed under the GPL-3.0-only:
 1、source package:blur-effect 1.1.3-2
-package:
-blur-effect
+package: blur-effect
 
 2、source package:distrobox 1.4.2.1-1
-package:
-distrobox
+package: distrobox
 
 3、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 4、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 5、source package:libpoppler-glib-dev 22.12.0-2
-package:
-libpoppler-glib-dev
+package: libpoppler-glib-dev
 
 6、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 7、source package:lightdm-gtk-greeter 2.0.8-3
-package:
-lightdm-gtk-greeter
+package: lightdm-gtk-greeter
 
 8、source package:mtools 4.0.9-1
-package:
-mtools
+package: mtools
 
 9、source package:python-is-python3 8
-package:
-python-is-python3
+package: python-is-python3
 
 10、source package:tpm2-tools 5.4-1
-package:
-tpm2-tools
+package: tpm2-tools
 
 
 Open Source Software Licensed under the GPL-2.0-or-later:
 1、source package:ColumnsPlusPlus v0.0.1.2-alpha
-package:
-ColumnsPlusPlus
+package: ColumnsPlusPlus
 
 2、source package:Grub-Themes a7ec0fd
-package:
-Grub-Themes
+package: Grub-Themes
 
 3、source package:acl 2.3.1-3
-package:
-acl
+package: acl
 
 4、source package:adduser 3.99
-package:
-adduser
+package: adduser
 
 5、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 6、source package:apt-utils 2.1.7_mips64el
-package:
-apt-utils
+package: apt-utils
 
 7、source package:aptitude 0.8.9-1
-package:
-aptitude
+package: aptitude
 
 8、source package:aria2 1.9.5-1
-package:
-aria2
+package: aria2
 
 9、source package:arj 3.10.22.orig
-package:
-arj
+package: arj
 
 10、source package:attr 2.4.48-5_s390x
-package:
-attr
+package: attr
 
 11、source package:bash-completion 20080705
-package:
-bash-completion
+package: bash-completion
 
 12、source package:bc 1.07.1-3
-package:
-bc
+package: bc
 
 13、source package:bluez 5.66-1
-package:
-bluez
+package: bluez
 
 14、source package:bluez-obexd 5.52-1_s390x
-package:
-bluez-obexd
+package: bluez-obexd
 
 15、source package:ca-certificates 20230311
-package:
-ca-certificates
+package: ca-certificates
 
 16、source package:cornrow v0.8.0
-package:
-cornrow
+package: cornrow
 
 17、source package:cups-filters 1.9.0-2
-package:
-cups-filters
+package: cups-filters
 
 18、source package:cyberduck release-4-9-1
-package:
-cyberduck
+package: cyberduck
 
 19、source package:debhelper 9.20160814
-package:
-debhelper
+package: debhelper
 
 20、source package:dh-dkms 3.0.9-1
-package:
-dh-dkms
+package: dh-dkms
 
 21、source package:dh-golang 1.9
-package:
-dh-golang
+package: dh-golang
 
 22、source package:dkms 3.0.8-3
-package:
-dkms
+package: dkms
 
 23、source package:dmidecode 3.5-1
-package:
-dmidecode
+package: dmidecode
 
 24、source package:dnsmasq-base 2.89-1
-package:
-dnsmasq-base
+package: dnsmasq-base
 
 25、source package:dpkg 1.9.21
-package:
-dpkg
+package: dpkg
 
 26、source package:dpkg-dev 1.9.21
-package:
-dpkg-dev
+package: dpkg-dev
 
 27、source package:efibootmgr 17-2
-package:
-efibootmgr
+package: efibootmgr
 
 28、source package:eject 2.35.2-7_ppc64el
-package:
-eject
+package: eject
 
 29、source package:ethtool 6-0
-package:
-ethtool
+package: ethtool
 
 30、source package:exfat-fuse 1.3.0-2_armel
-package:
-exfat-fuse
+package: exfat-fuse
 
 31、source package:exfatprogs 1.2.1-2
-package:
-exfatprogs
+package: exfatprogs
 
 32、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 33、source package:foomatic-db-compressed-ppds 20230107-1
-package:
-foomatic-db-compressed-ppds
+package: foomatic-db-compressed-ppds
 
 34、source package:fprintd 1.94.2-2
-package:
-fprintd
+package: fprintd
 
 35、source package:geoclue-2.0 2.7.0-2
-package:
-geoclue-2.0
+package: geoclue-2.0
 
 36、source package:gnome-keyring 42.1-1
-package:
-gnome-keyring
+package: gnome-keyring
 
 37、source package:hwdata 0.372-1
-package:
-hwdata
+package: hwdata
 
 38、source package:im-config 0.9
-package:
-im-config
+package: im-config
 
 39、source package:imwheel 1.0.0pre12.orig
-package:
-imwheel
+package: imwheel
 
 40、source package:input-leap v2.4.0
-package:
-input-leap
+package: input-leap
 
 41、source package:ipwatchd 1.3.0
-package:
-ipwatchd
+package: ipwatchd
 
 42、source package:jfsutils 1.1.8-1
-package:
-jfsutils
+package: jfsutils
 
 43、source package:kbd 2.5.1-1
-package:
-kbd
+package: kbd
 
 44、source package:kscreenlocker-dev 5.8.6-2_s390x
-package:
-kscreenlocker-dev
+package: kscreenlocker-dev
 
 45、source package:lcov 1.9.orig
-package:
-lcov
+package: lcov
 
 46、source package:libappstreamqt-dev 0.9.8-4_kfreebsd-i386
-package:
-libappstreamqt-dev
+package: libappstreamqt-dev
 
 47、source package:libblkid-dev 2.35.2-7_mipsel
-package:
-libblkid-dev
+package: libblkid-dev
 
 48、source package:libcryptsetup-dev 2:2.4.0-1
-package:
-libcryptsetup-dev
+package: libcryptsetup-dev
 
 49、source package:libddcutil-dev 0.9.8-4_s390x
-package:
-libddcutil-dev
+package: libddcutil-dev
 
 50、source package:libdpkg-dev 1.20.5_ppc64el
-package:
-libdpkg-dev
+package: libdpkg-dev
 
 51、source package:libdvdnav-dev 6.1.0-1_s390x
-package:
-libdvdnav-dev
+package: libdvdnav-dev
 
 52、source package:libffmpegthumbnailer-dev 2.1.1-0.2_kfreebsd-amd64
-package:
-libffmpegthumbnailer-dev
+package: libffmpegthumbnailer-dev
 
 53、source package:libffmpegthumbnailer4v5 2.1.1-0.2_kfreebsd-amd64
-package:
-libffmpegthumbnailer4v5
+package: libffmpegthumbnailer4v5
 
 54、source package:libltdl-dev 2.4.7-6
-package:
-libltdl-dev
+package: libltdl-dev
 
 55、source package:libmount-dev 2.35.2-7_s390x
-package:
-libmount-dev
+package: libmount-dev
 
 56、source package:libmpv-dev 0.9.2-1+ffmpeg
-package:
-libmpv-dev
+package: libmpv-dev
 
 57、source package:libmpv1 0.6.2-2_s390x
-package:
-libmpv1
+package: libmpv1
 
 58、source package:libmpv2 0.36.0+git.20230723.60a26324
-package:
-libmpv2
+package: libmpv2
 
 59、source package:libnm-dev 1.6.2-3+deb9u2_s390x
-package:
-libnm-dev
+package: libnm-dev
 
 60、source package:libpam-fprintd 1.90.1-1_s390x
-package:
-libpam-fprintd
+package: libpam-fprintd
 
 61、source package:libvlc-dev 3.0.9.2-1
-package:
-libvlc-dev
+package: libvlc-dev
 
 62、source package:libvlc5 3.0.8-4_s390x
-package:
-libvlc5
+package: libvlc5
 
 63、source package:libvlccore-dev 3.0.8-4_s390x
-package:
-libvlccore-dev
+package: libvlccore-dev
 
 64、source package:libvncserver LibVNCServer-0.9.14
-package:
-libvncserver
+package: libvncserver
 
 65、source package:lzop 1.04-2
-package:
-lzop
+package: lzop
 
 66、source package:man-db 2.9.4-4
-package:
-man-db
+package: man-db
 
 67、source package:net-tools 2.10-0.1
-package:
-net-tools
+package: net-tools
 
 68、source package:network-manager 1.9.90-1
-package:
-network-manager
+package: network-manager
 
 69、source package:nilfs-tools 2.2.9-1
-package:
-nilfs-tools
+package: nilfs-tools
 
 70、source package:ntfs-3g 2017.3.23AR.5.orig
-package:
-ntfs-3g
+package: ntfs-3g
 
 71、source package:packagekit 1.2.6-5
-package:
-packagekit
+package: packagekit
 
 72、source package:pandoc 2.9.2.1-3
-package:
-pandoc
+package: pandoc
 
 73、source package:pciutils 3.7.0.orig
-package:
-pciutils
+package: pciutils
 
 74、source package:pinn 0.0
-package:
-pinn
+package: pinn
 
 75、source package:pkg-config 0.29.2.orig
-package:
-pkg-config
+package: pkg-config
 
 76、source package:pkg-kde-tools 0.9.5
-package:
-pkg-kde-tools
+package: pkg-kde-tools
 
 77、source package:plymouth 22.02.122-3
-package:
-plymouth
+package: plymouth
 
 78、source package:plymouth-label 0.9.4-3_s390x
-package:
-plymouth-label
+package: plymouth-label
 
 79、source package:pppoe 3.8-3_sparc
-package:
-pppoe
+package: pppoe
 
 80、source package:procps 3.3.9.orig
-package:
-procps
+package: procps
 
 81、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 82、source package:python3-smbc 1.0.23-2
-package:
-python3-smbc
+package: python3-smbc
 
 83、source package:rfkill 2.35.2-7_s390x
-package:
-rfkill
+package: rfkill
 
 84、source package:rzip 2.1.orig
-package:
-rzip
+package: rzip
 
 85、source package:sectpmctl 1.1.3
-package:
-sectpmctl
+package: sectpmctl
 
 86、source package:sensible-utils 0.0.9+nmu1
-package:
-sensible-utils
+package: sensible-utils
 
 87、source package:socat 2.0.0~beta9-1_ppc64el
-package:
-socat
+package: socat
 
 88、source package:squashfs-tools 4.4-2_s390x
-package:
-squashfs-tools
+package: squashfs-tools
 
 89、source package:syslinux 6.04~git20190206.bf6db5b4+dfsg1.orig
-package:
-syslinux
+package: syslinux
 
 90、source package:syslinux-common 6.04~git20190206.bf6db5b4+dfsg1-2_all
-package:
-syslinux-common
+package: syslinux-common
 
 91、source package:udisks2 2.9.4-4
-package:
-udisks2
+package: udisks2
 
 92、source package:unace 1.2b-9
-package:
-unace
+package: unace
 
 93、source package:upower 1.90.2-3
-package:
-upower
+package: upower
 
 94、source package:usb-modeswitch 2.6.1.orig
-package:
-usb-modeswitch
+package: usb-modeswitch
 
 95、source package:usbmuxd 1.1.1~git20191130.9af2b12-1_s390x
-package:
-usbmuxd
+package: usbmuxd
 
 96、source package:usbutils 1:015-1
-package:
-usbutils
+package: usbutils
 
 97、source package:user-setup 1.95
-package:
-user-setup
+package: user-setup
 
 98、source package:uuid-dev 2.35.2-7_ppc64el
-package:
-uuid-dev
+package: uuid-dev
 
 99、source package:vlc-plugin-base 3.0.8-4_s390x
-package:
-vlc-plugin-base
+package: vlc-plugin-base
 
 100、source package:xdg-user-dirs 0.9-1
-package:
-xdg-user-dirs
+package: xdg-user-dirs
 
 101、source package:xserver-xorg-input-wacom 1.2.0-1~exp1
-package:
-xserver-xorg-input-wacom
+package: xserver-xorg-input-wacom
 
 102、source package:zssh 1.5c.debian.1-8
-package:
-zssh
+package: zssh
 
 
 Open Source Software Licensed under the GPL-2.0-only:
 1、source package:GitQlient v1.4.3
-package:
-GitQlient
+package: GitQlient
 
 2、source package:alsa-utils 1.2.9-1
-package:
-alsa-utils
+package: alsa-utils
 
 3、source package:btrfs-progs 6.3.2-1
-package:
-btrfs-progs
+package: btrfs-progs
 
 4、source package:checkstyle checkstyle-10.3.4
-package:
-checkstyle
+package: checkstyle
 
 5、source package:dmsetup 1.02.90-2.2+deb8u1_s390x
-package:
-dmsetup
+package: dmsetup
 
 6、source package:doxygen 1.9.4-4
-package:
-doxygen
+package: doxygen
 
 7、source package:e2fsprogs 1.47.0-2
-package:
-e2fsprogs
+package: e2fsprogs
 
 8、source package:gcc 9.2.1-4.1_mips64el
-package:
-gcc
+package: gcc
 
 9、source package:genisoimage 9:1.1.11-3.4
-package:
-genisoimage
+package: genisoimage
 
 10、source package:git 4.3.20-9
-package:
-git
+package: git
 
 11、source package:grub-efi-amd64-signed 1+2.06+8.1
-package:
-grub-efi-amd64-signed
+package: grub-efi-amd64-signed
 
 12、source package:grub-efi-arm64-signed 1+2.06+8.1
-package:
-grub-efi-arm64-signed
+package: grub-efi-arm64-signed
 
 13、source package:gtk2-engines 2.20.2.orig
-package:
-gtk2-engines
+package: gtk2-engines
 
 14、source package:gtk2-engines-murrine 0.98.2.orig
-package:
-gtk2-engines-murrine
+package: gtk2-engines-murrine
 
 15、source package:iio-sensor-proxy 3.4-2
-package:
-iio-sensor-proxy
+package: iio-sensor-proxy
 
 16、source package:initramfs-tools-core 0.137_all
-package:
-initramfs-tools-core
+package: initramfs-tools-core
 
 17、source package:kwin v5.27.2
-package:
-kwin
+package: kwin
 
 18、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 19、source package:libdjvulibre-dev 3.5.28-2
-package:
-libdjvulibre-dev
+package: libdjvulibre-dev
 
 20、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 21、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 22、source package:libnm-qt 0.9.8.2.orig
-package:
-libnm-qt
+package: libnm-qt
 
 23、source package:libpoppler-glib-dev 22.12.0-2
-package:
-libpoppler-glib-dev
+package: libpoppler-glib-dev
 
 24、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 25、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 26、source package:lsb-base 9.20161125_all
-package:
-lsb-base
+package: lsb-base
 
 27、source package:lshw 02.19.git.2021.06.19.996aaad9c7-2~bpo11+1
-package:
-lshw
+package: lshw
 
 28、source package:lvm2 2.03.16-1.1
-package:
-lvm2
+package: lvm2
 
 29、source package:mawk 1.3.4.20230525-1~exp1
-package:
-mawk
+package: mawk
 
 30、source package:modemmanager 1.8.2.orig
-package:
-modemmanager
+package: modemmanager
 
 31、source package:networkmanager-qt 5.54.0.orig
-package:
-networkmanager-qt
+package: networkmanager-qt
 
 32、source package:openprinting-ppds 20200427-1_all
-package:
-openprinting-ppds
+package: openprinting-ppds
 
 33、source package:proxychains4 4.14-3_s390x
-package:
-proxychains4
+package: proxychains4
 
 34、source package:qt-creator tqtc/v2.6.0-rc
-package:
-qt-creator
+package: qt-creator
 
 35、source package:qtciphersqliteplugin 0.6
-package:
-qtciphersqliteplugin
+package: qtciphersqliteplugin
 
 36、source package:qtermwidget 0.7.1.orig
-package:
-qtermwidget
+package: qtermwidget
 
 37、source package:reiserfsprogs 3.x.1b-1
-package:
-reiserfsprogs
+package: reiserfsprogs
 
 38、source package:sane-airscan 0.99.8-2
-package:
-sane-airscan
+package: sane-airscan
 
 39、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 40、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 41、source package:synergy-stable-builds 1.8.2-stable
-package:
-synergy-stable-builds
+package: synergy-stable-builds
 
 42、source package:systemd 8-2
-package:
-systemd
+package: systemd
 
 43、source package:ttf-unifont 9.0.06-2_all
-package:
-ttf-unifont
+package: ttf-unifont
 
 44、source package:wireless-tools 30~pre9.orig
-package:
-wireless-tools
+package: wireless-tools
 
 45、source package:xfonts-wqy 1.0.0~rc1-7
-package:
-xfonts-wqy
+package: xfonts-wqy
 
 46、source package:xfsprogs 6.3.0-1
-package:
-xfsprogs
+package: xfsprogs
 
 
 Open Source Software Licensed under the LGPL-3.0-or-later:
 1、source package:kdecoration 4:5.26.90-2
-package:
-kdecoration
+package: kdecoration
 
 2、source package:libheif-dev 1.6.1-1_s390x
-package:
-libheif-dev
+package: libheif-dev
 
 3、source package:libzmq3-dev 4.3.2-2_s390x
-package:
-libzmq3-dev
+package: libzmq3-dev
 
 4、source package:python3-ldb 2.1.4-2_s390x
-package:
-python3-ldb
+package: python3-ldb
 
 5、source package:python3-tdb 1.4.3-1_s390x
-package:
-python3-tdb
+package: python3-tdb
 
 6、source package:tdb-tools 1.4.3-1_s390x
-package:
-tdb-tools
+package: tdb-tools
 
 
 Open Source Software Licensed under the LGPL-3.0-only:
 1、source package:QtZeroConf pre_Android_api30
-package:
-QtZeroConf
+package: QtZeroConf
 
 2、source package:cryfs 0.9.9-2
-package:
-cryfs
+package: cryfs
 
 3、source package:libgsettings-qt-dev 0.2-1_s390x
-package:
-libgsettings-qt-dev
+package: libgsettings-qt-dev
 
 4、source package:qt5integration 5.6.3
-package:
-qt5integration
+package: qt5integration
 
 5、source package:qtwebengine-opensource-src 5.14.2+dfsg1.orig
-package:
-qtwebengine-opensource-src
+package: qtwebengine-opensource-src
 
 
 Open Source Software Licensed under the LGPL-2.1-or-later:
 1、source package:fcitx5 5.0.9-2
-package:
-fcitx5
+package: fcitx5
 
 2、source package:fcitx5-chinese-addons 5.0.9-2
-package:
-fcitx5-chinese-addons
+package: fcitx5-chinese-addons
 
 3、source package:fcitx5-frontend-gtk2 5.0.9-1
-package:
-fcitx5-frontend-gtk2
+package: fcitx5-frontend-gtk2
 
 4、source package:fcitx5-frontend-qt5 0.0~git20200615.b6f2ef3-1_s390x
-package:
-fcitx5-frontend-qt5
+package: fcitx5-frontend-qt5
 
 5、source package:fcitx5-module-xorg 0~20191021+ds1-1_s390x
-package:
-fcitx5-module-xorg
+package: fcitx5-module-xorg
 
 6、source package:fcitx5-modules 0~20191021+ds1-1_s390x
-package:
-fcitx5-modules
+package: fcitx5-modules
 
 7、source package:fcitx5-modules-dev 5.0.23-2~exp1
-package:
-fcitx5-modules-dev
+package: fcitx5-modules-dev
 
 8、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 9、source package:gcr 3.8.2-4
-package:
-gcr
+package: gcr
 
 10、source package:iso-codes 4.9.0-1
-package:
-iso-codes
+package: iso-codes
 
 11、source package:kcm-fcitx5 5.0.13-1
-package:
-kcm-fcitx5
+package: kcm-fcitx5
 
 12、source package:libappstreamqt-dev 0.9.8-4_kfreebsd-i386
-package:
-libappstreamqt-dev
+package: libappstreamqt-dev
 
 13、source package:libavcodec-dev 4.3-3+b1_s390x
-package:
-libavcodec-dev
+package: libavcodec-dev
 
 14、source package:libavcodec58 4.3-3+b1_ppc64el
-package:
-libavcodec58
+package: libavcodec58
 
 15、source package:libavdevice-dev 4.3-3+b1_ppc64el
-package:
-libavdevice-dev
+package: libavdevice-dev
 
 16、source package:libavfilter-dev 4.3-3+b1_mips64el
-package:
-libavfilter-dev
+package: libavfilter-dev
 
 17、source package:libavformat-dev 4.3-3+b1_ppc64el
-package:
-libavformat-dev
+package: libavformat-dev
 
 18、source package:libavformat58 4.3-3+b1_i386
-package:
-libavformat58
+package: libavformat58
 
 19、source package:libavutil-dev 4.3-3+b1_s390x
-package:
-libavutil-dev
+package: libavutil-dev
 
 20、source package:libavutil56 4.3-3+b1_s390x
-package:
-libavutil56
+package: libavutil56
 
 21、source package:libblockdev-crypto2 2.24-2_mipsel
-package:
-libblockdev-crypto2
+package: libblockdev-crypto2
 
 22、source package:libdbusextended-qt5-dev 0.0.3-4_s390x
-package:
-libdbusextended-qt5-dev
+package: libdbusextended-qt5-dev
 
 23、source package:libfcitx5-qt-dev 0.0~git20200615.b6f2ef3-1_ppc64el
-package:
-libfcitx5-qt-dev
+package: libfcitx5-qt-dev
 
 24、source package:libfcitx5core-dev 0~20191021+ds1-1_s390x
-package:
-libfcitx5core-dev
+package: libfcitx5core-dev
 
 25、source package:libfcitx5utils-dev 0~20191021+ds1-1_s390x
-package:
-libfcitx5utils-dev
+package: libfcitx5utils-dev
 
 26、source package:libgxps-dev 0.3.1-1_s390x
-package:
-libgxps-dev
+package: libgxps-dev
 
 27、source package:libime-bin 0.0~git20200626.2c85668-1_s390x
-package:
-libime-bin
+package: libime-bin
 
 28、source package:libimobiledevice-utils 1.3.0-3_s390x
-package:
-libimobiledevice-utils
+package: libimobiledevice-utils
 
 29、source package:libnss-myhostname 245.6-2_s390x
-package:
-libnss-myhostname
+package: libnss-myhostname
 
 30、source package:libprocps-dev 3.3.16-5_s390x
-package:
-libprocps-dev
+package: libprocps-dev
 
 31、source package:libpulse-dev 7.1-2~bpo8+1_s390x
-package:
-libpulse-dev
+package: libpulse-dev
 
 32、source package:libpulse-mainloop-glib0 9.0-5
-package:
-libpulse-mainloop-glib0
+package: libpulse-mainloop-glib0
 
 33、source package:libpulse0 7.1-2~bpo8+1_s390x
-package:
-libpulse0
+package: libpulse0
 
 34、source package:libqrencode-dev 4.0.2-2_s390x
-package:
-libqrencode-dev
+package: libqrencode-dev
 
 35、source package:libqrencode4 4.1.1-1
-package:
-libqrencode4
+package: libqrencode4
 
 36、source package:libsecret-1-dev 0.20.5-3
-package:
-libsecret-1-dev
+package: libsecret-1-dev
 
 37、source package:libswresample-dev 4.3-3+b1_ppc64el
-package:
-libswresample-dev
+package: libswresample-dev
 
 38、source package:libswscale-dev 4.3-3+b1_s390x
-package:
-libswscale-dev
+package: libswscale-dev
 
 39、source package:libsystemd-dev 245.6-2_i386
-package:
-libsystemd-dev
+package: libsystemd-dev
 
 40、source package:libsystemd0 245.6-2_s390x
-package:
-libsystemd0
+package: libsystemd0
 
 41、source package:libudev-dev 245.6-2_s390x
-package:
-libudev-dev
+package: libudev-dev
 
 42、source package:packagekit 1.2.6-5
-package:
-packagekit
+package: packagekit
 
 43、source package:pulseaudio 9.99.1-1
-package:
-pulseaudio
+package: pulseaudio
 
 44、source package:pulseaudio-module-bluetooth 7.1-2~bpo8+1_s390x
-package:
-pulseaudio-module-bluetooth
+package: pulseaudio-module-bluetooth
 
 45、source package:pulseaudio-utils 7.1-2~bpo8+1_s390x
-package:
-pulseaudio-utils
+package: pulseaudio-utils
 
 46、source package:python3-gi 3.43.1-1
-package:
-python3-gi
+package: python3-gi
 
 47、source package:systemd-coredump 245.6-2_mipsel
-package:
-systemd-coredump
+package: systemd-coredump
 
 48、source package:systemd-timesyncd 245.6-2_ppc64el
-package:
-systemd-timesyncd
+package: systemd-timesyncd
 
 49、source package:udev 245.6-2_s390x
-package:
-udev
+package: udev
 
 50、source package:unar 1.9.1-1
-package:
-unar
+package: unar
 
 
 Open Source Software Licensed under the LGPL-2.1-only:
 1、source package:GitQlient v1.4.3
-package:
-GitQlient
+package: GitQlient
 
 2、source package:cgroup-tools 0.41-8.1_s390x
-package:
-cgroup-tools
+package: cgroup-tools
 
 3、source package:checkstyle checkstyle-10.3.4
-package:
-checkstyle
+package: checkstyle
 
 4、source package:cracklib-runtime 2.9.6-3_s390x
-package:
-cracklib-runtime
+package: cracklib-runtime
 
 5、source package:dialog 1.3-20230209-1
-package:
-dialog
+package: dialog
 
 6、source package:dmsetup 1.02.90-2.2+deb8u1_s390x
-package:
-dmsetup
+package: dmsetup
 
 7、source package:gettext-base 0.19.8.1-9_s390x
-package:
-gettext-base
+package: gettext-base
 
 8、source package:gstreamer1.0-libav 1.9.90-1
-package:
-gstreamer1.0-libav
+package: gstreamer1.0-libav
 
 9、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 10、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 11、source package:gstreamer1.0-plugins-ugly 1.9.90-1
-package:
-gstreamer1.0-plugins-ugly
+package: gstreamer1.0-plugins-ugly
 
 12、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 13、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 14、source package:gtk2-engines 2.20.2.orig
-package:
-gtk2-engines
+package: gtk2-engines
 
 15、source package:gtk2-engines-murrine 0.98.2.orig
-package:
-gtk2-engines-murrine
+package: gtk2-engines-murrine
 
 16、source package:gtk2-engines-pixbuf 2.8.9-2
-package:
-gtk2-engines-pixbuf
+package: gtk2-engines-pixbuf
 
 17、source package:kmod 9-3_sparc
-package:
-kmod
+package: kmod
 
 18、source package:libcairo2-dev 1.16.0-4_s390x
-package:
-libcairo2-dev
+package: libcairo2-dev
 
 19、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 20、source package:libcrack2-dev 2.9.6-5
-package:
-libcrack2-dev
+package: libcrack2-dev
 
 21、source package:libfprint 20110418git-2
-package:
-libfprint
+package: libfprint
 
 22、source package:libfprint-2-2 1.90.1-2_s390x
-package:
-libfprint-2-2
+package: libfprint-2-2
 
 23、source package:libfprint0 1.0-1_s390x
-package:
-libfprint0
+package: libfprint0
 
 24、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 25、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 26、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 27、source package:libgstreamer1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer1.0-0
+package: libgstreamer1.0-0
 
 28、source package:libgstreamer1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer1.0-dev
+package: libgstreamer1.0-dev
 
 29、source package:libgtk-3-dev 3.4.2-7+deb7u1_sparc
-package:
-libgtk-3-dev
+package: libgtk-3-dev
 
 30、source package:liblog4cpp5-dev 1.1.3-3_s390x
-package:
-liblog4cpp5-dev
+package: liblog4cpp5-dev
 
 31、source package:liblog4cpp5v5 1.1.3-3_ppc64el
-package:
-liblog4cpp5v5
+package: liblog4cpp5v5
 
 32、source package:libnm-qt 0.9.8.2.orig
-package:
-libnm-qt
+package: libnm-qt
 
 33、source package:libnotify-bin 0.7.9-1_s390x
-package:
-libnotify-bin
+package: libnotify-bin
 
 34、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 35、source package:librsvg2-dev 2.9.5-6
-package:
-librsvg2-dev
+package: librsvg2-dev
 
 36、source package:libsdl1.2debian 1.2.15-5_sparc
-package:
-libsdl1.2debian
+package: libsdl1.2debian
 
 37、source package:libseccomp-dev 2.4.3-1_s390x
-package:
-libseccomp-dev
+package: libseccomp-dev
 
 38、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 39、source package:libusb-1.0-0-dev 1.0.23-2_s390x
-package:
-libusb-1.0-0-dev
+package: libusb-1.0-0-dev
 
 40、source package:modemmanager 1.8.2.orig
-package:
-modemmanager
+package: modemmanager
 
 41、source package:networkmanager-qt 5.54.0.orig
-package:
-networkmanager-qt
+package: networkmanager-qt
 
 42、source package:p7zip 9.20.1~dfsg.1-5
-package:
-p7zip
+package: p7zip
 
 43、source package:p7zip-full 9.20.1~dfsg.1-4.1_kfreebsd-i386
-package:
-p7zip-full
+package: p7zip-full
 
 44、source package:qrencode 4.0.2.orig
-package:
-qrencode
+package: qrencode
 
 45、source package:qt-creator tqtc/v2.6.0-rc
-package:
-qt-creator
+package: qt-creator
 
 46、source package:qtciphersqliteplugin 0.6
-package:
-qtciphersqliteplugin
+package: qtciphersqliteplugin
 
 47、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2:
 1、source package:libqt5core5a 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5core5a
+package: libqt5core5a
 
 2、source package:libqt5opengl5-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5opengl5-dev
+package: libqt5opengl5-dev
 
 3、source package:libqt5sql5-sqlite 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5sql5-sqlite
+package: libqt5sql5-sqlite
 
 4、source package:libqt5svg5-dev 5.7.1~20161021-2+b2_s390x
-package:
-libqt5svg5-dev
+package: libqt5svg5-dev
 
 5、source package:libqt5x11extras5-dev 5.9.2-1
-package:
-libqt5x11extras5-dev
+package: libqt5x11extras5-dev
 
 6、source package:libqt6multimedia6 6.4.2-6
-package:
-libqt6multimedia6
+package: libqt6multimedia6
 
 7、source package:libqt6opengl6 6.4.2+dfsg~rc1-3+alpha.1
-package:
-libqt6opengl6
+package: libqt6opengl6
 
 8、source package:qml-module-qt-labs-platform 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qt-labs-platform
+package: qml-module-qt-labs-platform
 
 9、source package:qml-module-qtquick-controls2 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qtquick-controls2
+package: qml-module-qtquick-controls2
 
 10、source package:qml-module-qtquick-dialogs 5.7.1~20161021-2_s390x
-package:
-qml-module-qtquick-dialogs
+package: qml-module-qtquick-dialogs
 
 11、source package:qml-module-qtquick-templates2 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qtquick-templates2
+package: qml-module-qtquick-templates2
 
 12、source package:qt5-qmake 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qt5-qmake
+package: qt5-qmake
 
 13、source package:qt6-svg-dev 6.4.2~rc1-3
-package:
-qt6-svg-dev
+package: qt6-svg-dev
 
 14、source package:qt6-wayland 6.4.2~rc1-2
-package:
-qt6-wayland
+package: qt6-wayland
 
 15、source package:qtbase5-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qtbase5-dev
+package: qtbase5-dev
 
 16、source package:qtbase5-private-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qtbase5-private-dev
+package: qtbase5-private-dev
 
 17、source package:qtmultimedia5-dev 5.7.1~20161021-2_s390x
-package:
-qtmultimedia5-dev
+package: qtmultimedia5-dev
 
 18、source package:qtquickcontrols2-5-dev 5.9.2-2_kfreebsd-amd64
-package:
-qtquickcontrols2-5-dev
+package: qtquickcontrols2-5-dev
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2+:
 1、source package:qml-module-qtqml-models2 5.7.1-2+b2_s390x
-package:
-qml-module-qtqml-models2
+package: qml-module-qtqml-models2
 
 2、source package:qml-module-qtquick-layouts 5.7.1-2+b2_s390x
-package:
-qml-module-qtquick-layouts
+package: qml-module-qtquick-layouts
 
 3、source package:qml-module-qtquick2 5.7.1-2+b2_s390x
-package:
-qml-module-qtquick2
+package: qml-module-qtquick2
 
 4、source package:qtdeclarative5-dev 5.7.1-2+b2_s390x
-package:
-qtdeclarative5-dev
+package: qtdeclarative5-dev
 
 
 Open Source Software Licensed under the Apache-2.0:
 1、source package:AndroidProject-Kotlin 13.2
-package:
-AndroidProject-Kotlin
+package: AndroidProject-Kotlin
 
 2、source package:JSONStream 1.3.5
-package:
-JSONStream
+package: JSONStream
 
 3、source package:acorn-node 1.8.2
-package:
-acorn-node
+package: acorn-node
 
 4、source package:android-pdfium a56ccce4
-package:
-android-pdfium
+package: android-pdfium
 
 5、source package:androidsvg 1.4
-package:
-androidsvg
+package: androidsvg
 
 6、source package:atob 2.1.2
-package:
-atob
+package: atob
 
 7、source package:aws-sign2 0.7.0
-package:
-aws-sign2
+package: aws-sign2
 
 8、source package:caseless 0.12.0
-package:
-caseless
+package: caseless
 
 9、source package:cilium 1.14.3
-package:
-cilium
+package: cilium
 
 10、source package:circleindicator 2.1.6
-package:
-circleindicator
+package: circleindicator
 
 11、source package:cobra v0.0.3
-package:
-cobra
+package: cobra
 
 12、source package:compiler 4.12.0
-package:
-compiler
+package: compiler
 
 13、source package:concurrent 1.0.0
-package:
-concurrent
+package: concurrent
 
 14、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 15、source package:core 1.7.0
-package:
-core
+package: core
 
 16、source package:cppdap 87f8b4a
-package:
-cppdap
+package: cppdap
 
 17、source package:crypto v0.23.0
-package:
-crypto
+package: crypto
 
 18、source package:dash-ast 1.0.0
-package:
-dash-ast
+package: dash-ast
 
 19、source package:diff-match-patch 1.0.5
-package:
-diff-match-patch
+package: diff-match-patch
 
 20、source package:dompurify 2.4.1
-package:
-dompurify
+package: dompurify
 
 21、source package:external/github.com/google/benchmark v1.4.1
-package:
-external/github.com/google/benchmark
+package: external/github.com/google/benchmark
 
 22、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 23、source package:fonts-noto-color-emoji 2.038-1
-package:
-fonts-noto-color-emoji
+package: fonts-noto-color-emoji
 
 24、source package:forever-agent 0.6.1
-package:
-forever-agent
+package: forever-agent
 
 25、source package:get-assigned-identifiers 1.2.0
-package:
-get-assigned-identifiers
+package: get-assigned-identifiers
 
 26、source package:git 4.3.20-9
-package:
-git
+package: git
 
 27、source package:glide 4.12.0
-package:
-glide
+package: glide
 
 28、source package:gofuzz v1.0.0
-package:
-gofuzz
+package: gofuzz
 
 29、source package:golang-github-golang-groupcache-dev 0.0~git20200121.8c9f03a-2
-package:
-golang-github-golang-groupcache-dev
+package: golang-github-golang-groupcache-dev
 
 30、source package:golang-gopkg-yaml.v2-dev 2.4.0-3
-package:
-golang-gopkg-yaml.v2-dev
+package: golang-gopkg-yaml.v2-dev
 
 31、source package:golang-gopkg-yaml.v3-dev 3.0.1-3
-package:
-golang-gopkg-yaml.v3-dev
+package: golang-gopkg-yaml.v3-dev
 
 32、source package:gradle 7.4.2
-package:
-gradle
+package: gradle
 
 33、source package:gson 2.10.1
-package:
-gson
+package: gson
 
 34、source package:imgbrd-grabber v6.0.2
-package:
-imgbrd-grabber
+package: imgbrd-grabber
 
 35、source package:infratask_scheduler v0.1.0
-package:
-infratask_scheduler
+package: infratask_scheduler
 
 36、source package:junit 1.1.5
-package:
-junit
+package: junit
 
 37、source package:kata-containers CC-0.7.0
-package:
-kata-containers
+package: kata-containers
 
 38、source package:kotlin-gradle-plugin
-package:
-kotlin-gradle-plugin
+package: kotlin-gradle-plugin
 
 39、source package:kotlin-stdlib-jdk7
-package:
-kotlin-stdlib-jdk7
+package: kotlin-stdlib-jdk7
 
 40、source package:kotlinx-serialization-json 1.5.1
-package:
-kotlinx-serialization-json
+package: kotlinx-serialization-json
 
 41、source package:libcups2-dev 2.3~rc1-1_s390x
-package:
-libcups2-dev
+package: libcups2-dev
 
 42、source package:libcupsimage2 2.3~rc1-1_s390x
-package:
-libcupsimage2
+package: libcupsimage2
 
 43、source package:libpoppler-cpp-dev 0.85.0-1_s390x
-package:
-libpoppler-cpp-dev
+package: libpoppler-cpp-dev
 
 44、source package:libpoppler-cpp0v5 0.85.0-1_s390x
-package:
-libpoppler-cpp0v5
+package: libpoppler-cpp0v5
 
 45、source package:libssl-dev 3.0.0~~alpha4-1_s390x
-package:
-libssl-dev
+package: libssl-dev
 
 46、source package:libssl3 3.0.0~~alpha4-1_s390x
-package:
-libssl3
+package: libssl3
 
 47、source package:libwebrtc-bin 86.4240.20.0
-package:
-libwebrtc-bin
+package: libwebrtc-bin
 
 48、source package:libxerces-c-dev 3.2.3+debian-1_s390x
-package:
-libxerces-c-dev
+package: libxerces-c-dev
 
 49、source package:lottie 4.1.0
-package:
-lottie
+package: lottie
 
 50、source package:ms365 v2.0.5
-package:
-ms365
+package: ms365
 
 51、source package:oauth-sign 0.9.0
-package:
-oauth-sign
+package: oauth-sign
 
 52、source package:okhttp 3.12.13
-package:
-okhttp
+package: okhttp
 
 53、source package:podman 1.6.4+dfsg1-4_armel
-package:
-podman
+package: podman
 
 54、source package:preference 1.2.1
-package:
-preference
+package: preference
 
 55、source package:request 2.88.0
-package:
-request
+package: request
 
 56、source package:rsyslog 8.9.0-3
-package:
-rsyslog
+package: rsyslog
 
 57、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 58、source package:spdx-correct 3.1.1
-package:
-spdx-correct
+package: spdx-correct
 
 59、source package:sse v0.1.0
-package:
-sse
+package: sse
 
 60、source package:sync v0.10.0
-package:
-sync
+package: sync
 
 61、source package:through 2.3.8
-package:
-through
+package: through
 
 62、source package:timber 4.7.1
-package:
-timber
+package: timber
 
 63、source package:tinyrpc 2130294
-package:
-tinyrpc
+package: tinyrpc
 
 64、source package:tools_oat 373f560
-package:
-tools_oat
+package: tools_oat
 
 65、source package:true-case-path 1.0.3
-package:
-true-case-path
+package: true-case-path
 
 66、source package:tunnel-agent 0.6.0
-package:
-tunnel-agent
+package: tunnel-agent
 
 67、source package:typescript 4.8.4
-package:
-typescript
+package: typescript
 
 68、source package:undeclared-identifiers 1.1.3
-package:
-undeclared-identifiers
+package: undeclared-identifiers
 
 69、source package:validate-npm-package-license 3.0.4
-package:
-validate-npm-package-license
+package: validate-npm-package-license
 
 70、source package:vimspector 2938438041
-package:
-vimspector
+package: vimspector
 
 
 Open Source Software Licensed under the MIT:
 1、source package:@antfu/utils 0.7.7
-package:
-@antfu/utils
+package: @antfu/utils
 
 2、source package:@babel/runtime 7.6.0
-package:
-@babel/runtime
+package: @babel/runtime
 
 3、source package:@babel/standalone 7.20.15
-package:
-@babel/standalone
+package: @babel/standalone
 
 4、source package:@ctrl/tinycolor 3.4.1
-package:
-@ctrl/tinycolor
+package: @ctrl/tinycolor
 
 5、source package:@element-plus/icons-vue 2.0.9
-package:
-@element-plus/icons-vue
+package: @element-plus/icons-vue
 
 6、source package:@esbuild/android-arm 0.15.9
-package:
-@esbuild/android-arm
+package: @esbuild/android-arm
 
 7、source package:@esbuild/linux-loong64 0.15.9
-package:
-@esbuild/linux-loong64
+package: @esbuild/linux-loong64
 
 8、source package:@floating-ui/core 1.0.1
-package:
-@floating-ui/core
+package: @floating-ui/core
 
 9、source package:@floating-ui/dom 1.0.2
-package:
-@floating-ui/dom
+package: @floating-ui/dom
 
 10、source package:@jridgewell/gen-mapping 0.3.2
-package:
-@jridgewell/gen-mapping
+package: @jridgewell/gen-mapping
 
 11、source package:@jridgewell/resolve-uri 3.1.0
-package:
-@jridgewell/resolve-uri
+package: @jridgewell/resolve-uri
 
 12、source package:@jridgewell/set-array 1.1.2
-package:
-@jridgewell/set-array
+package: @jridgewell/set-array
 
 13、source package:@jridgewell/source-map 0.3.2
-package:
-@jridgewell/source-map
+package: @jridgewell/source-map
 
 14、source package:@jridgewell/sourcemap-codec 1.4.14
-package:
-@jridgewell/sourcemap-codec
+package: @jridgewell/sourcemap-codec
 
 15、source package:@jridgewell/trace-mapping 0.3.16
-package:
-@jridgewell/trace-mapping
+package: @jridgewell/trace-mapping
 
 16、source package:@nodelib/fs.scandir 2.1.5
-package:
-@nodelib/fs.scandir
+package: @nodelib/fs.scandir
 
 17、source package:@nodelib/fs.stat 2.0.5
-package:
-@nodelib/fs.stat
+package: @nodelib/fs.stat
 
 18、source package:@nodelib/fs.walk 1.2.8
-package:
-@nodelib/fs.walk
+package: @nodelib/fs.walk
 
 19、source package:@popperjs/core 2.11.7
-package:
-@popperjs/core
+package: @popperjs/core
 
 20、source package:@rollup/pluginutils 5.1.0
-package:
-@rollup/pluginutils
+package: @rollup/pluginutils
 
 21、source package:@smake/co 1.0.1
-package:
-@smake/co
+package: @smake/co
 
 22、source package:@types/estree 1.0.5
-package:
-@types/estree
+package: @types/estree
 
 23、source package:@types/json-schema 7.0.6
-package:
-@types/json-schema
+package: @types/json-schema
 
 24、source package:@types/lodash 4.14.185
-package:
-@types/lodash
+package: @types/lodash
 
 25、source package:@types/lodash-es 4.17.6
-package:
-@types/lodash-es
+package: @types/lodash-es
 
 26、source package:@types/node 14.14.6
-package:
-@types/node
+package: @types/node
 
 27、source package:@types/web-bluetooth 0.0.15
-package:
-@types/web-bluetooth
+package: @types/web-bluetooth
 
 28、source package:@vitejs/plugin-legacy 2.3.1
-package:
-@vitejs/plugin-legacy
+package: @vitejs/plugin-legacy
 
 29、source package:@vitejs/plugin-vue 3.1.0
-package:
-@vitejs/plugin-vue
+package: @vitejs/plugin-vue
 
 30、source package:@vue/devtools-api 6.4.1
-package:
-@vue/devtools-api
+package: @vue/devtools-api
 
 31、source package:@vueuse/core 9.3.0
-package:
-@vueuse/core
+package: @vueuse/core
 
 32、source package:@vueuse/metadata 9.3.0
-package:
-@vueuse/metadata
+package: @vueuse/metadata
 
 33、source package:@vueuse/shared 9.3.0
-package:
-@vueuse/shared
+package: @vueuse/shared
 
 34、source package:CppLogging 1.0.1.0
-package:
-CppLogging
+package: CppLogging
 
 35、source package:abbrev 1.1.1
-package:
-abbrev
+package: abbrev
 
 36、source package:acorn 7.0.0
-package:
-acorn
+package: acorn
 
 37、source package:acorn-dynamic-import 2.0.2
-package:
-acorn-dynamic-import
+package: acorn-dynamic-import
 
 38、source package:acorn-node 1.8.2
-package:
-acorn-node
+package: acorn-node
 
 39、source package:acorn-walk 7.0.0
-package:
-acorn-walk
+package: acorn-walk
 
 40、source package:add-px-to-style 1.0.0
-package:
-add-px-to-style
+package: add-px-to-style
 
 41、source package:ajv 6.12.6
-package:
-ajv
+package: ajv
 
 42、source package:ajv-keywords 3.5.2
-package:
-ajv-keywords
+package: ajv-keywords
 
 43、source package:align-text 0.1.4
-package:
-align-text
+package: align-text
 
 44、source package:amdefine 1.0.1
-package:
-amdefine
+package: amdefine
 
 45、source package:ansi-gray 0.1.1
-package:
-ansi-gray
+package: ansi-gray
 
 46、source package:ansi-regex 3.0.0
-package:
-ansi-regex
+package: ansi-regex
 
 47、source package:ansi-styles 2.2.1
-package:
-ansi-styles
+package: ansi-styles
 
 48、source package:ansi-wrap 0.1.0
-package:
-ansi-wrap
+package: ansi-wrap
 
 49、source package:anyks-lm 2.1.5
-package:
-anyks-lm
+package: anyks-lm
 
 50、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 51、source package:archy 1.0.0
-package:
-archy
+package: archy
 
 52、source package:arr-diff 4.0.0
-package:
-arr-diff
+package: arr-diff
 
 53、source package:arr-flatten 1.1.0
-package:
-arr-flatten
+package: arr-flatten
 
 54、source package:arr-union 3.1.0
-package:
-arr-union
+package: arr-union
 
 55、source package:array-differ 1.0.0
-package:
-array-differ
+package: array-differ
 
 56、source package:array-each 1.0.1
-package:
-array-each
+package: array-each
 
 57、source package:array-find-index 1.0.2
-package:
-array-find-index
+package: array-find-index
 
 58、source package:array-slice 1.1.0
-package:
-array-slice
+package: array-slice
 
 59、source package:array-uniq 1.0.3
-package:
-array-uniq
+package: array-uniq
 
 60、source package:array-unique 0.3.2
-package:
-array-unique
+package: array-unique
 
 61、source package:asn1 0.2.4
-package:
-asn1
+package: asn1
 
 62、source package:asn1.js 5.4.1
-package:
-asn1.js
+package: asn1.js
 
 63、source package:assert 1.5.0
-package:
-assert
+package: assert
 
 64、source package:assert-plus 1.0.0
-package:
-assert-plus
+package: assert-plus
 
 65、source package:assign-symbols 1.0.0
-package:
-assign-symbols
+package: assign-symbols
 
 66、source package:async 2.6.3
-package:
-async
+package: async
 
 67、source package:async-each 1.0.3
-package:
-async-each
+package: async-each
 
 68、source package:async-foreach 0.1.3
-package:
-async-foreach
+package: async-foreach
 
 69、source package:async-validator 4.2.5
-package:
-async-validator
+package: async-validator
 
 70、source package:asynckit 0.4.0
-package:
-asynckit
+package: asynckit
 
 71、source package:atob 2.1.2
-package:
-atob
+package: atob
 
 72、source package:aws4 1.8.0
-package:
-aws4
+package: aws4
 
 73、source package:babel-code-frame 6.26.0
-package:
-babel-code-frame
+package: babel-code-frame
 
 74、source package:babel-core 6.26.3
-package:
-babel-core
+package: babel-core
 
 75、source package:babel-generator 6.26.1
-package:
-babel-generator
+package: babel-generator
 
 76、source package:babel-helper-builder-binary-assignment-operator-visitor 6.24.1
-package:
-babel-helper-builder-binary-assignment-operator-visitor
+package: babel-helper-builder-binary-assignment-operator-visitor
 
 77、source package:babel-helper-builder-react-jsx 6.26.0
-package:
-babel-helper-builder-react-jsx
+package: babel-helper-builder-react-jsx
 
 78、source package:babel-helper-call-delegate 6.24.1
-package:
-babel-helper-call-delegate
+package: babel-helper-call-delegate
 
 79、source package:babel-helper-define-map 6.26.0
-package:
-babel-helper-define-map
+package: babel-helper-define-map
 
 80、source package:babel-helper-explode-assignable-expression 6.24.1
-package:
-babel-helper-explode-assignable-expression
+package: babel-helper-explode-assignable-expression
 
 81、source package:babel-helper-function-name 6.24.1
-package:
-babel-helper-function-name
+package: babel-helper-function-name
 
 82、source package:babel-helper-get-function-arity 6.24.1
-package:
-babel-helper-get-function-arity
+package: babel-helper-get-function-arity
 
 83、source package:babel-helper-hoist-variables 6.24.1
-package:
-babel-helper-hoist-variables
+package: babel-helper-hoist-variables
 
 84、source package:babel-helper-optimise-call-expression 6.24.1
-package:
-babel-helper-optimise-call-expression
+package: babel-helper-optimise-call-expression
 
 85、source package:babel-helper-regex 6.26.0
-package:
-babel-helper-regex
+package: babel-helper-regex
 
 86、source package:babel-helper-remap-async-to-generator 6.24.1
-package:
-babel-helper-remap-async-to-generator
+package: babel-helper-remap-async-to-generator
 
 87、source package:babel-helper-replace-supers 6.24.1
-package:
-babel-helper-replace-supers
+package: babel-helper-replace-supers
 
 88、source package:babel-helpers 6.24.1
-package:
-babel-helpers
+package: babel-helpers
 
 89、source package:babel-messages 6.23.0
-package:
-babel-messages
+package: babel-messages
 
 90、source package:babel-plugin-check-es2015-constants 6.22.0
-package:
-babel-plugin-check-es2015-constants
+package: babel-plugin-check-es2015-constants
 
 91、source package:babel-plugin-syntax-async-functions 6.13.0
-package:
-babel-plugin-syntax-async-functions
+package: babel-plugin-syntax-async-functions
 
 92、source package:babel-plugin-syntax-exponentiation-operator 6.13.0
-package:
-babel-plugin-syntax-exponentiation-operator
+package: babel-plugin-syntax-exponentiation-operator
 
 93、source package:babel-plugin-syntax-flow 6.18.0
-package:
-babel-plugin-syntax-flow
+package: babel-plugin-syntax-flow
 
 94、source package:babel-plugin-syntax-jsx 6.18.0
-package:
-babel-plugin-syntax-jsx
+package: babel-plugin-syntax-jsx
 
 95、source package:babel-plugin-syntax-trailing-function-commas 6.22.0
-package:
-babel-plugin-syntax-trailing-function-commas
+package: babel-plugin-syntax-trailing-function-commas
 
 96、source package:babel-plugin-transform-async-to-generator 6.24.1
-package:
-babel-plugin-transform-async-to-generator
+package: babel-plugin-transform-async-to-generator
 
 97、source package:babel-plugin-transform-es2015-arrow-functions 6.22.0
-package:
-babel-plugin-transform-es2015-arrow-functions
+package: babel-plugin-transform-es2015-arrow-functions
 
 98、source package:babel-plugin-transform-es2015-block-scoped-functions 6.22.0
-package:
-babel-plugin-transform-es2015-block-scoped-functions
+package: babel-plugin-transform-es2015-block-scoped-functions
 
 99、source package:babel-plugin-transform-es2015-block-scoping 6.26.0
-package:
-babel-plugin-transform-es2015-block-scoping
+package: babel-plugin-transform-es2015-block-scoping
 
 100、source package:babel-plugin-transform-es2015-classes 6.24.1
-package:
-babel-plugin-transform-es2015-classes
+package: babel-plugin-transform-es2015-classes
 
 101、source package:babel-plugin-transform-es2015-computed-properties 6.24.1
-package:
-babel-plugin-transform-es2015-computed-properties
+package: babel-plugin-transform-es2015-computed-properties
 
 102、source package:babel-plugin-transform-es2015-destructuring 6.23.0
-package:
-babel-plugin-transform-es2015-destructuring
+package: babel-plugin-transform-es2015-destructuring
 
 103、source package:babel-plugin-transform-es2015-duplicate-keys 6.24.1
-package:
-babel-plugin-transform-es2015-duplicate-keys
+package: babel-plugin-transform-es2015-duplicate-keys
 
 104、source package:babel-plugin-transform-es2015-for-of 6.23.0
-package:
-babel-plugin-transform-es2015-for-of
+package: babel-plugin-transform-es2015-for-of
 
 105、source package:babel-plugin-transform-es2015-function-name 6.24.1
-package:
-babel-plugin-transform-es2015-function-name
+package: babel-plugin-transform-es2015-function-name
 
 106、source package:babel-plugin-transform-es2015-literals 6.22.0
-package:
-babel-plugin-transform-es2015-literals
+package: babel-plugin-transform-es2015-literals
 
 107、source package:babel-plugin-transform-es2015-modules-amd 6.24.1
-package:
-babel-plugin-transform-es2015-modules-amd
+package: babel-plugin-transform-es2015-modules-amd
 
 108、source package:babel-plugin-transform-es2015-modules-commonjs 6.26.2
-package:
-babel-plugin-transform-es2015-modules-commonjs
+package: babel-plugin-transform-es2015-modules-commonjs
 
 109、source package:babel-plugin-transform-es2015-modules-systemjs 6.24.1
-package:
-babel-plugin-transform-es2015-modules-systemjs
+package: babel-plugin-transform-es2015-modules-systemjs
 
 110、source package:babel-plugin-transform-es2015-modules-umd 6.24.1
-package:
-babel-plugin-transform-es2015-modules-umd
+package: babel-plugin-transform-es2015-modules-umd
 
 111、source package:babel-plugin-transform-es2015-object-super 6.24.1
-package:
-babel-plugin-transform-es2015-object-super
+package: babel-plugin-transform-es2015-object-super
 
 112、source package:babel-plugin-transform-es2015-parameters 6.24.1
-package:
-babel-plugin-transform-es2015-parameters
+package: babel-plugin-transform-es2015-parameters
 
 113、source package:babel-plugin-transform-es2015-shorthand-properties 6.24.1
-package:
-babel-plugin-transform-es2015-shorthand-properties
+package: babel-plugin-transform-es2015-shorthand-properties
 
 114、source package:babel-plugin-transform-es2015-spread 6.22.0
-package:
-babel-plugin-transform-es2015-spread
+package: babel-plugin-transform-es2015-spread
 
 115、source package:babel-plugin-transform-es2015-sticky-regex 6.24.1
-package:
-babel-plugin-transform-es2015-sticky-regex
+package: babel-plugin-transform-es2015-sticky-regex
 
 116、source package:babel-plugin-transform-es2015-template-literals 6.22.0
-package:
-babel-plugin-transform-es2015-template-literals
+package: babel-plugin-transform-es2015-template-literals
 
 117、source package:babel-plugin-transform-es2015-typeof-symbol 6.23.0
-package:
-babel-plugin-transform-es2015-typeof-symbol
+package: babel-plugin-transform-es2015-typeof-symbol
 
 118、source package:babel-plugin-transform-es2015-unicode-regex 6.24.1
-package:
-babel-plugin-transform-es2015-unicode-regex
+package: babel-plugin-transform-es2015-unicode-regex
 
 119、source package:babel-plugin-transform-exponentiation-operator 6.24.1
-package:
-babel-plugin-transform-exponentiation-operator
+package: babel-plugin-transform-exponentiation-operator
 
 120、source package:babel-plugin-transform-flow-strip-types 6.22.0
-package:
-babel-plugin-transform-flow-strip-types
+package: babel-plugin-transform-flow-strip-types
 
 121、source package:babel-plugin-transform-react-display-name 6.25.0
-package:
-babel-plugin-transform-react-display-name
+package: babel-plugin-transform-react-display-name
 
 122、source package:babel-plugin-transform-react-jsx 6.24.1
-package:
-babel-plugin-transform-react-jsx
+package: babel-plugin-transform-react-jsx
 
 123、source package:babel-plugin-transform-react-jsx-self 6.22.0
-package:
-babel-plugin-transform-react-jsx-self
+package: babel-plugin-transform-react-jsx-self
 
 124、source package:babel-plugin-transform-react-jsx-source 6.22.0
-package:
-babel-plugin-transform-react-jsx-source
+package: babel-plugin-transform-react-jsx-source
 
 125、source package:babel-plugin-transform-regenerator 6.26.0
-package:
-babel-plugin-transform-regenerator
+package: babel-plugin-transform-regenerator
 
 126、source package:babel-plugin-transform-strict-mode 6.24.1
-package:
-babel-plugin-transform-strict-mode
+package: babel-plugin-transform-strict-mode
 
 127、source package:babel-polyfill 6.26.0
-package:
-babel-polyfill
+package: babel-polyfill
 
 128、source package:babel-preset-env 1.7.0
-package:
-babel-preset-env
+package: babel-preset-env
 
 129、source package:babel-preset-flow 6.23.0
-package:
-babel-preset-flow
+package: babel-preset-flow
 
 130、source package:babel-preset-react 6.24.1
-package:
-babel-preset-react
+package: babel-preset-react
 
 131、source package:babel-register 6.26.0
-package:
-babel-register
+package: babel-register
 
 132、source package:babel-runtime 6.26.0
-package:
-babel-runtime
+package: babel-runtime
 
 133、source package:babel-template 6.26.0
-package:
-babel-template
+package: babel-template
 
 134、source package:babel-traverse 6.26.0
-package:
-babel-traverse
+package: babel-traverse
 
 135、source package:babel-types 6.26.0
-package:
-babel-types
+package: babel-types
 
 136、source package:babelify 8.0.0
-package:
-babelify
+package: babelify
 
 137、source package:babylon 6.18.0
-package:
-babylon
+package: babylon
 
 138、source package:balanced-match 1.0.2
-package:
-balanced-match
+package: balanced-match
 
 139、source package:base 0.11.2
-package:
-base
+package: base
 
 140、source package:base64-js 1.3.1
-package:
-base64-js
+package: base64-js
 
 141、source package:beeper 1.1.1
-package:
-beeper
+package: beeper
 
 142、source package:big.js 5.2.2
-package:
-big.js
+package: big.js
 
 143、source package:binary-extensions 2.2.0
-package:
-binary-extensions
+package: binary-extensions
 
 144、source package:bl 1.2.2
-package:
-bl
+package: bl
 
 145、source package:bn.js 5.1.3
-package:
-bn.js
+package: bn.js
 
 146、source package:brace-expansion 2.0.1
-package:
-brace-expansion
+package: brace-expansion
 
 147、source package:braces 3.0.2
-package:
-braces
+package: braces
 
 148、source package:brorand 1.1.0
-package:
-brorand
+package: brorand
 
 149、source package:browser-pack 6.1.0
-package:
-browser-pack
+package: browser-pack
 
 150、source package:browser-resolve 1.11.3
-package:
-browser-resolve
+package: browser-resolve
 
 151、source package:browserify 14.5.0
-package:
-browserify
+package: browserify
 
 152、source package:browserify-aes 1.2.0
-package:
-browserify-aes
+package: browserify-aes
 
 153、source package:browserify-cipher 1.0.1
-package:
-browserify-cipher
+package: browserify-cipher
 
 154、source package:browserify-des 1.0.2
-package:
-browserify-des
+package: browserify-des
 
 155、source package:browserify-rsa 4.0.1
-package:
-browserify-rsa
+package: browserify-rsa
 
 156、source package:browserify-zlib 0.2.0
-package:
-browserify-zlib
+package: browserify-zlib
 
 157、source package:browserslist 3.2.8
-package:
-browserslist
+package: browserslist
 
 158、source package:buffer 5.4.2
-package:
-buffer
+package: buffer
 
 159、source package:buffer-from 1.1.2
-package:
-buffer-from
+package: buffer-from
 
 160、source package:buffer-xor 1.0.3
-package:
-buffer-xor
+package: buffer-xor
 
 161、source package:builtin-status-codes 3.0.0
-package:
-builtin-status-codes
+package: builtin-status-codes
 
 162、source package:cache-base 1.0.1
-package:
-cache-base
+package: cache-base
 
 163、source package:cached-path-relative 1.0.2
-package:
-cached-path-relative
+package: cached-path-relative
 
 164、source package:camelcase 4.1.0
-package:
-camelcase
+package: camelcase
 
 165、source package:camelcase-keys 2.1.0
-package:
-camelcase-keys
+package: camelcase-keys
 
 166、source package:center-align 0.1.3
-package:
-center-align
+package: center-align
 
 167、source package:chalk 1.1.3
-package:
-chalk
+package: chalk
 
 168、source package:cheerio 1.0.0-rc.3
-package:
-cheerio
+package: cheerio
 
 169、source package:chokidar 3.4.3
-package:
-chokidar
+package: chokidar
 
 170、source package:cipher-base 1.0.4
-package:
-cipher-base
+package: cipher-base
 
 171、source package:class-utils 0.3.6
-package:
-class-utils
+package: class-utils
 
 172、source package:clone 2.1.2
-package:
-clone
+package: clone
 
 173、source package:clone-buffer 1.0.0
-package:
-clone-buffer
+package: clone-buffer
 
 174、source package:clone-stats 1.0.0
-package:
-clone-stats
+package: clone-stats
 
 175、source package:cloneable-readable 1.1.3
-package:
-cloneable-readable
+package: cloneable-readable
 
 176、source package:code-point-at 1.1.0
-package:
-code-point-at
+package: code-point-at
 
 177、source package:collection-visit 1.0.0
-package:
-collection-visit
+package: collection-visit
 
 178、source package:combine-source-map 0.8.0
-package:
-combine-source-map
+package: combine-source-map
 
 179、source package:combined-stream 1.0.8
-package:
-combined-stream
+package: combined-stream
 
 180、source package:commander 2.20.3
-package:
-commander
+package: commander
 
 181、source package:component-emitter 1.3.0
-package:
-component-emitter
+package: component-emitter
 
 182、source package:compute-scroll-into-view 1.0.11
-package:
-compute-scroll-into-view
+package: compute-scroll-into-view
 
 183、source package:concat-map 0.0.1
-package:
-concat-map
+package: concat-map
 
 184、source package:concat-stream 1.6.2
-package:
-concat-stream
+package: concat-stream
 
 185、source package:console-browserify 1.2.0
-package:
-console-browserify
+package: console-browserify
 
 186、source package:constants-browserify 1.0.0
-package:
-constants-browserify
+package: constants-browserify
 
 187、source package:convert-source-map 1.6.0
-package:
-convert-source-map
+package: convert-source-map
 
 188、source package:cookiecutter-golang d372aa0
-package:
-cookiecutter-golang
+package: cookiecutter-golang
 
 189、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 190、source package:copy-descriptor 0.1.1
-package:
-copy-descriptor
+package: copy-descriptor
 
 191、source package:core-js 3.27.2
-package:
-core-js
+package: core-js
 
 192、source package:core-util-is 1.0.2
-package:
-core-util-is
+package: core-util-is
 
 193、source package:create-ecdh 4.0.4
-package:
-create-ecdh
+package: create-ecdh
 
 194、source package:create-hash 1.2.0
-package:
-create-hash
+package: create-hash
 
 195、source package:create-hmac 1.1.7
-package:
-create-hmac
+package: create-hmac
 
 196、source package:crelt 1.0.6
-package:
-crelt
+package: crelt
 
 197、source package:cross-spawn 5.1.0
-package:
-cross-spawn
+package: cross-spawn
 
 198、source package:crypto-browserify 3.12.0
-package:
-crypto-browserify
+package: crypto-browserify
 
 199、source package:currently-unhandled 0.4.1
-package:
-currently-unhandled
+package: currently-unhandled
 
 200、source package:dashdash 1.14.1
-package:
-dashdash
+package: dashdash
 
 201、source package:date-now 0.1.4
-package:
-date-now
+package: date-now
 
 202、source package:dateformat 2.2.0
-package:
-dateformat
+package: dateformat
 
 203、source package:dayjs 1.11.5
-package:
-dayjs
+package: dayjs
 
 204、source package:debug 4.3.4
-package:
-debug
+package: debug
 
 205、source package:decamelize 1.2.0
-package:
-decamelize
+package: decamelize
 
 206、source package:decode-uri-component 0.2.0
-package:
-decode-uri-component
+package: decode-uri-component
 
 207、source package:defaults 1.0.3
-package:
-defaults
+package: defaults
 
 208、source package:define-property 2.0.2
-package:
-define-property
+package: define-property
 
 209、source package:defined 1.0.0
-package:
-defined
+package: defined
 
 210、source package:delayed-stream 1.0.0
-package:
-delayed-stream
+package: delayed-stream
 
 211、source package:delegates 1.0.0
-package:
-delegates
+package: delegates
 
 212、source package:deprecated 0.0.1
-package:
-deprecated
+package: deprecated
 
 213、source package:deps-sort 2.0.0
-package:
-deps-sort
+package: deps-sort
 
 214、source package:des.js 1.0.1
-package:
-des.js
+package: des.js
 
 215、source package:detect-file 1.0.0
-package:
-detect-file
+package: detect-file
 
 216、source package:detect-indent 4.0.0
-package:
-detect-indent
+package: detect-indent
 
 217、source package:detective 4.7.1
-package:
-detective
+package: detective
 
 218、source package:diffie-hellman 5.0.3
-package:
-diffie-hellman
+package: diffie-hellman
 
 219、source package:dom-css 2.1.0
-package:
-dom-css
+package: dom-css
 
 220、source package:dom-serializer 0.1.1
-package:
-dom-serializer
+package: dom-serializer
 
 221、source package:domain-browser 1.2.0
-package:
-domain-browser
+package: domain-browser
 
 222、source package:ecc-jsbn 0.1.2
-package:
-ecc-jsbn
+package: ecc-jsbn
 
 223、source package:element-plus 2.2.17
-package:
-element-plus
+package: element-plus
 
 224、source package:elliptic 6.5.3
-package:
-elliptic
+package: elliptic
 
 225、source package:emojis-list 3.0.0
-package:
-emojis-list
+package: emojis-list
 
 226、source package:end-of-stream 0.1.5
-package:
-end-of-stream
+package: end-of-stream
 
 227、source package:enhanced-resolve 3.4.1
-package:
-enhanced-resolve
+package: enhanced-resolve
 
 228、source package:errno 0.1.7
-package:
-errno
+package: errno
 
 229、source package:error-ex 1.3.2
-package:
-error-ex
+package: error-ex
 
 230、source package:es6-iterator 2.0.3
-package:
-es6-iterator
+package: es6-iterator
 
 231、source package:es6-map 0.1.5
-package:
-es6-map
+package: es6-map
 
 232、source package:es6-set 0.1.5
-package:
-es6-set
+package: es6-set
 
 233、source package:es6-symbol 3.1.1
-package:
-es6-symbol
+package: es6-symbol
 
 234、source package:esbuild 0.15.9
-package:
-esbuild
+package: esbuild
 
 235、source package:esbuild-android-64 0.15.9
-package:
-esbuild-android-64
+package: esbuild-android-64
 
 236、source package:esbuild-android-arm64 0.15.9
-package:
-esbuild-android-arm64
+package: esbuild-android-arm64
 
 237、source package:esbuild-darwin-64 0.15.9
-package:
-esbuild-darwin-64
+package: esbuild-darwin-64
 
 238、source package:esbuild-darwin-arm64 0.15.9
-package:
-esbuild-darwin-arm64
+package: esbuild-darwin-arm64
 
 239、source package:esbuild-freebsd-64 0.15.9
-package:
-esbuild-freebsd-64
+package: esbuild-freebsd-64
 
 240、source package:esbuild-freebsd-arm64 0.15.9
-package:
-esbuild-freebsd-arm64
+package: esbuild-freebsd-arm64
 
 241、source package:esbuild-linux-32 0.15.9
-package:
-esbuild-linux-32
+package: esbuild-linux-32
 
 242、source package:esbuild-linux-64 0.15.9
-package:
-esbuild-linux-64
+package: esbuild-linux-64
 
 243、source package:esbuild-linux-arm 0.15.9
-package:
-esbuild-linux-arm
+package: esbuild-linux-arm
 
 244、source package:esbuild-linux-arm64 0.15.9
-package:
-esbuild-linux-arm64
+package: esbuild-linux-arm64
 
 245、source package:esbuild-linux-mips64le 0.15.9
-package:
-esbuild-linux-mips64le
+package: esbuild-linux-mips64le
 
 246、source package:esbuild-linux-ppc64le 0.15.9
-package:
-esbuild-linux-ppc64le
+package: esbuild-linux-ppc64le
 
 247、source package:esbuild-linux-riscv64 0.15.9
-package:
-esbuild-linux-riscv64
+package: esbuild-linux-riscv64
 
 248、source package:esbuild-linux-s390x 0.15.9
-package:
-esbuild-linux-s390x
+package: esbuild-linux-s390x
 
 249、source package:esbuild-netbsd-64 0.15.9
-package:
-esbuild-netbsd-64
+package: esbuild-netbsd-64
 
 250、source package:esbuild-openbsd-64 0.15.9
-package:
-esbuild-openbsd-64
+package: esbuild-openbsd-64
 
 251、source package:esbuild-sunos-64 0.15.9
-package:
-esbuild-sunos-64
+package: esbuild-sunos-64
 
 252、source package:esbuild-windows-32 0.15.9
-package:
-esbuild-windows-32
+package: esbuild-windows-32
 
 253、source package:esbuild-windows-64 0.15.9
-package:
-esbuild-windows-64
+package: esbuild-windows-64
 
 254、source package:esbuild-windows-arm64 0.15.9
-package:
-esbuild-windows-arm64
+package: esbuild-windows-arm64
 
 255、source package:escape-html 1.0.3
-package:
-escape-html
+package: escape-html
 
 256、source package:escape-string-regexp 5.0.0
-package:
-escape-string-regexp
+package: escape-string-regexp
 
 257、source package:estree-walker 2.0.2
-package:
-estree-walker
+package: estree-walker
 
 258、source package:event-emitter 0.3.5
-package:
-event-emitter
+package: event-emitter
 
 259、source package:events 3.2.0
-package:
-events
+package: events
 
 260、source package:evp_bytestokey 1.0.3
-package:
-evp_bytestokey
+package: evp_bytestokey
 
 261、source package:execa 0.7.0
-package:
-execa
+package: execa
 
 262、source package:expand-brackets 2.1.4
-package:
-expand-brackets
+package: expand-brackets
 
 263、source package:expand-tilde 2.0.2
-package:
-expand-tilde
+package: expand-tilde
 
 264、source package:expose-loader 1.0.1
-package:
-expose-loader
+package: expose-loader
 
 265、source package:extend 3.0.2
-package:
-extend
+package: extend
 
 266、source package:extend-shallow 3.0.2
-package:
-extend-shallow
+package: extend-shallow
 
 267、source package:extglob 2.0.4
-package:
-extglob
+package: extglob
 
 268、source package:extsprintf 1.3.0
-package:
-extsprintf
+package: extsprintf
 
 269、source package:fancy-log 1.3.3
-package:
-fancy-log
+package: fancy-log
 
 270、source package:fast-deep-equal 3.1.3
-package:
-fast-deep-equal
+package: fast-deep-equal
 
 271、source package:fast-glob 3.2.12
-package:
-fast-glob
+package: fast-glob
 
 272、source package:fast-json-stable-stringify 2.1.0
-package:
-fast-json-stable-stringify
+package: fast-json-stable-stringify
 
 273、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 274、source package:fill-range 7.0.1
-package:
-fill-range
+package: fill-range
 
 275、source package:find-index 0.1.1
-package:
-find-index
+package: find-index
 
 276、source package:find-up 2.1.0
-package:
-find-up
+package: find-up
 
 277、source package:findup-sync 2.0.0
-package:
-findup-sync
+package: findup-sync
 
 278、source package:fined 1.2.0
-package:
-fined
+package: fined
 
 279、source package:first-chunk-stream 1.0.0
-package:
-first-chunk-stream
+package: first-chunk-stream
 
 280、source package:flagged-respawn 1.0.1
-package:
-flagged-respawn
+package: flagged-respawn
 
 281、source package:for-in 1.0.2
-package:
-for-in
+package: for-in
 
 282、source package:for-own 1.0.0
-package:
-for-own
+package: for-own
 
 283、source package:form-data 2.3.3
-package:
-form-data
+package: form-data
 
 284、source package:fragment-cache 0.2.1
-package:
-fragment-cache
+package: fragment-cache
 
 285、source package:fs.realpath 1.0.0
-package:
-fs.realpath
+package: fs.realpath
 
 286、source package:fsevents 2.3.2
-package:
-fsevents
+package: fsevents
 
 287、source package:function-bind 1.1.1
-package:
-function-bind
+package: function-bind
 
 288、source package:gaze 1.1.3
-package:
-gaze
+package: gaze
 
 289、source package:get-stdin 4.0.1
-package:
-get-stdin
+package: get-stdin
 
 290、source package:get-stream 3.0.0
-package:
-get-stream
+package: get-stream
 
 291、source package:get-value 2.0.6
-package:
-get-value
+package: get-value
 
 292、source package:getpass 0.1.7
-package:
-getpass
+package: getpass
 
 293、source package:gg v1.3.0
-package:
-gg
+package: gg
 
 294、source package:gin v1.5.0
-package:
-gin
+package: gin
 
 295、source package:git 4.3.20-9
-package:
-git
+package: git
 
 296、source package:gitea v1.19.3
-package:
-gitea
+package: gitea
 
 297、source package:glob-stream 3.1.18
-package:
-glob-stream
+package: glob-stream
 
 298、source package:glob-watcher 0.0.6
-package:
-glob-watcher
+package: glob-watcher
 
 299、source package:glob2base 0.0.12
-package:
-glob2base
+package: glob2base
 
 300、source package:global-modules 1.0.0
-package:
-global-modules
+package: global-modules
 
 301、source package:global-prefix 1.0.2
-package:
-global-prefix
+package: global-prefix
 
 302、source package:globals 9.18.0
-package:
-globals
+package: globals
 
 303、source package:globule 1.2.1
-package:
-globule
+package: globule
 
 304、source package:glogg 1.0.2
-package:
-glogg
+package: glogg
 
 305、source package:go v1.1.7
-package:
-go
+package: go
 
 306、source package:go-isatty v0.0.9
-package:
-go-isatty
+package: go-isatty
 
 307、source package:go-pinyin v0.19.0
-package:
-go-pinyin
+package: go-pinyin
 
 308、source package:go-wav v0.3.2
-package:
-go-wav
+package: go-wav
 
 309、source package:go-windows-terminal-sequences v1.0.1
-package:
-go-windows-terminal-sequences
+package: go-windows-terminal-sequences
 
 310、source package:goconvey v1.8.1
-package:
-goconvey
+package: goconvey
 
 311、source package:golang-github-gosexy-gettext-dev 0~git20130221-2.1_all
-package:
-golang-github-gosexy-gettext-dev
+package: golang-github-gosexy-gettext-dev
 
 312、source package:gstreamer1.0-fluendo-mp3 0.10.32.debian-1_s390x
-package:
-gstreamer1.0-fluendo-mp3
+package: gstreamer1.0-fluendo-mp3
 
 313、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 314、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 315、source package:gstreamer1.0-plugins-ugly 1.9.90-1
-package:
-gstreamer1.0-plugins-ugly
+package: gstreamer1.0-plugins-ugly
 
 316、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 317、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 318、source package:gulp 3.9.1
-package:
-gulp
+package: gulp
 
 319、source package:gulp-concat 2.6.1
-package:
-gulp-concat
+package: gulp-concat
 
 320、source package:gulp-rename 1.4.0
-package:
-gulp-rename
+package: gulp-rename
 
 321、source package:gulp-sass 3.2.1
-package:
-gulp-sass
+package: gulp-sass
 
 322、source package:gulp-util 3.0.8
-package:
-gulp-util
+package: gulp-util
 
 323、source package:gulplog 1.0.0
-package:
-gulplog
+package: gulplog
 
 324、source package:har-validator 5.1.3
-package:
-har-validator
+package: har-validator
 
 325、source package:has 1.0.3
-package:
-has
+package: has
 
 326、source package:has-ansi 2.0.0
-package:
-has-ansi
+package: has-ansi
 
 327、source package:has-flag 2.0.0
-package:
-has-flag
+package: has-flag
 
 328、source package:has-gulplog 0.1.0
-package:
-has-gulplog
+package: has-gulplog
 
 329、source package:has-value 1.0.0
-package:
-has-value
+package: has-value
 
 330、source package:has-values 1.0.0
-package:
-has-values
+package: has-values
 
 331、source package:hash-base 3.1.0
-package:
-hash-base
+package: hash-base
 
 332、source package:hash.js 1.1.7
-package:
-hash.js
+package: hash.js
 
 333、source package:history 4.9.0
-package:
-history
+package: history
 
 334、source package:hmac-drbg 1.0.1
-package:
-hmac-drbg
+package: hmac-drbg
 
 335、source package:home-or-tmp 2.0.0
-package:
-home-or-tmp
+package: home-or-tmp
 
 336、source package:homedir-polyfill 1.0.3
-package:
-homedir-polyfill
+package: homedir-polyfill
 
 337、source package:htmlescape 1.1.1
-package:
-htmlescape
+package: htmlescape
 
 338、source package:htmlparser2 3.10.1
-package:
-htmlparser2
+package: htmlparser2
 
 339、source package:http-signature 1.2.0
-package:
-http-signature
+package: http-signature
 
 340、source package:https-browserify 1.0.0
-package:
-https-browserify
+package: https-browserify
 
 341、source package:image v0.10.0
-package:
-image
+package: image
 
 342、source package:immutable 4.1.0
-package:
-immutable
+package: immutable
 
 343、source package:indent-string 2.1.0
-package:
-indent-string
+package: indent-string
 
 344、source package:indexof 0.0.1
-package:
-indexof
+package: indexof
 
 345、source package:inline-source-map 0.6.2
-package:
-inline-source-map
+package: inline-source-map
 
 346、source package:insert-module-globals 7.2.0
-package:
-insert-module-globals
+package: insert-module-globals
 
 347、source package:interpret 1.4.0
-package:
-interpret
+package: interpret
 
 348、source package:invariant 2.2.4
-package:
-invariant
+package: invariant
 
 349、source package:invert-kv 1.0.0
-package:
-invert-kv
+package: invert-kv
 
 350、source package:is-absolute 1.0.0
-package:
-is-absolute
+package: is-absolute
 
 351、source package:is-accessor-descriptor 1.0.0
-package:
-is-accessor-descriptor
+package: is-accessor-descriptor
 
 352、source package:is-arrayish 0.2.1
-package:
-is-arrayish
+package: is-arrayish
 
 353、source package:is-binary-path 2.1.0
-package:
-is-binary-path
+package: is-binary-path
 
 354、source package:is-buffer 1.1.6
-package:
-is-buffer
+package: is-buffer
 
 355、source package:is-core-module 2.10.0
-package:
-is-core-module
+package: is-core-module
 
 356、source package:is-data-descriptor 1.0.0
-package:
-is-data-descriptor
+package: is-data-descriptor
 
 357、source package:is-descriptor 1.0.2
-package:
-is-descriptor
+package: is-descriptor
 
 358、source package:is-extendable 1.0.1
-package:
-is-extendable
+package: is-extendable
 
 359、source package:is-extglob 2.1.1
-package:
-is-extglob
+package: is-extglob
 
 360、source package:is-finite 1.0.2
-package:
-is-finite
+package: is-finite
 
 361、source package:is-fullwidth-code-point 2.0.0
-package:
-is-fullwidth-code-point
+package: is-fullwidth-code-point
 
 362、source package:is-glob 4.0.3
-package:
-is-glob
+package: is-glob
 
 363、source package:is-number 7.0.0
-package:
-is-number
+package: is-number
 
 364、source package:is-plain-object 2.0.4
-package:
-is-plain-object
+package: is-plain-object
 
 365、source package:is-relative 1.0.0
-package:
-is-relative
+package: is-relative
 
 366、source package:is-stream 1.1.0
-package:
-is-stream
+package: is-stream
 
 367、source package:is-typedarray 1.0.0
-package:
-is-typedarray
+package: is-typedarray
 
 368、source package:is-unc-path 1.0.0
-package:
-is-unc-path
+package: is-unc-path
 
 369、source package:is-utf8 0.2.1
-package:
-is-utf8
+package: is-utf8
 
 370、source package:is-windows 1.0.2
-package:
-is-windows
+package: is-windows
 
 371、source package:isarray 1.0.0
-package:
-isarray
+package: isarray
 
 372、source package:isobject 3.0.1
-package:
-isobject
+package: isobject
 
 373、source package:isstream 0.1.2
-package:
-isstream
+package: isstream
 
 374、source package:java_fpe_test 0.1.2
-package:
-java_fpe_test
+package: java_fpe_test
 
 375、source package:jq 1.6-2.1
-package:
-jq
+package: jq
 
 376、source package:jquery 3.6.1
-package:
-jquery
+package: jquery
 
 377、source package:js 0.1.0
-package:
-js
+package: js
 
 378、source package:js-tokens 3.0.2
-package:
-js-tokens
+package: js-tokens
 
 379、source package:jsbn 0.1.1
-package:
-jsbn
+package: jsbn
 
 380、source package:jsesc 1.3.0
-package:
-jsesc
+package: jsesc
 
 381、source package:json v3.7.0
-package:
-json
+package: json
 
 382、source package:json-loader 0.5.7
-package:
-json-loader
+package: json-loader
 
 383、source package:json-schema-traverse 0.4.1
-package:
-json-schema-traverse
+package: json-schema-traverse
 
 384、source package:json-stable-stringify 0.0.1
-package:
-json-stable-stringify
+package: json-stable-stringify
 
 385、source package:json5 2.1.3
-package:
-json5
+package: json5
 
 386、source package:jsonc-parser 3.2.0
-package:
-jsonc-parser
+package: jsonc-parser
 
 387、source package:jsonparse 1.3.1
-package:
-jsonparse
+package: jsonparse
 
 388、source package:jsprim 1.4.1
-package:
-jsprim
+package: jsprim
 
 389、source package:jwt-cpp v0.5.0
-package:
-jwt-cpp
+package: jwt-cpp
 
 390、source package:keypress 0.1.0
-package:
-keypress
+package: keypress
 
 391、source package:kind-of 6.0.3
-package:
-kind-of
+package: kind-of
 
 392、source package:labeled-stream-splicer 2.0.2
-package:
-labeled-stream-splicer
+package: labeled-stream-splicer
 
 393、source package:lazy-cache 1.0.4
-package:
-lazy-cache
+package: lazy-cache
 
 394、source package:lcid 1.0.0
-package:
-lcid
+package: lcid
 
 395、source package:libappimage-dev 0.1.9+dfsg-1_s390x
-package:
-libappimage-dev
+package: libappimage-dev
 
 396、source package:libboost-dev 1.71.0.3_s390x
-package:
-libboost-dev
+package: libboost-dev
 
 397、source package:libboost-filesystem-dev 1.71.0.3_s390x
-package:
-libboost-filesystem-dev
+package: libboost-filesystem-dev
 
 398、source package:libboost-serialization-dev 1.71.0.3_s390x
-package:
-libboost-serialization-dev
+package: libboost-serialization-dev
 
 399、source package:libboost-system-dev 1.71.0.3_s390x
-package:
-libboost-system-dev
+package: libboost-system-dev
 
 400、source package:libdrm-dev 2.4.99-1_s390x
-package:
-libdrm-dev
+package: libdrm-dev
 
 401、source package:libegl1-mesa-dev 8.0.5-4+deb7u2_sparc
-package:
-libegl1-mesa-dev
+package: libegl1-mesa-dev
 
 402、source package:libgbm-dev 8.0.5-4+deb7u2_sparc
-package:
-libgbm-dev
+package: libgbm-dev
 
 403、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 404、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 405、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 406、source package:libjson-c3 0.12.1-1.3_s390x
-package:
-libjson-c3
+package: libjson-c3
 
 407、source package:libjson-rpc-cpp v1.4.1
-package:
-libjson-rpc-cpp
+package: libjson-rpc-cpp
 
 408、source package:liblcms2-dev 2.9-4_s390x
-package:
-liblcms2-dev
+package: liblcms2-dev
 
 409、source package:libportaudio2 19.6.0-1_s390x
-package:
-libportaudio2
+package: libportaudio2
 
 410、source package:libx11-dev 2:1.8.4-2+deb12u1
-package:
-libx11-dev
+package: libx11-dev
 
 411、source package:libx11-xcb-dev 1.6.9-2_s390x
-package:
-libx11-xcb-dev
+package: libx11-xcb-dev
 
 412、source package:libxcb-composite0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-composite0-dev
+package: libxcb-composite0-dev
 
 413、source package:libxcb-cursor-dev 0.1.1-4_s390x
-package:
-libxcb-cursor-dev
+package: libxcb-cursor-dev
 
 414、source package:libxcb-damage0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-damage0-dev
+package: libxcb-damage0-dev
 
 415、source package:libxcb-ewmh-dev 0.4.1-1_s390x
-package:
-libxcb-ewmh-dev
+package: libxcb-ewmh-dev
 
 416、source package:libxcb-image0-dev 0.4.0-1_s390x
-package:
-libxcb-image0-dev
+package: libxcb-image0-dev
 
 417、source package:libxcb-keysyms1-dev 0.4.0-1_s390x
-package:
-libxcb-keysyms1-dev
+package: libxcb-keysyms1-dev
 
 418、source package:libxcb-randr0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-randr0-dev
+package: libxcb-randr0-dev
 
 419、source package:libxcb-record0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-record0-dev
+package: libxcb-record0-dev
 
 420、source package:libxcb-render-util0-dev 0.3.9-1_s390x
-package:
-libxcb-render-util0-dev
+package: libxcb-render-util0-dev
 
 421、source package:libxcb-render0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-render0-dev
+package: libxcb-render0-dev
 
 422、source package:libxcb-res0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-res0-dev
+package: libxcb-res0-dev
 
 423、source package:libxcb-shape0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-shape0-dev
+package: libxcb-shape0-dev
 
 424、source package:libxcb-sync-dev 1.14-2_s390x
-package:
-libxcb-sync-dev
+package: libxcb-sync-dev
 
 425、source package:libxcb-util0 0.3.8-3_s390x
-package:
-libxcb-util0
+package: libxcb-util0
 
 426、source package:libxcb-util0-dev 0.3.8-3_s390x
-package:
-libxcb-util0-dev
+package: libxcb-util0-dev
 
 427、source package:libxcb-util1 0.4.0-1
-package:
-libxcb-util1
+package: libxcb-util1
 
 428、source package:libxcb-xfixes0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xfixes0-dev
+package: libxcb-xfixes0-dev
 
 429、source package:libxcb-xinerama0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xinerama0-dev
+package: libxcb-xinerama0-dev
 
 430、source package:libxcb-xinput-dev 1.14-2_s390x
-package:
-libxcb-xinput-dev
+package: libxcb-xinput-dev
 
 431、source package:libxcb-xkb-dev 1.14-2_s390x
-package:
-libxcb-xkb-dev
+package: libxcb-xkb-dev
 
 432、source package:libxcb-xtest0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xtest0-dev
+package: libxcb-xtest0-dev
 
 433、source package:libxcb1-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb1-dev
+package: libxcb1-dev
 
 434、source package:libxext-dev 1.3.3-1_s390x
-package:
-libxext-dev
+package: libxext-dev
 
 435、source package:libxfixes-dev 5.0.3-2_s390x
-package:
-libxfixes-dev
+package: libxfixes-dev
 
 436、source package:libxinerama-dev 2:1.1.4-3
-package:
-libxinerama-dev
+package: libxinerama-dev
 
 437、source package:libxkbcommon-dev 0.9.1-1_s390x
-package:
-libxkbcommon-dev
+package: libxkbcommon-dev
 
 438、source package:libxkbcommon-x11-dev 0.9.1-1_s390x
-package:
-libxkbcommon-x11-dev
+package: libxkbcommon-x11-dev
 
 439、source package:libxss-dev 1.2.3-1_s390x
-package:
-libxss-dev
+package: libxss-dev
 
 440、source package:libxss1 1.2.3-1_s390x
-package:
-libxss1
+package: libxss1
 
 441、source package:libxtst-dev 1.2.3-1_s390x
-package:
-libxtst-dev
+package: libxtst-dev
 
 442、source package:liftoff 2.5.0
-package:
-liftoff
+package: liftoff
 
 443、source package:load-json-file 2.0.0
-package:
-load-json-file
+package: load-json-file
 
 444、source package:loader-runner 2.4.0
-package:
-loader-runner
+package: loader-runner
 
 445、source package:loader-utils 2.0.0
-package:
-loader-utils
+package: loader-utils
 
 446、source package:local-pkg 0.4.3
-package:
-local-pkg
+package: local-pkg
 
 447、source package:locales v0.12.1
-package:
-locales
+package: locales
 
 448、source package:locate-path 2.0.0
-package:
-locate-path
+package: locate-path
 
 449、source package:lodash 4.17.21
-package:
-lodash
+package: lodash
 
 450、source package:lodash-es 4.17.21
-package:
-lodash-es
+package: lodash-es
 
 451、source package:lodash-unified 1.0.2
-package:
-lodash-unified
+package: lodash-unified
 
 452、source package:lodash._basecopy 3.0.1
-package:
-lodash._basecopy
+package: lodash._basecopy
 
 453、source package:lodash._basetostring 3.0.1
-package:
-lodash._basetostring
+package: lodash._basetostring
 
 454、source package:lodash._basevalues 3.0.0
-package:
-lodash._basevalues
+package: lodash._basevalues
 
 455、source package:lodash._getnative 3.9.1
-package:
-lodash._getnative
+package: lodash._getnative
 
 456、source package:lodash._isiterateecall 3.0.9
-package:
-lodash._isiterateecall
+package: lodash._isiterateecall
 
 457、source package:lodash._reescape 3.0.0
-package:
-lodash._reescape
+package: lodash._reescape
 
 458、source package:lodash._reevaluate 3.0.0
-package:
-lodash._reevaluate
+package: lodash._reevaluate
 
 459、source package:lodash._reinterpolate 3.0.0
-package:
-lodash._reinterpolate
+package: lodash._reinterpolate
 
 460、source package:lodash._root 3.0.1
-package:
-lodash._root
+package: lodash._root
 
 461、source package:lodash.clonedeep 4.5.0
-package:
-lodash.clonedeep
+package: lodash.clonedeep
 
 462、source package:lodash.escape 3.2.0
-package:
-lodash.escape
+package: lodash.escape
 
 463、source package:lodash.isarguments 3.1.0
-package:
-lodash.isarguments
+package: lodash.isarguments
 
 464、source package:lodash.isarray 3.0.4
-package:
-lodash.isarray
+package: lodash.isarray
 
 465、source package:lodash.keys 3.1.2
-package:
-lodash.keys
+package: lodash.keys
 
 466、source package:lodash.memoize 3.0.4
-package:
-lodash.memoize
+package: lodash.memoize
 
 467、source package:lodash.restparam 3.6.1
-package:
-lodash.restparam
+package: lodash.restparam
 
 468、source package:lodash.template 3.6.2
-package:
-lodash.template
+package: lodash.template
 
 469、source package:lodash.templatesettings 3.1.1
-package:
-lodash.templatesettings
+package: lodash.templatesettings
 
 470、source package:logrus v1.9.3
-package:
-logrus
+package: logrus
 
 471、source package:longest 1.0.1
-package:
-longest
+package: longest
 
 472、source package:loose-envify 1.4.0
-package:
-loose-envify
+package: loose-envify
 
 473、source package:loud-rejection 1.6.0
-package:
-loud-rejection
+package: loud-rejection
 
 474、source package:magic-string 0.27.0
-package:
-magic-string
+package: magic-string
 
 475、source package:make-iterator 1.0.1
-package:
-make-iterator
+package: make-iterator
 
 476、source package:map-cache 0.2.2
-package:
-map-cache
+package: map-cache
 
 477、source package:map-obj 1.0.1
-package:
-map-obj
+package: map-obj
 
 478、source package:map-visit 1.0.0
-package:
-map-visit
+package: map-visit
 
 479、source package:marked 1.2.3
-package:
-marked
+package: marked
 
 480、source package:md5.js 1.3.5
-package:
-md5.js
+package: md5.js
 
 481、source package:mem 1.1.0
-package:
-mem
+package: mem
 
 482、source package:memoize-one 6.0.0
-package:
-memoize-one
+package: memoize-one
 
 483、source package:memory-fs 0.4.1
-package:
-memory-fs
+package: memory-fs
 
 484、source package:meow 3.7.0
-package:
-meow
+package: meow
 
 485、source package:merge2 1.4.1
-package:
-merge2
+package: merge2
 
 486、source package:mesa-utils 9.0.0-1
-package:
-mesa-utils
+package: mesa-utils
 
 487、source package:mesa-va-drivers 20.1.2-1_armel
-package:
-mesa-va-drivers
+package: mesa-va-drivers
 
 488、source package:mesa-vdpau-drivers 20.1.2-1_mipsel
-package:
-mesa-vdpau-drivers
+package: mesa-vdpau-drivers
 
 489、source package:mesa-vulkan-drivers 20.1.2-1_mips64el
-package:
-mesa-vulkan-drivers
+package: mesa-vulkan-drivers
 
 490、source package:micromatch 3.1.10
-package:
-micromatch
+package: micromatch
 
 491、source package:miller-rabin 4.0.1
-package:
-miller-rabin
+package: miller-rabin
 
 492、source package:mime-db 1.40.0
-package:
-mime-db
+package: mime-db
 
 493、source package:mime-types 2.1.24
-package:
-mime-types
+package: mime-types
 
 494、source package:mimic-fn 1.2.0
-package:
-mimic-fn
+package: mimic-fn
 
 495、source package:minimalistic-crypto-utils 1.0.1
-package:
-minimalistic-crypto-utils
+package: minimalistic-crypto-utils
 
 496、source package:minimatch 0.2.14
-package:
-minimatch
+package: minimatch
 
 497、source package:minimist 1.2.5
-package:
-minimist
+package: minimist
 
 498、source package:mitt 3.0.0
-package:
-mitt
+package: mitt
 
 499、source package:mixin-deep 1.3.2
-package:
-mixin-deep
+package: mixin-deep
 
 500、source package:mkdirp 0.5.5
-package:
-mkdirp
+package: mkdirp
 
 501、source package:mlly 1.4.2
-package:
-mlly
+package: mlly
 
 502、source package:module-deps 4.1.1
-package:
-module-deps
+package: module-deps
 
 503、source package:moment 2.29.4
-package:
-moment
+package: moment
 
 504、source package:mqt.qfr 1.10.0
-package:
-mqt.qfr
+package: mqt.qfr
 
 505、source package:ms 2.1.2
-package:
-ms
+package: ms
 
 506、source package:multipipe 0.1.2
-package:
-multipipe
+package: multipipe
 
 507、source package:nan 2.14.0
-package:
-nan
+package: nan
 
 508、source package:nanomatch 1.2.13
-package:
-nanomatch
+package: nanomatch
 
 509、source package:native v1.1.0
-package:
-native
+package: native
 
 510、source package:ncurses-base 6.2-1_all
-package:
-ncurses-base
+package: ncurses-base
 
 511、source package:neo-async 2.6.2
-package:
-neo-async
+package: neo-async
 
 512、source package:netlink v1.7.2
-package:
-netlink
+package: netlink
 
 513、source package:next-tick 1.0.0
-package:
-next-tick
+package: next-tick
 
 514、source package:nlohmann_json nlohmann_json-3.7.3
-package:
-nlohmann_json
+package: nlohmann_json
 
 515、source package:node 8.16.1
-package:
-node
+package: node
 
 516、source package:node-gyp 3.8.0
-package:
-node-gyp
+package: node-gyp
 
 517、source package:node-libs-browser 2.2.1
-package:
-node-libs-browser
+package: node-libs-browser
 
 518、source package:node-sass 4.12.0
-package:
-node-sass
+package: node-sass
 
 519、source package:normalize-path 3.0.0
-package:
-normalize-path
+package: normalize-path
 
 520、source package:npm-run-path 2.0.2
-package:
-npm-run-path
+package: npm-run-path
 
 521、source package:number-is-nan 1.0.1
-package:
-number-is-nan
+package: number-is-nan
 
 522、source package:object-assign 4.1.1
-package:
-object-assign
+package: object-assign
 
 523、source package:object-copy 0.1.0
-package:
-object-copy
+package: object-copy
 
 524、source package:object-visit 1.0.1
-package:
-object-visit
+package: object-visit
 
 525、source package:object.defaults 1.1.0
-package:
-object.defaults
+package: object.defaults
 
 526、source package:object.map 1.0.1
-package:
-object.map
+package: object.map
 
 527、source package:object.pick 1.3.0
-package:
-object.pick
+package: object.pick
 
 528、source package:objx v0.5.2
-package:
-objx
+package: objx
 
 529、source package:orchestrator 0.3.8
-package:
-orchestrator
+package: orchestrator
 
 530、source package:ordered-read-streams 0.1.0
-package:
-ordered-read-streams
+package: ordered-read-streams
 
 531、source package:os-browserify 0.3.0
-package:
-os-browserify
+package: os-browserify
 
 532、source package:os-config 0.2.3
-package:
-os-config
+package: os-config
 
 533、source package:os-homedir 1.0.2
-package:
-os-homedir
+package: os-homedir
 
 534、source package:os-locale 2.1.0
-package:
-os-locale
+package: os-locale
 
 535、source package:os-tmpdir 1.0.2
-package:
-os-tmpdir
+package: os-tmpdir
 
 536、source package:p-finally 1.0.0
-package:
-p-finally
+package: p-finally
 
 537、source package:p-limit 1.3.0
-package:
-p-limit
+package: p-limit
 
 538、source package:p-locate 2.0.0
-package:
-p-locate
+package: p-locate
 
 539、source package:p-try 1.0.0
-package:
-p-try
+package: p-try
 
 540、source package:pako 1.0.11
-package:
-pako
+package: pako
 
 541、source package:parents 1.0.1
-package:
-parents
+package: parents
 
 542、source package:parse-filepath 1.0.2
-package:
-parse-filepath
+package: parse-filepath
 
 543、source package:parse-json 2.2.0
-package:
-parse-json
+package: parse-json
 
 544、source package:parse-node-version 1.0.1
-package:
-parse-node-version
+package: parse-node-version
 
 545、source package:parse-passwd 1.0.0
-package:
-parse-passwd
+package: parse-passwd
 
 546、source package:parse5 3.0.3
-package:
-parse5
+package: parse5
 
 547、source package:pascalcase 0.1.1
-package:
-pascalcase
+package: pascalcase
 
 548、source package:path-browserify 0.0.1
-package:
-path-browserify
+package: path-browserify
 
 549、source package:path-dirname 1.0.2
-package:
-path-dirname
+package: path-dirname
 
 550、source package:path-exists 3.0.0
-package:
-path-exists
+package: path-exists
 
 551、source package:path-is-absolute 1.0.1
-package:
-path-is-absolute
+package: path-is-absolute
 
 552、source package:path-key 2.0.1
-package:
-path-key
+package: path-key
 
 553、source package:path-parse 1.0.7
-package:
-path-parse
+package: path-parse
 
 554、source package:path-platform 0.11.15
-package:
-path-platform
+package: path-platform
 
 555、source package:path-root 0.1.1
-package:
-path-root
+package: path-root
 
 556、source package:path-root-regex 0.1.2
-package:
-path-root-regex
+package: path-root-regex
 
 557、source package:path-to-regexp 1.7.0
-package:
-path-to-regexp
+package: path-to-regexp
 
 558、source package:path-type 2.0.0
-package:
-path-type
+package: path-type
 
 559、source package:pathe 1.1.1
-package:
-pathe
+package: pathe
 
 560、source package:pbkdf2 3.1.1
-package:
-pbkdf2
+package: pbkdf2
 
 561、source package:performance-now 2.1.0
-package:
-performance-now
+package: performance-now
 
 562、source package:picomatch 2.3.1
-package:
-picomatch
+package: picomatch
 
 563、source package:pify 2.3.0
-package:
-pify
+package: pify
 
 564、source package:pinia 2.0.22
-package:
-pinia
+package: pinia
 
 565、source package:pinkie 2.0.4
-package:
-pinkie
+package: pinkie
 
 566、source package:pinkie-promise 2.0.1
-package:
-pinkie-promise
+package: pinkie-promise
 
 567、source package:pipewire-pulse 0.3.71
-package:
-pipewire-pulse
+package: pipewire-pulse
 
 568、source package:pkg-types 1.0.3
-package:
-pkg-types
+package: pkg-types
 
 569、source package:platform/external/fmtlib upstream-master
-package:
-platform/external/fmtlib
+package: platform/external/fmtlib
 
 570、source package:portaudio19-dev 19.6.0-1_s390x
-package:
-portaudio19-dev
+package: portaudio19-dev
 
 571、source package:posix-character-classes 0.1.1
-package:
-posix-character-classes
+package: posix-character-classes
 
 572、source package:prefix-style 2.0.1
-package:
-prefix-style
+package: prefix-style
 
 573、source package:pretty v0.2.1
-package:
-pretty
+package: pretty
 
 574、source package:pretty-hrtime 1.0.3
-package:
-pretty-hrtime
+package: pretty-hrtime
 
 575、source package:private 0.1.8
-package:
-private
+package: private
 
 576、source package:process 0.11.10
-package:
-process
+package: process
 
 577、source package:process-nextick-args 2.0.1
-package:
-process-nextick-args
+package: process-nextick-args
 
 578、source package:promxy v0.0.81
-package:
-promxy
+package: promxy
 
 579、source package:prop-types 15.7.2
-package:
-prop-types
+package: prop-types
 
 580、source package:prr 1.0.1
-package:
-prr
+package: prr
 
 581、source package:psl 1.4.0
-package:
-psl
+package: psl
 
 582、source package:public-encrypt 4.0.3
-package:
-public-encrypt
+package: public-encrypt
 
 583、source package:punycode 2.1.1
-package:
-punycode
+package: punycode
 
 584、source package:python3 3.8.2-3_s390x
-package:
-python3
+package: python3
 
 585、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 586、source package:querystring 0.2.0
-package:
-querystring
+package: querystring
 
 587、source package:querystring-es3 0.2.1
-package:
-querystring-es3
+package: querystring-es3
 
 588、source package:queue-microtask 1.2.3
-package:
-queue-microtask
+package: queue-microtask
 
 589、source package:raf 3.4.1
-package:
-raf
+package: raf
 
 590、source package:randombytes 2.1.0
-package:
-randombytes
+package: randombytes
 
 591、source package:randomfill 1.0.4
-package:
-randomfill
+package: randomfill
 
 592、source package:react 16.9.0
-package:
-react
+package: react
 
 593、source package:react-custom-scrollbars 4.2.1
-package:
-react-custom-scrollbars
+package: react-custom-scrollbars
 
 594、source package:react-dom 16.9.0
-package:
-react-dom
+package: react-dom
 
 595、source package:react-is 16.9.0
-package:
-react-is
+package: react-is
 
 596、source package:react-router 4.3.1
-package:
-react-router
+package: react-router
 
 597、source package:react-router-dom 4.3.1
-package:
-react-router-dom
+package: react-router-dom
 
 598、source package:read-only-stream 2.0.0
-package:
-read-only-stream
+package: read-only-stream
 
 599、source package:read-pkg 2.0.0
-package:
-read-pkg
+package: read-pkg
 
 600、source package:read-pkg-up 2.0.0
-package:
-read-pkg-up
+package: read-pkg-up
 
 601、source package:readable-stream 3.6.0
-package:
-readable-stream
+package: readable-stream
 
 602、source package:readdirp 3.6.0
-package:
-readdirp
+package: readdirp
 
 603、source package:rechoir 0.6.2
-package:
-rechoir
+package: rechoir
 
 604、source package:redent 1.0.0
-package:
-redent
+package: redent
 
 605、source package:regenerate 1.4.0
-package:
-regenerate
+package: regenerate
 
 606、source package:regenerator-runtime 0.13.3
-package:
-regenerator-runtime
+package: regenerator-runtime
 
 607、source package:regex-not 1.0.2
-package:
-regex-not
+package: regex-not
 
 608、source package:regexpu-core 2.0.0
-package:
-regexpu-core
+package: regexpu-core
 
 609、source package:regjsgen 0.2.0
-package:
-regjsgen
+package: regjsgen
 
 610、source package:repeat-element 1.1.3
-package:
-repeat-element
+package: repeat-element
 
 611、source package:repeat-string 1.6.1
-package:
-repeat-string
+package: repeat-string
 
 612、source package:repeating 2.0.1
-package:
-repeating
+package: repeating
 
 613、source package:replace-ext 1.0.0
-package:
-replace-ext
+package: replace-ext
 
 614、source package:require-directory 2.1.1
-package:
-require-directory
+package: require-directory
 
 615、source package:resolve 1.22.1
-package:
-resolve
+package: resolve
 
 616、source package:resolve-dir 1.0.1
-package:
-resolve-dir
+package: resolve-dir
 
 617、source package:resolve-pathname 2.2.0
-package:
-resolve-pathname
+package: resolve-pathname
 
 618、source package:resolve-url 0.2.1
-package:
-resolve-url
+package: resolve-url
 
 619、source package:ret 0.1.15
-package:
-ret
+package: ret
 
 620、source package:reusify 1.0.4
-package:
-reusify
+package: reusify
 
 621、source package:right-align 0.1.3
-package:
-right-align
+package: right-align
 
 622、source package:ripemd160 2.0.2
-package:
-ripemd160
+package: ripemd160
 
 623、source package:rollup 2.79.1
-package:
-rollup
+package: rollup
 
 624、source package:run-parallel 1.2.0
-package:
-run-parallel
+package: run-parallel
 
 625、source package:safe-buffer 5.2.1
-package:
-safe-buffer
+package: safe-buffer
 
 626、source package:safe-regex 1.1.0
-package:
-safe-regex
+package: safe-regex
 
 627、source package:safer-buffer 2.1.2
-package:
-safer-buffer
+package: safer-buffer
 
 628、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 629、source package:sass-graph 2.2.4
-package:
-sass-graph
+package: sass-graph
 
 630、source package:scheduler 0.15.0
-package:
-scheduler
+package: scheduler
 
 631、source package:schema-utils 3.0.0
-package:
-schema-utils
+package: schema-utils
 
 632、source package:scroll-into-view-if-needed 2.2.20
-package:
-scroll-into-view-if-needed
+package: scroll-into-view-if-needed
 
 633、source package:scss-tokenizer 0.2.3
-package:
-scss-tokenizer
+package: scss-tokenizer
 
 634、source package:scule 1.1.1
-package:
-scule
+package: scule
 
 635、source package:sequencify 0.0.7
-package:
-sequencify
+package: sequencify
 
 636、source package:set-value 2.0.1
-package:
-set-value
+package: set-value
 
 637、source package:setimmediate 1.0.5
-package:
-setimmediate
+package: setimmediate
 
 638、source package:sha.js 2.4.11
-package:
-sha.js
+package: sha.js
 
 639、source package:shadered v1.5.3
-package:
-shadered
+package: shadered
 
 640、source package:shasum 1.0.2
-package:
-shasum
+package: shasum
 
 641、source package:shebang-command 1.2.0
-package:
-shebang-command
+package: shebang-command
 
 642、source package:shebang-regex 1.0.0
-package:
-shebang-regex
+package: shebang-regex
 
 643、source package:shell-quote 1.7.2
-package:
-shell-quote
+package: shell-quote
 
 644、source package:simple-concat 1.0.0
-package:
-simple-concat
+package: simple-concat
 
 645、source package:slash 1.0.0
-package:
-slash
+package: slash
 
 646、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 647、source package:smooth-scroll-into-view-if-needed 1.1.23
-package:
-smooth-scroll-into-view-if-needed
+package: smooth-scroll-into-view-if-needed
 
 648、source package:snapdragon 0.8.2
-package:
-snapdragon
+package: snapdragon
 
 649、source package:snapdragon-node 2.1.1
-package:
-snapdragon-node
+package: snapdragon-node
 
 650、source package:snapdragon-util 3.0.1
-package:
-snapdragon-util
+package: snapdragon-util
 
 651、source package:source-list-map 2.0.1
-package:
-source-list-map
+package: source-list-map
 
 652、source package:source-map-resolve 0.5.3
-package:
-source-map-resolve
+package: source-map-resolve
 
 653、source package:source-map-support 0.5.21
-package:
-source-map-support
+package: source-map-support
 
 654、source package:source-map-url 0.4.0
-package:
-source-map-url
+package: source-map-url
 
 655、source package:sourcemap-codec 1.4.8
-package:
-sourcemap-codec
+package: sourcemap-codec
 
 656、source package:sparkles 1.0.1
-package:
-sparkles
+package: sparkles
 
 657、source package:spdx-expression-parse 3.0.1
-package:
-spdx-expression-parse
+package: spdx-expression-parse
 
 658、source package:split-string 3.1.0
-package:
-split-string
+package: split-string
 
 659、source package:sqlclosecheck v0.5.0
-package:
-sqlclosecheck
+package: sqlclosecheck
 
 660、source package:sse v0.1.0
-package:
-sse
+package: sse
 
 661、source package:sshpk 1.16.1
-package:
-sshpk
+package: sshpk
 
 662、source package:static-extend 0.1.2
-package:
-static-extend
+package: static-extend
 
 663、source package:stdout-stream 1.4.1
-package:
-stdout-stream
+package: stdout-stream
 
 664、source package:stream-browserify 2.0.2
-package:
-stream-browserify
+package: stream-browserify
 
 665、source package:stream-combiner2 1.1.1
-package:
-stream-combiner2
+package: stream-combiner2
 
 666、source package:stream-consume 0.1.1
-package:
-stream-consume
+package: stream-consume
 
 667、source package:stream-http 2.8.3
-package:
-stream-http
+package: stream-http
 
 668、source package:stream-splicer 2.0.1
-package:
-stream-splicer
+package: stream-splicer
 
 669、source package:string-width 2.1.1
-package:
-string-width
+package: string-width
 
 670、source package:string_decoder 1.3.0
-package:
-string_decoder
+package: string_decoder
 
 671、source package:strip-ansi 4.0.0
-package:
-strip-ansi
+package: strip-ansi
 
 672、source package:strip-bom 3.0.0
-package:
-strip-bom
+package: strip-bom
 
 673、source package:strip-eof 1.0.0
-package:
-strip-eof
+package: strip-eof
 
 674、source package:strip-indent 1.0.1
-package:
-strip-indent
+package: strip-indent
 
 675、source package:strip-literal 1.3.0
-package:
-strip-literal
+package: strip-literal
 
 676、source package:subarg 1.0.0
-package:
-subarg
+package: subarg
 
 677、source package:sudo 1.9.8p2-1~exp1
-package:
-sudo
+package: sudo
 
 678、source package:supports-color 4.5.0
-package:
-supports-color
+package: supports-color
 
 679、source package:supports-preserve-symlinks-flag 1.0.0
-package:
-supports-preserve-symlinks-flag
+package: supports-preserve-symlinks-flag
 
 680、source package:syntax-error 1.4.0
-package:
-syntax-error
+package: syntax-error
 
 681、source package:sys v0.5.0
-package:
-sys
+package: sys
 
 682、source package:systemjs 6.13.0
-package:
-systemjs
+package: systemjs
 
 683、source package:tapable 0.2.9
-package:
-tapable
+package: tapable
 
 684、source package:testify v1.9.0
-package:
-testify
+package: testify
 
 685、source package:text v0.1.0
-package:
-text
+package: text
 
 686、source package:through2 2.0.5
-package:
-through2
+package: through2
 
 687、source package:tildify 1.2.0
-package:
-tildify
+package: tildify
 
 688、source package:time-stamp 1.1.0
-package:
-time-stamp
+package: time-stamp
 
 689、source package:timers-browserify 2.0.12
-package:
-timers-browserify
+package: timers-browserify
 
 690、source package:tiny-invariant 1.0.6
-package:
-tiny-invariant
+package: tiny-invariant
 
 691、source package:tiny-warning 1.0.3
-package:
-tiny-warning
+package: tiny-warning
 
 692、source package:tinyaes 1.0.4rc1
-package:
-tinyaes
+package: tinyaes
 
 693、source package:tlp 1.5.0-1~bpo11+1
-package:
-tlp
+package: tlp
 
 694、source package:to-arraybuffer 1.0.1
-package:
-to-arraybuffer
+package: to-arraybuffer
 
 695、source package:to-camel-case 1.0.0
-package:
-to-camel-case
+package: to-camel-case
 
 696、source package:to-fast-properties 1.0.3
-package:
-to-fast-properties
+package: to-fast-properties
 
 697、source package:to-no-case 1.0.2
-package:
-to-no-case
+package: to-no-case
 
 698、source package:to-object-path 0.3.0
-package:
-to-object-path
+package: to-object-path
 
 699、source package:to-regex 3.0.2
-package:
-to-regex
+package: to-regex
 
 700、source package:to-regex-range 5.0.1
-package:
-to-regex-range
+package: to-regex-range
 
 701、source package:to-space-case 1.0.0
-package:
-to-space-case
+package: to-space-case
 
 702、source package:toml v1.3.2
-package:
-toml
+package: toml
 
 703、source package:tools v0.6.0
-package:
-tools
+package: tools
 
 704、source package:tortellini 4f6795a
-package:
-tortellini
+package: tortellini
 
 705、source package:trim-newlines 1.0.0
-package:
-trim-newlines
+package: trim-newlines
 
 706、source package:trim-right 1.0.1
-package:
-trim-right
+package: trim-right
 
 707、source package:tty-browserify 0.0.1
-package:
-tty-browserify
+package: tty-browserify
 
 708、source package:typedarray 0.0.6
-package:
-typedarray
+package: typedarray
 
 709、source package:uglify-to-browserify 1.0.2
-package:
-uglify-to-browserify
+package: uglify-to-browserify
 
 710、source package:uglifyjs-webpack-plugin 0.4.6
-package:
-uglifyjs-webpack-plugin
+package: uglifyjs-webpack-plugin
 
 711、source package:umd 3.0.3
-package:
-umd
+package: umd
 
 712、source package:unc-path-regex 0.1.2
-package:
-unc-path-regex
+package: unc-path-regex
 
 713、source package:unimport 1.3.0
-package:
-unimport
+package: unimport
 
 714、source package:union-value 1.0.1
-package:
-union-value
+package: union-value
 
 715、source package:unique-stream 1.0.0
-package:
-unique-stream
+package: unique-stream
 
 716、source package:universal-translator v0.16.0
-package:
-universal-translator
+package: universal-translator
 
 717、source package:unplugin-auto-import 0.11.5
-package:
-unplugin-auto-import
+package: unplugin-auto-import
 
 718、source package:unplugin-vue-components 0.22.12
-package:
-unplugin-vue-components
+package: unplugin-vue-components
 
 719、source package:unset-value 1.0.0
-package:
-unset-value
+package: unset-value
 
 720、source package:upath 1.2.0
-package:
-upath
+package: upath
 
 721、source package:urix 0.1.0
-package:
-urix
+package: urix
 
 722、source package:url 0.11.0
-package:
-url
+package: url
 
 723、source package:use 3.1.1
-package:
-use
+package: use
 
 724、source package:user-home 1.1.1
-package:
-user-home
+package: user-home
 
 725、source package:util 0.11.1
-package:
-util
+package: util
 
 726、source package:util-deprecate 1.0.2
-package:
-util-deprecate
+package: util-deprecate
 
 727、source package:uuid 3.3.3
-package:
-uuid
+package: uuid
 
 728、source package:v-drag 3.0.9
-package:
-v-drag
+package: v-drag
 
 729、source package:v8flags 2.1.1
-package:
-v8flags
+package: v8flags
 
 730、source package:value-equal 0.4.0
-package:
-value-equal
+package: value-equal
 
 731、source package:verror 1.10.0
-package:
-verror
+package: verror
 
 732、source package:vinyl 2.2.0
-package:
-vinyl
+package: vinyl
 
 733、source package:vinyl-buffer 1.0.1
-package:
-vinyl-buffer
+package: vinyl-buffer
 
 734、source package:vinyl-fs 0.3.14
-package:
-vinyl-fs
+package: vinyl-fs
 
 735、source package:vinyl-source-stream 2.0.0
-package:
-vinyl-source-stream
+package: vinyl-source-stream
 
 736、source package:vm-browserify 1.1.2
-package:
-vm-browserify
+package: vm-browserify
 
 737、source package:vue-codemirror 6.1.1
-package:
-vue-codemirror
+package: vue-codemirror
 
 738、source package:vue-demi 0.13.11
-package:
-vue-demi
+package: vue-demi
 
 739、source package:vue-router 4.1.5
-package:
-vue-router
+package: vue-router
 
 740、source package:w3c-keyname 2.2.8
-package:
-w3c-keyname
+package: w3c-keyname
 
 741、source package:warning 4.0.3
-package:
-warning
+package: warning
 
 742、source package:watchpack 1.7.4
-package:
-watchpack
+package: watchpack
 
 743、source package:watchpack-chokidar2 2.0.0
-package:
-watchpack-chokidar2
+package: watchpack-chokidar2
 
 744、source package:webpack 3.12.0
-package:
-webpack
+package: webpack
 
 745、source package:webpack-sources 3.2.3
-package:
-webpack-sources
+package: webpack-sources
 
 746、source package:webpack-virtual-modules 0.6.1
-package:
-webpack-virtual-modules
+package: webpack-virtual-modules
 
 747、source package:window-size 0.1.0
-package:
-window-size
+package: window-size
 
 748、source package:wireplumber 0.4.9-1
-package:
-wireplumber
+package: wireplumber
 
 749、source package:wordwrap 0.0.2
-package:
-wordwrap
+package: wordwrap
 
 750、source package:wrap-ansi 2.1.0
-package:
-wrap-ansi
+package: wrap-ansi
 
 751、source package:x11-utils 7.7~1_sparc
-package:
-x11-utils
+package: x11-utils
 
 752、source package:x11-xserver-utils 7.7~3_sparc
-package:
-x11-xserver-utils
+package: x11-xserver-utils
 
 753、source package:x11proto-record-dev 2020.1-1_all
-package:
-x11proto-record-dev
+package: x11proto-record-dev
 
 754、source package:x11proto-xext-dev 7.3.0-1_all
-package:
-x11proto-xext-dev
+package: x11proto-xext-dev
 
 755、source package:xcb-proto 1.7.1.orig
-package:
-xcb-proto
+package: xcb-proto
 
 756、source package:xdg-utils 1.1.3-4.1
-package:
-xdg-utils
+package: xdg-utils
 
 757、source package:xkb-data 2.5.1-3_all
-package:
-xkb-data
+package: xkb-data
 
 758、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 759、source package:xserver-xorg-input-all 7.7+7_s390x
-package:
-xserver-xorg-input-all
+package: xserver-xorg-input-all
 
 760、source package:xserver-xorg-video-all 7.7+7_s390x
-package:
-xserver-xorg-video-all
+package: xserver-xorg-video-all
 
 761、source package:xtend 4.0.2
-package:
-xtend
+package: xtend
 
 762、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 763、source package:yargs 8.0.2
-package:
-yargs
+package: yargs
 
 
 Open Source Software Licensed under the Expat:
 1、source package:golang-github-adrg-xdg-dev 0.4.0-2
-package:
-golang-github-adrg-xdg-dev
+package: golang-github-adrg-xdg-dev
 
 2、source package:golang-github-disintegration-imaging-dev 1.6.2-2
-package:
-golang-github-disintegration-imaging-dev
+package: golang-github-disintegration-imaging-dev
 
 3、source package:golang-github-smartystreets-goconvey-dev 1.6.4+dfsg-1_all
-package:
-golang-github-smartystreets-goconvey-dev
+package: golang-github-smartystreets-goconvey-dev
 
 4、source package:golang-github-stretchr-testify-dev 1.8.0-1~bpo11+1
-package:
-golang-github-stretchr-testify-dev
+package: golang-github-stretchr-testify-dev
 
 5、source package:golang-github-teambition-rrule-go-dev 1.8.1-1
-package:
-golang-github-teambition-rrule-go-dev
+package: golang-github-teambition-rrule-go-dev
 
 6、source package:golang-gopkg-alecthomas-kingpin.v2-dev 2.2.6-4
-package:
-golang-gopkg-alecthomas-kingpin.v2-dev
+package: golang-gopkg-alecthomas-kingpin.v2-dev
 
 7、source package:intel-media-va-driver-non-free 23.2.3+ds1-1
-package:
-intel-media-va-driver-non-free
+package: intel-media-va-driver-non-free
 
 8、source package:libepoxy-dev 1.5.9-2
-package:
-libepoxy-dev
+package: libepoxy-dev
 
 9、source package:libiniparser-dev 4.1-4_s390x
-package:
-libiniparser-dev
+package: libiniparser-dev
 
 10、source package:libinput-dev 1.6.3-1_s390x
-package:
-libinput-dev
+package: libinput-dev
 
 11、source package:libjson-c-dev 0.16-2
-package:
-libjson-c-dev
+package: libjson-c-dev
 
 12、source package:libmtdev-dev 1.1.6-1_s390x
-package:
-libmtdev-dev
+package: libmtdev-dev
 
 13、source package:libsass-dev 3.6.4-4~exp_s390x
-package:
-libsass-dev
+package: libsass-dev
 
 14、source package:libspdlog-dev 1:1.3.1-1
-package:
-libspdlog-dev
+package: libspdlog-dev
 
 15、source package:libutf8proc-dev 2.7.0-4
-package:
-libutf8proc-dev
+package: libutf8proc-dev
 
 16、source package:libva-dev 2.8.0-1_s390x
-package:
-libva-dev
+package: libva-dev
 
 17、source package:nlohmann-json3-dev 3.9.1-1
-package:
-nlohmann-json3-dev
+package: nlohmann-json3-dev
 
 18、source package:rapidjson-dev 1.1.0-1
-package:
-rapidjson-dev
+package: rapidjson-dev
 
 19、source package:va-driver-all 2.8.0-1_s390x
-package:
-va-driver-all
+package: va-driver-all
 
 20、source package:wayland-protocols 1.9-1
-package:
-wayland-protocols
+package: wayland-protocols
 
 
 Open Source Software Licensed under the BSD-3-Clause:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 2、source package:alsa-topology-conf 1.2.5.1-2
-package:
-alsa-topology-conf
+package: alsa-topology-conf
 
 3、source package:alsa-ucm-conf 1.2.9-1
-package:
-alsa-ucm-conf
+package: alsa-ucm-conf
 
 4、source package:amdefine 1.0.1
-package:
-amdefine
+package: amdefine
 
 5、source package:android-pdfium a56ccce4
-package:
-android-pdfium
+package: android-pdfium
 
 6、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 7、source package:bcrypt-pbkdf 1.0.2
-package:
-bcrypt-pbkdf
+package: bcrypt-pbkdf
 
 8、source package:browserify 14.5.0
-package:
-browserify
+package: browserify
 
 9、source package:charenc 0.0.2
-package:
-charenc
+package: charenc
 
 10、source package:chromium 87.0.4280.88-0.4
-package:
-chromium
+package: chromium
 
 11、source package:cmake v3.27.0-rc5
-package:
-cmake
+package: cmake
 
 12、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 13、source package:crypt 0.0.2
-package:
-crypt
+package: crypt
 
 14、source package:crypto v0.13.0
-package:
-crypto
+package: crypto
 
 15、source package:css-select 1.2.0
-package:
-css-select
+package: css-select
 
 16、source package:css-what 2.1.3
-package:
-css-what
+package: css-what
 
 17、source package:dns v1.1.52
-package:
-dns
+package: dns
 
 18、source package:dnsutils 970203-0.1
-package:
-dnsutils
+package: dnsutils
 
 19、source package:duplexer2 0.1.4
-package:
-duplexer2
+package: duplexer2
 
 20、source package:entities 1.1.2
-package:
-entities
+package: entities
 
 21、source package:errwrap v1.5.0
-package:
-errwrap
+package: errwrap
 
 22、source package:external/github.com/protocolbuffers/protobuf v3.7.0-rc.3
-package:
-external/github.com/protocolbuffers/protobuf
+package: external/github.com/protocolbuffers/protobuf
 
 23、source package:extra-cmake-modules 5.98.0-2
-package:
-extra-cmake-modules
+package: extra-cmake-modules
 
 24、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 25、source package:fsnotify v1.6.0
-package:
-fsnotify
+package: fsnotify
 
 26、source package:go-cmp v0.6.0
-package:
-go-cmp
+package: go-cmp
 
 27、source package:golang 2:1.7~5~bpo8+1
-package:
-golang
+package: golang
 
 28、source package:golang-any 1.7~5~bpo8+1_s390x
-package:
-golang-any
+package: golang-any
 
 29、source package:golang-github-fsnotify-fsnotify-dev 1.6.0-1
-package:
-golang-github-fsnotify-fsnotify-dev
+package: golang-github-fsnotify-fsnotify-dev
 
 30、source package:golang-github-miekg-dns-dev 1.1.50-2
-package:
-golang-github-miekg-dns-dev
+package: golang-github-miekg-dns-dev
 
 31、source package:golang-github-rickb777-date-dev 1.20.1-1
-package:
-golang-github-rickb777-date-dev
+package: golang-github-rickb777-date-dev
 
 32、source package:golang-go 1.7~5~bpo8+1_ppc64el
-package:
-golang-go
+package: golang-go
 
 33、source package:golang-golang-x-sys-dev 0.3.0-1+hurd.1
-package:
-golang-golang-x-sys-dev
+package: golang-golang-x-sys-dev
 
 34、source package:golang-golang-x-xerrors-dev 0.0~git20191204.9bdfabe-1~bpo10+1
-package:
-golang-golang-x-xerrors-dev
+package: golang-golang-x-xerrors-dev
 
 35、source package:golang-google-protobuf-dev 1.28.1-3
-package:
-golang-google-protobuf-dev
+package: golang-google-protobuf-dev
 
 36、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 37、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 38、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 39、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 40、source package:hoist-non-react-statics 2.5.5
-package:
-hoist-non-react-statics
+package: hoist-non-react-statics
 
 41、source package:ieee754 1.2.1
-package:
-ieee754
+package: ieee754
 
 42、source package:init 1.65~exp2
-package:
-init
+package: init
 
 43、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 44、source package:js-base64 2.5.1
-package:
-js-base64
+package: js-base64
 
 45、source package:json-schema 0.2.3
-package:
-json-schema
+package: json-schema
 
 46、source package:libcli11-dev 2.1.2+ds-1
-package:
-libcli11-dev
+package: libcli11-dev
 
 47、source package:libgmock-dev 1.9.0.20190831-3
-package:
-libgmock-dev
+package: libgmock-dev
 
 48、source package:libgoogle-glog-dev 0.4.0-1_s390x
-package:
-libgoogle-glog-dev
+package: libgoogle-glog-dev
 
 49、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 50、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 51、source package:libgtest-dev 1.9.0.20190831-1_s390x
-package:
-libgtest-dev
+package: libgtest-dev
 
 52、source package:libjpeg-dev 2.0.5-1_all
-package:
-libjpeg-dev
+package: libjpeg-dev
 
 53、source package:libnl-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-3-dev
+package: libnl-3-dev
 
 54、source package:libnl-genl-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-genl-3-dev
+package: libnl-genl-3-dev
 
 55、source package:libnl-route-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-route-3-dev
+package: libnl-route-3-dev
 
 56、source package:libpcap-dev 1.9.1-4~bpo10+1_s390x
-package:
-libpcap-dev
+package: libpcap-dev
 
 57、source package:libtirpc-common 1.2.6-1_all
-package:
-libtirpc-common
+package: libtirpc-common
 
 58、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 59、source package:locales 2.31-0experimental0_all
-package:
-locales
+package: locales
 
 60、source package:lxqt-build-tools 0.8.0-1
-package:
-lxqt-build-tools
+package: lxqt-build-tools
 
 61、source package:marked 1.2.3
-package:
-marked
+package: marked
 
 62、source package:md5 2.2.1
-package:
-md5
+package: md5
 
 63、source package:mmkv-static 1.2.10
-package:
-mmkv-static
+package: mmkv-static
 
 64、source package:mod v0.8.0
-package:
-mod
+package: mod
 
 65、source package:mount 2.9g-6
-package:
-mount
+package: mount
 
 66、source package:net v0.15.0
-package:
-net
+package: net
 
 67、source package:node 8.16.1
-package:
-node
+package: node
 
 68、source package:normalize-wheel-es 1.2.0
-package:
-normalize-wheel-es
+package: normalize-wheel-es
 
 69、source package:nth-check 1.0.2
-package:
-nth-check
+package: nth-check
 
 70、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 71、source package:passwd 980403-0.3
-package:
-passwd
+package: passwd
 
 72、source package:pflag v1.0.5
-package:
-pflag
+package: pflag
 
 73、source package:protobuf v1.3.2
-package:
-protobuf
+package: protobuf
 
 74、source package:python3-click 8.1.6-1
-package:
-python3-click
+package: python3-click
 
 75、source package:qml-module-qtgraphicaleffects 5.7.1~20161021-3_s390x
-package:
-qml-module-qtgraphicaleffects
+package: qml-module-qtgraphicaleffects
 
 76、source package:qs 6.5.2
-package:
-qs
+package: qs
 
 77、source package:qtermwidget 0.14.1
-package:
-qtermwidget
+package: qtermwidget
 
 78、source package:regenerator-transform 0.10.1
-package:
-regenerator-transform
+package: regenerator-transform
 
 79、source package:regjsparser 0.1.5
-package:
-regjsparser
+package: regjsparser
 
 80、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 81、source package:sha.js 2.4.11
-package:
-sha.js
+package: sha.js
 
 82、source package:source-map 0.6.1
-package:
-source-map
+package: source-map
 
 83、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 84、source package:sys v0.6.0
-package:
-sys
+package: sys
 
 85、source package:syscall_intercept 4b3a3b5
-package:
-syscall_intercept
+package: syscall_intercept
 
 86、source package:term v0.13.0
-package:
-term
+package: term
 
 87、source package:terser 5.15.1
-package:
-terser
+package: terser
 
 88、source package:text v0.13.0
-package:
-text
+package: text
 
 89、source package:tough-cookie 2.4.3
-package:
-tough-cookie
+package: tough-cookie
 
 90、source package:uglify-js 2.8.29
-package:
-uglify-js
+package: uglify-js
 
 91、source package:util-linux 2.5-12
-package:
-util-linux
+package: util-linux
 
 92、source package:uuid v1.3.0
-package:
-uuid
+package: uuid
 
 93、source package:wpasupplicant 2.9.0-12_s390x
-package:
-wpasupplicant
+package: wpasupplicant
 
 94、source package:xdotool 3.20160805.1-4_s390x
-package:
-xdotool
+package: xdotool
 
 95、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 96、source package:xsettingsd 1.0.2-1
-package:
-xsettingsd
+package: xsettingsd
 
 97、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the BSD-2-Clause:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 2、source package:block-stream 0.0.9
-package:
-block-stream
+package: block-stream
 
 3、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 4、source package:domelementtype 1.3.1
-package:
-domelementtype
+package: domelementtype
 
 5、source package:domhandler 2.4.2
-package:
-domhandler
+package: domhandler
 
 6、source package:domutils 1.5.1
-package:
-domutils
+package: domutils
 
 7、source package:doxyqml 0.3.0-1.1.debian
-package:
-doxyqml
+package: doxyqml
 
 8、source package:escope 3.6.0
-package:
-escope
+package: escope
 
 9、source package:esrecurse 4.3.0
-package:
-esrecurse
+package: esrecurse
 
 10、source package:estraverse 5.2.0
-package:
-estraverse
+package: estraverse
 
 11、source package:esutils 2.0.3
-package:
-esutils
+package: esutils
 
 12、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 13、source package:glob 3.1.21
-package:
-glob
+package: glob
 
 14、source package:golang-dbus-dev 5.1.0-1~bpo11+1
-package:
-golang-dbus-dev
+package: golang-dbus-dev
 
 15、source package:golang-github-msteinert-pam-dev 1.1.0-1
-package:
-golang-github-msteinert-pam-dev
+package: golang-github-msteinert-pam-dev
 
 16、source package:golang-gopkg-check.v1-dev 0.0+git20200902.038fdea-1
-package:
-golang-gopkg-check.v1-dev
+package: golang-gopkg-check.v1-dev
 
 17、source package:graceful-fs 1.2.3
-package:
-graceful-fs
+package: graceful-fs
 
 18、source package:libarchive-dev 3.4.0-2~bpo9+1_amd64
-package:
-libarchive-dev
+package: libarchive-dev
 
 19、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 20、source package:libtss2-dev 2.4.0-1_s390x
-package:
-libtss2-dev
+package: libtss2-dev
 
 21、source package:libtss2-tcti-tabrmd0 3.0.0-1
-package:
-libtss2-tcti-tabrmd0
+package: libtss2-tcti-tabrmd0
 
 22、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 23、source package:normalize-package-data 2.5.0
-package:
-normalize-package-data
+package: normalize-package-data
 
 24、source package:sdparm 1.12-1
-package:
-sdparm
+package: sdparm
 
 25、source package:shim-signed 1.39~1+deb11u1
-package:
-shim-signed
+package: shim-signed
 
 26、source package:shim-unsigned 15+1533136590.3beb971-9_i386
-package:
-shim-unsigned
+package: shim-unsigned
 
 27、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 28、source package:tpm2-abrmd 3.0.0-1
-package:
-tpm2-abrmd
+package: tpm2-abrmd
 
 29、source package:tt v1.0.1
-package:
-tt
+package: tt
 
 30、source package:uri-js 4.4.0
-package:
-uri-js
+package: uri-js
 
 31、source package:usb-modeswitch 2.6.1.orig
-package:
-usb-modeswitch
+package: usb-modeswitch
 
 
 Open Source Software Licensed under the MPL-2.0:
 1、source package:browser-desktop 87.0-729282885
-package:
-browser-desktop
+package: browser-desktop
 
 2、source package:dompurify 2.4.1
-package:
-dompurify
+package: dompurify
 
 3、source package:libjwt-dev 1.9.0-4_mips64el
-package:
-libjwt-dev
+package: libjwt-dev
 
 4、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 
 Open Source Software Licensed under the MPL-1.1:
 1、source package:libcairo2-dev 1.16.0-4_s390x
-package:
-libcairo2-dev
+package: libcairo2-dev
 
 2、source package:libchardet 1.0.3
-package:
-libchardet
+package: libchardet
 
 3、source package:libpam-gnome-keyring 3.4.1-5_sparc
-package:
-libpam-gnome-keyring
+package: libpam-gnome-keyring
 
 4、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 
 Open Source Software Licensed under the AFL-2.1:
 1、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 
 Open Source Software Licensed under the AGPL-1.0-only:
 1、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 
 Open Source Software Licensed under the AGPL-3.0-only:
 1、source package:nging v3.5.2
-package:
-nging
+package: nging
 
 2、source package:sobjectizer 1.2.3
-package:
-sobjectizer
+package: sobjectizer
 
 
 Open Source Software Licensed under the Apache-2.0 or LGPL-3+:
 1、source package:liblucene++-dev 3.0.7-8+b2_s390x
-package:
-liblucene++-dev
+package: liblucene++-dev
 
 
 Open Source Software Licensed under the Apache-2.0-with-GPL2-LGPL2-Exception:
 1、source package:cups 2.4.2-3+deb12u1
-package:
-cups
+package: cups
 
 
 Open Source Software Licensed under the Artistic or GPL-1+:
 1、source package:libfile-mimeinfo-perl 0.33-1
-package:
-libfile-mimeinfo-perl
+package: libfile-mimeinfo-perl
 
 2、source package:perl-openssl-defaults 7
-package:
-perl-openssl-defaults
+package: perl-openssl-defaults
 
 
 Open Source Software Licensed under the Artistic-2.0:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the BSD:
 1、source package:compiler 4.12.0
-package:
-compiler
+package: compiler
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:glide 4.12.0
-package:
-glide
+package: glide
 
 4、source package:libnet-dev 1.2-rc3
-package:
-libnet-dev
+package: libnet-dev
 
 5、source package:libvncserver LibVNCServer-0.9.14
-package:
-libvncserver
+package: libvncserver
 
 6、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 7、source package:node 8.16.1
-package:
-node
+package: node
 
 8、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 9、source package:zip 3.0-9
-package:
-zip
+package: zip
 
 
 Open Source Software Licensed under the BSD-1-Clause:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 
 Open Source Software Licensed under the BSD-3-clause:
 1、source package:tpm2-tools 5.4-1
-package:
-tpm2-tools
+package: tpm2-tools
 
 
 Open Source Software Licensed under the BSD-3-clause or GPL-2:
 1、source package:libcap-dev 2.36-1_mips64el
-package:
-libcap-dev
+package: libcap-dev
 
 2、source package:libcap2-bin 2.36-1_s390x
-package:
-libcap2-bin
+package: libcap2-bin
 
 
 Open Source Software Licensed under the BSD-4-Clause:
 1、source package:unalz 0.65-9
-package:
-unalz
+package: unalz
 
 
 Open Source Software Licensed under the BSD-Source-Code:
 1、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 
 Open Source Software Licensed under the BSL-1.0:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 
 Open Source Software Licensed under the Bitstream-Vera:
 1、source package:fontconfig 2.9.0.orig
-package:
-fontconfig
+package: fontconfig
 
 
 Open Source Software Licensed under the Brian-Gladman-3-Clause:
 1、source package:libzip-dev 1.6.1-3_s390x
-package:
-libzip-dev
+package: libzip-dev
 
 2、source package:libzip4 1.6.1-3_s390x
-package:
-libzip4
+package: libzip4
 
 
 Open Source Software Licensed under the CC-BY-3.0:
 1、source package:spdx-exceptions 2.3.0
-package:
-spdx-exceptions
+package: spdx-exceptions
 
 
 Open Source Software Licensed under the CC-BY-4.0:
 1、source package:caniuse-lite 1.0.30000989
-package:
-caniuse-lite
+package: caniuse-lite
 
 
 Open Source Software Licensed under the CC-BY-SA-4.0:
 1、source package:glob 7.1.4
-package:
-glob
+package: glob
 
 
 Open Source Software Licensed under the CC0-1.0:
 1、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 
 Open Source Software Licensed under the CDDL-1.0:
 1、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 
 Open Source Software Licensed under the CPL-1.0:
 1、source package:graphviz 2.8-3+etch1
-package:
-graphviz
+package: graphviz
 
 2、source package:junit 4.11
-package:
-junit
+package: junit
 
 
 Open Source Software Licensed under the EPL-1.0:
 1、source package:aspectjrt 1.9.6
-package:
-aspectjrt
+package: aspectjrt
 
 2、source package:junit 4.13.2
-package:
-junit
+package: junit
 
 
 Open Source Software Licensed under the FTL:
 1、source package:freetype VER-2-10-3
-package:
-freetype
+package: freetype
 
 2、source package:libfreetype-dev 2.13.0+dfsg-1
-package:
-libfreetype-dev
+package: libfreetype-dev
 
 
 Open Source Software Licensed under the Font-exception-2.0:
 1、source package:ttf-unifont 9.0.06-2_all
-package:
-ttf-unifont
+package: ttf-unifont
 
 2、source package:xfonts-wqy 1.0.0~rc1-7
-package:
-xfonts-wqy
+package: xfonts-wqy
 
 
 Open Source Software Licensed under the GFDL-1.2-only:
 1、source package:kdevelop v22.11.80
-package:
-kdevelop
+package: kdevelop
 
 
 Open Source Software Licensed under the GPL+ and GPLv2+ and MIT and Redistributable no modification permitted:
 1、source package:linux-firmware 20230824
-package:
-linux-firmware
+package: linux-firmware
 
 
 Open Source Software Licensed under the GPL-2 or GPL-2+:
 1、source package:ipheth-utils 1.0-5_s390x
-package:
-ipheth-utils
+package: ipheth-utils
 
 
 Open Source Software Licensed under the GPL-2 with Font embedding exception and M+ FONTS License:
 1、source package:fonts-wqy-zenhei 0.9.45-8
-package:
-fonts-wqy-zenhei
+package: fonts-wqy-zenhei
 
 
 Open Source Software Licensed under the GPL-2 with OpenSSL exception:
 1、source package:barrier 2.4.0+dfsg-2
-package:
-barrier
+package: barrier
 
 
 Open Source Software Licensed under the GPL-2+ and LGPL-2+:
 1、source package:xdg-desktop-portal-gtk 1.8.0-1~bpo10+1
-package:
-xdg-desktop-portal-gtk
+package: xdg-desktop-portal-gtk
 
 
 Open Source Software Licensed under the GPL-2+ or AFL-2.1:
 1、source package:dbus 1.9.8-1
-package:
-dbus
+package: dbus
 
 2、source package:dbus-user-session 1.13.8-1_s390x
-package:
-dbus-user-session
+package: dbus-user-session
 
 3、source package:dbus-x11 1.8.22-0+deb8u1_s390x
-package:
-dbus-x11
+package: dbus-x11
 
 4、source package:libdbus-1-dev 1.8.22-0+deb8u1_s390x
-package:
-libdbus-1-dev
+package: libdbus-1-dev
 
 
 Open Source Software Licensed under the GPL-2+ or FTL:
 1、source package:libfreetype6-dev 2.9.1-4_s390x
-package:
-libfreetype6-dev
+package: libfreetype6-dev
 
 
 Open Source Software Licensed under the GPL-2+ or LGPL-2.1 or LGPL-3.0:
 1、source package:libquazip5-dev 0.7.6-6_s390x
-package:
-libquazip5-dev
+package: libquazip5-dev
 
 
 Open Source Software Licensed under the GPL-2+ with OpenSSL exception:
 1、source package:cryptsetup 2:2.6.1-4
-package:
-cryptsetup
+package: cryptsetup
 
 2、source package:cryptsetup-initramfs 2.3.1-1_all
-package:
-cryptsetup-initramfs
+package: cryptsetup-initramfs
 
 3、source package:libcryptsetup12 2.3.1-1_s390x
-package:
-libcryptsetup12
+package: libcryptsetup12
 
 
 Open Source Software Licensed under the GPL-2+ with SSL exception:
 1、source package:remmina 1.4.8+dfsg-2~bpo10+2
-package:
-remmina
+package: remmina
 
 2、source package:remmina-plugin-rdp 1.4.7+dfsg-1_s390x
-package:
-remmina-plugin-rdp
+package: remmina-plugin-rdp
 
 3、source package:remmina-plugin-vnc 1.4.7+dfsg-1_s390x
-package:
-remmina-plugin-vnc
+package: remmina-plugin-vnc
 
 
 Open Source Software Licensed under the GPL-2+ with sane exception:
 1、source package:libsane-dev 1.2.1-4
-package:
-libsane-dev
+package: libsane-dev
 
 
 Open Source Software Licensed under the GPL-2.0 or GPL-3.0 or FIPL-1.0:
 1、source package:libfreeimage-dev 3.18.0+ds2-3_s390x
-package:
-libfreeimage-dev
+package: libfreeimage-dev
 
 
 Open Source Software Licensed under the GPL-2.0+ or LGPL-2.1+:
 1、source package:fcitx5-frontend-gtk3 0.0~git20200606.fc335f1-2_s390x
-package:
-fcitx5-frontend-gtk3
+package: fcitx5-frontend-gtk3
 
 
 Open Source Software Licensed under the GPL-3 with Qt-1.0 exception:
 1、source package:qttools5-dev 5.9.2-4_kfreebsd-i386
-package:
-qttools5-dev
+package: qttools5-dev
 
 2、source package:qttools5-dev-tools 5.9.2-4_kfreebsd-i386
-package:
-qttools5-dev-tools
+package: qttools5-dev-tools
 
 3、source package:qttranslations5-l10n 5.9.2-1
-package:
-qttranslations5-l10n
+package: qttranslations5-l10n
 
 
 Open Source Software Licensed under the GPL-3+ or Less:
 1、source package:less 590-2
-package:
-less
+package: less
 
 
 Open Source Software Licensed under the GPL-3+ with OpenSSL exception:
 1、source package:libdmr-dev 5.7.6.147-1
-package:
-libdmr-dev
+package: libdmr-dev
 
 
 Open Source Software Licensed under the GPL-3.0-with-Qt-1.0-exception:
 1、source package:libqt5webchannel5-dev 5.7.1-2_s390x
-package:
-libqt5webchannel5-dev
+package: libqt5webchannel5-dev
 
 2、source package:qml-module-qtwebchannel 5.9.2-3
-package:
-qml-module-qtwebchannel
+package: qml-module-qtwebchannel
 
 
 Open Source Software Licensed under the GPL-any:
 1、source package:command-not-found 23.04.0-1
-package:
-command-not-found
+package: command-not-found
 
 
 Open Source Software Licensed under the Hylafax:
 1、source package:libtiff-dev 4.1.0+git191117-2~deb10u1_s390x
-package:
-libtiff-dev
+package: libtiff-dev
 
 
 Open Source Software Licensed under the ICU:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 2、source package:x11-xserver-utils 7.7~3_sparc
-package:
-x11-xserver-utils
+package: x11-xserver-utils
 
 3、source package:xkb-data 2.5.1-3_all
-package:
-xkb-data
+package: xkb-data
 
 4、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 5、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the ISC:
 1、source package:abbrev 1.1.1
-package:
-abbrev
+package: abbrev
 
 2、source package:anymatch 3.1.2
-package:
-anymatch
+package: anymatch
 
 3、source package:aproba 1.2.0
-package:
-aproba
+package: aproba
 
 4、source package:are-we-there-yet 1.1.5
-package:
-are-we-there-yet
+package: are-we-there-yet
 
 5、source package:boolbase 1.0.0
-package:
-boolbase
+package: boolbase
 
 6、source package:browserify-sign 4.2.1
-package:
-browserify-sign
+package: browserify-sign
 
 7、source package:cliui 4.1.0
-package:
-cliui
+package: cliui
 
 8、source package:color-support 1.1.3
-package:
-color-support
+package: color-support
 
 9、source package:concat-with-sourcemaps 1.1.0
-package:
-concat-with-sourcemaps
+package: concat-with-sourcemaps
 
 10、source package:console-control-strings 1.1.0
-package:
-console-control-strings
+package: console-control-strings
 
 11、source package:crda 4.14+git20191112.9856751.orig
-package:
-crda
+package: crda
 
 12、source package:d 1.0.1
-package:
-d
+package: d
 
 13、source package:distro-info-data 0.9~bpo60+1
-package:
-distro-info-data
+package: distro-info-data
 
 14、source package:electron-to-chromium 1.3.254
-package:
-electron-to-chromium
+package: electron-to-chromium
 
 15、source package:es5-ext 0.10.53
-package:
-es5-ext
+package: es5-ext
 
 16、source package:es6-symbol 3.1.3
-package:
-es6-symbol
+package: es6-symbol
 
 17、source package:es6-weak-map 2.0.3
-package:
-es6-weak-map
+package: es6-weak-map
 
 18、source package:ext 1.4.0
-package:
-ext
+package: ext
 
 19、source package:fastq 1.13.0
-package:
-fastq
+package: fastq
 
 20、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 21、source package:fs 0.0.1-security
-package:
-fs
+package: fs
 
 22、source package:fs.realpath 1.0.0
-package:
-fs.realpath
+package: fs.realpath
 
 23、source package:fstream 1.0.12
-package:
-fstream
+package: fstream
 
 24、source package:gauge 2.7.4
-package:
-gauge
+package: gauge
 
 25、source package:get-caller-file 1.0.3
-package:
-get-caller-file
+package: get-caller-file
 
 26、source package:glob 7.1.4
-package:
-glob
+package: glob
 
 27、source package:glob-parent 5.1.2
-package:
-glob-parent
+package: glob-parent
 
 28、source package:go-spew v1.1.1
-package:
-go-spew
+package: go-spew
 
 29、source package:go-wav v0.3.2
-package:
-go-wav
+package: go-wav
 
 30、source package:golang-github-nfnt-resize-dev 0.0~git20180221.83c6a99-2_all
-package:
-golang-github-nfnt-resize-dev
+package: golang-github-nfnt-resize-dev
 
 31、source package:graceful-fs 4.2.4
-package:
-graceful-fs
+package: graceful-fs
 
 32、source package:har-schema 2.0.0
-package:
-har-schema
+package: har-schema
 
 33、source package:has-unicode 2.0.1
-package:
-has-unicode
+package: has-unicode
 
 34、source package:hosted-git-info 2.8.8
-package:
-hosted-git-info
+package: hosted-git-info
 
 35、source package:in-publish 2.0.0
-package:
-in-publish
+package: in-publish
 
 36、source package:inflight 1.0.6
-package:
-inflight
+package: inflight
 
 37、source package:inherits 2.0.4
-package:
-inherits
+package: inherits
 
 38、source package:ini 1.3.5
-package:
-ini
+package: ini
 
 39、source package:isexe 2.0.0
-package:
-isexe
+package: isexe
 
 40、source package:json-stringify-safe 5.0.1
-package:
-json-stringify-safe
+package: json-stringify-safe
 
 41、source package:lru-cache 4.1.5
-package:
-lru-cache
+package: lru-cache
 
 42、source package:minimalistic-assert 1.0.1
-package:
-minimalistic-assert
+package: minimalistic-assert
 
 43、source package:minimatch 5.1.6
-package:
-minimatch
+package: minimatch
 
 44、source package:natives 1.1.6
-package:
-natives
+package: natives
 
 45、source package:node 8.16.1
-package:
-node
+package: node
 
 46、source package:node-bin-setup 1.0.6
-package:
-node-bin-setup
+package: node-bin-setup
 
 47、source package:nopt 3.0.6
-package:
-nopt
+package: nopt
 
 48、source package:npmlog 4.1.2
-package:
-npmlog
+package: npmlog
 
 49、source package:once 1.4.0
-package:
-once
+package: once
 
 50、source package:osenv 0.1.5
-package:
-osenv
+package: osenv
 
 51、source package:parse-asn1 5.1.6
-package:
-parse-asn1
+package: parse-asn1
 
 52、source package:pkgconf 1.8.1-2
-package:
-pkgconf
+package: pkgconf
 
 53、source package:pseudomap 1.0.2
-package:
-pseudomap
+package: pseudomap
 
 54、source package:python3-dnspython 2.4.0~rc1-1
-package:
-python3-dnspython
+package: python3-dnspython
 
 55、source package:remove-trailing-separator 1.1.0
-package:
-remove-trailing-separator
+package: remove-trailing-separator
 
 56、source package:require-main-filename 1.0.1
-package:
-require-main-filename
+package: require-main-filename
 
 57、source package:rimraf 2.7.1
-package:
-rimraf
+package: rimraf
 
 58、source package:rollup 2.79.1
-package:
-rollup
+package: rollup
 
 59、source package:semver 5.7.1
-package:
-semver
+package: semver
 
 60、source package:set-blocking 2.0.0
-package:
-set-blocking
+package: set-blocking
 
 61、source package:sigmund 1.0.1
-package:
-sigmund
+package: sigmund
 
 62、source package:signal-exit 3.0.3
-package:
-signal-exit
+package: signal-exit
 
 63、source package:tar 2.2.2
-package:
-tar
+package: tar
 
 64、source package:type 2.1.0
-package:
-type
+package: type
 
 65、source package:vinyl-sourcemaps-apply 0.2.1
-package:
-vinyl-sourcemaps-apply
+package: vinyl-sourcemaps-apply
 
 66、source package:which 1.3.1
-package:
-which
+package: which
 
 67、source package:which-module 2.0.0
-package:
-which-module
+package: which-module
 
 68、source package:wide-align 1.1.3
-package:
-wide-align
+package: wide-align
 
 69、source package:wrappy 1.0.2
-package:
-wrappy
+package: wrappy
 
 70、source package:y18n 3.2.1
-package:
-y18n
+package: y18n
 
 71、source package:yallist 2.1.2
-package:
-yallist
+package: yallist
 
 72、source package:yargs-parser 8.1.0
-package:
-yargs-parser
+package: yargs-parser
 
 
 Open Source Software Licensed under the ImageMagick:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 
 Open Source Software Licensed under the Info-ZIP:
 1、source package:unzip 6.0.orig
-package:
-unzip
+package: unzip
 
 
 Open Source Software Licensed under the LGPL:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 2、source package:libatspi2.0-dev 2.5.3-2_sparc
-package:
-libatspi2.0-dev
+package: libatspi2.0-dev
 
 3、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 4、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 5、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 6、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 
 Open Source Software Licensed under the LGPL-2+ and LGPL-2.1+:
 1、source package:ostree 2023.3-2
-package:
-ostree
+package: ostree
 
 
 Open Source Software Licensed under the LGPL-2+ and LGPL-2.1+ and FSFULLR and CC0-1.0 and Janik-permissive and Iconv-PD and Mingw-PD and Old-GLib-Tests-permissive:
 1、source package:libglib2.0-bin 2.76.4-1
-package:
-libglib2.0-bin
+package: libglib2.0-bin
 
 
 Open Source Software Licensed under the LGPL-2.0+ and Expat:
 1、source package:policykit-1 122-4
-package:
-policykit-1
+package: policykit-1
 
 
 Open Source Software Licensed under the LGPL-2.0-or-later:
 1、source package:bubblewrap 0~git160513-2
-package:
-bubblewrap
+package: bubblewrap
 
 2、source package:gvfs-backends 1.44.1-1_s390x
-package:
-gvfs-backends
+package: gvfs-backends
 
 3、source package:gvfs-bin 1.44.1-1_s390x
-package:
-gvfs-bin
+package: gvfs-bin
 
 4、source package:gvfs-fuse 1.44.1-1_s390x
-package:
-gvfs-fuse
+package: gvfs-fuse
 
 5、source package:kcalcore 5:5.85.0-2
-package:
-kcalcore
+package: kcalcore
 
 6、source package:kdeclarative 5.100.0-1
-package:
-kdeclarative
+package: kdeclarative
 
 7、source package:libasound2-dev 1.2.2-2.3_ppc64el
-package:
-libasound2-dev
+package: libasound2-dev
 
 8、source package:libgdk-pixbuf2.0-0 2.40.2-3
-package:
-libgdk-pixbuf2.0-0
+package: libgdk-pixbuf2.0-0
 
 9、source package:libgdk-pixbuf2.0-dev 2.40.0+dfsg-5_s390x
-package:
-libgdk-pixbuf2.0-dev
+package: libgdk-pixbuf2.0-dev
 
 10、source package:libkf5itemviews-dev 5.70.0-1_s390x
-package:
-libkf5itemviews-dev
+package: libkf5itemviews-dev
 
 11、source package:libkf5widgetsaddons-dev 5.70.0-1_s390x
-package:
-libkf5widgetsaddons-dev
+package: libkf5widgetsaddons-dev
 
 12、source package:libmtp-runtime 1.1.9-3~bpo8+1
-package:
-libmtp-runtime
+package: libmtp-runtime
 
 13、source package:libpolkit-agent-1-dev 0.116-2_s390x
-package:
-libpolkit-agent-1-dev
+package: libpolkit-agent-1-dev
 
 14、source package:libpolkit-qt5-1-dev 0.112.0-7_s390x
-package:
-libpolkit-qt5-1-dev
+package: libpolkit-qt5-1-dev
 
 15、source package:librsvg2-bin 2.48.7-1_ppc64el
-package:
-librsvg2-bin
+package: librsvg2-bin
 
 16、source package:platform/external/e2fsprogs lollipop-dev
-package:
-platform/external/e2fsprogs
+package: platform/external/e2fsprogs
 
 17、source package:xdg-desktop-portal 1.8.1-1~bpo10+1
-package:
-xdg-desktop-portal
+package: xdg-desktop-portal
 
 
 Open Source Software Licensed under the LGPL-2.1 or MPL-2.0:
 1、source package:libical-dev 3.0.8-2_mipsel
-package:
-libical-dev
+package: libical-dev
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2-or-3 with KDE Exception:
 1、source package:qml6-module-qtwebchannel 6.4.2~rc1-3
-package:
-qml6-module-qtwebchannel
+package: qml6-module-qtwebchannel
 
 
 Open Source Software Licensed under the LGPL-3Qt-1.1Exception or GPL-2Qt-1.1Exception:
 1、source package:qml-module-qtwebengine 5.7.1+dfsg-6.1_mipsel
-package:
-qml-module-qtwebengine
+package: qml-module-qtwebengine
 
 2、source package:qtwebengine5-dev 5.7.1+dfsg-6.1_mipsel
-package:
-qtwebengine5-dev
+package: qtwebengine5-dev
 
 
 Open Source Software Licensed under the LGPLv2 with exceptions or GPLv3 with exceptions and GFDL:
 1、source package:libqt6svg6 6.4.1
-package:
-libqt6svg6
+package: libqt6svg6
 
 
 Open Source Software Licensed under the Libpng:
 1、source package:libpng-dev 1.6.37-2_s390x
-package:
-libpng-dev
+package: libpng-dev
 
 2、source package:libsdl2-dev 2.0.9+dfsg1-1_s390x
-package:
-libsdl2-dev
+package: libsdl2-dev
 
 
 Open Source Software Licensed under the Linux-syscall-note:
 1、source package:pinn 0.0
-package:
-pinn
+package: pinn
 
 
 Open Source Software Licensed under the MITNFA:
 1、source package:through2 0.6.5
-package:
-through2
+package: through2
 
 
 Open Source Software Licensed under the MPL-1.1 or GPL-2+ or LGPL-2.1+:
 1、source package:libchardet-dev 1.0.4-1_s390x
-package:
-libchardet-dev
+package: libchardet-dev
 
 2、source package:libchardet1 1.0.4-1_s390x
-package:
-libchardet1
+package: libchardet1
 
 3、source package:libuchardet-dev 0.0.7-1_s390x
-package:
-libuchardet-dev
+package: libuchardet-dev
 
 4、source package:libuchardet0 0.0.7-1_s390x
-package:
-libuchardet0
+package: libuchardet0
 
 
 Open Source Software Licensed under the NAIST-2003:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Net-SNMP:
 1、source package:sudo 1.9.8p2-1~exp1
-package:
-sudo
+package: sudo
 
 
 Open Source Software Licensed under the OFL-1.1:
 1、source package:fonts-intel-one-mono 1.2.1-2
-package:
-fonts-intel-one-mono
+package: fonts-intel-one-mono
 
 2、source package:fonts-lohit-deva 2.95.4.orig
-package:
-fonts-lohit-deva
+package: fonts-lohit-deva
 
 3、source package:fonts-noto 20201225-1
-package:
-fonts-noto
+package: fonts-noto
 
 4、source package:fonts-noto-mono 20200323-1_all
-package:
-fonts-noto-mono
+package: fonts-noto-mono
 
 
 Open Source Software Licensed under the OpenSSL:
 1、source package:libssl1.1 1.1.1~~pre9-1
-package:
-libssl1.1
+package: libssl1.1
 
 2、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the PD:
 1、source package:xz-utils 5.4.1-0.2
-package:
-xz-utils
+package: xz-utils
 
 
 Open Source Software Licensed under the Public Domain:
 1、source package:debianutils 5.8-1
-package:
-debianutils
+package: debianutils
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:grub-efi-amd64-signed 1+2.06+8.1
-package:
-grub-efi-amd64-signed
+package: grub-efi-amd64-signed
 
 4、source package:grub-efi-arm64-signed 1+2.06+8.1
-package:
-grub-efi-arm64-signed
+package: grub-efi-arm64-signed
 
 5、source package:jsonify 0.0.0
-package:
-jsonify
+package: jsonify
 
 6、source package:libatspi2.0-dev 2.5.3-2_sparc
-package:
-libatspi2.0-dev
+package: libatspi2.0-dev
 
 7、source package:libsqlite3-0 3.8.7.1-1_kfreebsd-i386
-package:
-libsqlite3-0
+package: libsqlite3-0
 
 8、source package:libsqlite3-dev 3.8.7.1-1_kfreebsd-i386
-package:
-libsqlite3-dev
+package: libsqlite3-dev
 
 9、source package:sqlite3 3.9.2-1
-package:
-sqlite3
+package: sqlite3
 
 10、source package:tzdata 2023c-7
-package:
-tzdata
+package: tzdata
 
 
 Open Source Software Licensed under the Python-2.0:
 1、source package:python3 3.8.2-3_s390x
-package:
-python3
+package: python3
 
 
 Open Source Software Licensed under the Qt-GPL-exception-1.0:
 1、source package:qtremoteobjects v5.11.0-rc2
-package:
-qtremoteobjects
+package: qtremoteobjects
 
 
 Open Source Software Licensed under the Rdisc:
 1、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 
 Open Source Software Licensed under the SGI-B-1.1:
 1、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 2、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the SGI-B-2.0:
 1、source package:libegl1-mesa-dev 8.0.5-4+deb7u2_sparc
-package:
-libegl1-mesa-dev
+package: libegl1-mesa-dev
 
 2、source package:libgbm-dev 8.0.5-4+deb7u2_sparc
-package:
-libgbm-dev
+package: libgbm-dev
 
 3、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 4、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the SIL-1.1:
 1、source package:fonts-noto-cjk 20190410+repack1-2.debian
-package:
-fonts-noto-cjk
+package: fonts-noto-cjk
 
 
 Open Source Software Licensed under the SSLeay:
 1、source package:libssl1.1 1.1.1~~pre9-1
-package:
-libssl1.1
+package: libssl1.1
 
 
 Open Source Software Licensed under the Sleepycat:
 1、source package:go-difflib v1.0.0
-package:
-go-difflib
+package: go-difflib
 
 
 Open Source Software Licensed under the The Bugly Software License Version 1.0:
 1、source package:crashreport 3.4.4
-package:
-crashreport
+package: crashreport
 
 2、source package:nativecrashreport 3.9.2
-package:
-nativecrashreport
+package: nativecrashreport
 
 
 Open Source Software Licensed under the Unicode-DFS-2015:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 
 Open Source Software Licensed under the Unicode-DFS-2016:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Unicode-TOU:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Unlicense:
 1、source package:ncompress 4.2.4.6.orig
-package:
-ncompress
+package: ncompress
 
 2、source package:tortellini 4f6795a
-package:
-tortellini
+package: tortellini
 
 3、source package:tweetnacl 0.14.5
-package:
-tweetnacl
+package: tweetnacl
 
 
 Open Source Software Licensed under the Vim:
 1、source package:vim 8.2.0716.orig
-package:
-vim
+package: vim
 
 
 Open Source Software Licensed under the X11:
 1、source package:libwayland-dev 1.6.0-2_s390x
-package:
-libwayland-dev
+package: libwayland-dev
 
 2、source package:libxcb-image0-dev 0.4.0-1_s390x
-package:
-libxcb-image0-dev
+package: libxcb-image0-dev
 
 3、source package:libxcb-keysyms1-dev 0.4.0-1_s390x
-package:
-libxcb-keysyms1-dev
+package: libxcb-keysyms1-dev
 
 4、source package:libyaml-cpp-dev 0.6.3-9_s390x
-package:
-libyaml-cpp-dev
+package: libyaml-cpp-dev
 
 5、source package:ncurses-base 6.2-1_all
-package:
-ncurses-base
+package: ncurses-base
 
 6、source package:wordwrap 0.0.2
-package:
-wordwrap
+package: wordwrap
 
 
 Open Source Software Licensed under the Xnet:
 1、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 
 Open Source Software Licensed under the Zlib:
 1、source package:avfs 1.1.4-2
-package:
-avfs
+package: avfs
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:libminizip-dev 1.1-8_hurd-i386
-package:
-libminizip-dev
+package: libminizip-dev
 
 4、source package:libsdl2-dev 2.0.9+dfsg1-1_s390x
-package:
-libsdl2-dev
+package: libsdl2-dev
 
 5、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 6、source package:node 8.16.1
-package:
-node
+package: node
 
 7、source package:pako 1.0.11
-package:
-pako
+package: pako
 
 8、source package:pigz 2.6-1
-package:
-pigz
+package: pigz
 
 9、source package:unalz 0.65-9
-package:
-unalz
+package: unalz
 
 10、source package:zlib1g 1.2.8.dfsg-5_s390x
-package:
-zlib1g
+package: zlib1g
 
 11、source package:zlib1g-dev 1:1.2.3.3.dfsg-1
-package:
-zlib1g-dev
+package: zlib1g-dev
 
 
 Open Source Software Licensed under the copyleft-next-0.3.0:
 1、source package:crda 4.14+git20191112.9856751.orig
-package:
-crda
+package: crda
 
 
 Open Source Software Licensed under the cryptsetup-OpenSSL-exception:
 1、source package:aria2 1.9.5-1
-package:
-aria2
+package: aria2
 
 2、source package:libcryptsetup-dev 2:2.4.0-1
-package:
-libcryptsetup-dev
+package: libcryptsetup-dev
 
 
 Open Source Software Licensed under the curl:
 1、source package:curl 8.0.1-1~exp1
-package:
-curl
+package: curl
 
 2、source package:libcurl4-openssl-dev 7.68.0-1_s390x
-package:
-libcurl4-openssl-dev
+package: libcurl4-openssl-dev
 
 
 Open Source Software Licensed under the hdparm:
 1、source package:hdparm 9.65+ds-1
-package:
-hdparm
+package: hdparm
 
 
 Open Source Software Licensed under the nolicense:
 1、source package:FreeBSD-Electron v9.0.3
-package:
-FreeBSD-Electron
+package: FreeBSD-Electron
 
 2、source package:LTSLAM 94d7e0f
-package:
-LTSLAM
+package: LTSLAM
 
 3、source package:TSFileEditor 0.2.1
-package:
-TSFileEditor
+package: TSFileEditor
 
 4、source package:asio asio-1-29-0
-package:
-asio
+package: asio
 
 5、source package:chromium-source-tarball 59.0.3071.57
-package:
-chromium-source-tarball
+package: chromium-source-tarball
 
 6、source package:geek-navigation 5a521f2
-package:
-geek-navigation
+package: geek-navigation
 
 7、source package:gentoo 202
-package:
-gentoo
+package: gentoo
 
 8、source package:go-urn v1.1.0
-package:
-go-urn
+package: go-urn
 
 9、source package:imaging v1.6.2
-package:
-imaging
+package: imaging
 
 10、source package:kcrash 5.103.0-1
-package:
-kcrash
+package: kcrash
 
 11、source package:ncnn_paddleocr 9c054d3
-package:
-ncnn_paddleocr
+package: ncnn_paddleocr
 
 12、source package:plasma-workspace v5.25.90
-package:
-plasma-workspace
+package: plasma-workspace
 
 13、source package:platform/external/qt emu-29.0-release
-package:
-platform/external/qt
+package: platform/external/qt
 
 14、source package:qtbase v6.5.1
-package:
-qtbase
+package: qtbase
 
 15、source package:qtxlsxwriter v0.3.0
-package:
-qtxlsxwriter
+package: qtxlsxwriter
 
 16、source package:scriptcommunicator_serial-terminal Release_06_02
-package:
-scriptcommunicator_serial-terminal
+package: scriptcommunicator_serial-terminal
 
 17、source package:socket v0.4.1
-package:
-socket
+package: socket
 
 18、source package:strace v4.14
-package:
-strace
+package: strace
 
 19、source package:v5 v5.1.0
-package:
-v5
+package: v5
 
 20、source package:wlr-protocols d278d20
-package:
-wlr-protocols
+package: wlr-protocols
 
 
 Copy of Licenses

--- a/src/plugin-systeminfo/operation/qrc/gpl/gpl-3.0-zh_CN-body.txt
+++ b/src/plugin-systeminfo/operation/qrc/gpl/gpl-3.0-zh_CN-body.txt
@@ -2,6580 +2,4989 @@ The notice provides license information of respective open source software conta
 
 Open Source Software Licensed under the GPL-3.0-or-later:
 1、source package:accountsservice 23.13.9-2
-package:
-accountsservice
+package: accountsservice
 
 2、source package:cifs-utils 6.9.orig
-package:
-cifs-utils
+package: cifs-utils
 
 3、source package:coreutils 9.1-1
-package:
-coreutils
+package: coreutils
 
 4、source package:dosfstools 4.2-1
-package:
-dosfstools
+package: dosfstools
 
 5、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 6、source package:fonts-wqy-microhei 0.2.0-beta-3.1
-package:
-fonts-wqy-microhei
+package: fonts-wqy-microhei
 
 7、source package:gawk 5.0.1+dfsg.orig
-package:
-gawk
+package: gawk
 
 8、source package:gettext 0.21.1
-package:
-gettext
+package: gettext
 
 9、source package:gettext-base 0.19.8.1-9_s390x
-package:
-gettext-base
+package: gettext-base
 
 10、source package:gnupg 2.2.19-3_all
-package:
-gnupg
+package: gnupg
 
 11、source package:golang-gir-gobject-2.0-dev 2.2.0-1
-package:
-golang-gir-gobject-2.0-dev
+package: golang-gir-gobject-2.0-dev
 
 12、source package:gpgv 2.2.20-1~bpo9+1_s390x
-package:
-gpgv
+package: gpgv
 
 13、source package:grub-common 2.06-9
-package:
-grub-common
+package: grub-common
 
 14、source package:grub2-common 2.04~rc1-3_ppc64el
-package:
-grub2-common
+package: grub2-common
 
 15、source package:grub2-theme-vimix c7ab3ce
-package:
-grub2-theme-vimix
+package: grub2-theme-vimix
 
 16、source package:guvcview 2.0.2
-package:
-guvcview
+package: guvcview
 
 17、source package:hello 2.9-2_kfreebsd-i386
-package:
-hello
+package: hello
 
 18、source package:libparted-dev 3.3-4_s390x
-package:
-libparted-dev
+package: libparted-dev
 
 19、source package:libparted-fs-resize0 3.3-4_s390x
-package:
-libparted-fs-resize0
+package: libparted-fs-resize0
 
 20、source package:live-boot 5.0~a5-2
-package:
-live-boot
+package: live-boot
 
 21、source package:live-boot-initramfs-tools 4.0.2-1_all
-package:
-live-boot-initramfs-tools
+package: live-boot-initramfs-tools
 
 22、source package:live-config 5.20190519_all
-package:
-live-config
+package: live-config
 
 23、source package:live-config-systemd 5.20190519_all
-package:
-live-config-systemd
+package: live-config-systemd
 
 24、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 25、source package:parted 3.6-3
-package:
-parted
+package: parted
 
 26、source package:patchelf 0.9.orig
-package:
-patchelf
+package: patchelf
 
 27、source package:pkg-kde-tools 0.9.5
-package:
-pkg-kde-tools
+package: pkg-kde-tools
 
 28、source package:python3-samba 4.12.5+dfsg-3_s390x
-package:
-python3-samba
+package: python3-samba
 
 29、source package:qtchooser 66.orig
-package:
-qtchooser
+package: qtchooser
 
 30、source package:qtremoteobjects v5.11.0-rc2
-package:
-qtremoteobjects
+package: qtremoteobjects
 
 31、source package:redshift 1.9.1-4_s390x
-package:
-redshift
+package: redshift
 
 32、source package:rsync 3.2.7-1~bpo11+1
-package:
-rsync
+package: rsync
 
 33、source package:rsyslog 8.9.0-3
-package:
-rsyslog
+package: rsyslog
 
 34、source package:samba 4.9.5+dfsg-5_mips64el
-package:
-samba
+package: samba
 
 35、source package:samba-common-bin 4.9.5+dfsg-5_s390x
-package:
-samba-common-bin
+package: samba-common-bin
 
 36、source package:samba-dsdb-modules 4.9.5+dfsg-5_s390x
-package:
-samba-dsdb-modules
+package: samba-dsdb-modules
 
 37、source package:samba-vfs-modules 4.9.5+dfsg-5_s390x
-package:
-samba-vfs-modules
+package: samba-vfs-modules
 
 38、source package:sed 4.9-1
-package:
-sed
+package: sed
 
 39、source package:smbclient 4.9.5+dfsg-5_s390x
-package:
-smbclient
+package: smbclient
 
 40、source package:startdde 6.0.6
-package:
-startdde
+package: startdde
 
 41、source package:viper v1.3.2
-package:
-viper
+package: viper
 
 
 Open Source Software Licensed under the GPL-3.0-only:
 1、source package:blur-effect 1.1.3-2
-package:
-blur-effect
+package: blur-effect
 
 2、source package:distrobox 1.4.2.1-1
-package:
-distrobox
+package: distrobox
 
 3、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 4、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 5、source package:libpoppler-glib-dev 22.12.0-2
-package:
-libpoppler-glib-dev
+package: libpoppler-glib-dev
 
 6、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 7、source package:lightdm-gtk-greeter 2.0.8-3
-package:
-lightdm-gtk-greeter
+package: lightdm-gtk-greeter
 
 8、source package:mtools 4.0.9-1
-package:
-mtools
+package: mtools
 
 9、source package:python-is-python3 8
-package:
-python-is-python3
+package: python-is-python3
 
 10、source package:tpm2-tools 5.4-1
-package:
-tpm2-tools
+package: tpm2-tools
 
 
 Open Source Software Licensed under the GPL-2.0-or-later:
 1、source package:ColumnsPlusPlus v0.0.1.2-alpha
-package:
-ColumnsPlusPlus
+package: ColumnsPlusPlus
 
 2、source package:Grub-Themes a7ec0fd
-package:
-Grub-Themes
+package: Grub-Themes
 
 3、source package:acl 2.3.1-3
-package:
-acl
+package: acl
 
 4、source package:adduser 3.99
-package:
-adduser
+package: adduser
 
 5、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 6、source package:apt-utils 2.1.7_mips64el
-package:
-apt-utils
+package: apt-utils
 
 7、source package:aptitude 0.8.9-1
-package:
-aptitude
+package: aptitude
 
 8、source package:aria2 1.9.5-1
-package:
-aria2
+package: aria2
 
 9、source package:arj 3.10.22.orig
-package:
-arj
+package: arj
 
 10、source package:attr 2.4.48-5_s390x
-package:
-attr
+package: attr
 
 11、source package:bash-completion 20080705
-package:
-bash-completion
+package: bash-completion
 
 12、source package:bc 1.07.1-3
-package:
-bc
+package: bc
 
 13、source package:bluez 5.66-1
-package:
-bluez
+package: bluez
 
 14、source package:bluez-obexd 5.52-1_s390x
-package:
-bluez-obexd
+package: bluez-obexd
 
 15、source package:ca-certificates 20230311
-package:
-ca-certificates
+package: ca-certificates
 
 16、source package:cornrow v0.8.0
-package:
-cornrow
+package: cornrow
 
 17、source package:cups-filters 1.9.0-2
-package:
-cups-filters
+package: cups-filters
 
 18、source package:cyberduck release-4-9-1
-package:
-cyberduck
+package: cyberduck
 
 19、source package:debhelper 9.20160814
-package:
-debhelper
+package: debhelper
 
 20、source package:dh-dkms 3.0.9-1
-package:
-dh-dkms
+package: dh-dkms
 
 21、source package:dh-golang 1.9
-package:
-dh-golang
+package: dh-golang
 
 22、source package:dkms 3.0.8-3
-package:
-dkms
+package: dkms
 
 23、source package:dmidecode 3.5-1
-package:
-dmidecode
+package: dmidecode
 
 24、source package:dnsmasq-base 2.89-1
-package:
-dnsmasq-base
+package: dnsmasq-base
 
 25、source package:dpkg 1.9.21
-package:
-dpkg
+package: dpkg
 
 26、source package:dpkg-dev 1.9.21
-package:
-dpkg-dev
+package: dpkg-dev
 
 27、source package:efibootmgr 17-2
-package:
-efibootmgr
+package: efibootmgr
 
 28、source package:eject 2.35.2-7_ppc64el
-package:
-eject
+package: eject
 
 29、source package:ethtool 6-0
-package:
-ethtool
+package: ethtool
 
 30、source package:exfat-fuse 1.3.0-2_armel
-package:
-exfat-fuse
+package: exfat-fuse
 
 31、source package:exfatprogs 1.2.1-2
-package:
-exfatprogs
+package: exfatprogs
 
 32、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 33、source package:foomatic-db-compressed-ppds 20230107-1
-package:
-foomatic-db-compressed-ppds
+package: foomatic-db-compressed-ppds
 
 34、source package:fprintd 1.94.2-2
-package:
-fprintd
+package: fprintd
 
 35、source package:geoclue-2.0 2.7.0-2
-package:
-geoclue-2.0
+package: geoclue-2.0
 
 36、source package:gnome-keyring 42.1-1
-package:
-gnome-keyring
+package: gnome-keyring
 
 37、source package:hwdata 0.372-1
-package:
-hwdata
+package: hwdata
 
 38、source package:im-config 0.9
-package:
-im-config
+package: im-config
 
 39、source package:imwheel 1.0.0pre12.orig
-package:
-imwheel
+package: imwheel
 
 40、source package:input-leap v2.4.0
-package:
-input-leap
+package: input-leap
 
 41、source package:ipwatchd 1.3.0
-package:
-ipwatchd
+package: ipwatchd
 
 42、source package:jfsutils 1.1.8-1
-package:
-jfsutils
+package: jfsutils
 
 43、source package:kbd 2.5.1-1
-package:
-kbd
+package: kbd
 
 44、source package:kscreenlocker-dev 5.8.6-2_s390x
-package:
-kscreenlocker-dev
+package: kscreenlocker-dev
 
 45、source package:lcov 1.9.orig
-package:
-lcov
+package: lcov
 
 46、source package:libappstreamqt-dev 0.9.8-4_kfreebsd-i386
-package:
-libappstreamqt-dev
+package: libappstreamqt-dev
 
 47、source package:libblkid-dev 2.35.2-7_mipsel
-package:
-libblkid-dev
+package: libblkid-dev
 
 48、source package:libcryptsetup-dev 2:2.4.0-1
-package:
-libcryptsetup-dev
+package: libcryptsetup-dev
 
 49、source package:libddcutil-dev 0.9.8-4_s390x
-package:
-libddcutil-dev
+package: libddcutil-dev
 
 50、source package:libdpkg-dev 1.20.5_ppc64el
-package:
-libdpkg-dev
+package: libdpkg-dev
 
 51、source package:libdvdnav-dev 6.1.0-1_s390x
-package:
-libdvdnav-dev
+package: libdvdnav-dev
 
 52、source package:libffmpegthumbnailer-dev 2.1.1-0.2_kfreebsd-amd64
-package:
-libffmpegthumbnailer-dev
+package: libffmpegthumbnailer-dev
 
 53、source package:libffmpegthumbnailer4v5 2.1.1-0.2_kfreebsd-amd64
-package:
-libffmpegthumbnailer4v5
+package: libffmpegthumbnailer4v5
 
 54、source package:libltdl-dev 2.4.7-6
-package:
-libltdl-dev
+package: libltdl-dev
 
 55、source package:libmount-dev 2.35.2-7_s390x
-package:
-libmount-dev
+package: libmount-dev
 
 56、source package:libmpv-dev 0.9.2-1+ffmpeg
-package:
-libmpv-dev
+package: libmpv-dev
 
 57、source package:libmpv1 0.6.2-2_s390x
-package:
-libmpv1
+package: libmpv1
 
 58、source package:libmpv2 0.36.0+git.20230723.60a26324
-package:
-libmpv2
+package: libmpv2
 
 59、source package:libnm-dev 1.6.2-3+deb9u2_s390x
-package:
-libnm-dev
+package: libnm-dev
 
 60、source package:libpam-fprintd 1.90.1-1_s390x
-package:
-libpam-fprintd
+package: libpam-fprintd
 
 61、source package:libvlc-dev 3.0.9.2-1
-package:
-libvlc-dev
+package: libvlc-dev
 
 62、source package:libvlc5 3.0.8-4_s390x
-package:
-libvlc5
+package: libvlc5
 
 63、source package:libvlccore-dev 3.0.8-4_s390x
-package:
-libvlccore-dev
+package: libvlccore-dev
 
 64、source package:libvncserver LibVNCServer-0.9.14
-package:
-libvncserver
+package: libvncserver
 
 65、source package:lzop 1.04-2
-package:
-lzop
+package: lzop
 
 66、source package:man-db 2.9.4-4
-package:
-man-db
+package: man-db
 
 67、source package:net-tools 2.10-0.1
-package:
-net-tools
+package: net-tools
 
 68、source package:network-manager 1.9.90-1
-package:
-network-manager
+package: network-manager
 
 69、source package:nilfs-tools 2.2.9-1
-package:
-nilfs-tools
+package: nilfs-tools
 
 70、source package:ntfs-3g 2017.3.23AR.5.orig
-package:
-ntfs-3g
+package: ntfs-3g
 
 71、source package:packagekit 1.2.6-5
-package:
-packagekit
+package: packagekit
 
 72、source package:pandoc 2.9.2.1-3
-package:
-pandoc
+package: pandoc
 
 73、source package:pciutils 3.7.0.orig
-package:
-pciutils
+package: pciutils
 
 74、source package:pinn 0.0
-package:
-pinn
+package: pinn
 
 75、source package:pkg-config 0.29.2.orig
-package:
-pkg-config
+package: pkg-config
 
 76、source package:pkg-kde-tools 0.9.5
-package:
-pkg-kde-tools
+package: pkg-kde-tools
 
 77、source package:plymouth 22.02.122-3
-package:
-plymouth
+package: plymouth
 
 78、source package:plymouth-label 0.9.4-3_s390x
-package:
-plymouth-label
+package: plymouth-label
 
 79、source package:pppoe 3.8-3_sparc
-package:
-pppoe
+package: pppoe
 
 80、source package:procps 3.3.9.orig
-package:
-procps
+package: procps
 
 81、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 82、source package:python3-smbc 1.0.23-2
-package:
-python3-smbc
+package: python3-smbc
 
 83、source package:rfkill 2.35.2-7_s390x
-package:
-rfkill
+package: rfkill
 
 84、source package:rzip 2.1.orig
-package:
-rzip
+package: rzip
 
 85、source package:sectpmctl 1.1.3
-package:
-sectpmctl
+package: sectpmctl
 
 86、source package:sensible-utils 0.0.9+nmu1
-package:
-sensible-utils
+package: sensible-utils
 
 87、source package:socat 2.0.0~beta9-1_ppc64el
-package:
-socat
+package: socat
 
 88、source package:squashfs-tools 4.4-2_s390x
-package:
-squashfs-tools
+package: squashfs-tools
 
 89、source package:syslinux 6.04~git20190206.bf6db5b4+dfsg1.orig
-package:
-syslinux
+package: syslinux
 
 90、source package:syslinux-common 6.04~git20190206.bf6db5b4+dfsg1-2_all
-package:
-syslinux-common
+package: syslinux-common
 
 91、source package:udisks2 2.9.4-4
-package:
-udisks2
+package: udisks2
 
 92、source package:unace 1.2b-9
-package:
-unace
+package: unace
 
 93、source package:upower 1.90.2-3
-package:
-upower
+package: upower
 
 94、source package:usb-modeswitch 2.6.1.orig
-package:
-usb-modeswitch
+package: usb-modeswitch
 
 95、source package:usbmuxd 1.1.1~git20191130.9af2b12-1_s390x
-package:
-usbmuxd
+package: usbmuxd
 
 96、source package:usbutils 1:015-1
-package:
-usbutils
+package: usbutils
 
 97、source package:user-setup 1.95
-package:
-user-setup
+package: user-setup
 
 98、source package:uuid-dev 2.35.2-7_ppc64el
-package:
-uuid-dev
+package: uuid-dev
 
 99、source package:vlc-plugin-base 3.0.8-4_s390x
-package:
-vlc-plugin-base
+package: vlc-plugin-base
 
 100、source package:xdg-user-dirs 0.9-1
-package:
-xdg-user-dirs
+package: xdg-user-dirs
 
 101、source package:xserver-xorg-input-wacom 1.2.0-1~exp1
-package:
-xserver-xorg-input-wacom
+package: xserver-xorg-input-wacom
 
 102、source package:zssh 1.5c.debian.1-8
-package:
-zssh
+package: zssh
 
 
 Open Source Software Licensed under the GPL-2.0-only:
 1、source package:GitQlient v1.4.3
-package:
-GitQlient
+package: GitQlient
 
 2、source package:alsa-utils 1.2.9-1
-package:
-alsa-utils
+package: alsa-utils
 
 3、source package:btrfs-progs 6.3.2-1
-package:
-btrfs-progs
+package: btrfs-progs
 
 4、source package:checkstyle checkstyle-10.3.4
-package:
-checkstyle
+package: checkstyle
 
 5、source package:dmsetup 1.02.90-2.2+deb8u1_s390x
-package:
-dmsetup
+package: dmsetup
 
 6、source package:doxygen 1.9.4-4
-package:
-doxygen
+package: doxygen
 
 7、source package:e2fsprogs 1.47.0-2
-package:
-e2fsprogs
+package: e2fsprogs
 
 8、source package:gcc 9.2.1-4.1_mips64el
-package:
-gcc
+package: gcc
 
 9、source package:genisoimage 9:1.1.11-3.4
-package:
-genisoimage
+package: genisoimage
 
 10、source package:git 4.3.20-9
-package:
-git
+package: git
 
 11、source package:grub-efi-amd64-signed 1+2.06+8.1
-package:
-grub-efi-amd64-signed
+package: grub-efi-amd64-signed
 
 12、source package:grub-efi-arm64-signed 1+2.06+8.1
-package:
-grub-efi-arm64-signed
+package: grub-efi-arm64-signed
 
 13、source package:gtk2-engines 2.20.2.orig
-package:
-gtk2-engines
+package: gtk2-engines
 
 14、source package:gtk2-engines-murrine 0.98.2.orig
-package:
-gtk2-engines-murrine
+package: gtk2-engines-murrine
 
 15、source package:iio-sensor-proxy 3.4-2
-package:
-iio-sensor-proxy
+package: iio-sensor-proxy
 
 16、source package:initramfs-tools-core 0.137_all
-package:
-initramfs-tools-core
+package: initramfs-tools-core
 
 17、source package:kwin v5.27.2
-package:
-kwin
+package: kwin
 
 18、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 19、source package:libdjvulibre-dev 3.5.28-2
-package:
-libdjvulibre-dev
+package: libdjvulibre-dev
 
 20、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 21、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 22、source package:libnm-qt 0.9.8.2.orig
-package:
-libnm-qt
+package: libnm-qt
 
 23、source package:libpoppler-glib-dev 22.12.0-2
-package:
-libpoppler-glib-dev
+package: libpoppler-glib-dev
 
 24、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 25、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 26、source package:lsb-base 9.20161125_all
-package:
-lsb-base
+package: lsb-base
 
 27、source package:lshw 02.19.git.2021.06.19.996aaad9c7-2~bpo11+1
-package:
-lshw
+package: lshw
 
 28、source package:lvm2 2.03.16-1.1
-package:
-lvm2
+package: lvm2
 
 29、source package:mawk 1.3.4.20230525-1~exp1
-package:
-mawk
+package: mawk
 
 30、source package:modemmanager 1.8.2.orig
-package:
-modemmanager
+package: modemmanager
 
 31、source package:networkmanager-qt 5.54.0.orig
-package:
-networkmanager-qt
+package: networkmanager-qt
 
 32、source package:openprinting-ppds 20200427-1_all
-package:
-openprinting-ppds
+package: openprinting-ppds
 
 33、source package:proxychains4 4.14-3_s390x
-package:
-proxychains4
+package: proxychains4
 
 34、source package:qt-creator tqtc/v2.6.0-rc
-package:
-qt-creator
+package: qt-creator
 
 35、source package:qtciphersqliteplugin 0.6
-package:
-qtciphersqliteplugin
+package: qtciphersqliteplugin
 
 36、source package:qtermwidget 0.7.1.orig
-package:
-qtermwidget
+package: qtermwidget
 
 37、source package:reiserfsprogs 3.x.1b-1
-package:
-reiserfsprogs
+package: reiserfsprogs
 
 38、source package:sane-airscan 0.99.8-2
-package:
-sane-airscan
+package: sane-airscan
 
 39、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 40、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 41、source package:synergy-stable-builds 1.8.2-stable
-package:
-synergy-stable-builds
+package: synergy-stable-builds
 
 42、source package:systemd 8-2
-package:
-systemd
+package: systemd
 
 43、source package:ttf-unifont 9.0.06-2_all
-package:
-ttf-unifont
+package: ttf-unifont
 
 44、source package:wireless-tools 30~pre9.orig
-package:
-wireless-tools
+package: wireless-tools
 
 45、source package:xfonts-wqy 1.0.0~rc1-7
-package:
-xfonts-wqy
+package: xfonts-wqy
 
 46、source package:xfsprogs 6.3.0-1
-package:
-xfsprogs
+package: xfsprogs
 
 
 Open Source Software Licensed under the LGPL-3.0-or-later:
 1、source package:kdecoration 4:5.26.90-2
-package:
-kdecoration
+package: kdecoration
 
 2、source package:libheif-dev 1.6.1-1_s390x
-package:
-libheif-dev
+package: libheif-dev
 
 3、source package:libzmq3-dev 4.3.2-2_s390x
-package:
-libzmq3-dev
+package: libzmq3-dev
 
 4、source package:python3-ldb 2.1.4-2_s390x
-package:
-python3-ldb
+package: python3-ldb
 
 5、source package:python3-tdb 1.4.3-1_s390x
-package:
-python3-tdb
+package: python3-tdb
 
 6、source package:tdb-tools 1.4.3-1_s390x
-package:
-tdb-tools
+package: tdb-tools
 
 
 Open Source Software Licensed under the LGPL-3.0-only:
 1、source package:QtZeroConf pre_Android_api30
-package:
-QtZeroConf
+package: QtZeroConf
 
 2、source package:cryfs 0.9.9-2
-package:
-cryfs
+package: cryfs
 
 3、source package:libgsettings-qt-dev 0.2-1_s390x
-package:
-libgsettings-qt-dev
+package: libgsettings-qt-dev
 
 4、source package:qt5integration 5.6.3
-package:
-qt5integration
+package: qt5integration
 
 5、source package:qtwebengine-opensource-src 5.14.2+dfsg1.orig
-package:
-qtwebengine-opensource-src
+package: qtwebengine-opensource-src
 
 
 Open Source Software Licensed under the LGPL-2.1-or-later:
 1、source package:fcitx5 5.0.9-2
-package:
-fcitx5
+package: fcitx5
 
 2、source package:fcitx5-chinese-addons 5.0.9-2
-package:
-fcitx5-chinese-addons
+package: fcitx5-chinese-addons
 
 3、source package:fcitx5-frontend-gtk2 5.0.9-1
-package:
-fcitx5-frontend-gtk2
+package: fcitx5-frontend-gtk2
 
 4、source package:fcitx5-frontend-qt5 0.0~git20200615.b6f2ef3-1_s390x
-package:
-fcitx5-frontend-qt5
+package: fcitx5-frontend-qt5
 
 5、source package:fcitx5-module-xorg 0~20191021+ds1-1_s390x
-package:
-fcitx5-module-xorg
+package: fcitx5-module-xorg
 
 6、source package:fcitx5-modules 0~20191021+ds1-1_s390x
-package:
-fcitx5-modules
+package: fcitx5-modules
 
 7、source package:fcitx5-modules-dev 5.0.23-2~exp1
-package:
-fcitx5-modules-dev
+package: fcitx5-modules-dev
 
 8、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 9、source package:gcr 3.8.2-4
-package:
-gcr
+package: gcr
 
 10、source package:iso-codes 4.9.0-1
-package:
-iso-codes
+package: iso-codes
 
 11、source package:kcm-fcitx5 5.0.13-1
-package:
-kcm-fcitx5
+package: kcm-fcitx5
 
 12、source package:libappstreamqt-dev 0.9.8-4_kfreebsd-i386
-package:
-libappstreamqt-dev
+package: libappstreamqt-dev
 
 13、source package:libavcodec-dev 4.3-3+b1_s390x
-package:
-libavcodec-dev
+package: libavcodec-dev
 
 14、source package:libavcodec58 4.3-3+b1_ppc64el
-package:
-libavcodec58
+package: libavcodec58
 
 15、source package:libavdevice-dev 4.3-3+b1_ppc64el
-package:
-libavdevice-dev
+package: libavdevice-dev
 
 16、source package:libavfilter-dev 4.3-3+b1_mips64el
-package:
-libavfilter-dev
+package: libavfilter-dev
 
 17、source package:libavformat-dev 4.3-3+b1_ppc64el
-package:
-libavformat-dev
+package: libavformat-dev
 
 18、source package:libavformat58 4.3-3+b1_i386
-package:
-libavformat58
+package: libavformat58
 
 19、source package:libavutil-dev 4.3-3+b1_s390x
-package:
-libavutil-dev
+package: libavutil-dev
 
 20、source package:libavutil56 4.3-3+b1_s390x
-package:
-libavutil56
+package: libavutil56
 
 21、source package:libblockdev-crypto2 2.24-2_mipsel
-package:
-libblockdev-crypto2
+package: libblockdev-crypto2
 
 22、source package:libdbusextended-qt5-dev 0.0.3-4_s390x
-package:
-libdbusextended-qt5-dev
+package: libdbusextended-qt5-dev
 
 23、source package:libfcitx5-qt-dev 0.0~git20200615.b6f2ef3-1_ppc64el
-package:
-libfcitx5-qt-dev
+package: libfcitx5-qt-dev
 
 24、source package:libfcitx5core-dev 0~20191021+ds1-1_s390x
-package:
-libfcitx5core-dev
+package: libfcitx5core-dev
 
 25、source package:libfcitx5utils-dev 0~20191021+ds1-1_s390x
-package:
-libfcitx5utils-dev
+package: libfcitx5utils-dev
 
 26、source package:libgxps-dev 0.3.1-1_s390x
-package:
-libgxps-dev
+package: libgxps-dev
 
 27、source package:libime-bin 0.0~git20200626.2c85668-1_s390x
-package:
-libime-bin
+package: libime-bin
 
 28、source package:libimobiledevice-utils 1.3.0-3_s390x
-package:
-libimobiledevice-utils
+package: libimobiledevice-utils
 
 29、source package:libnss-myhostname 245.6-2_s390x
-package:
-libnss-myhostname
+package: libnss-myhostname
 
 30、source package:libprocps-dev 3.3.16-5_s390x
-package:
-libprocps-dev
+package: libprocps-dev
 
 31、source package:libpulse-dev 7.1-2~bpo8+1_s390x
-package:
-libpulse-dev
+package: libpulse-dev
 
 32、source package:libpulse-mainloop-glib0 9.0-5
-package:
-libpulse-mainloop-glib0
+package: libpulse-mainloop-glib0
 
 33、source package:libpulse0 7.1-2~bpo8+1_s390x
-package:
-libpulse0
+package: libpulse0
 
 34、source package:libqrencode-dev 4.0.2-2_s390x
-package:
-libqrencode-dev
+package: libqrencode-dev
 
 35、source package:libqrencode4 4.1.1-1
-package:
-libqrencode4
+package: libqrencode4
 
 36、source package:libsecret-1-dev 0.20.5-3
-package:
-libsecret-1-dev
+package: libsecret-1-dev
 
 37、source package:libswresample-dev 4.3-3+b1_ppc64el
-package:
-libswresample-dev
+package: libswresample-dev
 
 38、source package:libswscale-dev 4.3-3+b1_s390x
-package:
-libswscale-dev
+package: libswscale-dev
 
 39、source package:libsystemd-dev 245.6-2_i386
-package:
-libsystemd-dev
+package: libsystemd-dev
 
 40、source package:libsystemd0 245.6-2_s390x
-package:
-libsystemd0
+package: libsystemd0
 
 41、source package:libudev-dev 245.6-2_s390x
-package:
-libudev-dev
+package: libudev-dev
 
 42、source package:packagekit 1.2.6-5
-package:
-packagekit
+package: packagekit
 
 43、source package:pulseaudio 9.99.1-1
-package:
-pulseaudio
+package: pulseaudio
 
 44、source package:pulseaudio-module-bluetooth 7.1-2~bpo8+1_s390x
-package:
-pulseaudio-module-bluetooth
+package: pulseaudio-module-bluetooth
 
 45、source package:pulseaudio-utils 7.1-2~bpo8+1_s390x
-package:
-pulseaudio-utils
+package: pulseaudio-utils
 
 46、source package:python3-gi 3.43.1-1
-package:
-python3-gi
+package: python3-gi
 
 47、source package:systemd-coredump 245.6-2_mipsel
-package:
-systemd-coredump
+package: systemd-coredump
 
 48、source package:systemd-timesyncd 245.6-2_ppc64el
-package:
-systemd-timesyncd
+package: systemd-timesyncd
 
 49、source package:udev 245.6-2_s390x
-package:
-udev
+package: udev
 
 50、source package:unar 1.9.1-1
-package:
-unar
+package: unar
 
 
 Open Source Software Licensed under the LGPL-2.1-only:
 1、source package:GitQlient v1.4.3
-package:
-GitQlient
+package: GitQlient
 
 2、source package:cgroup-tools 0.41-8.1_s390x
-package:
-cgroup-tools
+package: cgroup-tools
 
 3、source package:checkstyle checkstyle-10.3.4
-package:
-checkstyle
+package: checkstyle
 
 4、source package:cracklib-runtime 2.9.6-3_s390x
-package:
-cracklib-runtime
+package: cracklib-runtime
 
 5、source package:dialog 1.3-20230209-1
-package:
-dialog
+package: dialog
 
 6、source package:dmsetup 1.02.90-2.2+deb8u1_s390x
-package:
-dmsetup
+package: dmsetup
 
 7、source package:gettext-base 0.19.8.1-9_s390x
-package:
-gettext-base
+package: gettext-base
 
 8、source package:gstreamer1.0-libav 1.9.90-1
-package:
-gstreamer1.0-libav
+package: gstreamer1.0-libav
 
 9、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 10、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 11、source package:gstreamer1.0-plugins-ugly 1.9.90-1
-package:
-gstreamer1.0-plugins-ugly
+package: gstreamer1.0-plugins-ugly
 
 12、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 13、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 14、source package:gtk2-engines 2.20.2.orig
-package:
-gtk2-engines
+package: gtk2-engines
 
 15、source package:gtk2-engines-murrine 0.98.2.orig
-package:
-gtk2-engines-murrine
+package: gtk2-engines-murrine
 
 16、source package:gtk2-engines-pixbuf 2.8.9-2
-package:
-gtk2-engines-pixbuf
+package: gtk2-engines-pixbuf
 
 17、source package:kmod 9-3_sparc
-package:
-kmod
+package: kmod
 
 18、source package:libcairo2-dev 1.16.0-4_s390x
-package:
-libcairo2-dev
+package: libcairo2-dev
 
 19、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 20、source package:libcrack2-dev 2.9.6-5
-package:
-libcrack2-dev
+package: libcrack2-dev
 
 21、source package:libfprint 20110418git-2
-package:
-libfprint
+package: libfprint
 
 22、source package:libfprint-2-2 1.90.1-2_s390x
-package:
-libfprint-2-2
+package: libfprint-2-2
 
 23、source package:libfprint0 1.0-1_s390x
-package:
-libfprint0
+package: libfprint0
 
 24、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 25、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 26、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 27、source package:libgstreamer1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer1.0-0
+package: libgstreamer1.0-0
 
 28、source package:libgstreamer1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer1.0-dev
+package: libgstreamer1.0-dev
 
 29、source package:libgtk-3-dev 3.4.2-7+deb7u1_sparc
-package:
-libgtk-3-dev
+package: libgtk-3-dev
 
 30、source package:liblog4cpp5-dev 1.1.3-3_s390x
-package:
-liblog4cpp5-dev
+package: liblog4cpp5-dev
 
 31、source package:liblog4cpp5v5 1.1.3-3_ppc64el
-package:
-liblog4cpp5v5
+package: liblog4cpp5v5
 
 32、source package:libnm-qt 0.9.8.2.orig
-package:
-libnm-qt
+package: libnm-qt
 
 33、source package:libnotify-bin 0.7.9-1_s390x
-package:
-libnotify-bin
+package: libnotify-bin
 
 34、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 35、source package:librsvg2-dev 2.9.5-6
-package:
-librsvg2-dev
+package: librsvg2-dev
 
 36、source package:libsdl1.2debian 1.2.15-5_sparc
-package:
-libsdl1.2debian
+package: libsdl1.2debian
 
 37、source package:libseccomp-dev 2.4.3-1_s390x
-package:
-libseccomp-dev
+package: libseccomp-dev
 
 38、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 39、source package:libusb-1.0-0-dev 1.0.23-2_s390x
-package:
-libusb-1.0-0-dev
+package: libusb-1.0-0-dev
 
 40、source package:modemmanager 1.8.2.orig
-package:
-modemmanager
+package: modemmanager
 
 41、source package:networkmanager-qt 5.54.0.orig
-package:
-networkmanager-qt
+package: networkmanager-qt
 
 42、source package:p7zip 9.20.1~dfsg.1-5
-package:
-p7zip
+package: p7zip
 
 43、source package:p7zip-full 9.20.1~dfsg.1-4.1_kfreebsd-i386
-package:
-p7zip-full
+package: p7zip-full
 
 44、source package:qrencode 4.0.2.orig
-package:
-qrencode
+package: qrencode
 
 45、source package:qt-creator tqtc/v2.6.0-rc
-package:
-qt-creator
+package: qt-creator
 
 46、source package:qtciphersqliteplugin 0.6
-package:
-qtciphersqliteplugin
+package: qtciphersqliteplugin
 
 47、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2:
 1、source package:libqt5core5a 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5core5a
+package: libqt5core5a
 
 2、source package:libqt5opengl5-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5opengl5-dev
+package: libqt5opengl5-dev
 
 3、source package:libqt5sql5-sqlite 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5sql5-sqlite
+package: libqt5sql5-sqlite
 
 4、source package:libqt5svg5-dev 5.7.1~20161021-2+b2_s390x
-package:
-libqt5svg5-dev
+package: libqt5svg5-dev
 
 5、source package:libqt5x11extras5-dev 5.9.2-1
-package:
-libqt5x11extras5-dev
+package: libqt5x11extras5-dev
 
 6、source package:libqt6multimedia6 6.4.2-6
-package:
-libqt6multimedia6
+package: libqt6multimedia6
 
 7、source package:libqt6opengl6 6.4.2+dfsg~rc1-3+alpha.1
-package:
-libqt6opengl6
+package: libqt6opengl6
 
 8、source package:qml-module-qt-labs-platform 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qt-labs-platform
+package: qml-module-qt-labs-platform
 
 9、source package:qml-module-qtquick-controls2 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qtquick-controls2
+package: qml-module-qtquick-controls2
 
 10、source package:qml-module-qtquick-dialogs 5.7.1~20161021-2_s390x
-package:
-qml-module-qtquick-dialogs
+package: qml-module-qtquick-dialogs
 
 11、source package:qml-module-qtquick-templates2 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qtquick-templates2
+package: qml-module-qtquick-templates2
 
 12、source package:qt5-qmake 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qt5-qmake
+package: qt5-qmake
 
 13、source package:qt6-svg-dev 6.4.2~rc1-3
-package:
-qt6-svg-dev
+package: qt6-svg-dev
 
 14、source package:qt6-wayland 6.4.2~rc1-2
-package:
-qt6-wayland
+package: qt6-wayland
 
 15、source package:qtbase5-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qtbase5-dev
+package: qtbase5-dev
 
 16、source package:qtbase5-private-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qtbase5-private-dev
+package: qtbase5-private-dev
 
 17、source package:qtmultimedia5-dev 5.7.1~20161021-2_s390x
-package:
-qtmultimedia5-dev
+package: qtmultimedia5-dev
 
 18、source package:qtquickcontrols2-5-dev 5.9.2-2_kfreebsd-amd64
-package:
-qtquickcontrols2-5-dev
+package: qtquickcontrols2-5-dev
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2+:
 1、source package:qml-module-qtqml-models2 5.7.1-2+b2_s390x
-package:
-qml-module-qtqml-models2
+package: qml-module-qtqml-models2
 
 2、source package:qml-module-qtquick-layouts 5.7.1-2+b2_s390x
-package:
-qml-module-qtquick-layouts
+package: qml-module-qtquick-layouts
 
 3、source package:qml-module-qtquick2 5.7.1-2+b2_s390x
-package:
-qml-module-qtquick2
+package: qml-module-qtquick2
 
 4、source package:qtdeclarative5-dev 5.7.1-2+b2_s390x
-package:
-qtdeclarative5-dev
+package: qtdeclarative5-dev
 
 
 Open Source Software Licensed under the Apache-2.0:
 1、source package:AndroidProject-Kotlin 13.2
-package:
-AndroidProject-Kotlin
+package: AndroidProject-Kotlin
 
 2、source package:JSONStream 1.3.5
-package:
-JSONStream
+package: JSONStream
 
 3、source package:acorn-node 1.8.2
-package:
-acorn-node
+package: acorn-node
 
 4、source package:android-pdfium a56ccce4
-package:
-android-pdfium
+package: android-pdfium
 
 5、source package:androidsvg 1.4
-package:
-androidsvg
+package: androidsvg
 
 6、source package:atob 2.1.2
-package:
-atob
+package: atob
 
 7、source package:aws-sign2 0.7.0
-package:
-aws-sign2
+package: aws-sign2
 
 8、source package:caseless 0.12.0
-package:
-caseless
+package: caseless
 
 9、source package:cilium 1.14.3
-package:
-cilium
+package: cilium
 
 10、source package:circleindicator 2.1.6
-package:
-circleindicator
+package: circleindicator
 
 11、source package:cobra v0.0.3
-package:
-cobra
+package: cobra
 
 12、source package:compiler 4.12.0
-package:
-compiler
+package: compiler
 
 13、source package:concurrent 1.0.0
-package:
-concurrent
+package: concurrent
 
 14、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 15、source package:core 1.7.0
-package:
-core
+package: core
 
 16、source package:cppdap 87f8b4a
-package:
-cppdap
+package: cppdap
 
 17、source package:crypto v0.23.0
-package:
-crypto
+package: crypto
 
 18、source package:dash-ast 1.0.0
-package:
-dash-ast
+package: dash-ast
 
 19、source package:diff-match-patch 1.0.5
-package:
-diff-match-patch
+package: diff-match-patch
 
 20、source package:dompurify 2.4.1
-package:
-dompurify
+package: dompurify
 
 21、source package:external/github.com/google/benchmark v1.4.1
-package:
-external/github.com/google/benchmark
+package: external/github.com/google/benchmark
 
 22、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 23、source package:fonts-noto-color-emoji 2.038-1
-package:
-fonts-noto-color-emoji
+package: fonts-noto-color-emoji
 
 24、source package:forever-agent 0.6.1
-package:
-forever-agent
+package: forever-agent
 
 25、source package:get-assigned-identifiers 1.2.0
-package:
-get-assigned-identifiers
+package: get-assigned-identifiers
 
 26、source package:git 4.3.20-9
-package:
-git
+package: git
 
 27、source package:glide 4.12.0
-package:
-glide
+package: glide
 
 28、source package:gofuzz v1.0.0
-package:
-gofuzz
+package: gofuzz
 
 29、source package:golang-github-golang-groupcache-dev 0.0~git20200121.8c9f03a-2
-package:
-golang-github-golang-groupcache-dev
+package: golang-github-golang-groupcache-dev
 
 30、source package:golang-gopkg-yaml.v2-dev 2.4.0-3
-package:
-golang-gopkg-yaml.v2-dev
+package: golang-gopkg-yaml.v2-dev
 
 31、source package:golang-gopkg-yaml.v3-dev 3.0.1-3
-package:
-golang-gopkg-yaml.v3-dev
+package: golang-gopkg-yaml.v3-dev
 
 32、source package:gradle 7.4.2
-package:
-gradle
+package: gradle
 
 33、source package:gson 2.10.1
-package:
-gson
+package: gson
 
 34、source package:imgbrd-grabber v6.0.2
-package:
-imgbrd-grabber
+package: imgbrd-grabber
 
 35、source package:infratask_scheduler v0.1.0
-package:
-infratask_scheduler
+package: infratask_scheduler
 
 36、source package:junit 1.1.5
-package:
-junit
+package: junit
 
 37、source package:kata-containers CC-0.7.0
-package:
-kata-containers
+package: kata-containers
 
 38、source package:kotlin-gradle-plugin
-package:
-kotlin-gradle-plugin
+package: kotlin-gradle-plugin
 
 39、source package:kotlin-stdlib-jdk7
-package:
-kotlin-stdlib-jdk7
+package: kotlin-stdlib-jdk7
 
 40、source package:kotlinx-serialization-json 1.5.1
-package:
-kotlinx-serialization-json
+package: kotlinx-serialization-json
 
 41、source package:libcups2-dev 2.3~rc1-1_s390x
-package:
-libcups2-dev
+package: libcups2-dev
 
 42、source package:libcupsimage2 2.3~rc1-1_s390x
-package:
-libcupsimage2
+package: libcupsimage2
 
 43、source package:libpoppler-cpp-dev 0.85.0-1_s390x
-package:
-libpoppler-cpp-dev
+package: libpoppler-cpp-dev
 
 44、source package:libpoppler-cpp0v5 0.85.0-1_s390x
-package:
-libpoppler-cpp0v5
+package: libpoppler-cpp0v5
 
 45、source package:libssl-dev 3.0.0~~alpha4-1_s390x
-package:
-libssl-dev
+package: libssl-dev
 
 46、source package:libssl3 3.0.0~~alpha4-1_s390x
-package:
-libssl3
+package: libssl3
 
 47、source package:libwebrtc-bin 86.4240.20.0
-package:
-libwebrtc-bin
+package: libwebrtc-bin
 
 48、source package:libxerces-c-dev 3.2.3+debian-1_s390x
-package:
-libxerces-c-dev
+package: libxerces-c-dev
 
 49、source package:lottie 4.1.0
-package:
-lottie
+package: lottie
 
 50、source package:ms365 v2.0.5
-package:
-ms365
+package: ms365
 
 51、source package:oauth-sign 0.9.0
-package:
-oauth-sign
+package: oauth-sign
 
 52、source package:okhttp 3.12.13
-package:
-okhttp
+package: okhttp
 
 53、source package:podman 1.6.4+dfsg1-4_armel
-package:
-podman
+package: podman
 
 54、source package:preference 1.2.1
-package:
-preference
+package: preference
 
 55、source package:request 2.88.0
-package:
-request
+package: request
 
 56、source package:rsyslog 8.9.0-3
-package:
-rsyslog
+package: rsyslog
 
 57、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 58、source package:spdx-correct 3.1.1
-package:
-spdx-correct
+package: spdx-correct
 
 59、source package:sse v0.1.0
-package:
-sse
+package: sse
 
 60、source package:sync v0.10.0
-package:
-sync
+package: sync
 
 61、source package:through 2.3.8
-package:
-through
+package: through
 
 62、source package:timber 4.7.1
-package:
-timber
+package: timber
 
 63、source package:tinyrpc 2130294
-package:
-tinyrpc
+package: tinyrpc
 
 64、source package:tools_oat 373f560
-package:
-tools_oat
+package: tools_oat
 
 65、source package:true-case-path 1.0.3
-package:
-true-case-path
+package: true-case-path
 
 66、source package:tunnel-agent 0.6.0
-package:
-tunnel-agent
+package: tunnel-agent
 
 67、source package:typescript 4.8.4
-package:
-typescript
+package: typescript
 
 68、source package:undeclared-identifiers 1.1.3
-package:
-undeclared-identifiers
+package: undeclared-identifiers
 
 69、source package:validate-npm-package-license 3.0.4
-package:
-validate-npm-package-license
+package: validate-npm-package-license
 
 70、source package:vimspector 2938438041
-package:
-vimspector
+package: vimspector
 
 
 Open Source Software Licensed under the MIT:
 1、source package:@antfu/utils 0.7.7
-package:
-@antfu/utils
+package: @antfu/utils
 
 2、source package:@babel/runtime 7.6.0
-package:
-@babel/runtime
+package: @babel/runtime
 
 3、source package:@babel/standalone 7.20.15
-package:
-@babel/standalone
+package: @babel/standalone
 
 4、source package:@ctrl/tinycolor 3.4.1
-package:
-@ctrl/tinycolor
+package: @ctrl/tinycolor
 
 5、source package:@element-plus/icons-vue 2.0.9
-package:
-@element-plus/icons-vue
+package: @element-plus/icons-vue
 
 6、source package:@esbuild/android-arm 0.15.9
-package:
-@esbuild/android-arm
+package: @esbuild/android-arm
 
 7、source package:@esbuild/linux-loong64 0.15.9
-package:
-@esbuild/linux-loong64
+package: @esbuild/linux-loong64
 
 8、source package:@floating-ui/core 1.0.1
-package:
-@floating-ui/core
+package: @floating-ui/core
 
 9、source package:@floating-ui/dom 1.0.2
-package:
-@floating-ui/dom
+package: @floating-ui/dom
 
 10、source package:@jridgewell/gen-mapping 0.3.2
-package:
-@jridgewell/gen-mapping
+package: @jridgewell/gen-mapping
 
 11、source package:@jridgewell/resolve-uri 3.1.0
-package:
-@jridgewell/resolve-uri
+package: @jridgewell/resolve-uri
 
 12、source package:@jridgewell/set-array 1.1.2
-package:
-@jridgewell/set-array
+package: @jridgewell/set-array
 
 13、source package:@jridgewell/source-map 0.3.2
-package:
-@jridgewell/source-map
+package: @jridgewell/source-map
 
 14、source package:@jridgewell/sourcemap-codec 1.4.14
-package:
-@jridgewell/sourcemap-codec
+package: @jridgewell/sourcemap-codec
 
 15、source package:@jridgewell/trace-mapping 0.3.16
-package:
-@jridgewell/trace-mapping
+package: @jridgewell/trace-mapping
 
 16、source package:@nodelib/fs.scandir 2.1.5
-package:
-@nodelib/fs.scandir
+package: @nodelib/fs.scandir
 
 17、source package:@nodelib/fs.stat 2.0.5
-package:
-@nodelib/fs.stat
+package: @nodelib/fs.stat
 
 18、source package:@nodelib/fs.walk 1.2.8
-package:
-@nodelib/fs.walk
+package: @nodelib/fs.walk
 
 19、source package:@popperjs/core 2.11.7
-package:
-@popperjs/core
+package: @popperjs/core
 
 20、source package:@rollup/pluginutils 5.1.0
-package:
-@rollup/pluginutils
+package: @rollup/pluginutils
 
 21、source package:@smake/co 1.0.1
-package:
-@smake/co
+package: @smake/co
 
 22、source package:@types/estree 1.0.5
-package:
-@types/estree
+package: @types/estree
 
 23、source package:@types/json-schema 7.0.6
-package:
-@types/json-schema
+package: @types/json-schema
 
 24、source package:@types/lodash 4.14.185
-package:
-@types/lodash
+package: @types/lodash
 
 25、source package:@types/lodash-es 4.17.6
-package:
-@types/lodash-es
+package: @types/lodash-es
 
 26、source package:@types/node 14.14.6
-package:
-@types/node
+package: @types/node
 
 27、source package:@types/web-bluetooth 0.0.15
-package:
-@types/web-bluetooth
+package: @types/web-bluetooth
 
 28、source package:@vitejs/plugin-legacy 2.3.1
-package:
-@vitejs/plugin-legacy
+package: @vitejs/plugin-legacy
 
 29、source package:@vitejs/plugin-vue 3.1.0
-package:
-@vitejs/plugin-vue
+package: @vitejs/plugin-vue
 
 30、source package:@vue/devtools-api 6.4.1
-package:
-@vue/devtools-api
+package: @vue/devtools-api
 
 31、source package:@vueuse/core 9.3.0
-package:
-@vueuse/core
+package: @vueuse/core
 
 32、source package:@vueuse/metadata 9.3.0
-package:
-@vueuse/metadata
+package: @vueuse/metadata
 
 33、source package:@vueuse/shared 9.3.0
-package:
-@vueuse/shared
+package: @vueuse/shared
 
 34、source package:CppLogging 1.0.1.0
-package:
-CppLogging
+package: CppLogging
 
 35、source package:abbrev 1.1.1
-package:
-abbrev
+package: abbrev
 
 36、source package:acorn 7.0.0
-package:
-acorn
+package: acorn
 
 37、source package:acorn-dynamic-import 2.0.2
-package:
-acorn-dynamic-import
+package: acorn-dynamic-import
 
 38、source package:acorn-node 1.8.2
-package:
-acorn-node
+package: acorn-node
 
 39、source package:acorn-walk 7.0.0
-package:
-acorn-walk
+package: acorn-walk
 
 40、source package:add-px-to-style 1.0.0
-package:
-add-px-to-style
+package: add-px-to-style
 
 41、source package:ajv 6.12.6
-package:
-ajv
+package: ajv
 
 42、source package:ajv-keywords 3.5.2
-package:
-ajv-keywords
+package: ajv-keywords
 
 43、source package:align-text 0.1.4
-package:
-align-text
+package: align-text
 
 44、source package:amdefine 1.0.1
-package:
-amdefine
+package: amdefine
 
 45、source package:ansi-gray 0.1.1
-package:
-ansi-gray
+package: ansi-gray
 
 46、source package:ansi-regex 3.0.0
-package:
-ansi-regex
+package: ansi-regex
 
 47、source package:ansi-styles 2.2.1
-package:
-ansi-styles
+package: ansi-styles
 
 48、source package:ansi-wrap 0.1.0
-package:
-ansi-wrap
+package: ansi-wrap
 
 49、source package:anyks-lm 2.1.5
-package:
-anyks-lm
+package: anyks-lm
 
 50、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 51、source package:archy 1.0.0
-package:
-archy
+package: archy
 
 52、source package:arr-diff 4.0.0
-package:
-arr-diff
+package: arr-diff
 
 53、source package:arr-flatten 1.1.0
-package:
-arr-flatten
+package: arr-flatten
 
 54、source package:arr-union 3.1.0
-package:
-arr-union
+package: arr-union
 
 55、source package:array-differ 1.0.0
-package:
-array-differ
+package: array-differ
 
 56、source package:array-each 1.0.1
-package:
-array-each
+package: array-each
 
 57、source package:array-find-index 1.0.2
-package:
-array-find-index
+package: array-find-index
 
 58、source package:array-slice 1.1.0
-package:
-array-slice
+package: array-slice
 
 59、source package:array-uniq 1.0.3
-package:
-array-uniq
+package: array-uniq
 
 60、source package:array-unique 0.3.2
-package:
-array-unique
+package: array-unique
 
 61、source package:asn1 0.2.4
-package:
-asn1
+package: asn1
 
 62、source package:asn1.js 5.4.1
-package:
-asn1.js
+package: asn1.js
 
 63、source package:assert 1.5.0
-package:
-assert
+package: assert
 
 64、source package:assert-plus 1.0.0
-package:
-assert-plus
+package: assert-plus
 
 65、source package:assign-symbols 1.0.0
-package:
-assign-symbols
+package: assign-symbols
 
 66、source package:async 2.6.3
-package:
-async
+package: async
 
 67、source package:async-each 1.0.3
-package:
-async-each
+package: async-each
 
 68、source package:async-foreach 0.1.3
-package:
-async-foreach
+package: async-foreach
 
 69、source package:async-validator 4.2.5
-package:
-async-validator
+package: async-validator
 
 70、source package:asynckit 0.4.0
-package:
-asynckit
+package: asynckit
 
 71、source package:atob 2.1.2
-package:
-atob
+package: atob
 
 72、source package:aws4 1.8.0
-package:
-aws4
+package: aws4
 
 73、source package:babel-code-frame 6.26.0
-package:
-babel-code-frame
+package: babel-code-frame
 
 74、source package:babel-core 6.26.3
-package:
-babel-core
+package: babel-core
 
 75、source package:babel-generator 6.26.1
-package:
-babel-generator
+package: babel-generator
 
 76、source package:babel-helper-builder-binary-assignment-operator-visitor 6.24.1
-package:
-babel-helper-builder-binary-assignment-operator-visitor
+package: babel-helper-builder-binary-assignment-operator-visitor
 
 77、source package:babel-helper-builder-react-jsx 6.26.0
-package:
-babel-helper-builder-react-jsx
+package: babel-helper-builder-react-jsx
 
 78、source package:babel-helper-call-delegate 6.24.1
-package:
-babel-helper-call-delegate
+package: babel-helper-call-delegate
 
 79、source package:babel-helper-define-map 6.26.0
-package:
-babel-helper-define-map
+package: babel-helper-define-map
 
 80、source package:babel-helper-explode-assignable-expression 6.24.1
-package:
-babel-helper-explode-assignable-expression
+package: babel-helper-explode-assignable-expression
 
 81、source package:babel-helper-function-name 6.24.1
-package:
-babel-helper-function-name
+package: babel-helper-function-name
 
 82、source package:babel-helper-get-function-arity 6.24.1
-package:
-babel-helper-get-function-arity
+package: babel-helper-get-function-arity
 
 83、source package:babel-helper-hoist-variables 6.24.1
-package:
-babel-helper-hoist-variables
+package: babel-helper-hoist-variables
 
 84、source package:babel-helper-optimise-call-expression 6.24.1
-package:
-babel-helper-optimise-call-expression
+package: babel-helper-optimise-call-expression
 
 85、source package:babel-helper-regex 6.26.0
-package:
-babel-helper-regex
+package: babel-helper-regex
 
 86、source package:babel-helper-remap-async-to-generator 6.24.1
-package:
-babel-helper-remap-async-to-generator
+package: babel-helper-remap-async-to-generator
 
 87、source package:babel-helper-replace-supers 6.24.1
-package:
-babel-helper-replace-supers
+package: babel-helper-replace-supers
 
 88、source package:babel-helpers 6.24.1
-package:
-babel-helpers
+package: babel-helpers
 
 89、source package:babel-messages 6.23.0
-package:
-babel-messages
+package: babel-messages
 
 90、source package:babel-plugin-check-es2015-constants 6.22.0
-package:
-babel-plugin-check-es2015-constants
+package: babel-plugin-check-es2015-constants
 
 91、source package:babel-plugin-syntax-async-functions 6.13.0
-package:
-babel-plugin-syntax-async-functions
+package: babel-plugin-syntax-async-functions
 
 92、source package:babel-plugin-syntax-exponentiation-operator 6.13.0
-package:
-babel-plugin-syntax-exponentiation-operator
+package: babel-plugin-syntax-exponentiation-operator
 
 93、source package:babel-plugin-syntax-flow 6.18.0
-package:
-babel-plugin-syntax-flow
+package: babel-plugin-syntax-flow
 
 94、source package:babel-plugin-syntax-jsx 6.18.0
-package:
-babel-plugin-syntax-jsx
+package: babel-plugin-syntax-jsx
 
 95、source package:babel-plugin-syntax-trailing-function-commas 6.22.0
-package:
-babel-plugin-syntax-trailing-function-commas
+package: babel-plugin-syntax-trailing-function-commas
 
 96、source package:babel-plugin-transform-async-to-generator 6.24.1
-package:
-babel-plugin-transform-async-to-generator
+package: babel-plugin-transform-async-to-generator
 
 97、source package:babel-plugin-transform-es2015-arrow-functions 6.22.0
-package:
-babel-plugin-transform-es2015-arrow-functions
+package: babel-plugin-transform-es2015-arrow-functions
 
 98、source package:babel-plugin-transform-es2015-block-scoped-functions 6.22.0
-package:
-babel-plugin-transform-es2015-block-scoped-functions
+package: babel-plugin-transform-es2015-block-scoped-functions
 
 99、source package:babel-plugin-transform-es2015-block-scoping 6.26.0
-package:
-babel-plugin-transform-es2015-block-scoping
+package: babel-plugin-transform-es2015-block-scoping
 
 100、source package:babel-plugin-transform-es2015-classes 6.24.1
-package:
-babel-plugin-transform-es2015-classes
+package: babel-plugin-transform-es2015-classes
 
 101、source package:babel-plugin-transform-es2015-computed-properties 6.24.1
-package:
-babel-plugin-transform-es2015-computed-properties
+package: babel-plugin-transform-es2015-computed-properties
 
 102、source package:babel-plugin-transform-es2015-destructuring 6.23.0
-package:
-babel-plugin-transform-es2015-destructuring
+package: babel-plugin-transform-es2015-destructuring
 
 103、source package:babel-plugin-transform-es2015-duplicate-keys 6.24.1
-package:
-babel-plugin-transform-es2015-duplicate-keys
+package: babel-plugin-transform-es2015-duplicate-keys
 
 104、source package:babel-plugin-transform-es2015-for-of 6.23.0
-package:
-babel-plugin-transform-es2015-for-of
+package: babel-plugin-transform-es2015-for-of
 
 105、source package:babel-plugin-transform-es2015-function-name 6.24.1
-package:
-babel-plugin-transform-es2015-function-name
+package: babel-plugin-transform-es2015-function-name
 
 106、source package:babel-plugin-transform-es2015-literals 6.22.0
-package:
-babel-plugin-transform-es2015-literals
+package: babel-plugin-transform-es2015-literals
 
 107、source package:babel-plugin-transform-es2015-modules-amd 6.24.1
-package:
-babel-plugin-transform-es2015-modules-amd
+package: babel-plugin-transform-es2015-modules-amd
 
 108、source package:babel-plugin-transform-es2015-modules-commonjs 6.26.2
-package:
-babel-plugin-transform-es2015-modules-commonjs
+package: babel-plugin-transform-es2015-modules-commonjs
 
 109、source package:babel-plugin-transform-es2015-modules-systemjs 6.24.1
-package:
-babel-plugin-transform-es2015-modules-systemjs
+package: babel-plugin-transform-es2015-modules-systemjs
 
 110、source package:babel-plugin-transform-es2015-modules-umd 6.24.1
-package:
-babel-plugin-transform-es2015-modules-umd
+package: babel-plugin-transform-es2015-modules-umd
 
 111、source package:babel-plugin-transform-es2015-object-super 6.24.1
-package:
-babel-plugin-transform-es2015-object-super
+package: babel-plugin-transform-es2015-object-super
 
 112、source package:babel-plugin-transform-es2015-parameters 6.24.1
-package:
-babel-plugin-transform-es2015-parameters
+package: babel-plugin-transform-es2015-parameters
 
 113、source package:babel-plugin-transform-es2015-shorthand-properties 6.24.1
-package:
-babel-plugin-transform-es2015-shorthand-properties
+package: babel-plugin-transform-es2015-shorthand-properties
 
 114、source package:babel-plugin-transform-es2015-spread 6.22.0
-package:
-babel-plugin-transform-es2015-spread
+package: babel-plugin-transform-es2015-spread
 
 115、source package:babel-plugin-transform-es2015-sticky-regex 6.24.1
-package:
-babel-plugin-transform-es2015-sticky-regex
+package: babel-plugin-transform-es2015-sticky-regex
 
 116、source package:babel-plugin-transform-es2015-template-literals 6.22.0
-package:
-babel-plugin-transform-es2015-template-literals
+package: babel-plugin-transform-es2015-template-literals
 
 117、source package:babel-plugin-transform-es2015-typeof-symbol 6.23.0
-package:
-babel-plugin-transform-es2015-typeof-symbol
+package: babel-plugin-transform-es2015-typeof-symbol
 
 118、source package:babel-plugin-transform-es2015-unicode-regex 6.24.1
-package:
-babel-plugin-transform-es2015-unicode-regex
+package: babel-plugin-transform-es2015-unicode-regex
 
 119、source package:babel-plugin-transform-exponentiation-operator 6.24.1
-package:
-babel-plugin-transform-exponentiation-operator
+package: babel-plugin-transform-exponentiation-operator
 
 120、source package:babel-plugin-transform-flow-strip-types 6.22.0
-package:
-babel-plugin-transform-flow-strip-types
+package: babel-plugin-transform-flow-strip-types
 
 121、source package:babel-plugin-transform-react-display-name 6.25.0
-package:
-babel-plugin-transform-react-display-name
+package: babel-plugin-transform-react-display-name
 
 122、source package:babel-plugin-transform-react-jsx 6.24.1
-package:
-babel-plugin-transform-react-jsx
+package: babel-plugin-transform-react-jsx
 
 123、source package:babel-plugin-transform-react-jsx-self 6.22.0
-package:
-babel-plugin-transform-react-jsx-self
+package: babel-plugin-transform-react-jsx-self
 
 124、source package:babel-plugin-transform-react-jsx-source 6.22.0
-package:
-babel-plugin-transform-react-jsx-source
+package: babel-plugin-transform-react-jsx-source
 
 125、source package:babel-plugin-transform-regenerator 6.26.0
-package:
-babel-plugin-transform-regenerator
+package: babel-plugin-transform-regenerator
 
 126、source package:babel-plugin-transform-strict-mode 6.24.1
-package:
-babel-plugin-transform-strict-mode
+package: babel-plugin-transform-strict-mode
 
 127、source package:babel-polyfill 6.26.0
-package:
-babel-polyfill
+package: babel-polyfill
 
 128、source package:babel-preset-env 1.7.0
-package:
-babel-preset-env
+package: babel-preset-env
 
 129、source package:babel-preset-flow 6.23.0
-package:
-babel-preset-flow
+package: babel-preset-flow
 
 130、source package:babel-preset-react 6.24.1
-package:
-babel-preset-react
+package: babel-preset-react
 
 131、source package:babel-register 6.26.0
-package:
-babel-register
+package: babel-register
 
 132、source package:babel-runtime 6.26.0
-package:
-babel-runtime
+package: babel-runtime
 
 133、source package:babel-template 6.26.0
-package:
-babel-template
+package: babel-template
 
 134、source package:babel-traverse 6.26.0
-package:
-babel-traverse
+package: babel-traverse
 
 135、source package:babel-types 6.26.0
-package:
-babel-types
+package: babel-types
 
 136、source package:babelify 8.0.0
-package:
-babelify
+package: babelify
 
 137、source package:babylon 6.18.0
-package:
-babylon
+package: babylon
 
 138、source package:balanced-match 1.0.2
-package:
-balanced-match
+package: balanced-match
 
 139、source package:base 0.11.2
-package:
-base
+package: base
 
 140、source package:base64-js 1.3.1
-package:
-base64-js
+package: base64-js
 
 141、source package:beeper 1.1.1
-package:
-beeper
+package: beeper
 
 142、source package:big.js 5.2.2
-package:
-big.js
+package: big.js
 
 143、source package:binary-extensions 2.2.0
-package:
-binary-extensions
+package: binary-extensions
 
 144、source package:bl 1.2.2
-package:
-bl
+package: bl
 
 145、source package:bn.js 5.1.3
-package:
-bn.js
+package: bn.js
 
 146、source package:brace-expansion 2.0.1
-package:
-brace-expansion
+package: brace-expansion
 
 147、source package:braces 3.0.2
-package:
-braces
+package: braces
 
 148、source package:brorand 1.1.0
-package:
-brorand
+package: brorand
 
 149、source package:browser-pack 6.1.0
-package:
-browser-pack
+package: browser-pack
 
 150、source package:browser-resolve 1.11.3
-package:
-browser-resolve
+package: browser-resolve
 
 151、source package:browserify 14.5.0
-package:
-browserify
+package: browserify
 
 152、source package:browserify-aes 1.2.0
-package:
-browserify-aes
+package: browserify-aes
 
 153、source package:browserify-cipher 1.0.1
-package:
-browserify-cipher
+package: browserify-cipher
 
 154、source package:browserify-des 1.0.2
-package:
-browserify-des
+package: browserify-des
 
 155、source package:browserify-rsa 4.0.1
-package:
-browserify-rsa
+package: browserify-rsa
 
 156、source package:browserify-zlib 0.2.0
-package:
-browserify-zlib
+package: browserify-zlib
 
 157、source package:browserslist 3.2.8
-package:
-browserslist
+package: browserslist
 
 158、source package:buffer 5.4.2
-package:
-buffer
+package: buffer
 
 159、source package:buffer-from 1.1.2
-package:
-buffer-from
+package: buffer-from
 
 160、source package:buffer-xor 1.0.3
-package:
-buffer-xor
+package: buffer-xor
 
 161、source package:builtin-status-codes 3.0.0
-package:
-builtin-status-codes
+package: builtin-status-codes
 
 162、source package:cache-base 1.0.1
-package:
-cache-base
+package: cache-base
 
 163、source package:cached-path-relative 1.0.2
-package:
-cached-path-relative
+package: cached-path-relative
 
 164、source package:camelcase 4.1.0
-package:
-camelcase
+package: camelcase
 
 165、source package:camelcase-keys 2.1.0
-package:
-camelcase-keys
+package: camelcase-keys
 
 166、source package:center-align 0.1.3
-package:
-center-align
+package: center-align
 
 167、source package:chalk 1.1.3
-package:
-chalk
+package: chalk
 
 168、source package:cheerio 1.0.0-rc.3
-package:
-cheerio
+package: cheerio
 
 169、source package:chokidar 3.4.3
-package:
-chokidar
+package: chokidar
 
 170、source package:cipher-base 1.0.4
-package:
-cipher-base
+package: cipher-base
 
 171、source package:class-utils 0.3.6
-package:
-class-utils
+package: class-utils
 
 172、source package:clone 2.1.2
-package:
-clone
+package: clone
 
 173、source package:clone-buffer 1.0.0
-package:
-clone-buffer
+package: clone-buffer
 
 174、source package:clone-stats 1.0.0
-package:
-clone-stats
+package: clone-stats
 
 175、source package:cloneable-readable 1.1.3
-package:
-cloneable-readable
+package: cloneable-readable
 
 176、source package:code-point-at 1.1.0
-package:
-code-point-at
+package: code-point-at
 
 177、source package:collection-visit 1.0.0
-package:
-collection-visit
+package: collection-visit
 
 178、source package:combine-source-map 0.8.0
-package:
-combine-source-map
+package: combine-source-map
 
 179、source package:combined-stream 1.0.8
-package:
-combined-stream
+package: combined-stream
 
 180、source package:commander 2.20.3
-package:
-commander
+package: commander
 
 181、source package:component-emitter 1.3.0
-package:
-component-emitter
+package: component-emitter
 
 182、source package:compute-scroll-into-view 1.0.11
-package:
-compute-scroll-into-view
+package: compute-scroll-into-view
 
 183、source package:concat-map 0.0.1
-package:
-concat-map
+package: concat-map
 
 184、source package:concat-stream 1.6.2
-package:
-concat-stream
+package: concat-stream
 
 185、source package:console-browserify 1.2.0
-package:
-console-browserify
+package: console-browserify
 
 186、source package:constants-browserify 1.0.0
-package:
-constants-browserify
+package: constants-browserify
 
 187、source package:convert-source-map 1.6.0
-package:
-convert-source-map
+package: convert-source-map
 
 188、source package:cookiecutter-golang d372aa0
-package:
-cookiecutter-golang
+package: cookiecutter-golang
 
 189、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 190、source package:copy-descriptor 0.1.1
-package:
-copy-descriptor
+package: copy-descriptor
 
 191、source package:core-js 3.27.2
-package:
-core-js
+package: core-js
 
 192、source package:core-util-is 1.0.2
-package:
-core-util-is
+package: core-util-is
 
 193、source package:create-ecdh 4.0.4
-package:
-create-ecdh
+package: create-ecdh
 
 194、source package:create-hash 1.2.0
-package:
-create-hash
+package: create-hash
 
 195、source package:create-hmac 1.1.7
-package:
-create-hmac
+package: create-hmac
 
 196、source package:crelt 1.0.6
-package:
-crelt
+package: crelt
 
 197、source package:cross-spawn 5.1.0
-package:
-cross-spawn
+package: cross-spawn
 
 198、source package:crypto-browserify 3.12.0
-package:
-crypto-browserify
+package: crypto-browserify
 
 199、source package:currently-unhandled 0.4.1
-package:
-currently-unhandled
+package: currently-unhandled
 
 200、source package:dashdash 1.14.1
-package:
-dashdash
+package: dashdash
 
 201、source package:date-now 0.1.4
-package:
-date-now
+package: date-now
 
 202、source package:dateformat 2.2.0
-package:
-dateformat
+package: dateformat
 
 203、source package:dayjs 1.11.5
-package:
-dayjs
+package: dayjs
 
 204、source package:debug 4.3.4
-package:
-debug
+package: debug
 
 205、source package:decamelize 1.2.0
-package:
-decamelize
+package: decamelize
 
 206、source package:decode-uri-component 0.2.0
-package:
-decode-uri-component
+package: decode-uri-component
 
 207、source package:defaults 1.0.3
-package:
-defaults
+package: defaults
 
 208、source package:define-property 2.0.2
-package:
-define-property
+package: define-property
 
 209、source package:defined 1.0.0
-package:
-defined
+package: defined
 
 210、source package:delayed-stream 1.0.0
-package:
-delayed-stream
+package: delayed-stream
 
 211、source package:delegates 1.0.0
-package:
-delegates
+package: delegates
 
 212、source package:deprecated 0.0.1
-package:
-deprecated
+package: deprecated
 
 213、source package:deps-sort 2.0.0
-package:
-deps-sort
+package: deps-sort
 
 214、source package:des.js 1.0.1
-package:
-des.js
+package: des.js
 
 215、source package:detect-file 1.0.0
-package:
-detect-file
+package: detect-file
 
 216、source package:detect-indent 4.0.0
-package:
-detect-indent
+package: detect-indent
 
 217、source package:detective 4.7.1
-package:
-detective
+package: detective
 
 218、source package:diffie-hellman 5.0.3
-package:
-diffie-hellman
+package: diffie-hellman
 
 219、source package:dom-css 2.1.0
-package:
-dom-css
+package: dom-css
 
 220、source package:dom-serializer 0.1.1
-package:
-dom-serializer
+package: dom-serializer
 
 221、source package:domain-browser 1.2.0
-package:
-domain-browser
+package: domain-browser
 
 222、source package:ecc-jsbn 0.1.2
-package:
-ecc-jsbn
+package: ecc-jsbn
 
 223、source package:element-plus 2.2.17
-package:
-element-plus
+package: element-plus
 
 224、source package:elliptic 6.5.3
-package:
-elliptic
+package: elliptic
 
 225、source package:emojis-list 3.0.0
-package:
-emojis-list
+package: emojis-list
 
 226、source package:end-of-stream 0.1.5
-package:
-end-of-stream
+package: end-of-stream
 
 227、source package:enhanced-resolve 3.4.1
-package:
-enhanced-resolve
+package: enhanced-resolve
 
 228、source package:errno 0.1.7
-package:
-errno
+package: errno
 
 229、source package:error-ex 1.3.2
-package:
-error-ex
+package: error-ex
 
 230、source package:es6-iterator 2.0.3
-package:
-es6-iterator
+package: es6-iterator
 
 231、source package:es6-map 0.1.5
-package:
-es6-map
+package: es6-map
 
 232、source package:es6-set 0.1.5
-package:
-es6-set
+package: es6-set
 
 233、source package:es6-symbol 3.1.1
-package:
-es6-symbol
+package: es6-symbol
 
 234、source package:esbuild 0.15.9
-package:
-esbuild
+package: esbuild
 
 235、source package:esbuild-android-64 0.15.9
-package:
-esbuild-android-64
+package: esbuild-android-64
 
 236、source package:esbuild-android-arm64 0.15.9
-package:
-esbuild-android-arm64
+package: esbuild-android-arm64
 
 237、source package:esbuild-darwin-64 0.15.9
-package:
-esbuild-darwin-64
+package: esbuild-darwin-64
 
 238、source package:esbuild-darwin-arm64 0.15.9
-package:
-esbuild-darwin-arm64
+package: esbuild-darwin-arm64
 
 239、source package:esbuild-freebsd-64 0.15.9
-package:
-esbuild-freebsd-64
+package: esbuild-freebsd-64
 
 240、source package:esbuild-freebsd-arm64 0.15.9
-package:
-esbuild-freebsd-arm64
+package: esbuild-freebsd-arm64
 
 241、source package:esbuild-linux-32 0.15.9
-package:
-esbuild-linux-32
+package: esbuild-linux-32
 
 242、source package:esbuild-linux-64 0.15.9
-package:
-esbuild-linux-64
+package: esbuild-linux-64
 
 243、source package:esbuild-linux-arm 0.15.9
-package:
-esbuild-linux-arm
+package: esbuild-linux-arm
 
 244、source package:esbuild-linux-arm64 0.15.9
-package:
-esbuild-linux-arm64
+package: esbuild-linux-arm64
 
 245、source package:esbuild-linux-mips64le 0.15.9
-package:
-esbuild-linux-mips64le
+package: esbuild-linux-mips64le
 
 246、source package:esbuild-linux-ppc64le 0.15.9
-package:
-esbuild-linux-ppc64le
+package: esbuild-linux-ppc64le
 
 247、source package:esbuild-linux-riscv64 0.15.9
-package:
-esbuild-linux-riscv64
+package: esbuild-linux-riscv64
 
 248、source package:esbuild-linux-s390x 0.15.9
-package:
-esbuild-linux-s390x
+package: esbuild-linux-s390x
 
 249、source package:esbuild-netbsd-64 0.15.9
-package:
-esbuild-netbsd-64
+package: esbuild-netbsd-64
 
 250、source package:esbuild-openbsd-64 0.15.9
-package:
-esbuild-openbsd-64
+package: esbuild-openbsd-64
 
 251、source package:esbuild-sunos-64 0.15.9
-package:
-esbuild-sunos-64
+package: esbuild-sunos-64
 
 252、source package:esbuild-windows-32 0.15.9
-package:
-esbuild-windows-32
+package: esbuild-windows-32
 
 253、source package:esbuild-windows-64 0.15.9
-package:
-esbuild-windows-64
+package: esbuild-windows-64
 
 254、source package:esbuild-windows-arm64 0.15.9
-package:
-esbuild-windows-arm64
+package: esbuild-windows-arm64
 
 255、source package:escape-html 1.0.3
-package:
-escape-html
+package: escape-html
 
 256、source package:escape-string-regexp 5.0.0
-package:
-escape-string-regexp
+package: escape-string-regexp
 
 257、source package:estree-walker 2.0.2
-package:
-estree-walker
+package: estree-walker
 
 258、source package:event-emitter 0.3.5
-package:
-event-emitter
+package: event-emitter
 
 259、source package:events 3.2.0
-package:
-events
+package: events
 
 260、source package:evp_bytestokey 1.0.3
-package:
-evp_bytestokey
+package: evp_bytestokey
 
 261、source package:execa 0.7.0
-package:
-execa
+package: execa
 
 262、source package:expand-brackets 2.1.4
-package:
-expand-brackets
+package: expand-brackets
 
 263、source package:expand-tilde 2.0.2
-package:
-expand-tilde
+package: expand-tilde
 
 264、source package:expose-loader 1.0.1
-package:
-expose-loader
+package: expose-loader
 
 265、source package:extend 3.0.2
-package:
-extend
+package: extend
 
 266、source package:extend-shallow 3.0.2
-package:
-extend-shallow
+package: extend-shallow
 
 267、source package:extglob 2.0.4
-package:
-extglob
+package: extglob
 
 268、source package:extsprintf 1.3.0
-package:
-extsprintf
+package: extsprintf
 
 269、source package:fancy-log 1.3.3
-package:
-fancy-log
+package: fancy-log
 
 270、source package:fast-deep-equal 3.1.3
-package:
-fast-deep-equal
+package: fast-deep-equal
 
 271、source package:fast-glob 3.2.12
-package:
-fast-glob
+package: fast-glob
 
 272、source package:fast-json-stable-stringify 2.1.0
-package:
-fast-json-stable-stringify
+package: fast-json-stable-stringify
 
 273、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 274、source package:fill-range 7.0.1
-package:
-fill-range
+package: fill-range
 
 275、source package:find-index 0.1.1
-package:
-find-index
+package: find-index
 
 276、source package:find-up 2.1.0
-package:
-find-up
+package: find-up
 
 277、source package:findup-sync 2.0.0
-package:
-findup-sync
+package: findup-sync
 
 278、source package:fined 1.2.0
-package:
-fined
+package: fined
 
 279、source package:first-chunk-stream 1.0.0
-package:
-first-chunk-stream
+package: first-chunk-stream
 
 280、source package:flagged-respawn 1.0.1
-package:
-flagged-respawn
+package: flagged-respawn
 
 281、source package:for-in 1.0.2
-package:
-for-in
+package: for-in
 
 282、source package:for-own 1.0.0
-package:
-for-own
+package: for-own
 
 283、source package:form-data 2.3.3
-package:
-form-data
+package: form-data
 
 284、source package:fragment-cache 0.2.1
-package:
-fragment-cache
+package: fragment-cache
 
 285、source package:fs.realpath 1.0.0
-package:
-fs.realpath
+package: fs.realpath
 
 286、source package:fsevents 2.3.2
-package:
-fsevents
+package: fsevents
 
 287、source package:function-bind 1.1.1
-package:
-function-bind
+package: function-bind
 
 288、source package:gaze 1.1.3
-package:
-gaze
+package: gaze
 
 289、source package:get-stdin 4.0.1
-package:
-get-stdin
+package: get-stdin
 
 290、source package:get-stream 3.0.0
-package:
-get-stream
+package: get-stream
 
 291、source package:get-value 2.0.6
-package:
-get-value
+package: get-value
 
 292、source package:getpass 0.1.7
-package:
-getpass
+package: getpass
 
 293、source package:gg v1.3.0
-package:
-gg
+package: gg
 
 294、source package:gin v1.5.0
-package:
-gin
+package: gin
 
 295、source package:git 4.3.20-9
-package:
-git
+package: git
 
 296、source package:gitea v1.19.3
-package:
-gitea
+package: gitea
 
 297、source package:glob-stream 3.1.18
-package:
-glob-stream
+package: glob-stream
 
 298、source package:glob-watcher 0.0.6
-package:
-glob-watcher
+package: glob-watcher
 
 299、source package:glob2base 0.0.12
-package:
-glob2base
+package: glob2base
 
 300、source package:global-modules 1.0.0
-package:
-global-modules
+package: global-modules
 
 301、source package:global-prefix 1.0.2
-package:
-global-prefix
+package: global-prefix
 
 302、source package:globals 9.18.0
-package:
-globals
+package: globals
 
 303、source package:globule 1.2.1
-package:
-globule
+package: globule
 
 304、source package:glogg 1.0.2
-package:
-glogg
+package: glogg
 
 305、source package:go v1.1.7
-package:
-go
+package: go
 
 306、source package:go-isatty v0.0.9
-package:
-go-isatty
+package: go-isatty
 
 307、source package:go-pinyin v0.19.0
-package:
-go-pinyin
+package: go-pinyin
 
 308、source package:go-wav v0.3.2
-package:
-go-wav
+package: go-wav
 
 309、source package:go-windows-terminal-sequences v1.0.1
-package:
-go-windows-terminal-sequences
+package: go-windows-terminal-sequences
 
 310、source package:goconvey v1.8.1
-package:
-goconvey
+package: goconvey
 
 311、source package:golang-github-gosexy-gettext-dev 0~git20130221-2.1_all
-package:
-golang-github-gosexy-gettext-dev
+package: golang-github-gosexy-gettext-dev
 
 312、source package:gstreamer1.0-fluendo-mp3 0.10.32.debian-1_s390x
-package:
-gstreamer1.0-fluendo-mp3
+package: gstreamer1.0-fluendo-mp3
 
 313、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 314、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 315、source package:gstreamer1.0-plugins-ugly 1.9.90-1
-package:
-gstreamer1.0-plugins-ugly
+package: gstreamer1.0-plugins-ugly
 
 316、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 317、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 318、source package:gulp 3.9.1
-package:
-gulp
+package: gulp
 
 319、source package:gulp-concat 2.6.1
-package:
-gulp-concat
+package: gulp-concat
 
 320、source package:gulp-rename 1.4.0
-package:
-gulp-rename
+package: gulp-rename
 
 321、source package:gulp-sass 3.2.1
-package:
-gulp-sass
+package: gulp-sass
 
 322、source package:gulp-util 3.0.8
-package:
-gulp-util
+package: gulp-util
 
 323、source package:gulplog 1.0.0
-package:
-gulplog
+package: gulplog
 
 324、source package:har-validator 5.1.3
-package:
-har-validator
+package: har-validator
 
 325、source package:has 1.0.3
-package:
-has
+package: has
 
 326、source package:has-ansi 2.0.0
-package:
-has-ansi
+package: has-ansi
 
 327、source package:has-flag 2.0.0
-package:
-has-flag
+package: has-flag
 
 328、source package:has-gulplog 0.1.0
-package:
-has-gulplog
+package: has-gulplog
 
 329、source package:has-value 1.0.0
-package:
-has-value
+package: has-value
 
 330、source package:has-values 1.0.0
-package:
-has-values
+package: has-values
 
 331、source package:hash-base 3.1.0
-package:
-hash-base
+package: hash-base
 
 332、source package:hash.js 1.1.7
-package:
-hash.js
+package: hash.js
 
 333、source package:history 4.9.0
-package:
-history
+package: history
 
 334、source package:hmac-drbg 1.0.1
-package:
-hmac-drbg
+package: hmac-drbg
 
 335、source package:home-or-tmp 2.0.0
-package:
-home-or-tmp
+package: home-or-tmp
 
 336、source package:homedir-polyfill 1.0.3
-package:
-homedir-polyfill
+package: homedir-polyfill
 
 337、source package:htmlescape 1.1.1
-package:
-htmlescape
+package: htmlescape
 
 338、source package:htmlparser2 3.10.1
-package:
-htmlparser2
+package: htmlparser2
 
 339、source package:http-signature 1.2.0
-package:
-http-signature
+package: http-signature
 
 340、source package:https-browserify 1.0.0
-package:
-https-browserify
+package: https-browserify
 
 341、source package:image v0.10.0
-package:
-image
+package: image
 
 342、source package:immutable 4.1.0
-package:
-immutable
+package: immutable
 
 343、source package:indent-string 2.1.0
-package:
-indent-string
+package: indent-string
 
 344、source package:indexof 0.0.1
-package:
-indexof
+package: indexof
 
 345、source package:inline-source-map 0.6.2
-package:
-inline-source-map
+package: inline-source-map
 
 346、source package:insert-module-globals 7.2.0
-package:
-insert-module-globals
+package: insert-module-globals
 
 347、source package:interpret 1.4.0
-package:
-interpret
+package: interpret
 
 348、source package:invariant 2.2.4
-package:
-invariant
+package: invariant
 
 349、source package:invert-kv 1.0.0
-package:
-invert-kv
+package: invert-kv
 
 350、source package:is-absolute 1.0.0
-package:
-is-absolute
+package: is-absolute
 
 351、source package:is-accessor-descriptor 1.0.0
-package:
-is-accessor-descriptor
+package: is-accessor-descriptor
 
 352、source package:is-arrayish 0.2.1
-package:
-is-arrayish
+package: is-arrayish
 
 353、source package:is-binary-path 2.1.0
-package:
-is-binary-path
+package: is-binary-path
 
 354、source package:is-buffer 1.1.6
-package:
-is-buffer
+package: is-buffer
 
 355、source package:is-core-module 2.10.0
-package:
-is-core-module
+package: is-core-module
 
 356、source package:is-data-descriptor 1.0.0
-package:
-is-data-descriptor
+package: is-data-descriptor
 
 357、source package:is-descriptor 1.0.2
-package:
-is-descriptor
+package: is-descriptor
 
 358、source package:is-extendable 1.0.1
-package:
-is-extendable
+package: is-extendable
 
 359、source package:is-extglob 2.1.1
-package:
-is-extglob
+package: is-extglob
 
 360、source package:is-finite 1.0.2
-package:
-is-finite
+package: is-finite
 
 361、source package:is-fullwidth-code-point 2.0.0
-package:
-is-fullwidth-code-point
+package: is-fullwidth-code-point
 
 362、source package:is-glob 4.0.3
-package:
-is-glob
+package: is-glob
 
 363、source package:is-number 7.0.0
-package:
-is-number
+package: is-number
 
 364、source package:is-plain-object 2.0.4
-package:
-is-plain-object
+package: is-plain-object
 
 365、source package:is-relative 1.0.0
-package:
-is-relative
+package: is-relative
 
 366、source package:is-stream 1.1.0
-package:
-is-stream
+package: is-stream
 
 367、source package:is-typedarray 1.0.0
-package:
-is-typedarray
+package: is-typedarray
 
 368、source package:is-unc-path 1.0.0
-package:
-is-unc-path
+package: is-unc-path
 
 369、source package:is-utf8 0.2.1
-package:
-is-utf8
+package: is-utf8
 
 370、source package:is-windows 1.0.2
-package:
-is-windows
+package: is-windows
 
 371、source package:isarray 1.0.0
-package:
-isarray
+package: isarray
 
 372、source package:isobject 3.0.1
-package:
-isobject
+package: isobject
 
 373、source package:isstream 0.1.2
-package:
-isstream
+package: isstream
 
 374、source package:java_fpe_test 0.1.2
-package:
-java_fpe_test
+package: java_fpe_test
 
 375、source package:jq 1.6-2.1
-package:
-jq
+package: jq
 
 376、source package:jquery 3.6.1
-package:
-jquery
+package: jquery
 
 377、source package:js 0.1.0
-package:
-js
+package: js
 
 378、source package:js-tokens 3.0.2
-package:
-js-tokens
+package: js-tokens
 
 379、source package:jsbn 0.1.1
-package:
-jsbn
+package: jsbn
 
 380、source package:jsesc 1.3.0
-package:
-jsesc
+package: jsesc
 
 381、source package:json v3.7.0
-package:
-json
+package: json
 
 382、source package:json-loader 0.5.7
-package:
-json-loader
+package: json-loader
 
 383、source package:json-schema-traverse 0.4.1
-package:
-json-schema-traverse
+package: json-schema-traverse
 
 384、source package:json-stable-stringify 0.0.1
-package:
-json-stable-stringify
+package: json-stable-stringify
 
 385、source package:json5 2.1.3
-package:
-json5
+package: json5
 
 386、source package:jsonc-parser 3.2.0
-package:
-jsonc-parser
+package: jsonc-parser
 
 387、source package:jsonparse 1.3.1
-package:
-jsonparse
+package: jsonparse
 
 388、source package:jsprim 1.4.1
-package:
-jsprim
+package: jsprim
 
 389、source package:jwt-cpp v0.5.0
-package:
-jwt-cpp
+package: jwt-cpp
 
 390、source package:keypress 0.1.0
-package:
-keypress
+package: keypress
 
 391、source package:kind-of 6.0.3
-package:
-kind-of
+package: kind-of
 
 392、source package:labeled-stream-splicer 2.0.2
-package:
-labeled-stream-splicer
+package: labeled-stream-splicer
 
 393、source package:lazy-cache 1.0.4
-package:
-lazy-cache
+package: lazy-cache
 
 394、source package:lcid 1.0.0
-package:
-lcid
+package: lcid
 
 395、source package:libappimage-dev 0.1.9+dfsg-1_s390x
-package:
-libappimage-dev
+package: libappimage-dev
 
 396、source package:libboost-dev 1.71.0.3_s390x
-package:
-libboost-dev
+package: libboost-dev
 
 397、source package:libboost-filesystem-dev 1.71.0.3_s390x
-package:
-libboost-filesystem-dev
+package: libboost-filesystem-dev
 
 398、source package:libboost-serialization-dev 1.71.0.3_s390x
-package:
-libboost-serialization-dev
+package: libboost-serialization-dev
 
 399、source package:libboost-system-dev 1.71.0.3_s390x
-package:
-libboost-system-dev
+package: libboost-system-dev
 
 400、source package:libdrm-dev 2.4.99-1_s390x
-package:
-libdrm-dev
+package: libdrm-dev
 
 401、source package:libegl1-mesa-dev 8.0.5-4+deb7u2_sparc
-package:
-libegl1-mesa-dev
+package: libegl1-mesa-dev
 
 402、source package:libgbm-dev 8.0.5-4+deb7u2_sparc
-package:
-libgbm-dev
+package: libgbm-dev
 
 403、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 404、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 405、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 406、source package:libjson-c3 0.12.1-1.3_s390x
-package:
-libjson-c3
+package: libjson-c3
 
 407、source package:libjson-rpc-cpp v1.4.1
-package:
-libjson-rpc-cpp
+package: libjson-rpc-cpp
 
 408、source package:liblcms2-dev 2.9-4_s390x
-package:
-liblcms2-dev
+package: liblcms2-dev
 
 409、source package:libportaudio2 19.6.0-1_s390x
-package:
-libportaudio2
+package: libportaudio2
 
 410、source package:libx11-dev 2:1.8.4-2+deb12u1
-package:
-libx11-dev
+package: libx11-dev
 
 411、source package:libx11-xcb-dev 1.6.9-2_s390x
-package:
-libx11-xcb-dev
+package: libx11-xcb-dev
 
 412、source package:libxcb-composite0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-composite0-dev
+package: libxcb-composite0-dev
 
 413、source package:libxcb-cursor-dev 0.1.1-4_s390x
-package:
-libxcb-cursor-dev
+package: libxcb-cursor-dev
 
 414、source package:libxcb-damage0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-damage0-dev
+package: libxcb-damage0-dev
 
 415、source package:libxcb-ewmh-dev 0.4.1-1_s390x
-package:
-libxcb-ewmh-dev
+package: libxcb-ewmh-dev
 
 416、source package:libxcb-image0-dev 0.4.0-1_s390x
-package:
-libxcb-image0-dev
+package: libxcb-image0-dev
 
 417、source package:libxcb-keysyms1-dev 0.4.0-1_s390x
-package:
-libxcb-keysyms1-dev
+package: libxcb-keysyms1-dev
 
 418、source package:libxcb-randr0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-randr0-dev
+package: libxcb-randr0-dev
 
 419、source package:libxcb-record0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-record0-dev
+package: libxcb-record0-dev
 
 420、source package:libxcb-render-util0-dev 0.3.9-1_s390x
-package:
-libxcb-render-util0-dev
+package: libxcb-render-util0-dev
 
 421、source package:libxcb-render0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-render0-dev
+package: libxcb-render0-dev
 
 422、source package:libxcb-res0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-res0-dev
+package: libxcb-res0-dev
 
 423、source package:libxcb-shape0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-shape0-dev
+package: libxcb-shape0-dev
 
 424、source package:libxcb-sync-dev 1.14-2_s390x
-package:
-libxcb-sync-dev
+package: libxcb-sync-dev
 
 425、source package:libxcb-util0 0.3.8-3_s390x
-package:
-libxcb-util0
+package: libxcb-util0
 
 426、source package:libxcb-util0-dev 0.3.8-3_s390x
-package:
-libxcb-util0-dev
+package: libxcb-util0-dev
 
 427、source package:libxcb-util1 0.4.0-1
-package:
-libxcb-util1
+package: libxcb-util1
 
 428、source package:libxcb-xfixes0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xfixes0-dev
+package: libxcb-xfixes0-dev
 
 429、source package:libxcb-xinerama0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xinerama0-dev
+package: libxcb-xinerama0-dev
 
 430、source package:libxcb-xinput-dev 1.14-2_s390x
-package:
-libxcb-xinput-dev
+package: libxcb-xinput-dev
 
 431、source package:libxcb-xkb-dev 1.14-2_s390x
-package:
-libxcb-xkb-dev
+package: libxcb-xkb-dev
 
 432、source package:libxcb-xtest0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xtest0-dev
+package: libxcb-xtest0-dev
 
 433、source package:libxcb1-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb1-dev
+package: libxcb1-dev
 
 434、source package:libxext-dev 1.3.3-1_s390x
-package:
-libxext-dev
+package: libxext-dev
 
 435、source package:libxfixes-dev 5.0.3-2_s390x
-package:
-libxfixes-dev
+package: libxfixes-dev
 
 436、source package:libxinerama-dev 2:1.1.4-3
-package:
-libxinerama-dev
+package: libxinerama-dev
 
 437、source package:libxkbcommon-dev 0.9.1-1_s390x
-package:
-libxkbcommon-dev
+package: libxkbcommon-dev
 
 438、source package:libxkbcommon-x11-dev 0.9.1-1_s390x
-package:
-libxkbcommon-x11-dev
+package: libxkbcommon-x11-dev
 
 439、source package:libxss-dev 1.2.3-1_s390x
-package:
-libxss-dev
+package: libxss-dev
 
 440、source package:libxss1 1.2.3-1_s390x
-package:
-libxss1
+package: libxss1
 
 441、source package:libxtst-dev 1.2.3-1_s390x
-package:
-libxtst-dev
+package: libxtst-dev
 
 442、source package:liftoff 2.5.0
-package:
-liftoff
+package: liftoff
 
 443、source package:load-json-file 2.0.0
-package:
-load-json-file
+package: load-json-file
 
 444、source package:loader-runner 2.4.0
-package:
-loader-runner
+package: loader-runner
 
 445、source package:loader-utils 2.0.0
-package:
-loader-utils
+package: loader-utils
 
 446、source package:local-pkg 0.4.3
-package:
-local-pkg
+package: local-pkg
 
 447、source package:locales v0.12.1
-package:
-locales
+package: locales
 
 448、source package:locate-path 2.0.0
-package:
-locate-path
+package: locate-path
 
 449、source package:lodash 4.17.21
-package:
-lodash
+package: lodash
 
 450、source package:lodash-es 4.17.21
-package:
-lodash-es
+package: lodash-es
 
 451、source package:lodash-unified 1.0.2
-package:
-lodash-unified
+package: lodash-unified
 
 452、source package:lodash._basecopy 3.0.1
-package:
-lodash._basecopy
+package: lodash._basecopy
 
 453、source package:lodash._basetostring 3.0.1
-package:
-lodash._basetostring
+package: lodash._basetostring
 
 454、source package:lodash._basevalues 3.0.0
-package:
-lodash._basevalues
+package: lodash._basevalues
 
 455、source package:lodash._getnative 3.9.1
-package:
-lodash._getnative
+package: lodash._getnative
 
 456、source package:lodash._isiterateecall 3.0.9
-package:
-lodash._isiterateecall
+package: lodash._isiterateecall
 
 457、source package:lodash._reescape 3.0.0
-package:
-lodash._reescape
+package: lodash._reescape
 
 458、source package:lodash._reevaluate 3.0.0
-package:
-lodash._reevaluate
+package: lodash._reevaluate
 
 459、source package:lodash._reinterpolate 3.0.0
-package:
-lodash._reinterpolate
+package: lodash._reinterpolate
 
 460、source package:lodash._root 3.0.1
-package:
-lodash._root
+package: lodash._root
 
 461、source package:lodash.clonedeep 4.5.0
-package:
-lodash.clonedeep
+package: lodash.clonedeep
 
 462、source package:lodash.escape 3.2.0
-package:
-lodash.escape
+package: lodash.escape
 
 463、source package:lodash.isarguments 3.1.0
-package:
-lodash.isarguments
+package: lodash.isarguments
 
 464、source package:lodash.isarray 3.0.4
-package:
-lodash.isarray
+package: lodash.isarray
 
 465、source package:lodash.keys 3.1.2
-package:
-lodash.keys
+package: lodash.keys
 
 466、source package:lodash.memoize 3.0.4
-package:
-lodash.memoize
+package: lodash.memoize
 
 467、source package:lodash.restparam 3.6.1
-package:
-lodash.restparam
+package: lodash.restparam
 
 468、source package:lodash.template 3.6.2
-package:
-lodash.template
+package: lodash.template
 
 469、source package:lodash.templatesettings 3.1.1
-package:
-lodash.templatesettings
+package: lodash.templatesettings
 
 470、source package:logrus v1.9.3
-package:
-logrus
+package: logrus
 
 471、source package:longest 1.0.1
-package:
-longest
+package: longest
 
 472、source package:loose-envify 1.4.0
-package:
-loose-envify
+package: loose-envify
 
 473、source package:loud-rejection 1.6.0
-package:
-loud-rejection
+package: loud-rejection
 
 474、source package:magic-string 0.27.0
-package:
-magic-string
+package: magic-string
 
 475、source package:make-iterator 1.0.1
-package:
-make-iterator
+package: make-iterator
 
 476、source package:map-cache 0.2.2
-package:
-map-cache
+package: map-cache
 
 477、source package:map-obj 1.0.1
-package:
-map-obj
+package: map-obj
 
 478、source package:map-visit 1.0.0
-package:
-map-visit
+package: map-visit
 
 479、source package:marked 1.2.3
-package:
-marked
+package: marked
 
 480、source package:md5.js 1.3.5
-package:
-md5.js
+package: md5.js
 
 481、source package:mem 1.1.0
-package:
-mem
+package: mem
 
 482、source package:memoize-one 6.0.0
-package:
-memoize-one
+package: memoize-one
 
 483、source package:memory-fs 0.4.1
-package:
-memory-fs
+package: memory-fs
 
 484、source package:meow 3.7.0
-package:
-meow
+package: meow
 
 485、source package:merge2 1.4.1
-package:
-merge2
+package: merge2
 
 486、source package:mesa-utils 9.0.0-1
-package:
-mesa-utils
+package: mesa-utils
 
 487、source package:mesa-va-drivers 20.1.2-1_armel
-package:
-mesa-va-drivers
+package: mesa-va-drivers
 
 488、source package:mesa-vdpau-drivers 20.1.2-1_mipsel
-package:
-mesa-vdpau-drivers
+package: mesa-vdpau-drivers
 
 489、source package:mesa-vulkan-drivers 20.1.2-1_mips64el
-package:
-mesa-vulkan-drivers
+package: mesa-vulkan-drivers
 
 490、source package:micromatch 3.1.10
-package:
-micromatch
+package: micromatch
 
 491、source package:miller-rabin 4.0.1
-package:
-miller-rabin
+package: miller-rabin
 
 492、source package:mime-db 1.40.0
-package:
-mime-db
+package: mime-db
 
 493、source package:mime-types 2.1.24
-package:
-mime-types
+package: mime-types
 
 494、source package:mimic-fn 1.2.0
-package:
-mimic-fn
+package: mimic-fn
 
 495、source package:minimalistic-crypto-utils 1.0.1
-package:
-minimalistic-crypto-utils
+package: minimalistic-crypto-utils
 
 496、source package:minimatch 0.2.14
-package:
-minimatch
+package: minimatch
 
 497、source package:minimist 1.2.5
-package:
-minimist
+package: minimist
 
 498、source package:mitt 3.0.0
-package:
-mitt
+package: mitt
 
 499、source package:mixin-deep 1.3.2
-package:
-mixin-deep
+package: mixin-deep
 
 500、source package:mkdirp 0.5.5
-package:
-mkdirp
+package: mkdirp
 
 501、source package:mlly 1.4.2
-package:
-mlly
+package: mlly
 
 502、source package:module-deps 4.1.1
-package:
-module-deps
+package: module-deps
 
 503、source package:moment 2.29.4
-package:
-moment
+package: moment
 
 504、source package:mqt.qfr 1.10.0
-package:
-mqt.qfr
+package: mqt.qfr
 
 505、source package:ms 2.1.2
-package:
-ms
+package: ms
 
 506、source package:multipipe 0.1.2
-package:
-multipipe
+package: multipipe
 
 507、source package:nan 2.14.0
-package:
-nan
+package: nan
 
 508、source package:nanomatch 1.2.13
-package:
-nanomatch
+package: nanomatch
 
 509、source package:native v1.1.0
-package:
-native
+package: native
 
 510、source package:ncurses-base 6.2-1_all
-package:
-ncurses-base
+package: ncurses-base
 
 511、source package:neo-async 2.6.2
-package:
-neo-async
+package: neo-async
 
 512、source package:netlink v1.7.2
-package:
-netlink
+package: netlink
 
 513、source package:next-tick 1.0.0
-package:
-next-tick
+package: next-tick
 
 514、source package:nlohmann_json nlohmann_json-3.7.3
-package:
-nlohmann_json
+package: nlohmann_json
 
 515、source package:node 8.16.1
-package:
-node
+package: node
 
 516、source package:node-gyp 3.8.0
-package:
-node-gyp
+package: node-gyp
 
 517、source package:node-libs-browser 2.2.1
-package:
-node-libs-browser
+package: node-libs-browser
 
 518、source package:node-sass 4.12.0
-package:
-node-sass
+package: node-sass
 
 519、source package:normalize-path 3.0.0
-package:
-normalize-path
+package: normalize-path
 
 520、source package:npm-run-path 2.0.2
-package:
-npm-run-path
+package: npm-run-path
 
 521、source package:number-is-nan 1.0.1
-package:
-number-is-nan
+package: number-is-nan
 
 522、source package:object-assign 4.1.1
-package:
-object-assign
+package: object-assign
 
 523、source package:object-copy 0.1.0
-package:
-object-copy
+package: object-copy
 
 524、source package:object-visit 1.0.1
-package:
-object-visit
+package: object-visit
 
 525、source package:object.defaults 1.1.0
-package:
-object.defaults
+package: object.defaults
 
 526、source package:object.map 1.0.1
-package:
-object.map
+package: object.map
 
 527、source package:object.pick 1.3.0
-package:
-object.pick
+package: object.pick
 
 528、source package:objx v0.5.2
-package:
-objx
+package: objx
 
 529、source package:orchestrator 0.3.8
-package:
-orchestrator
+package: orchestrator
 
 530、source package:ordered-read-streams 0.1.0
-package:
-ordered-read-streams
+package: ordered-read-streams
 
 531、source package:os-browserify 0.3.0
-package:
-os-browserify
+package: os-browserify
 
 532、source package:os-config 0.2.3
-package:
-os-config
+package: os-config
 
 533、source package:os-homedir 1.0.2
-package:
-os-homedir
+package: os-homedir
 
 534、source package:os-locale 2.1.0
-package:
-os-locale
+package: os-locale
 
 535、source package:os-tmpdir 1.0.2
-package:
-os-tmpdir
+package: os-tmpdir
 
 536、source package:p-finally 1.0.0
-package:
-p-finally
+package: p-finally
 
 537、source package:p-limit 1.3.0
-package:
-p-limit
+package: p-limit
 
 538、source package:p-locate 2.0.0
-package:
-p-locate
+package: p-locate
 
 539、source package:p-try 1.0.0
-package:
-p-try
+package: p-try
 
 540、source package:pako 1.0.11
-package:
-pako
+package: pako
 
 541、source package:parents 1.0.1
-package:
-parents
+package: parents
 
 542、source package:parse-filepath 1.0.2
-package:
-parse-filepath
+package: parse-filepath
 
 543、source package:parse-json 2.2.0
-package:
-parse-json
+package: parse-json
 
 544、source package:parse-node-version 1.0.1
-package:
-parse-node-version
+package: parse-node-version
 
 545、source package:parse-passwd 1.0.0
-package:
-parse-passwd
+package: parse-passwd
 
 546、source package:parse5 3.0.3
-package:
-parse5
+package: parse5
 
 547、source package:pascalcase 0.1.1
-package:
-pascalcase
+package: pascalcase
 
 548、source package:path-browserify 0.0.1
-package:
-path-browserify
+package: path-browserify
 
 549、source package:path-dirname 1.0.2
-package:
-path-dirname
+package: path-dirname
 
 550、source package:path-exists 3.0.0
-package:
-path-exists
+package: path-exists
 
 551、source package:path-is-absolute 1.0.1
-package:
-path-is-absolute
+package: path-is-absolute
 
 552、source package:path-key 2.0.1
-package:
-path-key
+package: path-key
 
 553、source package:path-parse 1.0.7
-package:
-path-parse
+package: path-parse
 
 554、source package:path-platform 0.11.15
-package:
-path-platform
+package: path-platform
 
 555、source package:path-root 0.1.1
-package:
-path-root
+package: path-root
 
 556、source package:path-root-regex 0.1.2
-package:
-path-root-regex
+package: path-root-regex
 
 557、source package:path-to-regexp 1.7.0
-package:
-path-to-regexp
+package: path-to-regexp
 
 558、source package:path-type 2.0.0
-package:
-path-type
+package: path-type
 
 559、source package:pathe 1.1.1
-package:
-pathe
+package: pathe
 
 560、source package:pbkdf2 3.1.1
-package:
-pbkdf2
+package: pbkdf2
 
 561、source package:performance-now 2.1.0
-package:
-performance-now
+package: performance-now
 
 562、source package:picomatch 2.3.1
-package:
-picomatch
+package: picomatch
 
 563、source package:pify 2.3.0
-package:
-pify
+package: pify
 
 564、source package:pinia 2.0.22
-package:
-pinia
+package: pinia
 
 565、source package:pinkie 2.0.4
-package:
-pinkie
+package: pinkie
 
 566、source package:pinkie-promise 2.0.1
-package:
-pinkie-promise
+package: pinkie-promise
 
 567、source package:pipewire-pulse 0.3.71
-package:
-pipewire-pulse
+package: pipewire-pulse
 
 568、source package:pkg-types 1.0.3
-package:
-pkg-types
+package: pkg-types
 
 569、source package:platform/external/fmtlib upstream-master
-package:
-platform/external/fmtlib
+package: platform/external/fmtlib
 
 570、source package:portaudio19-dev 19.6.0-1_s390x
-package:
-portaudio19-dev
+package: portaudio19-dev
 
 571、source package:posix-character-classes 0.1.1
-package:
-posix-character-classes
+package: posix-character-classes
 
 572、source package:prefix-style 2.0.1
-package:
-prefix-style
+package: prefix-style
 
 573、source package:pretty v0.2.1
-package:
-pretty
+package: pretty
 
 574、source package:pretty-hrtime 1.0.3
-package:
-pretty-hrtime
+package: pretty-hrtime
 
 575、source package:private 0.1.8
-package:
-private
+package: private
 
 576、source package:process 0.11.10
-package:
-process
+package: process
 
 577、source package:process-nextick-args 2.0.1
-package:
-process-nextick-args
+package: process-nextick-args
 
 578、source package:promxy v0.0.81
-package:
-promxy
+package: promxy
 
 579、source package:prop-types 15.7.2
-package:
-prop-types
+package: prop-types
 
 580、source package:prr 1.0.1
-package:
-prr
+package: prr
 
 581、source package:psl 1.4.0
-package:
-psl
+package: psl
 
 582、source package:public-encrypt 4.0.3
-package:
-public-encrypt
+package: public-encrypt
 
 583、source package:punycode 2.1.1
-package:
-punycode
+package: punycode
 
 584、source package:python3 3.8.2-3_s390x
-package:
-python3
+package: python3
 
 585、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 586、source package:querystring 0.2.0
-package:
-querystring
+package: querystring
 
 587、source package:querystring-es3 0.2.1
-package:
-querystring-es3
+package: querystring-es3
 
 588、source package:queue-microtask 1.2.3
-package:
-queue-microtask
+package: queue-microtask
 
 589、source package:raf 3.4.1
-package:
-raf
+package: raf
 
 590、source package:randombytes 2.1.0
-package:
-randombytes
+package: randombytes
 
 591、source package:randomfill 1.0.4
-package:
-randomfill
+package: randomfill
 
 592、source package:react 16.9.0
-package:
-react
+package: react
 
 593、source package:react-custom-scrollbars 4.2.1
-package:
-react-custom-scrollbars
+package: react-custom-scrollbars
 
 594、source package:react-dom 16.9.0
-package:
-react-dom
+package: react-dom
 
 595、source package:react-is 16.9.0
-package:
-react-is
+package: react-is
 
 596、source package:react-router 4.3.1
-package:
-react-router
+package: react-router
 
 597、source package:react-router-dom 4.3.1
-package:
-react-router-dom
+package: react-router-dom
 
 598、source package:read-only-stream 2.0.0
-package:
-read-only-stream
+package: read-only-stream
 
 599、source package:read-pkg 2.0.0
-package:
-read-pkg
+package: read-pkg
 
 600、source package:read-pkg-up 2.0.0
-package:
-read-pkg-up
+package: read-pkg-up
 
 601、source package:readable-stream 3.6.0
-package:
-readable-stream
+package: readable-stream
 
 602、source package:readdirp 3.6.0
-package:
-readdirp
+package: readdirp
 
 603、source package:rechoir 0.6.2
-package:
-rechoir
+package: rechoir
 
 604、source package:redent 1.0.0
-package:
-redent
+package: redent
 
 605、source package:regenerate 1.4.0
-package:
-regenerate
+package: regenerate
 
 606、source package:regenerator-runtime 0.13.3
-package:
-regenerator-runtime
+package: regenerator-runtime
 
 607、source package:regex-not 1.0.2
-package:
-regex-not
+package: regex-not
 
 608、source package:regexpu-core 2.0.0
-package:
-regexpu-core
+package: regexpu-core
 
 609、source package:regjsgen 0.2.0
-package:
-regjsgen
+package: regjsgen
 
 610、source package:repeat-element 1.1.3
-package:
-repeat-element
+package: repeat-element
 
 611、source package:repeat-string 1.6.1
-package:
-repeat-string
+package: repeat-string
 
 612、source package:repeating 2.0.1
-package:
-repeating
+package: repeating
 
 613、source package:replace-ext 1.0.0
-package:
-replace-ext
+package: replace-ext
 
 614、source package:require-directory 2.1.1
-package:
-require-directory
+package: require-directory
 
 615、source package:resolve 1.22.1
-package:
-resolve
+package: resolve
 
 616、source package:resolve-dir 1.0.1
-package:
-resolve-dir
+package: resolve-dir
 
 617、source package:resolve-pathname 2.2.0
-package:
-resolve-pathname
+package: resolve-pathname
 
 618、source package:resolve-url 0.2.1
-package:
-resolve-url
+package: resolve-url
 
 619、source package:ret 0.1.15
-package:
-ret
+package: ret
 
 620、source package:reusify 1.0.4
-package:
-reusify
+package: reusify
 
 621、source package:right-align 0.1.3
-package:
-right-align
+package: right-align
 
 622、source package:ripemd160 2.0.2
-package:
-ripemd160
+package: ripemd160
 
 623、source package:rollup 2.79.1
-package:
-rollup
+package: rollup
 
 624、source package:run-parallel 1.2.0
-package:
-run-parallel
+package: run-parallel
 
 625、source package:safe-buffer 5.2.1
-package:
-safe-buffer
+package: safe-buffer
 
 626、source package:safe-regex 1.1.0
-package:
-safe-regex
+package: safe-regex
 
 627、source package:safer-buffer 2.1.2
-package:
-safer-buffer
+package: safer-buffer
 
 628、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 629、source package:sass-graph 2.2.4
-package:
-sass-graph
+package: sass-graph
 
 630、source package:scheduler 0.15.0
-package:
-scheduler
+package: scheduler
 
 631、source package:schema-utils 3.0.0
-package:
-schema-utils
+package: schema-utils
 
 632、source package:scroll-into-view-if-needed 2.2.20
-package:
-scroll-into-view-if-needed
+package: scroll-into-view-if-needed
 
 633、source package:scss-tokenizer 0.2.3
-package:
-scss-tokenizer
+package: scss-tokenizer
 
 634、source package:scule 1.1.1
-package:
-scule
+package: scule
 
 635、source package:sequencify 0.0.7
-package:
-sequencify
+package: sequencify
 
 636、source package:set-value 2.0.1
-package:
-set-value
+package: set-value
 
 637、source package:setimmediate 1.0.5
-package:
-setimmediate
+package: setimmediate
 
 638、source package:sha.js 2.4.11
-package:
-sha.js
+package: sha.js
 
 639、source package:shadered v1.5.3
-package:
-shadered
+package: shadered
 
 640、source package:shasum 1.0.2
-package:
-shasum
+package: shasum
 
 641、source package:shebang-command 1.2.0
-package:
-shebang-command
+package: shebang-command
 
 642、source package:shebang-regex 1.0.0
-package:
-shebang-regex
+package: shebang-regex
 
 643、source package:shell-quote 1.7.2
-package:
-shell-quote
+package: shell-quote
 
 644、source package:simple-concat 1.0.0
-package:
-simple-concat
+package: simple-concat
 
 645、source package:slash 1.0.0
-package:
-slash
+package: slash
 
 646、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 647、source package:smooth-scroll-into-view-if-needed 1.1.23
-package:
-smooth-scroll-into-view-if-needed
+package: smooth-scroll-into-view-if-needed
 
 648、source package:snapdragon 0.8.2
-package:
-snapdragon
+package: snapdragon
 
 649、source package:snapdragon-node 2.1.1
-package:
-snapdragon-node
+package: snapdragon-node
 
 650、source package:snapdragon-util 3.0.1
-package:
-snapdragon-util
+package: snapdragon-util
 
 651、source package:source-list-map 2.0.1
-package:
-source-list-map
+package: source-list-map
 
 652、source package:source-map-resolve 0.5.3
-package:
-source-map-resolve
+package: source-map-resolve
 
 653、source package:source-map-support 0.5.21
-package:
-source-map-support
+package: source-map-support
 
 654、source package:source-map-url 0.4.0
-package:
-source-map-url
+package: source-map-url
 
 655、source package:sourcemap-codec 1.4.8
-package:
-sourcemap-codec
+package: sourcemap-codec
 
 656、source package:sparkles 1.0.1
-package:
-sparkles
+package: sparkles
 
 657、source package:spdx-expression-parse 3.0.1
-package:
-spdx-expression-parse
+package: spdx-expression-parse
 
 658、source package:split-string 3.1.0
-package:
-split-string
+package: split-string
 
 659、source package:sqlclosecheck v0.5.0
-package:
-sqlclosecheck
+package: sqlclosecheck
 
 660、source package:sse v0.1.0
-package:
-sse
+package: sse
 
 661、source package:sshpk 1.16.1
-package:
-sshpk
+package: sshpk
 
 662、source package:static-extend 0.1.2
-package:
-static-extend
+package: static-extend
 
 663、source package:stdout-stream 1.4.1
-package:
-stdout-stream
+package: stdout-stream
 
 664、source package:stream-browserify 2.0.2
-package:
-stream-browserify
+package: stream-browserify
 
 665、source package:stream-combiner2 1.1.1
-package:
-stream-combiner2
+package: stream-combiner2
 
 666、source package:stream-consume 0.1.1
-package:
-stream-consume
+package: stream-consume
 
 667、source package:stream-http 2.8.3
-package:
-stream-http
+package: stream-http
 
 668、source package:stream-splicer 2.0.1
-package:
-stream-splicer
+package: stream-splicer
 
 669、source package:string-width 2.1.1
-package:
-string-width
+package: string-width
 
 670、source package:string_decoder 1.3.0
-package:
-string_decoder
+package: string_decoder
 
 671、source package:strip-ansi 4.0.0
-package:
-strip-ansi
+package: strip-ansi
 
 672、source package:strip-bom 3.0.0
-package:
-strip-bom
+package: strip-bom
 
 673、source package:strip-eof 1.0.0
-package:
-strip-eof
+package: strip-eof
 
 674、source package:strip-indent 1.0.1
-package:
-strip-indent
+package: strip-indent
 
 675、source package:strip-literal 1.3.0
-package:
-strip-literal
+package: strip-literal
 
 676、source package:subarg 1.0.0
-package:
-subarg
+package: subarg
 
 677、source package:sudo 1.9.8p2-1~exp1
-package:
-sudo
+package: sudo
 
 678、source package:supports-color 4.5.0
-package:
-supports-color
+package: supports-color
 
 679、source package:supports-preserve-symlinks-flag 1.0.0
-package:
-supports-preserve-symlinks-flag
+package: supports-preserve-symlinks-flag
 
 680、source package:syntax-error 1.4.0
-package:
-syntax-error
+package: syntax-error
 
 681、source package:sys v0.5.0
-package:
-sys
+package: sys
 
 682、source package:systemjs 6.13.0
-package:
-systemjs
+package: systemjs
 
 683、source package:tapable 0.2.9
-package:
-tapable
+package: tapable
 
 684、source package:testify v1.9.0
-package:
-testify
+package: testify
 
 685、source package:text v0.1.0
-package:
-text
+package: text
 
 686、source package:through2 2.0.5
-package:
-through2
+package: through2
 
 687、source package:tildify 1.2.0
-package:
-tildify
+package: tildify
 
 688、source package:time-stamp 1.1.0
-package:
-time-stamp
+package: time-stamp
 
 689、source package:timers-browserify 2.0.12
-package:
-timers-browserify
+package: timers-browserify
 
 690、source package:tiny-invariant 1.0.6
-package:
-tiny-invariant
+package: tiny-invariant
 
 691、source package:tiny-warning 1.0.3
-package:
-tiny-warning
+package: tiny-warning
 
 692、source package:tinyaes 1.0.4rc1
-package:
-tinyaes
+package: tinyaes
 
 693、source package:tlp 1.5.0-1~bpo11+1
-package:
-tlp
+package: tlp
 
 694、source package:to-arraybuffer 1.0.1
-package:
-to-arraybuffer
+package: to-arraybuffer
 
 695、source package:to-camel-case 1.0.0
-package:
-to-camel-case
+package: to-camel-case
 
 696、source package:to-fast-properties 1.0.3
-package:
-to-fast-properties
+package: to-fast-properties
 
 697、source package:to-no-case 1.0.2
-package:
-to-no-case
+package: to-no-case
 
 698、source package:to-object-path 0.3.0
-package:
-to-object-path
+package: to-object-path
 
 699、source package:to-regex 3.0.2
-package:
-to-regex
+package: to-regex
 
 700、source package:to-regex-range 5.0.1
-package:
-to-regex-range
+package: to-regex-range
 
 701、source package:to-space-case 1.0.0
-package:
-to-space-case
+package: to-space-case
 
 702、source package:toml v1.3.2
-package:
-toml
+package: toml
 
 703、source package:tools v0.6.0
-package:
-tools
+package: tools
 
 704、source package:tortellini 4f6795a
-package:
-tortellini
+package: tortellini
 
 705、source package:trim-newlines 1.0.0
-package:
-trim-newlines
+package: trim-newlines
 
 706、source package:trim-right 1.0.1
-package:
-trim-right
+package: trim-right
 
 707、source package:tty-browserify 0.0.1
-package:
-tty-browserify
+package: tty-browserify
 
 708、source package:typedarray 0.0.6
-package:
-typedarray
+package: typedarray
 
 709、source package:uglify-to-browserify 1.0.2
-package:
-uglify-to-browserify
+package: uglify-to-browserify
 
 710、source package:uglifyjs-webpack-plugin 0.4.6
-package:
-uglifyjs-webpack-plugin
+package: uglifyjs-webpack-plugin
 
 711、source package:umd 3.0.3
-package:
-umd
+package: umd
 
 712、source package:unc-path-regex 0.1.2
-package:
-unc-path-regex
+package: unc-path-regex
 
 713、source package:unimport 1.3.0
-package:
-unimport
+package: unimport
 
 714、source package:union-value 1.0.1
-package:
-union-value
+package: union-value
 
 715、source package:unique-stream 1.0.0
-package:
-unique-stream
+package: unique-stream
 
 716、source package:universal-translator v0.16.0
-package:
-universal-translator
+package: universal-translator
 
 717、source package:unplugin-auto-import 0.11.5
-package:
-unplugin-auto-import
+package: unplugin-auto-import
 
 718、source package:unplugin-vue-components 0.22.12
-package:
-unplugin-vue-components
+package: unplugin-vue-components
 
 719、source package:unset-value 1.0.0
-package:
-unset-value
+package: unset-value
 
 720、source package:upath 1.2.0
-package:
-upath
+package: upath
 
 721、source package:urix 0.1.0
-package:
-urix
+package: urix
 
 722、source package:url 0.11.0
-package:
-url
+package: url
 
 723、source package:use 3.1.1
-package:
-use
+package: use
 
 724、source package:user-home 1.1.1
-package:
-user-home
+package: user-home
 
 725、source package:util 0.11.1
-package:
-util
+package: util
 
 726、source package:util-deprecate 1.0.2
-package:
-util-deprecate
+package: util-deprecate
 
 727、source package:uuid 3.3.3
-package:
-uuid
+package: uuid
 
 728、source package:v-drag 3.0.9
-package:
-v-drag
+package: v-drag
 
 729、source package:v8flags 2.1.1
-package:
-v8flags
+package: v8flags
 
 730、source package:value-equal 0.4.0
-package:
-value-equal
+package: value-equal
 
 731、source package:verror 1.10.0
-package:
-verror
+package: verror
 
 732、source package:vinyl 2.2.0
-package:
-vinyl
+package: vinyl
 
 733、source package:vinyl-buffer 1.0.1
-package:
-vinyl-buffer
+package: vinyl-buffer
 
 734、source package:vinyl-fs 0.3.14
-package:
-vinyl-fs
+package: vinyl-fs
 
 735、source package:vinyl-source-stream 2.0.0
-package:
-vinyl-source-stream
+package: vinyl-source-stream
 
 736、source package:vm-browserify 1.1.2
-package:
-vm-browserify
+package: vm-browserify
 
 737、source package:vue-codemirror 6.1.1
-package:
-vue-codemirror
+package: vue-codemirror
 
 738、source package:vue-demi 0.13.11
-package:
-vue-demi
+package: vue-demi
 
 739、source package:vue-router 4.1.5
-package:
-vue-router
+package: vue-router
 
 740、source package:w3c-keyname 2.2.8
-package:
-w3c-keyname
+package: w3c-keyname
 
 741、source package:warning 4.0.3
-package:
-warning
+package: warning
 
 742、source package:watchpack 1.7.4
-package:
-watchpack
+package: watchpack
 
 743、source package:watchpack-chokidar2 2.0.0
-package:
-watchpack-chokidar2
+package: watchpack-chokidar2
 
 744、source package:webpack 3.12.0
-package:
-webpack
+package: webpack
 
 745、source package:webpack-sources 3.2.3
-package:
-webpack-sources
+package: webpack-sources
 
 746、source package:webpack-virtual-modules 0.6.1
-package:
-webpack-virtual-modules
+package: webpack-virtual-modules
 
 747、source package:window-size 0.1.0
-package:
-window-size
+package: window-size
 
 748、source package:wireplumber 0.4.9-1
-package:
-wireplumber
+package: wireplumber
 
 749、source package:wordwrap 0.0.2
-package:
-wordwrap
+package: wordwrap
 
 750、source package:wrap-ansi 2.1.0
-package:
-wrap-ansi
+package: wrap-ansi
 
 751、source package:x11-utils 7.7~1_sparc
-package:
-x11-utils
+package: x11-utils
 
 752、source package:x11-xserver-utils 7.7~3_sparc
-package:
-x11-xserver-utils
+package: x11-xserver-utils
 
 753、source package:x11proto-record-dev 2020.1-1_all
-package:
-x11proto-record-dev
+package: x11proto-record-dev
 
 754、source package:x11proto-xext-dev 7.3.0-1_all
-package:
-x11proto-xext-dev
+package: x11proto-xext-dev
 
 755、source package:xcb-proto 1.7.1.orig
-package:
-xcb-proto
+package: xcb-proto
 
 756、source package:xdg-utils 1.1.3-4.1
-package:
-xdg-utils
+package: xdg-utils
 
 757、source package:xkb-data 2.5.1-3_all
-package:
-xkb-data
+package: xkb-data
 
 758、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 759、source package:xserver-xorg-input-all 7.7+7_s390x
-package:
-xserver-xorg-input-all
+package: xserver-xorg-input-all
 
 760、source package:xserver-xorg-video-all 7.7+7_s390x
-package:
-xserver-xorg-video-all
+package: xserver-xorg-video-all
 
 761、source package:xtend 4.0.2
-package:
-xtend
+package: xtend
 
 762、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 763、source package:yargs 8.0.2
-package:
-yargs
+package: yargs
 
 
 Open Source Software Licensed under the Expat:
 1、source package:golang-github-adrg-xdg-dev 0.4.0-2
-package:
-golang-github-adrg-xdg-dev
+package: golang-github-adrg-xdg-dev
 
 2、source package:golang-github-disintegration-imaging-dev 1.6.2-2
-package:
-golang-github-disintegration-imaging-dev
+package: golang-github-disintegration-imaging-dev
 
 3、source package:golang-github-smartystreets-goconvey-dev 1.6.4+dfsg-1_all
-package:
-golang-github-smartystreets-goconvey-dev
+package: golang-github-smartystreets-goconvey-dev
 
 4、source package:golang-github-stretchr-testify-dev 1.8.0-1~bpo11+1
-package:
-golang-github-stretchr-testify-dev
+package: golang-github-stretchr-testify-dev
 
 5、source package:golang-github-teambition-rrule-go-dev 1.8.1-1
-package:
-golang-github-teambition-rrule-go-dev
+package: golang-github-teambition-rrule-go-dev
 
 6、source package:golang-gopkg-alecthomas-kingpin.v2-dev 2.2.6-4
-package:
-golang-gopkg-alecthomas-kingpin.v2-dev
+package: golang-gopkg-alecthomas-kingpin.v2-dev
 
 7、source package:intel-media-va-driver-non-free 23.2.3+ds1-1
-package:
-intel-media-va-driver-non-free
+package: intel-media-va-driver-non-free
 
 8、source package:libepoxy-dev 1.5.9-2
-package:
-libepoxy-dev
+package: libepoxy-dev
 
 9、source package:libiniparser-dev 4.1-4_s390x
-package:
-libiniparser-dev
+package: libiniparser-dev
 
 10、source package:libinput-dev 1.6.3-1_s390x
-package:
-libinput-dev
+package: libinput-dev
 
 11、source package:libjson-c-dev 0.16-2
-package:
-libjson-c-dev
+package: libjson-c-dev
 
 12、source package:libmtdev-dev 1.1.6-1_s390x
-package:
-libmtdev-dev
+package: libmtdev-dev
 
 13、source package:libsass-dev 3.6.4-4~exp_s390x
-package:
-libsass-dev
+package: libsass-dev
 
 14、source package:libspdlog-dev 1:1.3.1-1
-package:
-libspdlog-dev
+package: libspdlog-dev
 
 15、source package:libutf8proc-dev 2.7.0-4
-package:
-libutf8proc-dev
+package: libutf8proc-dev
 
 16、source package:libva-dev 2.8.0-1_s390x
-package:
-libva-dev
+package: libva-dev
 
 17、source package:nlohmann-json3-dev 3.9.1-1
-package:
-nlohmann-json3-dev
+package: nlohmann-json3-dev
 
 18、source package:rapidjson-dev 1.1.0-1
-package:
-rapidjson-dev
+package: rapidjson-dev
 
 19、source package:va-driver-all 2.8.0-1_s390x
-package:
-va-driver-all
+package: va-driver-all
 
 20、source package:wayland-protocols 1.9-1
-package:
-wayland-protocols
+package: wayland-protocols
 
 
 Open Source Software Licensed under the BSD-3-Clause:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 2、source package:alsa-topology-conf 1.2.5.1-2
-package:
-alsa-topology-conf
+package: alsa-topology-conf
 
 3、source package:alsa-ucm-conf 1.2.9-1
-package:
-alsa-ucm-conf
+package: alsa-ucm-conf
 
 4、source package:amdefine 1.0.1
-package:
-amdefine
+package: amdefine
 
 5、source package:android-pdfium a56ccce4
-package:
-android-pdfium
+package: android-pdfium
 
 6、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 7、source package:bcrypt-pbkdf 1.0.2
-package:
-bcrypt-pbkdf
+package: bcrypt-pbkdf
 
 8、source package:browserify 14.5.0
-package:
-browserify
+package: browserify
 
 9、source package:charenc 0.0.2
-package:
-charenc
+package: charenc
 
 10、source package:chromium 87.0.4280.88-0.4
-package:
-chromium
+package: chromium
 
 11、source package:cmake v3.27.0-rc5
-package:
-cmake
+package: cmake
 
 12、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 13、source package:crypt 0.0.2
-package:
-crypt
+package: crypt
 
 14、source package:crypto v0.13.0
-package:
-crypto
+package: crypto
 
 15、source package:css-select 1.2.0
-package:
-css-select
+package: css-select
 
 16、source package:css-what 2.1.3
-package:
-css-what
+package: css-what
 
 17、source package:dns v1.1.52
-package:
-dns
+package: dns
 
 18、source package:dnsutils 970203-0.1
-package:
-dnsutils
+package: dnsutils
 
 19、source package:duplexer2 0.1.4
-package:
-duplexer2
+package: duplexer2
 
 20、source package:entities 1.1.2
-package:
-entities
+package: entities
 
 21、source package:errwrap v1.5.0
-package:
-errwrap
+package: errwrap
 
 22、source package:external/github.com/protocolbuffers/protobuf v3.7.0-rc.3
-package:
-external/github.com/protocolbuffers/protobuf
+package: external/github.com/protocolbuffers/protobuf
 
 23、source package:extra-cmake-modules 5.98.0-2
-package:
-extra-cmake-modules
+package: extra-cmake-modules
 
 24、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 25、source package:fsnotify v1.6.0
-package:
-fsnotify
+package: fsnotify
 
 26、source package:go-cmp v0.6.0
-package:
-go-cmp
+package: go-cmp
 
 27、source package:golang 2:1.7~5~bpo8+1
-package:
-golang
+package: golang
 
 28、source package:golang-any 1.7~5~bpo8+1_s390x
-package:
-golang-any
+package: golang-any
 
 29、source package:golang-github-fsnotify-fsnotify-dev 1.6.0-1
-package:
-golang-github-fsnotify-fsnotify-dev
+package: golang-github-fsnotify-fsnotify-dev
 
 30、source package:golang-github-miekg-dns-dev 1.1.50-2
-package:
-golang-github-miekg-dns-dev
+package: golang-github-miekg-dns-dev
 
 31、source package:golang-github-rickb777-date-dev 1.20.1-1
-package:
-golang-github-rickb777-date-dev
+package: golang-github-rickb777-date-dev
 
 32、source package:golang-go 1.7~5~bpo8+1_ppc64el
-package:
-golang-go
+package: golang-go
 
 33、source package:golang-golang-x-sys-dev 0.3.0-1+hurd.1
-package:
-golang-golang-x-sys-dev
+package: golang-golang-x-sys-dev
 
 34、source package:golang-golang-x-xerrors-dev 0.0~git20191204.9bdfabe-1~bpo10+1
-package:
-golang-golang-x-xerrors-dev
+package: golang-golang-x-xerrors-dev
 
 35、source package:golang-google-protobuf-dev 1.28.1-3
-package:
-golang-google-protobuf-dev
+package: golang-google-protobuf-dev
 
 36、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 37、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 38、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 39、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 40、source package:hoist-non-react-statics 2.5.5
-package:
-hoist-non-react-statics
+package: hoist-non-react-statics
 
 41、source package:ieee754 1.2.1
-package:
-ieee754
+package: ieee754
 
 42、source package:init 1.65~exp2
-package:
-init
+package: init
 
 43、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 44、source package:js-base64 2.5.1
-package:
-js-base64
+package: js-base64
 
 45、source package:json-schema 0.2.3
-package:
-json-schema
+package: json-schema
 
 46、source package:libcli11-dev 2.1.2+ds-1
-package:
-libcli11-dev
+package: libcli11-dev
 
 47、source package:libgmock-dev 1.9.0.20190831-3
-package:
-libgmock-dev
+package: libgmock-dev
 
 48、source package:libgoogle-glog-dev 0.4.0-1_s390x
-package:
-libgoogle-glog-dev
+package: libgoogle-glog-dev
 
 49、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 50、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 51、source package:libgtest-dev 1.9.0.20190831-1_s390x
-package:
-libgtest-dev
+package: libgtest-dev
 
 52、source package:libjpeg-dev 2.0.5-1_all
-package:
-libjpeg-dev
+package: libjpeg-dev
 
 53、source package:libnl-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-3-dev
+package: libnl-3-dev
 
 54、source package:libnl-genl-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-genl-3-dev
+package: libnl-genl-3-dev
 
 55、source package:libnl-route-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-route-3-dev
+package: libnl-route-3-dev
 
 56、source package:libpcap-dev 1.9.1-4~bpo10+1_s390x
-package:
-libpcap-dev
+package: libpcap-dev
 
 57、source package:libtirpc-common 1.2.6-1_all
-package:
-libtirpc-common
+package: libtirpc-common
 
 58、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 59、source package:locales 2.31-0experimental0_all
-package:
-locales
+package: locales
 
 60、source package:lxqt-build-tools 0.8.0-1
-package:
-lxqt-build-tools
+package: lxqt-build-tools
 
 61、source package:marked 1.2.3
-package:
-marked
+package: marked
 
 62、source package:md5 2.2.1
-package:
-md5
+package: md5
 
 63、source package:mmkv-static 1.2.10
-package:
-mmkv-static
+package: mmkv-static
 
 64、source package:mod v0.8.0
-package:
-mod
+package: mod
 
 65、source package:mount 2.9g-6
-package:
-mount
+package: mount
 
 66、source package:net v0.15.0
-package:
-net
+package: net
 
 67、source package:node 8.16.1
-package:
-node
+package: node
 
 68、source package:normalize-wheel-es 1.2.0
-package:
-normalize-wheel-es
+package: normalize-wheel-es
 
 69、source package:nth-check 1.0.2
-package:
-nth-check
+package: nth-check
 
 70、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 71、source package:passwd 980403-0.3
-package:
-passwd
+package: passwd
 
 72、source package:pflag v1.0.5
-package:
-pflag
+package: pflag
 
 73、source package:protobuf v1.3.2
-package:
-protobuf
+package: protobuf
 
 74、source package:python3-click 8.1.6-1
-package:
-python3-click
+package: python3-click
 
 75、source package:qml-module-qtgraphicaleffects 5.7.1~20161021-3_s390x
-package:
-qml-module-qtgraphicaleffects
+package: qml-module-qtgraphicaleffects
 
 76、source package:qs 6.5.2
-package:
-qs
+package: qs
 
 77、source package:qtermwidget 0.14.1
-package:
-qtermwidget
+package: qtermwidget
 
 78、source package:regenerator-transform 0.10.1
-package:
-regenerator-transform
+package: regenerator-transform
 
 79、source package:regjsparser 0.1.5
-package:
-regjsparser
+package: regjsparser
 
 80、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 81、source package:sha.js 2.4.11
-package:
-sha.js
+package: sha.js
 
 82、source package:source-map 0.6.1
-package:
-source-map
+package: source-map
 
 83、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 84、source package:sys v0.6.0
-package:
-sys
+package: sys
 
 85、source package:syscall_intercept 4b3a3b5
-package:
-syscall_intercept
+package: syscall_intercept
 
 86、source package:term v0.13.0
-package:
-term
+package: term
 
 87、source package:terser 5.15.1
-package:
-terser
+package: terser
 
 88、source package:text v0.13.0
-package:
-text
+package: text
 
 89、source package:tough-cookie 2.4.3
-package:
-tough-cookie
+package: tough-cookie
 
 90、source package:uglify-js 2.8.29
-package:
-uglify-js
+package: uglify-js
 
 91、source package:util-linux 2.5-12
-package:
-util-linux
+package: util-linux
 
 92、source package:uuid v1.3.0
-package:
-uuid
+package: uuid
 
 93、source package:wpasupplicant 2.9.0-12_s390x
-package:
-wpasupplicant
+package: wpasupplicant
 
 94、source package:xdotool 3.20160805.1-4_s390x
-package:
-xdotool
+package: xdotool
 
 95、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 96、source package:xsettingsd 1.0.2-1
-package:
-xsettingsd
+package: xsettingsd
 
 97、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the BSD-2-Clause:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 2、source package:block-stream 0.0.9
-package:
-block-stream
+package: block-stream
 
 3、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 4、source package:domelementtype 1.3.1
-package:
-domelementtype
+package: domelementtype
 
 5、source package:domhandler 2.4.2
-package:
-domhandler
+package: domhandler
 
 6、source package:domutils 1.5.1
-package:
-domutils
+package: domutils
 
 7、source package:doxyqml 0.3.0-1.1.debian
-package:
-doxyqml
+package: doxyqml
 
 8、source package:escope 3.6.0
-package:
-escope
+package: escope
 
 9、source package:esrecurse 4.3.0
-package:
-esrecurse
+package: esrecurse
 
 10、source package:estraverse 5.2.0
-package:
-estraverse
+package: estraverse
 
 11、source package:esutils 2.0.3
-package:
-esutils
+package: esutils
 
 12、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 13、source package:glob 3.1.21
-package:
-glob
+package: glob
 
 14、source package:golang-dbus-dev 5.1.0-1~bpo11+1
-package:
-golang-dbus-dev
+package: golang-dbus-dev
 
 15、source package:golang-github-msteinert-pam-dev 1.1.0-1
-package:
-golang-github-msteinert-pam-dev
+package: golang-github-msteinert-pam-dev
 
 16、source package:golang-gopkg-check.v1-dev 0.0+git20200902.038fdea-1
-package:
-golang-gopkg-check.v1-dev
+package: golang-gopkg-check.v1-dev
 
 17、source package:graceful-fs 1.2.3
-package:
-graceful-fs
+package: graceful-fs
 
 18、source package:libarchive-dev 3.4.0-2~bpo9+1_amd64
-package:
-libarchive-dev
+package: libarchive-dev
 
 19、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 20、source package:libtss2-dev 2.4.0-1_s390x
-package:
-libtss2-dev
+package: libtss2-dev
 
 21、source package:libtss2-tcti-tabrmd0 3.0.0-1
-package:
-libtss2-tcti-tabrmd0
+package: libtss2-tcti-tabrmd0
 
 22、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 23、source package:normalize-package-data 2.5.0
-package:
-normalize-package-data
+package: normalize-package-data
 
 24、source package:sdparm 1.12-1
-package:
-sdparm
+package: sdparm
 
 25、source package:shim-signed 1.39~1+deb11u1
-package:
-shim-signed
+package: shim-signed
 
 26、source package:shim-unsigned 15+1533136590.3beb971-9_i386
-package:
-shim-unsigned
+package: shim-unsigned
 
 27、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 28、source package:tpm2-abrmd 3.0.0-1
-package:
-tpm2-abrmd
+package: tpm2-abrmd
 
 29、source package:tt v1.0.1
-package:
-tt
+package: tt
 
 30、source package:uri-js 4.4.0
-package:
-uri-js
+package: uri-js
 
 31、source package:usb-modeswitch 2.6.1.orig
-package:
-usb-modeswitch
+package: usb-modeswitch
 
 
 Open Source Software Licensed under the MPL-2.0:
 1、source package:browser-desktop 87.0-729282885
-package:
-browser-desktop
+package: browser-desktop
 
 2、source package:dompurify 2.4.1
-package:
-dompurify
+package: dompurify
 
 3、source package:libjwt-dev 1.9.0-4_mips64el
-package:
-libjwt-dev
+package: libjwt-dev
 
 4、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 
 Open Source Software Licensed under the MPL-1.1:
 1、source package:libcairo2-dev 1.16.0-4_s390x
-package:
-libcairo2-dev
+package: libcairo2-dev
 
 2、source package:libchardet 1.0.3
-package:
-libchardet
+package: libchardet
 
 3、source package:libpam-gnome-keyring 3.4.1-5_sparc
-package:
-libpam-gnome-keyring
+package: libpam-gnome-keyring
 
 4、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 
 Open Source Software Licensed under the AFL-2.1:
 1、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 
 Open Source Software Licensed under the AGPL-1.0-only:
 1、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 
 Open Source Software Licensed under the AGPL-3.0-only:
 1、source package:nging v3.5.2
-package:
-nging
+package: nging
 
 2、source package:sobjectizer 1.2.3
-package:
-sobjectizer
+package: sobjectizer
 
 
 Open Source Software Licensed under the Apache-2.0 or LGPL-3+:
 1、source package:liblucene++-dev 3.0.7-8+b2_s390x
-package:
-liblucene++-dev
+package: liblucene++-dev
 
 
 Open Source Software Licensed under the Apache-2.0-with-GPL2-LGPL2-Exception:
 1、source package:cups 2.4.2-3+deb12u1
-package:
-cups
+package: cups
 
 
 Open Source Software Licensed under the Artistic or GPL-1+:
 1、source package:libfile-mimeinfo-perl 0.33-1
-package:
-libfile-mimeinfo-perl
+package: libfile-mimeinfo-perl
 
 2、source package:perl-openssl-defaults 7
-package:
-perl-openssl-defaults
+package: perl-openssl-defaults
 
 
 Open Source Software Licensed under the Artistic-2.0:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the BSD:
 1、source package:compiler 4.12.0
-package:
-compiler
+package: compiler
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:glide 4.12.0
-package:
-glide
+package: glide
 
 4、source package:libnet-dev 1.2-rc3
-package:
-libnet-dev
+package: libnet-dev
 
 5、source package:libvncserver LibVNCServer-0.9.14
-package:
-libvncserver
+package: libvncserver
 
 6、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 7、source package:node 8.16.1
-package:
-node
+package: node
 
 8、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 9、source package:zip 3.0-9
-package:
-zip
+package: zip
 
 
 Open Source Software Licensed under the BSD-1-Clause:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 
 Open Source Software Licensed under the BSD-3-clause:
 1、source package:tpm2-tools 5.4-1
-package:
-tpm2-tools
+package: tpm2-tools
 
 
 Open Source Software Licensed under the BSD-3-clause or GPL-2:
 1、source package:libcap-dev 2.36-1_mips64el
-package:
-libcap-dev
+package: libcap-dev
 
 2、source package:libcap2-bin 2.36-1_s390x
-package:
-libcap2-bin
+package: libcap2-bin
 
 
 Open Source Software Licensed under the BSD-4-Clause:
 1、source package:unalz 0.65-9
-package:
-unalz
+package: unalz
 
 
 Open Source Software Licensed under the BSD-Source-Code:
 1、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 
 Open Source Software Licensed under the BSL-1.0:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 
 Open Source Software Licensed under the Bitstream-Vera:
 1、source package:fontconfig 2.9.0.orig
-package:
-fontconfig
+package: fontconfig
 
 
 Open Source Software Licensed under the Brian-Gladman-3-Clause:
 1、source package:libzip-dev 1.6.1-3_s390x
-package:
-libzip-dev
+package: libzip-dev
 
 2、source package:libzip4 1.6.1-3_s390x
-package:
-libzip4
+package: libzip4
 
 
 Open Source Software Licensed under the CC-BY-3.0:
 1、source package:spdx-exceptions 2.3.0
-package:
-spdx-exceptions
+package: spdx-exceptions
 
 
 Open Source Software Licensed under the CC-BY-4.0:
 1、source package:caniuse-lite 1.0.30000989
-package:
-caniuse-lite
+package: caniuse-lite
 
 
 Open Source Software Licensed under the CC-BY-SA-4.0:
 1、source package:glob 7.1.4
-package:
-glob
+package: glob
 
 
 Open Source Software Licensed under the CC0-1.0:
 1、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 
 Open Source Software Licensed under the CDDL-1.0:
 1、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 
 Open Source Software Licensed under the CPL-1.0:
 1、source package:graphviz 2.8-3+etch1
-package:
-graphviz
+package: graphviz
 
 2、source package:junit 4.11
-package:
-junit
+package: junit
 
 
 Open Source Software Licensed under the EPL-1.0:
 1、source package:aspectjrt 1.9.6
-package:
-aspectjrt
+package: aspectjrt
 
 2、source package:junit 4.13.2
-package:
-junit
+package: junit
 
 
 Open Source Software Licensed under the FTL:
 1、source package:freetype VER-2-10-3
-package:
-freetype
+package: freetype
 
 2、source package:libfreetype-dev 2.13.0+dfsg-1
-package:
-libfreetype-dev
+package: libfreetype-dev
 
 
 Open Source Software Licensed under the Font-exception-2.0:
 1、source package:ttf-unifont 9.0.06-2_all
-package:
-ttf-unifont
+package: ttf-unifont
 
 2、source package:xfonts-wqy 1.0.0~rc1-7
-package:
-xfonts-wqy
+package: xfonts-wqy
 
 
 Open Source Software Licensed under the GFDL-1.2-only:
 1、source package:kdevelop v22.11.80
-package:
-kdevelop
+package: kdevelop
 
 
 Open Source Software Licensed under the GPL+ and GPLv2+ and MIT and Redistributable no modification permitted:
 1、source package:linux-firmware 20230824
-package:
-linux-firmware
+package: linux-firmware
 
 
 Open Source Software Licensed under the GPL-2 or GPL-2+:
 1、source package:ipheth-utils 1.0-5_s390x
-package:
-ipheth-utils
+package: ipheth-utils
 
 
 Open Source Software Licensed under the GPL-2 with Font embedding exception and M+ FONTS License:
 1、source package:fonts-wqy-zenhei 0.9.45-8
-package:
-fonts-wqy-zenhei
+package: fonts-wqy-zenhei
 
 
 Open Source Software Licensed under the GPL-2 with OpenSSL exception:
 1、source package:barrier 2.4.0+dfsg-2
-package:
-barrier
+package: barrier
 
 
 Open Source Software Licensed under the GPL-2+ and LGPL-2+:
 1、source package:xdg-desktop-portal-gtk 1.8.0-1~bpo10+1
-package:
-xdg-desktop-portal-gtk
+package: xdg-desktop-portal-gtk
 
 
 Open Source Software Licensed under the GPL-2+ or AFL-2.1:
 1、source package:dbus 1.9.8-1
-package:
-dbus
+package: dbus
 
 2、source package:dbus-user-session 1.13.8-1_s390x
-package:
-dbus-user-session
+package: dbus-user-session
 
 3、source package:dbus-x11 1.8.22-0+deb8u1_s390x
-package:
-dbus-x11
+package: dbus-x11
 
 4、source package:libdbus-1-dev 1.8.22-0+deb8u1_s390x
-package:
-libdbus-1-dev
+package: libdbus-1-dev
 
 
 Open Source Software Licensed under the GPL-2+ or FTL:
 1、source package:libfreetype6-dev 2.9.1-4_s390x
-package:
-libfreetype6-dev
+package: libfreetype6-dev
 
 
 Open Source Software Licensed under the GPL-2+ or LGPL-2.1 or LGPL-3.0:
 1、source package:libquazip5-dev 0.7.6-6_s390x
-package:
-libquazip5-dev
+package: libquazip5-dev
 
 
 Open Source Software Licensed under the GPL-2+ with OpenSSL exception:
 1、source package:cryptsetup 2:2.6.1-4
-package:
-cryptsetup
+package: cryptsetup
 
 2、source package:cryptsetup-initramfs 2.3.1-1_all
-package:
-cryptsetup-initramfs
+package: cryptsetup-initramfs
 
 3、source package:libcryptsetup12 2.3.1-1_s390x
-package:
-libcryptsetup12
+package: libcryptsetup12
 
 
 Open Source Software Licensed under the GPL-2+ with SSL exception:
 1、source package:remmina 1.4.8+dfsg-2~bpo10+2
-package:
-remmina
+package: remmina
 
 2、source package:remmina-plugin-rdp 1.4.7+dfsg-1_s390x
-package:
-remmina-plugin-rdp
+package: remmina-plugin-rdp
 
 3、source package:remmina-plugin-vnc 1.4.7+dfsg-1_s390x
-package:
-remmina-plugin-vnc
+package: remmina-plugin-vnc
 
 
 Open Source Software Licensed under the GPL-2+ with sane exception:
 1、source package:libsane-dev 1.2.1-4
-package:
-libsane-dev
+package: libsane-dev
 
 
 Open Source Software Licensed under the GPL-2.0 or GPL-3.0 or FIPL-1.0:
 1、source package:libfreeimage-dev 3.18.0+ds2-3_s390x
-package:
-libfreeimage-dev
+package: libfreeimage-dev
 
 
 Open Source Software Licensed under the GPL-2.0+ or LGPL-2.1+:
 1、source package:fcitx5-frontend-gtk3 0.0~git20200606.fc335f1-2_s390x
-package:
-fcitx5-frontend-gtk3
+package: fcitx5-frontend-gtk3
 
 
 Open Source Software Licensed under the GPL-3 with Qt-1.0 exception:
 1、source package:qttools5-dev 5.9.2-4_kfreebsd-i386
-package:
-qttools5-dev
+package: qttools5-dev
 
 2、source package:qttools5-dev-tools 5.9.2-4_kfreebsd-i386
-package:
-qttools5-dev-tools
+package: qttools5-dev-tools
 
 3、source package:qttranslations5-l10n 5.9.2-1
-package:
-qttranslations5-l10n
+package: qttranslations5-l10n
 
 
 Open Source Software Licensed under the GPL-3+ or Less:
 1、source package:less 590-2
-package:
-less
+package: less
 
 
 Open Source Software Licensed under the GPL-3+ with OpenSSL exception:
 1、source package:libdmr-dev 5.7.6.147-1
-package:
-libdmr-dev
+package: libdmr-dev
 
 
 Open Source Software Licensed under the GPL-3.0-with-Qt-1.0-exception:
 1、source package:libqt5webchannel5-dev 5.7.1-2_s390x
-package:
-libqt5webchannel5-dev
+package: libqt5webchannel5-dev
 
 2、source package:qml-module-qtwebchannel 5.9.2-3
-package:
-qml-module-qtwebchannel
+package: qml-module-qtwebchannel
 
 
 Open Source Software Licensed under the GPL-any:
 1、source package:command-not-found 23.04.0-1
-package:
-command-not-found
+package: command-not-found
 
 
 Open Source Software Licensed under the Hylafax:
 1、source package:libtiff-dev 4.1.0+git191117-2~deb10u1_s390x
-package:
-libtiff-dev
+package: libtiff-dev
 
 
 Open Source Software Licensed under the ICU:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 2、source package:x11-xserver-utils 7.7~3_sparc
-package:
-x11-xserver-utils
+package: x11-xserver-utils
 
 3、source package:xkb-data 2.5.1-3_all
-package:
-xkb-data
+package: xkb-data
 
 4、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 5、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the ISC:
 1、source package:abbrev 1.1.1
-package:
-abbrev
+package: abbrev
 
 2、source package:anymatch 3.1.2
-package:
-anymatch
+package: anymatch
 
 3、source package:aproba 1.2.0
-package:
-aproba
+package: aproba
 
 4、source package:are-we-there-yet 1.1.5
-package:
-are-we-there-yet
+package: are-we-there-yet
 
 5、source package:boolbase 1.0.0
-package:
-boolbase
+package: boolbase
 
 6、source package:browserify-sign 4.2.1
-package:
-browserify-sign
+package: browserify-sign
 
 7、source package:cliui 4.1.0
-package:
-cliui
+package: cliui
 
 8、source package:color-support 1.1.3
-package:
-color-support
+package: color-support
 
 9、source package:concat-with-sourcemaps 1.1.0
-package:
-concat-with-sourcemaps
+package: concat-with-sourcemaps
 
 10、source package:console-control-strings 1.1.0
-package:
-console-control-strings
+package: console-control-strings
 
 11、source package:crda 4.14+git20191112.9856751.orig
-package:
-crda
+package: crda
 
 12、source package:d 1.0.1
-package:
-d
+package: d
 
 13、source package:distro-info-data 0.9~bpo60+1
-package:
-distro-info-data
+package: distro-info-data
 
 14、source package:electron-to-chromium 1.3.254
-package:
-electron-to-chromium
+package: electron-to-chromium
 
 15、source package:es5-ext 0.10.53
-package:
-es5-ext
+package: es5-ext
 
 16、source package:es6-symbol 3.1.3
-package:
-es6-symbol
+package: es6-symbol
 
 17、source package:es6-weak-map 2.0.3
-package:
-es6-weak-map
+package: es6-weak-map
 
 18、source package:ext 1.4.0
-package:
-ext
+package: ext
 
 19、source package:fastq 1.13.0
-package:
-fastq
+package: fastq
 
 20、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 21、source package:fs 0.0.1-security
-package:
-fs
+package: fs
 
 22、source package:fs.realpath 1.0.0
-package:
-fs.realpath
+package: fs.realpath
 
 23、source package:fstream 1.0.12
-package:
-fstream
+package: fstream
 
 24、source package:gauge 2.7.4
-package:
-gauge
+package: gauge
 
 25、source package:get-caller-file 1.0.3
-package:
-get-caller-file
+package: get-caller-file
 
 26、source package:glob 7.1.4
-package:
-glob
+package: glob
 
 27、source package:glob-parent 5.1.2
-package:
-glob-parent
+package: glob-parent
 
 28、source package:go-spew v1.1.1
-package:
-go-spew
+package: go-spew
 
 29、source package:go-wav v0.3.2
-package:
-go-wav
+package: go-wav
 
 30、source package:golang-github-nfnt-resize-dev 0.0~git20180221.83c6a99-2_all
-package:
-golang-github-nfnt-resize-dev
+package: golang-github-nfnt-resize-dev
 
 31、source package:graceful-fs 4.2.4
-package:
-graceful-fs
+package: graceful-fs
 
 32、source package:har-schema 2.0.0
-package:
-har-schema
+package: har-schema
 
 33、source package:has-unicode 2.0.1
-package:
-has-unicode
+package: has-unicode
 
 34、source package:hosted-git-info 2.8.8
-package:
-hosted-git-info
+package: hosted-git-info
 
 35、source package:in-publish 2.0.0
-package:
-in-publish
+package: in-publish
 
 36、source package:inflight 1.0.6
-package:
-inflight
+package: inflight
 
 37、source package:inherits 2.0.4
-package:
-inherits
+package: inherits
 
 38、source package:ini 1.3.5
-package:
-ini
+package: ini
 
 39、source package:isexe 2.0.0
-package:
-isexe
+package: isexe
 
 40、source package:json-stringify-safe 5.0.1
-package:
-json-stringify-safe
+package: json-stringify-safe
 
 41、source package:lru-cache 4.1.5
-package:
-lru-cache
+package: lru-cache
 
 42、source package:minimalistic-assert 1.0.1
-package:
-minimalistic-assert
+package: minimalistic-assert
 
 43、source package:minimatch 5.1.6
-package:
-minimatch
+package: minimatch
 
 44、source package:natives 1.1.6
-package:
-natives
+package: natives
 
 45、source package:node 8.16.1
-package:
-node
+package: node
 
 46、source package:node-bin-setup 1.0.6
-package:
-node-bin-setup
+package: node-bin-setup
 
 47、source package:nopt 3.0.6
-package:
-nopt
+package: nopt
 
 48、source package:npmlog 4.1.2
-package:
-npmlog
+package: npmlog
 
 49、source package:once 1.4.0
-package:
-once
+package: once
 
 50、source package:osenv 0.1.5
-package:
-osenv
+package: osenv
 
 51、source package:parse-asn1 5.1.6
-package:
-parse-asn1
+package: parse-asn1
 
 52、source package:pkgconf 1.8.1-2
-package:
-pkgconf
+package: pkgconf
 
 53、source package:pseudomap 1.0.2
-package:
-pseudomap
+package: pseudomap
 
 54、source package:python3-dnspython 2.4.0~rc1-1
-package:
-python3-dnspython
+package: python3-dnspython
 
 55、source package:remove-trailing-separator 1.1.0
-package:
-remove-trailing-separator
+package: remove-trailing-separator
 
 56、source package:require-main-filename 1.0.1
-package:
-require-main-filename
+package: require-main-filename
 
 57、source package:rimraf 2.7.1
-package:
-rimraf
+package: rimraf
 
 58、source package:rollup 2.79.1
-package:
-rollup
+package: rollup
 
 59、source package:semver 5.7.1
-package:
-semver
+package: semver
 
 60、source package:set-blocking 2.0.0
-package:
-set-blocking
+package: set-blocking
 
 61、source package:sigmund 1.0.1
-package:
-sigmund
+package: sigmund
 
 62、source package:signal-exit 3.0.3
-package:
-signal-exit
+package: signal-exit
 
 63、source package:tar 2.2.2
-package:
-tar
+package: tar
 
 64、source package:type 2.1.0
-package:
-type
+package: type
 
 65、source package:vinyl-sourcemaps-apply 0.2.1
-package:
-vinyl-sourcemaps-apply
+package: vinyl-sourcemaps-apply
 
 66、source package:which 1.3.1
-package:
-which
+package: which
 
 67、source package:which-module 2.0.0
-package:
-which-module
+package: which-module
 
 68、source package:wide-align 1.1.3
-package:
-wide-align
+package: wide-align
 
 69、source package:wrappy 1.0.2
-package:
-wrappy
+package: wrappy
 
 70、source package:y18n 3.2.1
-package:
-y18n
+package: y18n
 
 71、source package:yallist 2.1.2
-package:
-yallist
+package: yallist
 
 72、source package:yargs-parser 8.1.0
-package:
-yargs-parser
+package: yargs-parser
 
 
 Open Source Software Licensed under the ImageMagick:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 
 Open Source Software Licensed under the Info-ZIP:
 1、source package:unzip 6.0.orig
-package:
-unzip
+package: unzip
 
 
 Open Source Software Licensed under the LGPL:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 2、source package:libatspi2.0-dev 2.5.3-2_sparc
-package:
-libatspi2.0-dev
+package: libatspi2.0-dev
 
 3、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 4、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 5、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 6、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 
 Open Source Software Licensed under the LGPL-2+ and LGPL-2.1+:
 1、source package:ostree 2023.3-2
-package:
-ostree
+package: ostree
 
 
 Open Source Software Licensed under the LGPL-2+ and LGPL-2.1+ and FSFULLR and CC0-1.0 and Janik-permissive and Iconv-PD and Mingw-PD and Old-GLib-Tests-permissive:
 1、source package:libglib2.0-bin 2.76.4-1
-package:
-libglib2.0-bin
+package: libglib2.0-bin
 
 
 Open Source Software Licensed under the LGPL-2.0+ and Expat:
 1、source package:policykit-1 122-4
-package:
-policykit-1
+package: policykit-1
 
 
 Open Source Software Licensed under the LGPL-2.0-or-later:
 1、source package:bubblewrap 0~git160513-2
-package:
-bubblewrap
+package: bubblewrap
 
 2、source package:gvfs-backends 1.44.1-1_s390x
-package:
-gvfs-backends
+package: gvfs-backends
 
 3、source package:gvfs-bin 1.44.1-1_s390x
-package:
-gvfs-bin
+package: gvfs-bin
 
 4、source package:gvfs-fuse 1.44.1-1_s390x
-package:
-gvfs-fuse
+package: gvfs-fuse
 
 5、source package:kcalcore 5:5.85.0-2
-package:
-kcalcore
+package: kcalcore
 
 6、source package:kdeclarative 5.100.0-1
-package:
-kdeclarative
+package: kdeclarative
 
 7、source package:libasound2-dev 1.2.2-2.3_ppc64el
-package:
-libasound2-dev
+package: libasound2-dev
 
 8、source package:libgdk-pixbuf2.0-0 2.40.2-3
-package:
-libgdk-pixbuf2.0-0
+package: libgdk-pixbuf2.0-0
 
 9、source package:libgdk-pixbuf2.0-dev 2.40.0+dfsg-5_s390x
-package:
-libgdk-pixbuf2.0-dev
+package: libgdk-pixbuf2.0-dev
 
 10、source package:libkf5itemviews-dev 5.70.0-1_s390x
-package:
-libkf5itemviews-dev
+package: libkf5itemviews-dev
 
 11、source package:libkf5widgetsaddons-dev 5.70.0-1_s390x
-package:
-libkf5widgetsaddons-dev
+package: libkf5widgetsaddons-dev
 
 12、source package:libmtp-runtime 1.1.9-3~bpo8+1
-package:
-libmtp-runtime
+package: libmtp-runtime
 
 13、source package:libpolkit-agent-1-dev 0.116-2_s390x
-package:
-libpolkit-agent-1-dev
+package: libpolkit-agent-1-dev
 
 14、source package:libpolkit-qt5-1-dev 0.112.0-7_s390x
-package:
-libpolkit-qt5-1-dev
+package: libpolkit-qt5-1-dev
 
 15、source package:librsvg2-bin 2.48.7-1_ppc64el
-package:
-librsvg2-bin
+package: librsvg2-bin
 
 16、source package:platform/external/e2fsprogs lollipop-dev
-package:
-platform/external/e2fsprogs
+package: platform/external/e2fsprogs
 
 17、source package:xdg-desktop-portal 1.8.1-1~bpo10+1
-package:
-xdg-desktop-portal
+package: xdg-desktop-portal
 
 
 Open Source Software Licensed under the LGPL-2.1 or MPL-2.0:
 1、source package:libical-dev 3.0.8-2_mipsel
-package:
-libical-dev
+package: libical-dev
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2-or-3 with KDE Exception:
 1、source package:qml6-module-qtwebchannel 6.4.2~rc1-3
-package:
-qml6-module-qtwebchannel
+package: qml6-module-qtwebchannel
 
 
 Open Source Software Licensed under the LGPL-3Qt-1.1Exception or GPL-2Qt-1.1Exception:
 1、source package:qml-module-qtwebengine 5.7.1+dfsg-6.1_mipsel
-package:
-qml-module-qtwebengine
+package: qml-module-qtwebengine
 
 2、source package:qtwebengine5-dev 5.7.1+dfsg-6.1_mipsel
-package:
-qtwebengine5-dev
+package: qtwebengine5-dev
 
 
 Open Source Software Licensed under the LGPLv2 with exceptions or GPLv3 with exceptions and GFDL:
 1、source package:libqt6svg6 6.4.1
-package:
-libqt6svg6
+package: libqt6svg6
 
 
 Open Source Software Licensed under the Libpng:
 1、source package:libpng-dev 1.6.37-2_s390x
-package:
-libpng-dev
+package: libpng-dev
 
 2、source package:libsdl2-dev 2.0.9+dfsg1-1_s390x
-package:
-libsdl2-dev
+package: libsdl2-dev
 
 
 Open Source Software Licensed under the Linux-syscall-note:
 1、source package:pinn 0.0
-package:
-pinn
+package: pinn
 
 
 Open Source Software Licensed under the MITNFA:
 1、source package:through2 0.6.5
-package:
-through2
+package: through2
 
 
 Open Source Software Licensed under the MPL-1.1 or GPL-2+ or LGPL-2.1+:
 1、source package:libchardet-dev 1.0.4-1_s390x
-package:
-libchardet-dev
+package: libchardet-dev
 
 2、source package:libchardet1 1.0.4-1_s390x
-package:
-libchardet1
+package: libchardet1
 
 3、source package:libuchardet-dev 0.0.7-1_s390x
-package:
-libuchardet-dev
+package: libuchardet-dev
 
 4、source package:libuchardet0 0.0.7-1_s390x
-package:
-libuchardet0
+package: libuchardet0
 
 
 Open Source Software Licensed under the NAIST-2003:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Net-SNMP:
 1、source package:sudo 1.9.8p2-1~exp1
-package:
-sudo
+package: sudo
 
 
 Open Source Software Licensed under the OFL-1.1:
 1、source package:fonts-intel-one-mono 1.2.1-2
-package:
-fonts-intel-one-mono
+package: fonts-intel-one-mono
 
 2、source package:fonts-lohit-deva 2.95.4.orig
-package:
-fonts-lohit-deva
+package: fonts-lohit-deva
 
 3、source package:fonts-noto 20201225-1
-package:
-fonts-noto
+package: fonts-noto
 
 4、source package:fonts-noto-mono 20200323-1_all
-package:
-fonts-noto-mono
+package: fonts-noto-mono
 
 
 Open Source Software Licensed under the OpenSSL:
 1、source package:libssl1.1 1.1.1~~pre9-1
-package:
-libssl1.1
+package: libssl1.1
 
 2、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the PD:
 1、source package:xz-utils 5.4.1-0.2
-package:
-xz-utils
+package: xz-utils
 
 
 Open Source Software Licensed under the Public Domain:
 1、source package:debianutils 5.8-1
-package:
-debianutils
+package: debianutils
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:grub-efi-amd64-signed 1+2.06+8.1
-package:
-grub-efi-amd64-signed
+package: grub-efi-amd64-signed
 
 4、source package:grub-efi-arm64-signed 1+2.06+8.1
-package:
-grub-efi-arm64-signed
+package: grub-efi-arm64-signed
 
 5、source package:jsonify 0.0.0
-package:
-jsonify
+package: jsonify
 
 6、source package:libatspi2.0-dev 2.5.3-2_sparc
-package:
-libatspi2.0-dev
+package: libatspi2.0-dev
 
 7、source package:libsqlite3-0 3.8.7.1-1_kfreebsd-i386
-package:
-libsqlite3-0
+package: libsqlite3-0
 
 8、source package:libsqlite3-dev 3.8.7.1-1_kfreebsd-i386
-package:
-libsqlite3-dev
+package: libsqlite3-dev
 
 9、source package:sqlite3 3.9.2-1
-package:
-sqlite3
+package: sqlite3
 
 10、source package:tzdata 2023c-7
-package:
-tzdata
+package: tzdata
 
 
 Open Source Software Licensed under the Python-2.0:
 1、source package:python3 3.8.2-3_s390x
-package:
-python3
+package: python3
 
 
 Open Source Software Licensed under the Qt-GPL-exception-1.0:
 1、source package:qtremoteobjects v5.11.0-rc2
-package:
-qtremoteobjects
+package: qtremoteobjects
 
 
 Open Source Software Licensed under the Rdisc:
 1、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 
 Open Source Software Licensed under the SGI-B-1.1:
 1、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 2、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the SGI-B-2.0:
 1、source package:libegl1-mesa-dev 8.0.5-4+deb7u2_sparc
-package:
-libegl1-mesa-dev
+package: libegl1-mesa-dev
 
 2、source package:libgbm-dev 8.0.5-4+deb7u2_sparc
-package:
-libgbm-dev
+package: libgbm-dev
 
 3、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 4、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the SIL-1.1:
 1、source package:fonts-noto-cjk 20190410+repack1-2.debian
-package:
-fonts-noto-cjk
+package: fonts-noto-cjk
 
 
 Open Source Software Licensed under the SSLeay:
 1、source package:libssl1.1 1.1.1~~pre9-1
-package:
-libssl1.1
+package: libssl1.1
 
 
 Open Source Software Licensed under the Sleepycat:
 1、source package:go-difflib v1.0.0
-package:
-go-difflib
+package: go-difflib
 
 
 Open Source Software Licensed under the The Bugly Software License Version 1.0:
 1、source package:crashreport 3.4.4
-package:
-crashreport
+package: crashreport
 
 2、source package:nativecrashreport 3.9.2
-package:
-nativecrashreport
+package: nativecrashreport
 
 
 Open Source Software Licensed under the Unicode-DFS-2015:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 
 Open Source Software Licensed under the Unicode-DFS-2016:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Unicode-TOU:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Unlicense:
 1、source package:ncompress 4.2.4.6.orig
-package:
-ncompress
+package: ncompress
 
 2、source package:tortellini 4f6795a
-package:
-tortellini
+package: tortellini
 
 3、source package:tweetnacl 0.14.5
-package:
-tweetnacl
+package: tweetnacl
 
 
 Open Source Software Licensed under the Vim:
 1、source package:vim 8.2.0716.orig
-package:
-vim
+package: vim
 
 
 Open Source Software Licensed under the X11:
 1、source package:libwayland-dev 1.6.0-2_s390x
-package:
-libwayland-dev
+package: libwayland-dev
 
 2、source package:libxcb-image0-dev 0.4.0-1_s390x
-package:
-libxcb-image0-dev
+package: libxcb-image0-dev
 
 3、source package:libxcb-keysyms1-dev 0.4.0-1_s390x
-package:
-libxcb-keysyms1-dev
+package: libxcb-keysyms1-dev
 
 4、source package:libyaml-cpp-dev 0.6.3-9_s390x
-package:
-libyaml-cpp-dev
+package: libyaml-cpp-dev
 
 5、source package:ncurses-base 6.2-1_all
-package:
-ncurses-base
+package: ncurses-base
 
 6、source package:wordwrap 0.0.2
-package:
-wordwrap
+package: wordwrap
 
 
 Open Source Software Licensed under the Xnet:
 1、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 
 Open Source Software Licensed under the Zlib:
 1、source package:avfs 1.1.4-2
-package:
-avfs
+package: avfs
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:libminizip-dev 1.1-8_hurd-i386
-package:
-libminizip-dev
+package: libminizip-dev
 
 4、source package:libsdl2-dev 2.0.9+dfsg1-1_s390x
-package:
-libsdl2-dev
+package: libsdl2-dev
 
 5、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 6、source package:node 8.16.1
-package:
-node
+package: node
 
 7、source package:pako 1.0.11
-package:
-pako
+package: pako
 
 8、source package:pigz 2.6-1
-package:
-pigz
+package: pigz
 
 9、source package:unalz 0.65-9
-package:
-unalz
+package: unalz
 
 10、source package:zlib1g 1.2.8.dfsg-5_s390x
-package:
-zlib1g
+package: zlib1g
 
 11、source package:zlib1g-dev 1:1.2.3.3.dfsg-1
-package:
-zlib1g-dev
+package: zlib1g-dev
 
 
 Open Source Software Licensed under the copyleft-next-0.3.0:
 1、source package:crda 4.14+git20191112.9856751.orig
-package:
-crda
+package: crda
 
 
 Open Source Software Licensed under the cryptsetup-OpenSSL-exception:
 1、source package:aria2 1.9.5-1
-package:
-aria2
+package: aria2
 
 2、source package:libcryptsetup-dev 2:2.4.0-1
-package:
-libcryptsetup-dev
+package: libcryptsetup-dev
 
 
 Open Source Software Licensed under the curl:
 1、source package:curl 8.0.1-1~exp1
-package:
-curl
+package: curl
 
 2、source package:libcurl4-openssl-dev 7.68.0-1_s390x
-package:
-libcurl4-openssl-dev
+package: libcurl4-openssl-dev
 
 
 Open Source Software Licensed under the hdparm:
 1、source package:hdparm 9.65+ds-1
-package:
-hdparm
+package: hdparm
 
 
 Open Source Software Licensed under the nolicense:
 1、source package:FreeBSD-Electron v9.0.3
-package:
-FreeBSD-Electron
+package: FreeBSD-Electron
 
 2、source package:LTSLAM 94d7e0f
-package:
-LTSLAM
+package: LTSLAM
 
 3、source package:TSFileEditor 0.2.1
-package:
-TSFileEditor
+package: TSFileEditor
 
 4、source package:asio asio-1-29-0
-package:
-asio
+package: asio
 
 5、source package:chromium-source-tarball 59.0.3071.57
-package:
-chromium-source-tarball
+package: chromium-source-tarball
 
 6、source package:geek-navigation 5a521f2
-package:
-geek-navigation
+package: geek-navigation
 
 7、source package:gentoo 202
-package:
-gentoo
+package: gentoo
 
 8、source package:go-urn v1.1.0
-package:
-go-urn
+package: go-urn
 
 9、source package:imaging v1.6.2
-package:
-imaging
+package: imaging
 
 10、source package:kcrash 5.103.0-1
-package:
-kcrash
+package: kcrash
 
 11、source package:ncnn_paddleocr 9c054d3
-package:
-ncnn_paddleocr
+package: ncnn_paddleocr
 
 12、source package:plasma-workspace v5.25.90
-package:
-plasma-workspace
+package: plasma-workspace
 
 13、source package:platform/external/qt emu-29.0-release
-package:
-platform/external/qt
+package: platform/external/qt
 
 14、source package:qtbase v6.5.1
-package:
-qtbase
+package: qtbase
 
 15、source package:qtxlsxwriter v0.3.0
-package:
-qtxlsxwriter
+package: qtxlsxwriter
 
 16、source package:scriptcommunicator_serial-terminal Release_06_02
-package:
-scriptcommunicator_serial-terminal
+package: scriptcommunicator_serial-terminal
 
 17、source package:socket v0.4.1
-package:
-socket
+package: socket
 
 18、source package:strace v4.14
-package:
-strace
+package: strace
 
 19、source package:v5 v5.1.0
-package:
-v5
+package: v5
 
 20、source package:wlr-protocols d278d20
-package:
-wlr-protocols
+package: wlr-protocols
 
 
 Copy of Licenses

--- a/src/plugin-systeminfo/operation/qrc/gpl/gpl-3.0-zh_TW-body.txt
+++ b/src/plugin-systeminfo/operation/qrc/gpl/gpl-3.0-zh_TW-body.txt
@@ -2,6580 +2,4989 @@ The notice provides license information of respective open source software conta
 
 Open Source Software Licensed under the GPL-3.0-or-later:
 1、source package:accountsservice 23.13.9-2
-package:
-accountsservice
+package: accountsservice
 
 2、source package:cifs-utils 6.9.orig
-package:
-cifs-utils
+package: cifs-utils
 
 3、source package:coreutils 9.1-1
-package:
-coreutils
+package: coreutils
 
 4、source package:dosfstools 4.2-1
-package:
-dosfstools
+package: dosfstools
 
 5、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 6、source package:fonts-wqy-microhei 0.2.0-beta-3.1
-package:
-fonts-wqy-microhei
+package: fonts-wqy-microhei
 
 7、source package:gawk 5.0.1+dfsg.orig
-package:
-gawk
+package: gawk
 
 8、source package:gettext 0.21.1
-package:
-gettext
+package: gettext
 
 9、source package:gettext-base 0.19.8.1-9_s390x
-package:
-gettext-base
+package: gettext-base
 
 10、source package:gnupg 2.2.19-3_all
-package:
-gnupg
+package: gnupg
 
 11、source package:golang-gir-gobject-2.0-dev 2.2.0-1
-package:
-golang-gir-gobject-2.0-dev
+package: golang-gir-gobject-2.0-dev
 
 12、source package:gpgv 2.2.20-1~bpo9+1_s390x
-package:
-gpgv
+package: gpgv
 
 13、source package:grub-common 2.06-9
-package:
-grub-common
+package: grub-common
 
 14、source package:grub2-common 2.04~rc1-3_ppc64el
-package:
-grub2-common
+package: grub2-common
 
 15、source package:grub2-theme-vimix c7ab3ce
-package:
-grub2-theme-vimix
+package: grub2-theme-vimix
 
 16、source package:guvcview 2.0.2
-package:
-guvcview
+package: guvcview
 
 17、source package:hello 2.9-2_kfreebsd-i386
-package:
-hello
+package: hello
 
 18、source package:libparted-dev 3.3-4_s390x
-package:
-libparted-dev
+package: libparted-dev
 
 19、source package:libparted-fs-resize0 3.3-4_s390x
-package:
-libparted-fs-resize0
+package: libparted-fs-resize0
 
 20、source package:live-boot 5.0~a5-2
-package:
-live-boot
+package: live-boot
 
 21、source package:live-boot-initramfs-tools 4.0.2-1_all
-package:
-live-boot-initramfs-tools
+package: live-boot-initramfs-tools
 
 22、source package:live-config 5.20190519_all
-package:
-live-config
+package: live-config
 
 23、source package:live-config-systemd 5.20190519_all
-package:
-live-config-systemd
+package: live-config-systemd
 
 24、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 25、source package:parted 3.6-3
-package:
-parted
+package: parted
 
 26、source package:patchelf 0.9.orig
-package:
-patchelf
+package: patchelf
 
 27、source package:pkg-kde-tools 0.9.5
-package:
-pkg-kde-tools
+package: pkg-kde-tools
 
 28、source package:python3-samba 4.12.5+dfsg-3_s390x
-package:
-python3-samba
+package: python3-samba
 
 29、source package:qtchooser 66.orig
-package:
-qtchooser
+package: qtchooser
 
 30、source package:qtremoteobjects v5.11.0-rc2
-package:
-qtremoteobjects
+package: qtremoteobjects
 
 31、source package:redshift 1.9.1-4_s390x
-package:
-redshift
+package: redshift
 
 32、source package:rsync 3.2.7-1~bpo11+1
-package:
-rsync
+package: rsync
 
 33、source package:rsyslog 8.9.0-3
-package:
-rsyslog
+package: rsyslog
 
 34、source package:samba 4.9.5+dfsg-5_mips64el
-package:
-samba
+package: samba
 
 35、source package:samba-common-bin 4.9.5+dfsg-5_s390x
-package:
-samba-common-bin
+package: samba-common-bin
 
 36、source package:samba-dsdb-modules 4.9.5+dfsg-5_s390x
-package:
-samba-dsdb-modules
+package: samba-dsdb-modules
 
 37、source package:samba-vfs-modules 4.9.5+dfsg-5_s390x
-package:
-samba-vfs-modules
+package: samba-vfs-modules
 
 38、source package:sed 4.9-1
-package:
-sed
+package: sed
 
 39、source package:smbclient 4.9.5+dfsg-5_s390x
-package:
-smbclient
+package: smbclient
 
 40、source package:startdde 6.0.6
-package:
-startdde
+package: startdde
 
 41、source package:viper v1.3.2
-package:
-viper
+package: viper
 
 
 Open Source Software Licensed under the GPL-3.0-only:
 1、source package:blur-effect 1.1.3-2
-package:
-blur-effect
+package: blur-effect
 
 2、source package:distrobox 1.4.2.1-1
-package:
-distrobox
+package: distrobox
 
 3、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 4、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 5、source package:libpoppler-glib-dev 22.12.0-2
-package:
-libpoppler-glib-dev
+package: libpoppler-glib-dev
 
 6、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 7、source package:lightdm-gtk-greeter 2.0.8-3
-package:
-lightdm-gtk-greeter
+package: lightdm-gtk-greeter
 
 8、source package:mtools 4.0.9-1
-package:
-mtools
+package: mtools
 
 9、source package:python-is-python3 8
-package:
-python-is-python3
+package: python-is-python3
 
 10、source package:tpm2-tools 5.4-1
-package:
-tpm2-tools
+package: tpm2-tools
 
 
 Open Source Software Licensed under the GPL-2.0-or-later:
 1、source package:ColumnsPlusPlus v0.0.1.2-alpha
-package:
-ColumnsPlusPlus
+package: ColumnsPlusPlus
 
 2、source package:Grub-Themes a7ec0fd
-package:
-Grub-Themes
+package: Grub-Themes
 
 3、source package:acl 2.3.1-3
-package:
-acl
+package: acl
 
 4、source package:adduser 3.99
-package:
-adduser
+package: adduser
 
 5、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 6、source package:apt-utils 2.1.7_mips64el
-package:
-apt-utils
+package: apt-utils
 
 7、source package:aptitude 0.8.9-1
-package:
-aptitude
+package: aptitude
 
 8、source package:aria2 1.9.5-1
-package:
-aria2
+package: aria2
 
 9、source package:arj 3.10.22.orig
-package:
-arj
+package: arj
 
 10、source package:attr 2.4.48-5_s390x
-package:
-attr
+package: attr
 
 11、source package:bash-completion 20080705
-package:
-bash-completion
+package: bash-completion
 
 12、source package:bc 1.07.1-3
-package:
-bc
+package: bc
 
 13、source package:bluez 5.66-1
-package:
-bluez
+package: bluez
 
 14、source package:bluez-obexd 5.52-1_s390x
-package:
-bluez-obexd
+package: bluez-obexd
 
 15、source package:ca-certificates 20230311
-package:
-ca-certificates
+package: ca-certificates
 
 16、source package:cornrow v0.8.0
-package:
-cornrow
+package: cornrow
 
 17、source package:cups-filters 1.9.0-2
-package:
-cups-filters
+package: cups-filters
 
 18、source package:cyberduck release-4-9-1
-package:
-cyberduck
+package: cyberduck
 
 19、source package:debhelper 9.20160814
-package:
-debhelper
+package: debhelper
 
 20、source package:dh-dkms 3.0.9-1
-package:
-dh-dkms
+package: dh-dkms
 
 21、source package:dh-golang 1.9
-package:
-dh-golang
+package: dh-golang
 
 22、source package:dkms 3.0.8-3
-package:
-dkms
+package: dkms
 
 23、source package:dmidecode 3.5-1
-package:
-dmidecode
+package: dmidecode
 
 24、source package:dnsmasq-base 2.89-1
-package:
-dnsmasq-base
+package: dnsmasq-base
 
 25、source package:dpkg 1.9.21
-package:
-dpkg
+package: dpkg
 
 26、source package:dpkg-dev 1.9.21
-package:
-dpkg-dev
+package: dpkg-dev
 
 27、source package:efibootmgr 17-2
-package:
-efibootmgr
+package: efibootmgr
 
 28、source package:eject 2.35.2-7_ppc64el
-package:
-eject
+package: eject
 
 29、source package:ethtool 6-0
-package:
-ethtool
+package: ethtool
 
 30、source package:exfat-fuse 1.3.0-2_armel
-package:
-exfat-fuse
+package: exfat-fuse
 
 31、source package:exfatprogs 1.2.1-2
-package:
-exfatprogs
+package: exfatprogs
 
 32、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 33、source package:foomatic-db-compressed-ppds 20230107-1
-package:
-foomatic-db-compressed-ppds
+package: foomatic-db-compressed-ppds
 
 34、source package:fprintd 1.94.2-2
-package:
-fprintd
+package: fprintd
 
 35、source package:geoclue-2.0 2.7.0-2
-package:
-geoclue-2.0
+package: geoclue-2.0
 
 36、source package:gnome-keyring 42.1-1
-package:
-gnome-keyring
+package: gnome-keyring
 
 37、source package:hwdata 0.372-1
-package:
-hwdata
+package: hwdata
 
 38、source package:im-config 0.9
-package:
-im-config
+package: im-config
 
 39、source package:imwheel 1.0.0pre12.orig
-package:
-imwheel
+package: imwheel
 
 40、source package:input-leap v2.4.0
-package:
-input-leap
+package: input-leap
 
 41、source package:ipwatchd 1.3.0
-package:
-ipwatchd
+package: ipwatchd
 
 42、source package:jfsutils 1.1.8-1
-package:
-jfsutils
+package: jfsutils
 
 43、source package:kbd 2.5.1-1
-package:
-kbd
+package: kbd
 
 44、source package:kscreenlocker-dev 5.8.6-2_s390x
-package:
-kscreenlocker-dev
+package: kscreenlocker-dev
 
 45、source package:lcov 1.9.orig
-package:
-lcov
+package: lcov
 
 46、source package:libappstreamqt-dev 0.9.8-4_kfreebsd-i386
-package:
-libappstreamqt-dev
+package: libappstreamqt-dev
 
 47、source package:libblkid-dev 2.35.2-7_mipsel
-package:
-libblkid-dev
+package: libblkid-dev
 
 48、source package:libcryptsetup-dev 2:2.4.0-1
-package:
-libcryptsetup-dev
+package: libcryptsetup-dev
 
 49、source package:libddcutil-dev 0.9.8-4_s390x
-package:
-libddcutil-dev
+package: libddcutil-dev
 
 50、source package:libdpkg-dev 1.20.5_ppc64el
-package:
-libdpkg-dev
+package: libdpkg-dev
 
 51、source package:libdvdnav-dev 6.1.0-1_s390x
-package:
-libdvdnav-dev
+package: libdvdnav-dev
 
 52、source package:libffmpegthumbnailer-dev 2.1.1-0.2_kfreebsd-amd64
-package:
-libffmpegthumbnailer-dev
+package: libffmpegthumbnailer-dev
 
 53、source package:libffmpegthumbnailer4v5 2.1.1-0.2_kfreebsd-amd64
-package:
-libffmpegthumbnailer4v5
+package: libffmpegthumbnailer4v5
 
 54、source package:libltdl-dev 2.4.7-6
-package:
-libltdl-dev
+package: libltdl-dev
 
 55、source package:libmount-dev 2.35.2-7_s390x
-package:
-libmount-dev
+package: libmount-dev
 
 56、source package:libmpv-dev 0.9.2-1+ffmpeg
-package:
-libmpv-dev
+package: libmpv-dev
 
 57、source package:libmpv1 0.6.2-2_s390x
-package:
-libmpv1
+package: libmpv1
 
 58、source package:libmpv2 0.36.0+git.20230723.60a26324
-package:
-libmpv2
+package: libmpv2
 
 59、source package:libnm-dev 1.6.2-3+deb9u2_s390x
-package:
-libnm-dev
+package: libnm-dev
 
 60、source package:libpam-fprintd 1.90.1-1_s390x
-package:
-libpam-fprintd
+package: libpam-fprintd
 
 61、source package:libvlc-dev 3.0.9.2-1
-package:
-libvlc-dev
+package: libvlc-dev
 
 62、source package:libvlc5 3.0.8-4_s390x
-package:
-libvlc5
+package: libvlc5
 
 63、source package:libvlccore-dev 3.0.8-4_s390x
-package:
-libvlccore-dev
+package: libvlccore-dev
 
 64、source package:libvncserver LibVNCServer-0.9.14
-package:
-libvncserver
+package: libvncserver
 
 65、source package:lzop 1.04-2
-package:
-lzop
+package: lzop
 
 66、source package:man-db 2.9.4-4
-package:
-man-db
+package: man-db
 
 67、source package:net-tools 2.10-0.1
-package:
-net-tools
+package: net-tools
 
 68、source package:network-manager 1.9.90-1
-package:
-network-manager
+package: network-manager
 
 69、source package:nilfs-tools 2.2.9-1
-package:
-nilfs-tools
+package: nilfs-tools
 
 70、source package:ntfs-3g 2017.3.23AR.5.orig
-package:
-ntfs-3g
+package: ntfs-3g
 
 71、source package:packagekit 1.2.6-5
-package:
-packagekit
+package: packagekit
 
 72、source package:pandoc 2.9.2.1-3
-package:
-pandoc
+package: pandoc
 
 73、source package:pciutils 3.7.0.orig
-package:
-pciutils
+package: pciutils
 
 74、source package:pinn 0.0
-package:
-pinn
+package: pinn
 
 75、source package:pkg-config 0.29.2.orig
-package:
-pkg-config
+package: pkg-config
 
 76、source package:pkg-kde-tools 0.9.5
-package:
-pkg-kde-tools
+package: pkg-kde-tools
 
 77、source package:plymouth 22.02.122-3
-package:
-plymouth
+package: plymouth
 
 78、source package:plymouth-label 0.9.4-3_s390x
-package:
-plymouth-label
+package: plymouth-label
 
 79、source package:pppoe 3.8-3_sparc
-package:
-pppoe
+package: pppoe
 
 80、source package:procps 3.3.9.orig
-package:
-procps
+package: procps
 
 81、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 82、source package:python3-smbc 1.0.23-2
-package:
-python3-smbc
+package: python3-smbc
 
 83、source package:rfkill 2.35.2-7_s390x
-package:
-rfkill
+package: rfkill
 
 84、source package:rzip 2.1.orig
-package:
-rzip
+package: rzip
 
 85、source package:sectpmctl 1.1.3
-package:
-sectpmctl
+package: sectpmctl
 
 86、source package:sensible-utils 0.0.9+nmu1
-package:
-sensible-utils
+package: sensible-utils
 
 87、source package:socat 2.0.0~beta9-1_ppc64el
-package:
-socat
+package: socat
 
 88、source package:squashfs-tools 4.4-2_s390x
-package:
-squashfs-tools
+package: squashfs-tools
 
 89、source package:syslinux 6.04~git20190206.bf6db5b4+dfsg1.orig
-package:
-syslinux
+package: syslinux
 
 90、source package:syslinux-common 6.04~git20190206.bf6db5b4+dfsg1-2_all
-package:
-syslinux-common
+package: syslinux-common
 
 91、source package:udisks2 2.9.4-4
-package:
-udisks2
+package: udisks2
 
 92、source package:unace 1.2b-9
-package:
-unace
+package: unace
 
 93、source package:upower 1.90.2-3
-package:
-upower
+package: upower
 
 94、source package:usb-modeswitch 2.6.1.orig
-package:
-usb-modeswitch
+package: usb-modeswitch
 
 95、source package:usbmuxd 1.1.1~git20191130.9af2b12-1_s390x
-package:
-usbmuxd
+package: usbmuxd
 
 96、source package:usbutils 1:015-1
-package:
-usbutils
+package: usbutils
 
 97、source package:user-setup 1.95
-package:
-user-setup
+package: user-setup
 
 98、source package:uuid-dev 2.35.2-7_ppc64el
-package:
-uuid-dev
+package: uuid-dev
 
 99、source package:vlc-plugin-base 3.0.8-4_s390x
-package:
-vlc-plugin-base
+package: vlc-plugin-base
 
 100、source package:xdg-user-dirs 0.9-1
-package:
-xdg-user-dirs
+package: xdg-user-dirs
 
 101、source package:xserver-xorg-input-wacom 1.2.0-1~exp1
-package:
-xserver-xorg-input-wacom
+package: xserver-xorg-input-wacom
 
 102、source package:zssh 1.5c.debian.1-8
-package:
-zssh
+package: zssh
 
 
 Open Source Software Licensed under the GPL-2.0-only:
 1、source package:GitQlient v1.4.3
-package:
-GitQlient
+package: GitQlient
 
 2、source package:alsa-utils 1.2.9-1
-package:
-alsa-utils
+package: alsa-utils
 
 3、source package:btrfs-progs 6.3.2-1
-package:
-btrfs-progs
+package: btrfs-progs
 
 4、source package:checkstyle checkstyle-10.3.4
-package:
-checkstyle
+package: checkstyle
 
 5、source package:dmsetup 1.02.90-2.2+deb8u1_s390x
-package:
-dmsetup
+package: dmsetup
 
 6、source package:doxygen 1.9.4-4
-package:
-doxygen
+package: doxygen
 
 7、source package:e2fsprogs 1.47.0-2
-package:
-e2fsprogs
+package: e2fsprogs
 
 8、source package:gcc 9.2.1-4.1_mips64el
-package:
-gcc
+package: gcc
 
 9、source package:genisoimage 9:1.1.11-3.4
-package:
-genisoimage
+package: genisoimage
 
 10、source package:git 4.3.20-9
-package:
-git
+package: git
 
 11、source package:grub-efi-amd64-signed 1+2.06+8.1
-package:
-grub-efi-amd64-signed
+package: grub-efi-amd64-signed
 
 12、source package:grub-efi-arm64-signed 1+2.06+8.1
-package:
-grub-efi-arm64-signed
+package: grub-efi-arm64-signed
 
 13、source package:gtk2-engines 2.20.2.orig
-package:
-gtk2-engines
+package: gtk2-engines
 
 14、source package:gtk2-engines-murrine 0.98.2.orig
-package:
-gtk2-engines-murrine
+package: gtk2-engines-murrine
 
 15、source package:iio-sensor-proxy 3.4-2
-package:
-iio-sensor-proxy
+package: iio-sensor-proxy
 
 16、source package:initramfs-tools-core 0.137_all
-package:
-initramfs-tools-core
+package: initramfs-tools-core
 
 17、source package:kwin v5.27.2
-package:
-kwin
+package: kwin
 
 18、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 19、source package:libdjvulibre-dev 3.5.28-2
-package:
-libdjvulibre-dev
+package: libdjvulibre-dev
 
 20、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 21、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 22、source package:libnm-qt 0.9.8.2.orig
-package:
-libnm-qt
+package: libnm-qt
 
 23、source package:libpoppler-glib-dev 22.12.0-2
-package:
-libpoppler-glib-dev
+package: libpoppler-glib-dev
 
 24、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 25、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 26、source package:lsb-base 9.20161125_all
-package:
-lsb-base
+package: lsb-base
 
 27、source package:lshw 02.19.git.2021.06.19.996aaad9c7-2~bpo11+1
-package:
-lshw
+package: lshw
 
 28、source package:lvm2 2.03.16-1.1
-package:
-lvm2
+package: lvm2
 
 29、source package:mawk 1.3.4.20230525-1~exp1
-package:
-mawk
+package: mawk
 
 30、source package:modemmanager 1.8.2.orig
-package:
-modemmanager
+package: modemmanager
 
 31、source package:networkmanager-qt 5.54.0.orig
-package:
-networkmanager-qt
+package: networkmanager-qt
 
 32、source package:openprinting-ppds 20200427-1_all
-package:
-openprinting-ppds
+package: openprinting-ppds
 
 33、source package:proxychains4 4.14-3_s390x
-package:
-proxychains4
+package: proxychains4
 
 34、source package:qt-creator tqtc/v2.6.0-rc
-package:
-qt-creator
+package: qt-creator
 
 35、source package:qtciphersqliteplugin 0.6
-package:
-qtciphersqliteplugin
+package: qtciphersqliteplugin
 
 36、source package:qtermwidget 0.7.1.orig
-package:
-qtermwidget
+package: qtermwidget
 
 37、source package:reiserfsprogs 3.x.1b-1
-package:
-reiserfsprogs
+package: reiserfsprogs
 
 38、source package:sane-airscan 0.99.8-2
-package:
-sane-airscan
+package: sane-airscan
 
 39、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 40、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 41、source package:synergy-stable-builds 1.8.2-stable
-package:
-synergy-stable-builds
+package: synergy-stable-builds
 
 42、source package:systemd 8-2
-package:
-systemd
+package: systemd
 
 43、source package:ttf-unifont 9.0.06-2_all
-package:
-ttf-unifont
+package: ttf-unifont
 
 44、source package:wireless-tools 30~pre9.orig
-package:
-wireless-tools
+package: wireless-tools
 
 45、source package:xfonts-wqy 1.0.0~rc1-7
-package:
-xfonts-wqy
+package: xfonts-wqy
 
 46、source package:xfsprogs 6.3.0-1
-package:
-xfsprogs
+package: xfsprogs
 
 
 Open Source Software Licensed under the LGPL-3.0-or-later:
 1、source package:kdecoration 4:5.26.90-2
-package:
-kdecoration
+package: kdecoration
 
 2、source package:libheif-dev 1.6.1-1_s390x
-package:
-libheif-dev
+package: libheif-dev
 
 3、source package:libzmq3-dev 4.3.2-2_s390x
-package:
-libzmq3-dev
+package: libzmq3-dev
 
 4、source package:python3-ldb 2.1.4-2_s390x
-package:
-python3-ldb
+package: python3-ldb
 
 5、source package:python3-tdb 1.4.3-1_s390x
-package:
-python3-tdb
+package: python3-tdb
 
 6、source package:tdb-tools 1.4.3-1_s390x
-package:
-tdb-tools
+package: tdb-tools
 
 
 Open Source Software Licensed under the LGPL-3.0-only:
 1、source package:QtZeroConf pre_Android_api30
-package:
-QtZeroConf
+package: QtZeroConf
 
 2、source package:cryfs 0.9.9-2
-package:
-cryfs
+package: cryfs
 
 3、source package:libgsettings-qt-dev 0.2-1_s390x
-package:
-libgsettings-qt-dev
+package: libgsettings-qt-dev
 
 4、source package:qt5integration 5.6.3
-package:
-qt5integration
+package: qt5integration
 
 5、source package:qtwebengine-opensource-src 5.14.2+dfsg1.orig
-package:
-qtwebengine-opensource-src
+package: qtwebengine-opensource-src
 
 
 Open Source Software Licensed under the LGPL-2.1-or-later:
 1、source package:fcitx5 5.0.9-2
-package:
-fcitx5
+package: fcitx5
 
 2、source package:fcitx5-chinese-addons 5.0.9-2
-package:
-fcitx5-chinese-addons
+package: fcitx5-chinese-addons
 
 3、source package:fcitx5-frontend-gtk2 5.0.9-1
-package:
-fcitx5-frontend-gtk2
+package: fcitx5-frontend-gtk2
 
 4、source package:fcitx5-frontend-qt5 0.0~git20200615.b6f2ef3-1_s390x
-package:
-fcitx5-frontend-qt5
+package: fcitx5-frontend-qt5
 
 5、source package:fcitx5-module-xorg 0~20191021+ds1-1_s390x
-package:
-fcitx5-module-xorg
+package: fcitx5-module-xorg
 
 6、source package:fcitx5-modules 0~20191021+ds1-1_s390x
-package:
-fcitx5-modules
+package: fcitx5-modules
 
 7、source package:fcitx5-modules-dev 5.0.23-2~exp1
-package:
-fcitx5-modules-dev
+package: fcitx5-modules-dev
 
 8、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 9、source package:gcr 3.8.2-4
-package:
-gcr
+package: gcr
 
 10、source package:iso-codes 4.9.0-1
-package:
-iso-codes
+package: iso-codes
 
 11、source package:kcm-fcitx5 5.0.13-1
-package:
-kcm-fcitx5
+package: kcm-fcitx5
 
 12、source package:libappstreamqt-dev 0.9.8-4_kfreebsd-i386
-package:
-libappstreamqt-dev
+package: libappstreamqt-dev
 
 13、source package:libavcodec-dev 4.3-3+b1_s390x
-package:
-libavcodec-dev
+package: libavcodec-dev
 
 14、source package:libavcodec58 4.3-3+b1_ppc64el
-package:
-libavcodec58
+package: libavcodec58
 
 15、source package:libavdevice-dev 4.3-3+b1_ppc64el
-package:
-libavdevice-dev
+package: libavdevice-dev
 
 16、source package:libavfilter-dev 4.3-3+b1_mips64el
-package:
-libavfilter-dev
+package: libavfilter-dev
 
 17、source package:libavformat-dev 4.3-3+b1_ppc64el
-package:
-libavformat-dev
+package: libavformat-dev
 
 18、source package:libavformat58 4.3-3+b1_i386
-package:
-libavformat58
+package: libavformat58
 
 19、source package:libavutil-dev 4.3-3+b1_s390x
-package:
-libavutil-dev
+package: libavutil-dev
 
 20、source package:libavutil56 4.3-3+b1_s390x
-package:
-libavutil56
+package: libavutil56
 
 21、source package:libblockdev-crypto2 2.24-2_mipsel
-package:
-libblockdev-crypto2
+package: libblockdev-crypto2
 
 22、source package:libdbusextended-qt5-dev 0.0.3-4_s390x
-package:
-libdbusextended-qt5-dev
+package: libdbusextended-qt5-dev
 
 23、source package:libfcitx5-qt-dev 0.0~git20200615.b6f2ef3-1_ppc64el
-package:
-libfcitx5-qt-dev
+package: libfcitx5-qt-dev
 
 24、source package:libfcitx5core-dev 0~20191021+ds1-1_s390x
-package:
-libfcitx5core-dev
+package: libfcitx5core-dev
 
 25、source package:libfcitx5utils-dev 0~20191021+ds1-1_s390x
-package:
-libfcitx5utils-dev
+package: libfcitx5utils-dev
 
 26、source package:libgxps-dev 0.3.1-1_s390x
-package:
-libgxps-dev
+package: libgxps-dev
 
 27、source package:libime-bin 0.0~git20200626.2c85668-1_s390x
-package:
-libime-bin
+package: libime-bin
 
 28、source package:libimobiledevice-utils 1.3.0-3_s390x
-package:
-libimobiledevice-utils
+package: libimobiledevice-utils
 
 29、source package:libnss-myhostname 245.6-2_s390x
-package:
-libnss-myhostname
+package: libnss-myhostname
 
 30、source package:libprocps-dev 3.3.16-5_s390x
-package:
-libprocps-dev
+package: libprocps-dev
 
 31、source package:libpulse-dev 7.1-2~bpo8+1_s390x
-package:
-libpulse-dev
+package: libpulse-dev
 
 32、source package:libpulse-mainloop-glib0 9.0-5
-package:
-libpulse-mainloop-glib0
+package: libpulse-mainloop-glib0
 
 33、source package:libpulse0 7.1-2~bpo8+1_s390x
-package:
-libpulse0
+package: libpulse0
 
 34、source package:libqrencode-dev 4.0.2-2_s390x
-package:
-libqrencode-dev
+package: libqrencode-dev
 
 35、source package:libqrencode4 4.1.1-1
-package:
-libqrencode4
+package: libqrencode4
 
 36、source package:libsecret-1-dev 0.20.5-3
-package:
-libsecret-1-dev
+package: libsecret-1-dev
 
 37、source package:libswresample-dev 4.3-3+b1_ppc64el
-package:
-libswresample-dev
+package: libswresample-dev
 
 38、source package:libswscale-dev 4.3-3+b1_s390x
-package:
-libswscale-dev
+package: libswscale-dev
 
 39、source package:libsystemd-dev 245.6-2_i386
-package:
-libsystemd-dev
+package: libsystemd-dev
 
 40、source package:libsystemd0 245.6-2_s390x
-package:
-libsystemd0
+package: libsystemd0
 
 41、source package:libudev-dev 245.6-2_s390x
-package:
-libudev-dev
+package: libudev-dev
 
 42、source package:packagekit 1.2.6-5
-package:
-packagekit
+package: packagekit
 
 43、source package:pulseaudio 9.99.1-1
-package:
-pulseaudio
+package: pulseaudio
 
 44、source package:pulseaudio-module-bluetooth 7.1-2~bpo8+1_s390x
-package:
-pulseaudio-module-bluetooth
+package: pulseaudio-module-bluetooth
 
 45、source package:pulseaudio-utils 7.1-2~bpo8+1_s390x
-package:
-pulseaudio-utils
+package: pulseaudio-utils
 
 46、source package:python3-gi 3.43.1-1
-package:
-python3-gi
+package: python3-gi
 
 47、source package:systemd-coredump 245.6-2_mipsel
-package:
-systemd-coredump
+package: systemd-coredump
 
 48、source package:systemd-timesyncd 245.6-2_ppc64el
-package:
-systemd-timesyncd
+package: systemd-timesyncd
 
 49、source package:udev 245.6-2_s390x
-package:
-udev
+package: udev
 
 50、source package:unar 1.9.1-1
-package:
-unar
+package: unar
 
 
 Open Source Software Licensed under the LGPL-2.1-only:
 1、source package:GitQlient v1.4.3
-package:
-GitQlient
+package: GitQlient
 
 2、source package:cgroup-tools 0.41-8.1_s390x
-package:
-cgroup-tools
+package: cgroup-tools
 
 3、source package:checkstyle checkstyle-10.3.4
-package:
-checkstyle
+package: checkstyle
 
 4、source package:cracklib-runtime 2.9.6-3_s390x
-package:
-cracklib-runtime
+package: cracklib-runtime
 
 5、source package:dialog 1.3-20230209-1
-package:
-dialog
+package: dialog
 
 6、source package:dmsetup 1.02.90-2.2+deb8u1_s390x
-package:
-dmsetup
+package: dmsetup
 
 7、source package:gettext-base 0.19.8.1-9_s390x
-package:
-gettext-base
+package: gettext-base
 
 8、source package:gstreamer1.0-libav 1.9.90-1
-package:
-gstreamer1.0-libav
+package: gstreamer1.0-libav
 
 9、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 10、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 11、source package:gstreamer1.0-plugins-ugly 1.9.90-1
-package:
-gstreamer1.0-plugins-ugly
+package: gstreamer1.0-plugins-ugly
 
 12、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 13、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 14、source package:gtk2-engines 2.20.2.orig
-package:
-gtk2-engines
+package: gtk2-engines
 
 15、source package:gtk2-engines-murrine 0.98.2.orig
-package:
-gtk2-engines-murrine
+package: gtk2-engines-murrine
 
 16、source package:gtk2-engines-pixbuf 2.8.9-2
-package:
-gtk2-engines-pixbuf
+package: gtk2-engines-pixbuf
 
 17、source package:kmod 9-3_sparc
-package:
-kmod
+package: kmod
 
 18、source package:libcairo2-dev 1.16.0-4_s390x
-package:
-libcairo2-dev
+package: libcairo2-dev
 
 19、source package:libcap-ng-dev 0.7.9-2_s390x
-package:
-libcap-ng-dev
+package: libcap-ng-dev
 
 20、source package:libcrack2-dev 2.9.6-5
-package:
-libcrack2-dev
+package: libcrack2-dev
 
 21、source package:libfprint 20110418git-2
-package:
-libfprint
+package: libfprint
 
 22、source package:libfprint-2-2 1.90.1-2_s390x
-package:
-libfprint-2-2
+package: libfprint-2-2
 
 23、source package:libfprint0 1.0-1_s390x
-package:
-libfprint0
+package: libfprint0
 
 24、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 25、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 26、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 27、source package:libgstreamer1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer1.0-0
+package: libgstreamer1.0-0
 
 28、source package:libgstreamer1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer1.0-dev
+package: libgstreamer1.0-dev
 
 29、source package:libgtk-3-dev 3.4.2-7+deb7u1_sparc
-package:
-libgtk-3-dev
+package: libgtk-3-dev
 
 30、source package:liblog4cpp5-dev 1.1.3-3_s390x
-package:
-liblog4cpp5-dev
+package: liblog4cpp5-dev
 
 31、source package:liblog4cpp5v5 1.1.3-3_ppc64el
-package:
-liblog4cpp5v5
+package: liblog4cpp5v5
 
 32、source package:libnm-qt 0.9.8.2.orig
-package:
-libnm-qt
+package: libnm-qt
 
 33、source package:libnotify-bin 0.7.9-1_s390x
-package:
-libnotify-bin
+package: libnotify-bin
 
 34、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 35、source package:librsvg2-dev 2.9.5-6
-package:
-librsvg2-dev
+package: librsvg2-dev
 
 36、source package:libsdl1.2debian 1.2.15-5_sparc
-package:
-libsdl1.2debian
+package: libsdl1.2debian
 
 37、source package:libseccomp-dev 2.4.3-1_s390x
-package:
-libseccomp-dev
+package: libseccomp-dev
 
 38、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 39、source package:libusb-1.0-0-dev 1.0.23-2_s390x
-package:
-libusb-1.0-0-dev
+package: libusb-1.0-0-dev
 
 40、source package:modemmanager 1.8.2.orig
-package:
-modemmanager
+package: modemmanager
 
 41、source package:networkmanager-qt 5.54.0.orig
-package:
-networkmanager-qt
+package: networkmanager-qt
 
 42、source package:p7zip 9.20.1~dfsg.1-5
-package:
-p7zip
+package: p7zip
 
 43、source package:p7zip-full 9.20.1~dfsg.1-4.1_kfreebsd-i386
-package:
-p7zip-full
+package: p7zip-full
 
 44、source package:qrencode 4.0.2.orig
-package:
-qrencode
+package: qrencode
 
 45、source package:qt-creator tqtc/v2.6.0-rc
-package:
-qt-creator
+package: qt-creator
 
 46、source package:qtciphersqliteplugin 0.6
-package:
-qtciphersqliteplugin
+package: qtciphersqliteplugin
 
 47、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2:
 1、source package:libqt5core5a 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5core5a
+package: libqt5core5a
 
 2、source package:libqt5opengl5-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5opengl5-dev
+package: libqt5opengl5-dev
 
 3、source package:libqt5sql5-sqlite 5.7.1+dfsg-3+deb9u2_s390x
-package:
-libqt5sql5-sqlite
+package: libqt5sql5-sqlite
 
 4、source package:libqt5svg5-dev 5.7.1~20161021-2+b2_s390x
-package:
-libqt5svg5-dev
+package: libqt5svg5-dev
 
 5、source package:libqt5x11extras5-dev 5.9.2-1
-package:
-libqt5x11extras5-dev
+package: libqt5x11extras5-dev
 
 6、source package:libqt6multimedia6 6.4.2-6
-package:
-libqt6multimedia6
+package: libqt6multimedia6
 
 7、source package:libqt6opengl6 6.4.2+dfsg~rc1-3+alpha.1
-package:
-libqt6opengl6
+package: libqt6opengl6
 
 8、source package:qml-module-qt-labs-platform 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qt-labs-platform
+package: qml-module-qt-labs-platform
 
 9、source package:qml-module-qtquick-controls2 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qtquick-controls2
+package: qml-module-qtquick-controls2
 
 10、source package:qml-module-qtquick-dialogs 5.7.1~20161021-2_s390x
-package:
-qml-module-qtquick-dialogs
+package: qml-module-qtquick-dialogs
 
 11、source package:qml-module-qtquick-templates2 5.9.2-2_kfreebsd-amd64
-package:
-qml-module-qtquick-templates2
+package: qml-module-qtquick-templates2
 
 12、source package:qt5-qmake 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qt5-qmake
+package: qt5-qmake
 
 13、source package:qt6-svg-dev 6.4.2~rc1-3
-package:
-qt6-svg-dev
+package: qt6-svg-dev
 
 14、source package:qt6-wayland 6.4.2~rc1-2
-package:
-qt6-wayland
+package: qt6-wayland
 
 15、source package:qtbase5-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qtbase5-dev
+package: qtbase5-dev
 
 16、source package:qtbase5-private-dev 5.7.1+dfsg-3+deb9u2_s390x
-package:
-qtbase5-private-dev
+package: qtbase5-private-dev
 
 17、source package:qtmultimedia5-dev 5.7.1~20161021-2_s390x
-package:
-qtmultimedia5-dev
+package: qtmultimedia5-dev
 
 18、source package:qtquickcontrols2-5-dev 5.9.2-2_kfreebsd-amd64
-package:
-qtquickcontrols2-5-dev
+package: qtquickcontrols2-5-dev
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2+:
 1、source package:qml-module-qtqml-models2 5.7.1-2+b2_s390x
-package:
-qml-module-qtqml-models2
+package: qml-module-qtqml-models2
 
 2、source package:qml-module-qtquick-layouts 5.7.1-2+b2_s390x
-package:
-qml-module-qtquick-layouts
+package: qml-module-qtquick-layouts
 
 3、source package:qml-module-qtquick2 5.7.1-2+b2_s390x
-package:
-qml-module-qtquick2
+package: qml-module-qtquick2
 
 4、source package:qtdeclarative5-dev 5.7.1-2+b2_s390x
-package:
-qtdeclarative5-dev
+package: qtdeclarative5-dev
 
 
 Open Source Software Licensed under the Apache-2.0:
 1、source package:AndroidProject-Kotlin 13.2
-package:
-AndroidProject-Kotlin
+package: AndroidProject-Kotlin
 
 2、source package:JSONStream 1.3.5
-package:
-JSONStream
+package: JSONStream
 
 3、source package:acorn-node 1.8.2
-package:
-acorn-node
+package: acorn-node
 
 4、source package:android-pdfium a56ccce4
-package:
-android-pdfium
+package: android-pdfium
 
 5、source package:androidsvg 1.4
-package:
-androidsvg
+package: androidsvg
 
 6、source package:atob 2.1.2
-package:
-atob
+package: atob
 
 7、source package:aws-sign2 0.7.0
-package:
-aws-sign2
+package: aws-sign2
 
 8、source package:caseless 0.12.0
-package:
-caseless
+package: caseless
 
 9、source package:cilium 1.14.3
-package:
-cilium
+package: cilium
 
 10、source package:circleindicator 2.1.6
-package:
-circleindicator
+package: circleindicator
 
 11、source package:cobra v0.0.3
-package:
-cobra
+package: cobra
 
 12、source package:compiler 4.12.0
-package:
-compiler
+package: compiler
 
 13、source package:concurrent 1.0.0
-package:
-concurrent
+package: concurrent
 
 14、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 15、source package:core 1.7.0
-package:
-core
+package: core
 
 16、source package:cppdap 87f8b4a
-package:
-cppdap
+package: cppdap
 
 17、source package:crypto v0.23.0
-package:
-crypto
+package: crypto
 
 18、source package:dash-ast 1.0.0
-package:
-dash-ast
+package: dash-ast
 
 19、source package:diff-match-patch 1.0.5
-package:
-diff-match-patch
+package: diff-match-patch
 
 20、source package:dompurify 2.4.1
-package:
-dompurify
+package: dompurify
 
 21、source package:external/github.com/google/benchmark v1.4.1
-package:
-external/github.com/google/benchmark
+package: external/github.com/google/benchmark
 
 22、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 23、source package:fonts-noto-color-emoji 2.038-1
-package:
-fonts-noto-color-emoji
+package: fonts-noto-color-emoji
 
 24、source package:forever-agent 0.6.1
-package:
-forever-agent
+package: forever-agent
 
 25、source package:get-assigned-identifiers 1.2.0
-package:
-get-assigned-identifiers
+package: get-assigned-identifiers
 
 26、source package:git 4.3.20-9
-package:
-git
+package: git
 
 27、source package:glide 4.12.0
-package:
-glide
+package: glide
 
 28、source package:gofuzz v1.0.0
-package:
-gofuzz
+package: gofuzz
 
 29、source package:golang-github-golang-groupcache-dev 0.0~git20200121.8c9f03a-2
-package:
-golang-github-golang-groupcache-dev
+package: golang-github-golang-groupcache-dev
 
 30、source package:golang-gopkg-yaml.v2-dev 2.4.0-3
-package:
-golang-gopkg-yaml.v2-dev
+package: golang-gopkg-yaml.v2-dev
 
 31、source package:golang-gopkg-yaml.v3-dev 3.0.1-3
-package:
-golang-gopkg-yaml.v3-dev
+package: golang-gopkg-yaml.v3-dev
 
 32、source package:gradle 7.4.2
-package:
-gradle
+package: gradle
 
 33、source package:gson 2.10.1
-package:
-gson
+package: gson
 
 34、source package:imgbrd-grabber v6.0.2
-package:
-imgbrd-grabber
+package: imgbrd-grabber
 
 35、source package:infratask_scheduler v0.1.0
-package:
-infratask_scheduler
+package: infratask_scheduler
 
 36、source package:junit 1.1.5
-package:
-junit
+package: junit
 
 37、source package:kata-containers CC-0.7.0
-package:
-kata-containers
+package: kata-containers
 
 38、source package:kotlin-gradle-plugin
-package:
-kotlin-gradle-plugin
+package: kotlin-gradle-plugin
 
 39、source package:kotlin-stdlib-jdk7
-package:
-kotlin-stdlib-jdk7
+package: kotlin-stdlib-jdk7
 
 40、source package:kotlinx-serialization-json 1.5.1
-package:
-kotlinx-serialization-json
+package: kotlinx-serialization-json
 
 41、source package:libcups2-dev 2.3~rc1-1_s390x
-package:
-libcups2-dev
+package: libcups2-dev
 
 42、source package:libcupsimage2 2.3~rc1-1_s390x
-package:
-libcupsimage2
+package: libcupsimage2
 
 43、source package:libpoppler-cpp-dev 0.85.0-1_s390x
-package:
-libpoppler-cpp-dev
+package: libpoppler-cpp-dev
 
 44、source package:libpoppler-cpp0v5 0.85.0-1_s390x
-package:
-libpoppler-cpp0v5
+package: libpoppler-cpp0v5
 
 45、source package:libssl-dev 3.0.0~~alpha4-1_s390x
-package:
-libssl-dev
+package: libssl-dev
 
 46、source package:libssl3 3.0.0~~alpha4-1_s390x
-package:
-libssl3
+package: libssl3
 
 47、source package:libwebrtc-bin 86.4240.20.0
-package:
-libwebrtc-bin
+package: libwebrtc-bin
 
 48、source package:libxerces-c-dev 3.2.3+debian-1_s390x
-package:
-libxerces-c-dev
+package: libxerces-c-dev
 
 49、source package:lottie 4.1.0
-package:
-lottie
+package: lottie
 
 50、source package:ms365 v2.0.5
-package:
-ms365
+package: ms365
 
 51、source package:oauth-sign 0.9.0
-package:
-oauth-sign
+package: oauth-sign
 
 52、source package:okhttp 3.12.13
-package:
-okhttp
+package: okhttp
 
 53、source package:podman 1.6.4+dfsg1-4_armel
-package:
-podman
+package: podman
 
 54、source package:preference 1.2.1
-package:
-preference
+package: preference
 
 55、source package:request 2.88.0
-package:
-request
+package: request
 
 56、source package:rsyslog 8.9.0-3
-package:
-rsyslog
+package: rsyslog
 
 57、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 58、source package:spdx-correct 3.1.1
-package:
-spdx-correct
+package: spdx-correct
 
 59、source package:sse v0.1.0
-package:
-sse
+package: sse
 
 60、source package:sync v0.10.0
-package:
-sync
+package: sync
 
 61、source package:through 2.3.8
-package:
-through
+package: through
 
 62、source package:timber 4.7.1
-package:
-timber
+package: timber
 
 63、source package:tinyrpc 2130294
-package:
-tinyrpc
+package: tinyrpc
 
 64、source package:tools_oat 373f560
-package:
-tools_oat
+package: tools_oat
 
 65、source package:true-case-path 1.0.3
-package:
-true-case-path
+package: true-case-path
 
 66、source package:tunnel-agent 0.6.0
-package:
-tunnel-agent
+package: tunnel-agent
 
 67、source package:typescript 4.8.4
-package:
-typescript
+package: typescript
 
 68、source package:undeclared-identifiers 1.1.3
-package:
-undeclared-identifiers
+package: undeclared-identifiers
 
 69、source package:validate-npm-package-license 3.0.4
-package:
-validate-npm-package-license
+package: validate-npm-package-license
 
 70、source package:vimspector 2938438041
-package:
-vimspector
+package: vimspector
 
 
 Open Source Software Licensed under the MIT:
 1、source package:@antfu/utils 0.7.7
-package:
-@antfu/utils
+package: @antfu/utils
 
 2、source package:@babel/runtime 7.6.0
-package:
-@babel/runtime
+package: @babel/runtime
 
 3、source package:@babel/standalone 7.20.15
-package:
-@babel/standalone
+package: @babel/standalone
 
 4、source package:@ctrl/tinycolor 3.4.1
-package:
-@ctrl/tinycolor
+package: @ctrl/tinycolor
 
 5、source package:@element-plus/icons-vue 2.0.9
-package:
-@element-plus/icons-vue
+package: @element-plus/icons-vue
 
 6、source package:@esbuild/android-arm 0.15.9
-package:
-@esbuild/android-arm
+package: @esbuild/android-arm
 
 7、source package:@esbuild/linux-loong64 0.15.9
-package:
-@esbuild/linux-loong64
+package: @esbuild/linux-loong64
 
 8、source package:@floating-ui/core 1.0.1
-package:
-@floating-ui/core
+package: @floating-ui/core
 
 9、source package:@floating-ui/dom 1.0.2
-package:
-@floating-ui/dom
+package: @floating-ui/dom
 
 10、source package:@jridgewell/gen-mapping 0.3.2
-package:
-@jridgewell/gen-mapping
+package: @jridgewell/gen-mapping
 
 11、source package:@jridgewell/resolve-uri 3.1.0
-package:
-@jridgewell/resolve-uri
+package: @jridgewell/resolve-uri
 
 12、source package:@jridgewell/set-array 1.1.2
-package:
-@jridgewell/set-array
+package: @jridgewell/set-array
 
 13、source package:@jridgewell/source-map 0.3.2
-package:
-@jridgewell/source-map
+package: @jridgewell/source-map
 
 14、source package:@jridgewell/sourcemap-codec 1.4.14
-package:
-@jridgewell/sourcemap-codec
+package: @jridgewell/sourcemap-codec
 
 15、source package:@jridgewell/trace-mapping 0.3.16
-package:
-@jridgewell/trace-mapping
+package: @jridgewell/trace-mapping
 
 16、source package:@nodelib/fs.scandir 2.1.5
-package:
-@nodelib/fs.scandir
+package: @nodelib/fs.scandir
 
 17、source package:@nodelib/fs.stat 2.0.5
-package:
-@nodelib/fs.stat
+package: @nodelib/fs.stat
 
 18、source package:@nodelib/fs.walk 1.2.8
-package:
-@nodelib/fs.walk
+package: @nodelib/fs.walk
 
 19、source package:@popperjs/core 2.11.7
-package:
-@popperjs/core
+package: @popperjs/core
 
 20、source package:@rollup/pluginutils 5.1.0
-package:
-@rollup/pluginutils
+package: @rollup/pluginutils
 
 21、source package:@smake/co 1.0.1
-package:
-@smake/co
+package: @smake/co
 
 22、source package:@types/estree 1.0.5
-package:
-@types/estree
+package: @types/estree
 
 23、source package:@types/json-schema 7.0.6
-package:
-@types/json-schema
+package: @types/json-schema
 
 24、source package:@types/lodash 4.14.185
-package:
-@types/lodash
+package: @types/lodash
 
 25、source package:@types/lodash-es 4.17.6
-package:
-@types/lodash-es
+package: @types/lodash-es
 
 26、source package:@types/node 14.14.6
-package:
-@types/node
+package: @types/node
 
 27、source package:@types/web-bluetooth 0.0.15
-package:
-@types/web-bluetooth
+package: @types/web-bluetooth
 
 28、source package:@vitejs/plugin-legacy 2.3.1
-package:
-@vitejs/plugin-legacy
+package: @vitejs/plugin-legacy
 
 29、source package:@vitejs/plugin-vue 3.1.0
-package:
-@vitejs/plugin-vue
+package: @vitejs/plugin-vue
 
 30、source package:@vue/devtools-api 6.4.1
-package:
-@vue/devtools-api
+package: @vue/devtools-api
 
 31、source package:@vueuse/core 9.3.0
-package:
-@vueuse/core
+package: @vueuse/core
 
 32、source package:@vueuse/metadata 9.3.0
-package:
-@vueuse/metadata
+package: @vueuse/metadata
 
 33、source package:@vueuse/shared 9.3.0
-package:
-@vueuse/shared
+package: @vueuse/shared
 
 34、source package:CppLogging 1.0.1.0
-package:
-CppLogging
+package: CppLogging
 
 35、source package:abbrev 1.1.1
-package:
-abbrev
+package: abbrev
 
 36、source package:acorn 7.0.0
-package:
-acorn
+package: acorn
 
 37、source package:acorn-dynamic-import 2.0.2
-package:
-acorn-dynamic-import
+package: acorn-dynamic-import
 
 38、source package:acorn-node 1.8.2
-package:
-acorn-node
+package: acorn-node
 
 39、source package:acorn-walk 7.0.0
-package:
-acorn-walk
+package: acorn-walk
 
 40、source package:add-px-to-style 1.0.0
-package:
-add-px-to-style
+package: add-px-to-style
 
 41、source package:ajv 6.12.6
-package:
-ajv
+package: ajv
 
 42、source package:ajv-keywords 3.5.2
-package:
-ajv-keywords
+package: ajv-keywords
 
 43、source package:align-text 0.1.4
-package:
-align-text
+package: align-text
 
 44、source package:amdefine 1.0.1
-package:
-amdefine
+package: amdefine
 
 45、source package:ansi-gray 0.1.1
-package:
-ansi-gray
+package: ansi-gray
 
 46、source package:ansi-regex 3.0.0
-package:
-ansi-regex
+package: ansi-regex
 
 47、source package:ansi-styles 2.2.1
-package:
-ansi-styles
+package: ansi-styles
 
 48、source package:ansi-wrap 0.1.0
-package:
-ansi-wrap
+package: ansi-wrap
 
 49、source package:anyks-lm 2.1.5
-package:
-anyks-lm
+package: anyks-lm
 
 50、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 51、source package:archy 1.0.0
-package:
-archy
+package: archy
 
 52、source package:arr-diff 4.0.0
-package:
-arr-diff
+package: arr-diff
 
 53、source package:arr-flatten 1.1.0
-package:
-arr-flatten
+package: arr-flatten
 
 54、source package:arr-union 3.1.0
-package:
-arr-union
+package: arr-union
 
 55、source package:array-differ 1.0.0
-package:
-array-differ
+package: array-differ
 
 56、source package:array-each 1.0.1
-package:
-array-each
+package: array-each
 
 57、source package:array-find-index 1.0.2
-package:
-array-find-index
+package: array-find-index
 
 58、source package:array-slice 1.1.0
-package:
-array-slice
+package: array-slice
 
 59、source package:array-uniq 1.0.3
-package:
-array-uniq
+package: array-uniq
 
 60、source package:array-unique 0.3.2
-package:
-array-unique
+package: array-unique
 
 61、source package:asn1 0.2.4
-package:
-asn1
+package: asn1
 
 62、source package:asn1.js 5.4.1
-package:
-asn1.js
+package: asn1.js
 
 63、source package:assert 1.5.0
-package:
-assert
+package: assert
 
 64、source package:assert-plus 1.0.0
-package:
-assert-plus
+package: assert-plus
 
 65、source package:assign-symbols 1.0.0
-package:
-assign-symbols
+package: assign-symbols
 
 66、source package:async 2.6.3
-package:
-async
+package: async
 
 67、source package:async-each 1.0.3
-package:
-async-each
+package: async-each
 
 68、source package:async-foreach 0.1.3
-package:
-async-foreach
+package: async-foreach
 
 69、source package:async-validator 4.2.5
-package:
-async-validator
+package: async-validator
 
 70、source package:asynckit 0.4.0
-package:
-asynckit
+package: asynckit
 
 71、source package:atob 2.1.2
-package:
-atob
+package: atob
 
 72、source package:aws4 1.8.0
-package:
-aws4
+package: aws4
 
 73、source package:babel-code-frame 6.26.0
-package:
-babel-code-frame
+package: babel-code-frame
 
 74、source package:babel-core 6.26.3
-package:
-babel-core
+package: babel-core
 
 75、source package:babel-generator 6.26.1
-package:
-babel-generator
+package: babel-generator
 
 76、source package:babel-helper-builder-binary-assignment-operator-visitor 6.24.1
-package:
-babel-helper-builder-binary-assignment-operator-visitor
+package: babel-helper-builder-binary-assignment-operator-visitor
 
 77、source package:babel-helper-builder-react-jsx 6.26.0
-package:
-babel-helper-builder-react-jsx
+package: babel-helper-builder-react-jsx
 
 78、source package:babel-helper-call-delegate 6.24.1
-package:
-babel-helper-call-delegate
+package: babel-helper-call-delegate
 
 79、source package:babel-helper-define-map 6.26.0
-package:
-babel-helper-define-map
+package: babel-helper-define-map
 
 80、source package:babel-helper-explode-assignable-expression 6.24.1
-package:
-babel-helper-explode-assignable-expression
+package: babel-helper-explode-assignable-expression
 
 81、source package:babel-helper-function-name 6.24.1
-package:
-babel-helper-function-name
+package: babel-helper-function-name
 
 82、source package:babel-helper-get-function-arity 6.24.1
-package:
-babel-helper-get-function-arity
+package: babel-helper-get-function-arity
 
 83、source package:babel-helper-hoist-variables 6.24.1
-package:
-babel-helper-hoist-variables
+package: babel-helper-hoist-variables
 
 84、source package:babel-helper-optimise-call-expression 6.24.1
-package:
-babel-helper-optimise-call-expression
+package: babel-helper-optimise-call-expression
 
 85、source package:babel-helper-regex 6.26.0
-package:
-babel-helper-regex
+package: babel-helper-regex
 
 86、source package:babel-helper-remap-async-to-generator 6.24.1
-package:
-babel-helper-remap-async-to-generator
+package: babel-helper-remap-async-to-generator
 
 87、source package:babel-helper-replace-supers 6.24.1
-package:
-babel-helper-replace-supers
+package: babel-helper-replace-supers
 
 88、source package:babel-helpers 6.24.1
-package:
-babel-helpers
+package: babel-helpers
 
 89、source package:babel-messages 6.23.0
-package:
-babel-messages
+package: babel-messages
 
 90、source package:babel-plugin-check-es2015-constants 6.22.0
-package:
-babel-plugin-check-es2015-constants
+package: babel-plugin-check-es2015-constants
 
 91、source package:babel-plugin-syntax-async-functions 6.13.0
-package:
-babel-plugin-syntax-async-functions
+package: babel-plugin-syntax-async-functions
 
 92、source package:babel-plugin-syntax-exponentiation-operator 6.13.0
-package:
-babel-plugin-syntax-exponentiation-operator
+package: babel-plugin-syntax-exponentiation-operator
 
 93、source package:babel-plugin-syntax-flow 6.18.0
-package:
-babel-plugin-syntax-flow
+package: babel-plugin-syntax-flow
 
 94、source package:babel-plugin-syntax-jsx 6.18.0
-package:
-babel-plugin-syntax-jsx
+package: babel-plugin-syntax-jsx
 
 95、source package:babel-plugin-syntax-trailing-function-commas 6.22.0
-package:
-babel-plugin-syntax-trailing-function-commas
+package: babel-plugin-syntax-trailing-function-commas
 
 96、source package:babel-plugin-transform-async-to-generator 6.24.1
-package:
-babel-plugin-transform-async-to-generator
+package: babel-plugin-transform-async-to-generator
 
 97、source package:babel-plugin-transform-es2015-arrow-functions 6.22.0
-package:
-babel-plugin-transform-es2015-arrow-functions
+package: babel-plugin-transform-es2015-arrow-functions
 
 98、source package:babel-plugin-transform-es2015-block-scoped-functions 6.22.0
-package:
-babel-plugin-transform-es2015-block-scoped-functions
+package: babel-plugin-transform-es2015-block-scoped-functions
 
 99、source package:babel-plugin-transform-es2015-block-scoping 6.26.0
-package:
-babel-plugin-transform-es2015-block-scoping
+package: babel-plugin-transform-es2015-block-scoping
 
 100、source package:babel-plugin-transform-es2015-classes 6.24.1
-package:
-babel-plugin-transform-es2015-classes
+package: babel-plugin-transform-es2015-classes
 
 101、source package:babel-plugin-transform-es2015-computed-properties 6.24.1
-package:
-babel-plugin-transform-es2015-computed-properties
+package: babel-plugin-transform-es2015-computed-properties
 
 102、source package:babel-plugin-transform-es2015-destructuring 6.23.0
-package:
-babel-plugin-transform-es2015-destructuring
+package: babel-plugin-transform-es2015-destructuring
 
 103、source package:babel-plugin-transform-es2015-duplicate-keys 6.24.1
-package:
-babel-plugin-transform-es2015-duplicate-keys
+package: babel-plugin-transform-es2015-duplicate-keys
 
 104、source package:babel-plugin-transform-es2015-for-of 6.23.0
-package:
-babel-plugin-transform-es2015-for-of
+package: babel-plugin-transform-es2015-for-of
 
 105、source package:babel-plugin-transform-es2015-function-name 6.24.1
-package:
-babel-plugin-transform-es2015-function-name
+package: babel-plugin-transform-es2015-function-name
 
 106、source package:babel-plugin-transform-es2015-literals 6.22.0
-package:
-babel-plugin-transform-es2015-literals
+package: babel-plugin-transform-es2015-literals
 
 107、source package:babel-plugin-transform-es2015-modules-amd 6.24.1
-package:
-babel-plugin-transform-es2015-modules-amd
+package: babel-plugin-transform-es2015-modules-amd
 
 108、source package:babel-plugin-transform-es2015-modules-commonjs 6.26.2
-package:
-babel-plugin-transform-es2015-modules-commonjs
+package: babel-plugin-transform-es2015-modules-commonjs
 
 109、source package:babel-plugin-transform-es2015-modules-systemjs 6.24.1
-package:
-babel-plugin-transform-es2015-modules-systemjs
+package: babel-plugin-transform-es2015-modules-systemjs
 
 110、source package:babel-plugin-transform-es2015-modules-umd 6.24.1
-package:
-babel-plugin-transform-es2015-modules-umd
+package: babel-plugin-transform-es2015-modules-umd
 
 111、source package:babel-plugin-transform-es2015-object-super 6.24.1
-package:
-babel-plugin-transform-es2015-object-super
+package: babel-plugin-transform-es2015-object-super
 
 112、source package:babel-plugin-transform-es2015-parameters 6.24.1
-package:
-babel-plugin-transform-es2015-parameters
+package: babel-plugin-transform-es2015-parameters
 
 113、source package:babel-plugin-transform-es2015-shorthand-properties 6.24.1
-package:
-babel-plugin-transform-es2015-shorthand-properties
+package: babel-plugin-transform-es2015-shorthand-properties
 
 114、source package:babel-plugin-transform-es2015-spread 6.22.0
-package:
-babel-plugin-transform-es2015-spread
+package: babel-plugin-transform-es2015-spread
 
 115、source package:babel-plugin-transform-es2015-sticky-regex 6.24.1
-package:
-babel-plugin-transform-es2015-sticky-regex
+package: babel-plugin-transform-es2015-sticky-regex
 
 116、source package:babel-plugin-transform-es2015-template-literals 6.22.0
-package:
-babel-plugin-transform-es2015-template-literals
+package: babel-plugin-transform-es2015-template-literals
 
 117、source package:babel-plugin-transform-es2015-typeof-symbol 6.23.0
-package:
-babel-plugin-transform-es2015-typeof-symbol
+package: babel-plugin-transform-es2015-typeof-symbol
 
 118、source package:babel-plugin-transform-es2015-unicode-regex 6.24.1
-package:
-babel-plugin-transform-es2015-unicode-regex
+package: babel-plugin-transform-es2015-unicode-regex
 
 119、source package:babel-plugin-transform-exponentiation-operator 6.24.1
-package:
-babel-plugin-transform-exponentiation-operator
+package: babel-plugin-transform-exponentiation-operator
 
 120、source package:babel-plugin-transform-flow-strip-types 6.22.0
-package:
-babel-plugin-transform-flow-strip-types
+package: babel-plugin-transform-flow-strip-types
 
 121、source package:babel-plugin-transform-react-display-name 6.25.0
-package:
-babel-plugin-transform-react-display-name
+package: babel-plugin-transform-react-display-name
 
 122、source package:babel-plugin-transform-react-jsx 6.24.1
-package:
-babel-plugin-transform-react-jsx
+package: babel-plugin-transform-react-jsx
 
 123、source package:babel-plugin-transform-react-jsx-self 6.22.0
-package:
-babel-plugin-transform-react-jsx-self
+package: babel-plugin-transform-react-jsx-self
 
 124、source package:babel-plugin-transform-react-jsx-source 6.22.0
-package:
-babel-plugin-transform-react-jsx-source
+package: babel-plugin-transform-react-jsx-source
 
 125、source package:babel-plugin-transform-regenerator 6.26.0
-package:
-babel-plugin-transform-regenerator
+package: babel-plugin-transform-regenerator
 
 126、source package:babel-plugin-transform-strict-mode 6.24.1
-package:
-babel-plugin-transform-strict-mode
+package: babel-plugin-transform-strict-mode
 
 127、source package:babel-polyfill 6.26.0
-package:
-babel-polyfill
+package: babel-polyfill
 
 128、source package:babel-preset-env 1.7.0
-package:
-babel-preset-env
+package: babel-preset-env
 
 129、source package:babel-preset-flow 6.23.0
-package:
-babel-preset-flow
+package: babel-preset-flow
 
 130、source package:babel-preset-react 6.24.1
-package:
-babel-preset-react
+package: babel-preset-react
 
 131、source package:babel-register 6.26.0
-package:
-babel-register
+package: babel-register
 
 132、source package:babel-runtime 6.26.0
-package:
-babel-runtime
+package: babel-runtime
 
 133、source package:babel-template 6.26.0
-package:
-babel-template
+package: babel-template
 
 134、source package:babel-traverse 6.26.0
-package:
-babel-traverse
+package: babel-traverse
 
 135、source package:babel-types 6.26.0
-package:
-babel-types
+package: babel-types
 
 136、source package:babelify 8.0.0
-package:
-babelify
+package: babelify
 
 137、source package:babylon 6.18.0
-package:
-babylon
+package: babylon
 
 138、source package:balanced-match 1.0.2
-package:
-balanced-match
+package: balanced-match
 
 139、source package:base 0.11.2
-package:
-base
+package: base
 
 140、source package:base64-js 1.3.1
-package:
-base64-js
+package: base64-js
 
 141、source package:beeper 1.1.1
-package:
-beeper
+package: beeper
 
 142、source package:big.js 5.2.2
-package:
-big.js
+package: big.js
 
 143、source package:binary-extensions 2.2.0
-package:
-binary-extensions
+package: binary-extensions
 
 144、source package:bl 1.2.2
-package:
-bl
+package: bl
 
 145、source package:bn.js 5.1.3
-package:
-bn.js
+package: bn.js
 
 146、source package:brace-expansion 2.0.1
-package:
-brace-expansion
+package: brace-expansion
 
 147、source package:braces 3.0.2
-package:
-braces
+package: braces
 
 148、source package:brorand 1.1.0
-package:
-brorand
+package: brorand
 
 149、source package:browser-pack 6.1.0
-package:
-browser-pack
+package: browser-pack
 
 150、source package:browser-resolve 1.11.3
-package:
-browser-resolve
+package: browser-resolve
 
 151、source package:browserify 14.5.0
-package:
-browserify
+package: browserify
 
 152、source package:browserify-aes 1.2.0
-package:
-browserify-aes
+package: browserify-aes
 
 153、source package:browserify-cipher 1.0.1
-package:
-browserify-cipher
+package: browserify-cipher
 
 154、source package:browserify-des 1.0.2
-package:
-browserify-des
+package: browserify-des
 
 155、source package:browserify-rsa 4.0.1
-package:
-browserify-rsa
+package: browserify-rsa
 
 156、source package:browserify-zlib 0.2.0
-package:
-browserify-zlib
+package: browserify-zlib
 
 157、source package:browserslist 3.2.8
-package:
-browserslist
+package: browserslist
 
 158、source package:buffer 5.4.2
-package:
-buffer
+package: buffer
 
 159、source package:buffer-from 1.1.2
-package:
-buffer-from
+package: buffer-from
 
 160、source package:buffer-xor 1.0.3
-package:
-buffer-xor
+package: buffer-xor
 
 161、source package:builtin-status-codes 3.0.0
-package:
-builtin-status-codes
+package: builtin-status-codes
 
 162、source package:cache-base 1.0.1
-package:
-cache-base
+package: cache-base
 
 163、source package:cached-path-relative 1.0.2
-package:
-cached-path-relative
+package: cached-path-relative
 
 164、source package:camelcase 4.1.0
-package:
-camelcase
+package: camelcase
 
 165、source package:camelcase-keys 2.1.0
-package:
-camelcase-keys
+package: camelcase-keys
 
 166、source package:center-align 0.1.3
-package:
-center-align
+package: center-align
 
 167、source package:chalk 1.1.3
-package:
-chalk
+package: chalk
 
 168、source package:cheerio 1.0.0-rc.3
-package:
-cheerio
+package: cheerio
 
 169、source package:chokidar 3.4.3
-package:
-chokidar
+package: chokidar
 
 170、source package:cipher-base 1.0.4
-package:
-cipher-base
+package: cipher-base
 
 171、source package:class-utils 0.3.6
-package:
-class-utils
+package: class-utils
 
 172、source package:clone 2.1.2
-package:
-clone
+package: clone
 
 173、source package:clone-buffer 1.0.0
-package:
-clone-buffer
+package: clone-buffer
 
 174、source package:clone-stats 1.0.0
-package:
-clone-stats
+package: clone-stats
 
 175、source package:cloneable-readable 1.1.3
-package:
-cloneable-readable
+package: cloneable-readable
 
 176、source package:code-point-at 1.1.0
-package:
-code-point-at
+package: code-point-at
 
 177、source package:collection-visit 1.0.0
-package:
-collection-visit
+package: collection-visit
 
 178、source package:combine-source-map 0.8.0
-package:
-combine-source-map
+package: combine-source-map
 
 179、source package:combined-stream 1.0.8
-package:
-combined-stream
+package: combined-stream
 
 180、source package:commander 2.20.3
-package:
-commander
+package: commander
 
 181、source package:component-emitter 1.3.0
-package:
-component-emitter
+package: component-emitter
 
 182、source package:compute-scroll-into-view 1.0.11
-package:
-compute-scroll-into-view
+package: compute-scroll-into-view
 
 183、source package:concat-map 0.0.1
-package:
-concat-map
+package: concat-map
 
 184、source package:concat-stream 1.6.2
-package:
-concat-stream
+package: concat-stream
 
 185、source package:console-browserify 1.2.0
-package:
-console-browserify
+package: console-browserify
 
 186、source package:constants-browserify 1.0.0
-package:
-constants-browserify
+package: constants-browserify
 
 187、source package:convert-source-map 1.6.0
-package:
-convert-source-map
+package: convert-source-map
 
 188、source package:cookiecutter-golang d372aa0
-package:
-cookiecutter-golang
+package: cookiecutter-golang
 
 189、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 190、source package:copy-descriptor 0.1.1
-package:
-copy-descriptor
+package: copy-descriptor
 
 191、source package:core-js 3.27.2
-package:
-core-js
+package: core-js
 
 192、source package:core-util-is 1.0.2
-package:
-core-util-is
+package: core-util-is
 
 193、source package:create-ecdh 4.0.4
-package:
-create-ecdh
+package: create-ecdh
 
 194、source package:create-hash 1.2.0
-package:
-create-hash
+package: create-hash
 
 195、source package:create-hmac 1.1.7
-package:
-create-hmac
+package: create-hmac
 
 196、source package:crelt 1.0.6
-package:
-crelt
+package: crelt
 
 197、source package:cross-spawn 5.1.0
-package:
-cross-spawn
+package: cross-spawn
 
 198、source package:crypto-browserify 3.12.0
-package:
-crypto-browserify
+package: crypto-browserify
 
 199、source package:currently-unhandled 0.4.1
-package:
-currently-unhandled
+package: currently-unhandled
 
 200、source package:dashdash 1.14.1
-package:
-dashdash
+package: dashdash
 
 201、source package:date-now 0.1.4
-package:
-date-now
+package: date-now
 
 202、source package:dateformat 2.2.0
-package:
-dateformat
+package: dateformat
 
 203、source package:dayjs 1.11.5
-package:
-dayjs
+package: dayjs
 
 204、source package:debug 4.3.4
-package:
-debug
+package: debug
 
 205、source package:decamelize 1.2.0
-package:
-decamelize
+package: decamelize
 
 206、source package:decode-uri-component 0.2.0
-package:
-decode-uri-component
+package: decode-uri-component
 
 207、source package:defaults 1.0.3
-package:
-defaults
+package: defaults
 
 208、source package:define-property 2.0.2
-package:
-define-property
+package: define-property
 
 209、source package:defined 1.0.0
-package:
-defined
+package: defined
 
 210、source package:delayed-stream 1.0.0
-package:
-delayed-stream
+package: delayed-stream
 
 211、source package:delegates 1.0.0
-package:
-delegates
+package: delegates
 
 212、source package:deprecated 0.0.1
-package:
-deprecated
+package: deprecated
 
 213、source package:deps-sort 2.0.0
-package:
-deps-sort
+package: deps-sort
 
 214、source package:des.js 1.0.1
-package:
-des.js
+package: des.js
 
 215、source package:detect-file 1.0.0
-package:
-detect-file
+package: detect-file
 
 216、source package:detect-indent 4.0.0
-package:
-detect-indent
+package: detect-indent
 
 217、source package:detective 4.7.1
-package:
-detective
+package: detective
 
 218、source package:diffie-hellman 5.0.3
-package:
-diffie-hellman
+package: diffie-hellman
 
 219、source package:dom-css 2.1.0
-package:
-dom-css
+package: dom-css
 
 220、source package:dom-serializer 0.1.1
-package:
-dom-serializer
+package: dom-serializer
 
 221、source package:domain-browser 1.2.0
-package:
-domain-browser
+package: domain-browser
 
 222、source package:ecc-jsbn 0.1.2
-package:
-ecc-jsbn
+package: ecc-jsbn
 
 223、source package:element-plus 2.2.17
-package:
-element-plus
+package: element-plus
 
 224、source package:elliptic 6.5.3
-package:
-elliptic
+package: elliptic
 
 225、source package:emojis-list 3.0.0
-package:
-emojis-list
+package: emojis-list
 
 226、source package:end-of-stream 0.1.5
-package:
-end-of-stream
+package: end-of-stream
 
 227、source package:enhanced-resolve 3.4.1
-package:
-enhanced-resolve
+package: enhanced-resolve
 
 228、source package:errno 0.1.7
-package:
-errno
+package: errno
 
 229、source package:error-ex 1.3.2
-package:
-error-ex
+package: error-ex
 
 230、source package:es6-iterator 2.0.3
-package:
-es6-iterator
+package: es6-iterator
 
 231、source package:es6-map 0.1.5
-package:
-es6-map
+package: es6-map
 
 232、source package:es6-set 0.1.5
-package:
-es6-set
+package: es6-set
 
 233、source package:es6-symbol 3.1.1
-package:
-es6-symbol
+package: es6-symbol
 
 234、source package:esbuild 0.15.9
-package:
-esbuild
+package: esbuild
 
 235、source package:esbuild-android-64 0.15.9
-package:
-esbuild-android-64
+package: esbuild-android-64
 
 236、source package:esbuild-android-arm64 0.15.9
-package:
-esbuild-android-arm64
+package: esbuild-android-arm64
 
 237、source package:esbuild-darwin-64 0.15.9
-package:
-esbuild-darwin-64
+package: esbuild-darwin-64
 
 238、source package:esbuild-darwin-arm64 0.15.9
-package:
-esbuild-darwin-arm64
+package: esbuild-darwin-arm64
 
 239、source package:esbuild-freebsd-64 0.15.9
-package:
-esbuild-freebsd-64
+package: esbuild-freebsd-64
 
 240、source package:esbuild-freebsd-arm64 0.15.9
-package:
-esbuild-freebsd-arm64
+package: esbuild-freebsd-arm64
 
 241、source package:esbuild-linux-32 0.15.9
-package:
-esbuild-linux-32
+package: esbuild-linux-32
 
 242、source package:esbuild-linux-64 0.15.9
-package:
-esbuild-linux-64
+package: esbuild-linux-64
 
 243、source package:esbuild-linux-arm 0.15.9
-package:
-esbuild-linux-arm
+package: esbuild-linux-arm
 
 244、source package:esbuild-linux-arm64 0.15.9
-package:
-esbuild-linux-arm64
+package: esbuild-linux-arm64
 
 245、source package:esbuild-linux-mips64le 0.15.9
-package:
-esbuild-linux-mips64le
+package: esbuild-linux-mips64le
 
 246、source package:esbuild-linux-ppc64le 0.15.9
-package:
-esbuild-linux-ppc64le
+package: esbuild-linux-ppc64le
 
 247、source package:esbuild-linux-riscv64 0.15.9
-package:
-esbuild-linux-riscv64
+package: esbuild-linux-riscv64
 
 248、source package:esbuild-linux-s390x 0.15.9
-package:
-esbuild-linux-s390x
+package: esbuild-linux-s390x
 
 249、source package:esbuild-netbsd-64 0.15.9
-package:
-esbuild-netbsd-64
+package: esbuild-netbsd-64
 
 250、source package:esbuild-openbsd-64 0.15.9
-package:
-esbuild-openbsd-64
+package: esbuild-openbsd-64
 
 251、source package:esbuild-sunos-64 0.15.9
-package:
-esbuild-sunos-64
+package: esbuild-sunos-64
 
 252、source package:esbuild-windows-32 0.15.9
-package:
-esbuild-windows-32
+package: esbuild-windows-32
 
 253、source package:esbuild-windows-64 0.15.9
-package:
-esbuild-windows-64
+package: esbuild-windows-64
 
 254、source package:esbuild-windows-arm64 0.15.9
-package:
-esbuild-windows-arm64
+package: esbuild-windows-arm64
 
 255、source package:escape-html 1.0.3
-package:
-escape-html
+package: escape-html
 
 256、source package:escape-string-regexp 5.0.0
-package:
-escape-string-regexp
+package: escape-string-regexp
 
 257、source package:estree-walker 2.0.2
-package:
-estree-walker
+package: estree-walker
 
 258、source package:event-emitter 0.3.5
-package:
-event-emitter
+package: event-emitter
 
 259、source package:events 3.2.0
-package:
-events
+package: events
 
 260、source package:evp_bytestokey 1.0.3
-package:
-evp_bytestokey
+package: evp_bytestokey
 
 261、source package:execa 0.7.0
-package:
-execa
+package: execa
 
 262、source package:expand-brackets 2.1.4
-package:
-expand-brackets
+package: expand-brackets
 
 263、source package:expand-tilde 2.0.2
-package:
-expand-tilde
+package: expand-tilde
 
 264、source package:expose-loader 1.0.1
-package:
-expose-loader
+package: expose-loader
 
 265、source package:extend 3.0.2
-package:
-extend
+package: extend
 
 266、source package:extend-shallow 3.0.2
-package:
-extend-shallow
+package: extend-shallow
 
 267、source package:extglob 2.0.4
-package:
-extglob
+package: extglob
 
 268、source package:extsprintf 1.3.0
-package:
-extsprintf
+package: extsprintf
 
 269、source package:fancy-log 1.3.3
-package:
-fancy-log
+package: fancy-log
 
 270、source package:fast-deep-equal 3.1.3
-package:
-fast-deep-equal
+package: fast-deep-equal
 
 271、source package:fast-glob 3.2.12
-package:
-fast-glob
+package: fast-glob
 
 272、source package:fast-json-stable-stringify 2.1.0
-package:
-fast-json-stable-stringify
+package: fast-json-stable-stringify
 
 273、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 274、source package:fill-range 7.0.1
-package:
-fill-range
+package: fill-range
 
 275、source package:find-index 0.1.1
-package:
-find-index
+package: find-index
 
 276、source package:find-up 2.1.0
-package:
-find-up
+package: find-up
 
 277、source package:findup-sync 2.0.0
-package:
-findup-sync
+package: findup-sync
 
 278、source package:fined 1.2.0
-package:
-fined
+package: fined
 
 279、source package:first-chunk-stream 1.0.0
-package:
-first-chunk-stream
+package: first-chunk-stream
 
 280、source package:flagged-respawn 1.0.1
-package:
-flagged-respawn
+package: flagged-respawn
 
 281、source package:for-in 1.0.2
-package:
-for-in
+package: for-in
 
 282、source package:for-own 1.0.0
-package:
-for-own
+package: for-own
 
 283、source package:form-data 2.3.3
-package:
-form-data
+package: form-data
 
 284、source package:fragment-cache 0.2.1
-package:
-fragment-cache
+package: fragment-cache
 
 285、source package:fs.realpath 1.0.0
-package:
-fs.realpath
+package: fs.realpath
 
 286、source package:fsevents 2.3.2
-package:
-fsevents
+package: fsevents
 
 287、source package:function-bind 1.1.1
-package:
-function-bind
+package: function-bind
 
 288、source package:gaze 1.1.3
-package:
-gaze
+package: gaze
 
 289、source package:get-stdin 4.0.1
-package:
-get-stdin
+package: get-stdin
 
 290、source package:get-stream 3.0.0
-package:
-get-stream
+package: get-stream
 
 291、source package:get-value 2.0.6
-package:
-get-value
+package: get-value
 
 292、source package:getpass 0.1.7
-package:
-getpass
+package: getpass
 
 293、source package:gg v1.3.0
-package:
-gg
+package: gg
 
 294、source package:gin v1.5.0
-package:
-gin
+package: gin
 
 295、source package:git 4.3.20-9
-package:
-git
+package: git
 
 296、source package:gitea v1.19.3
-package:
-gitea
+package: gitea
 
 297、source package:glob-stream 3.1.18
-package:
-glob-stream
+package: glob-stream
 
 298、source package:glob-watcher 0.0.6
-package:
-glob-watcher
+package: glob-watcher
 
 299、source package:glob2base 0.0.12
-package:
-glob2base
+package: glob2base
 
 300、source package:global-modules 1.0.0
-package:
-global-modules
+package: global-modules
 
 301、source package:global-prefix 1.0.2
-package:
-global-prefix
+package: global-prefix
 
 302、source package:globals 9.18.0
-package:
-globals
+package: globals
 
 303、source package:globule 1.2.1
-package:
-globule
+package: globule
 
 304、source package:glogg 1.0.2
-package:
-glogg
+package: glogg
 
 305、source package:go v1.1.7
-package:
-go
+package: go
 
 306、source package:go-isatty v0.0.9
-package:
-go-isatty
+package: go-isatty
 
 307、source package:go-pinyin v0.19.0
-package:
-go-pinyin
+package: go-pinyin
 
 308、source package:go-wav v0.3.2
-package:
-go-wav
+package: go-wav
 
 309、source package:go-windows-terminal-sequences v1.0.1
-package:
-go-windows-terminal-sequences
+package: go-windows-terminal-sequences
 
 310、source package:goconvey v1.8.1
-package:
-goconvey
+package: goconvey
 
 311、source package:golang-github-gosexy-gettext-dev 0~git20130221-2.1_all
-package:
-golang-github-gosexy-gettext-dev
+package: golang-github-gosexy-gettext-dev
 
 312、source package:gstreamer1.0-fluendo-mp3 0.10.32.debian-1_s390x
-package:
-gstreamer1.0-fluendo-mp3
+package: gstreamer1.0-fluendo-mp3
 
 313、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 314、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 315、source package:gstreamer1.0-plugins-ugly 1.9.90-1
-package:
-gstreamer1.0-plugins-ugly
+package: gstreamer1.0-plugins-ugly
 
 316、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 317、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 318、source package:gulp 3.9.1
-package:
-gulp
+package: gulp
 
 319、source package:gulp-concat 2.6.1
-package:
-gulp-concat
+package: gulp-concat
 
 320、source package:gulp-rename 1.4.0
-package:
-gulp-rename
+package: gulp-rename
 
 321、source package:gulp-sass 3.2.1
-package:
-gulp-sass
+package: gulp-sass
 
 322、source package:gulp-util 3.0.8
-package:
-gulp-util
+package: gulp-util
 
 323、source package:gulplog 1.0.0
-package:
-gulplog
+package: gulplog
 
 324、source package:har-validator 5.1.3
-package:
-har-validator
+package: har-validator
 
 325、source package:has 1.0.3
-package:
-has
+package: has
 
 326、source package:has-ansi 2.0.0
-package:
-has-ansi
+package: has-ansi
 
 327、source package:has-flag 2.0.0
-package:
-has-flag
+package: has-flag
 
 328、source package:has-gulplog 0.1.0
-package:
-has-gulplog
+package: has-gulplog
 
 329、source package:has-value 1.0.0
-package:
-has-value
+package: has-value
 
 330、source package:has-values 1.0.0
-package:
-has-values
+package: has-values
 
 331、source package:hash-base 3.1.0
-package:
-hash-base
+package: hash-base
 
 332、source package:hash.js 1.1.7
-package:
-hash.js
+package: hash.js
 
 333、source package:history 4.9.0
-package:
-history
+package: history
 
 334、source package:hmac-drbg 1.0.1
-package:
-hmac-drbg
+package: hmac-drbg
 
 335、source package:home-or-tmp 2.0.0
-package:
-home-or-tmp
+package: home-or-tmp
 
 336、source package:homedir-polyfill 1.0.3
-package:
-homedir-polyfill
+package: homedir-polyfill
 
 337、source package:htmlescape 1.1.1
-package:
-htmlescape
+package: htmlescape
 
 338、source package:htmlparser2 3.10.1
-package:
-htmlparser2
+package: htmlparser2
 
 339、source package:http-signature 1.2.0
-package:
-http-signature
+package: http-signature
 
 340、source package:https-browserify 1.0.0
-package:
-https-browserify
+package: https-browserify
 
 341、source package:image v0.10.0
-package:
-image
+package: image
 
 342、source package:immutable 4.1.0
-package:
-immutable
+package: immutable
 
 343、source package:indent-string 2.1.0
-package:
-indent-string
+package: indent-string
 
 344、source package:indexof 0.0.1
-package:
-indexof
+package: indexof
 
 345、source package:inline-source-map 0.6.2
-package:
-inline-source-map
+package: inline-source-map
 
 346、source package:insert-module-globals 7.2.0
-package:
-insert-module-globals
+package: insert-module-globals
 
 347、source package:interpret 1.4.0
-package:
-interpret
+package: interpret
 
 348、source package:invariant 2.2.4
-package:
-invariant
+package: invariant
 
 349、source package:invert-kv 1.0.0
-package:
-invert-kv
+package: invert-kv
 
 350、source package:is-absolute 1.0.0
-package:
-is-absolute
+package: is-absolute
 
 351、source package:is-accessor-descriptor 1.0.0
-package:
-is-accessor-descriptor
+package: is-accessor-descriptor
 
 352、source package:is-arrayish 0.2.1
-package:
-is-arrayish
+package: is-arrayish
 
 353、source package:is-binary-path 2.1.0
-package:
-is-binary-path
+package: is-binary-path
 
 354、source package:is-buffer 1.1.6
-package:
-is-buffer
+package: is-buffer
 
 355、source package:is-core-module 2.10.0
-package:
-is-core-module
+package: is-core-module
 
 356、source package:is-data-descriptor 1.0.0
-package:
-is-data-descriptor
+package: is-data-descriptor
 
 357、source package:is-descriptor 1.0.2
-package:
-is-descriptor
+package: is-descriptor
 
 358、source package:is-extendable 1.0.1
-package:
-is-extendable
+package: is-extendable
 
 359、source package:is-extglob 2.1.1
-package:
-is-extglob
+package: is-extglob
 
 360、source package:is-finite 1.0.2
-package:
-is-finite
+package: is-finite
 
 361、source package:is-fullwidth-code-point 2.0.0
-package:
-is-fullwidth-code-point
+package: is-fullwidth-code-point
 
 362、source package:is-glob 4.0.3
-package:
-is-glob
+package: is-glob
 
 363、source package:is-number 7.0.0
-package:
-is-number
+package: is-number
 
 364、source package:is-plain-object 2.0.4
-package:
-is-plain-object
+package: is-plain-object
 
 365、source package:is-relative 1.0.0
-package:
-is-relative
+package: is-relative
 
 366、source package:is-stream 1.1.0
-package:
-is-stream
+package: is-stream
 
 367、source package:is-typedarray 1.0.0
-package:
-is-typedarray
+package: is-typedarray
 
 368、source package:is-unc-path 1.0.0
-package:
-is-unc-path
+package: is-unc-path
 
 369、source package:is-utf8 0.2.1
-package:
-is-utf8
+package: is-utf8
 
 370、source package:is-windows 1.0.2
-package:
-is-windows
+package: is-windows
 
 371、source package:isarray 1.0.0
-package:
-isarray
+package: isarray
 
 372、source package:isobject 3.0.1
-package:
-isobject
+package: isobject
 
 373、source package:isstream 0.1.2
-package:
-isstream
+package: isstream
 
 374、source package:java_fpe_test 0.1.2
-package:
-java_fpe_test
+package: java_fpe_test
 
 375、source package:jq 1.6-2.1
-package:
-jq
+package: jq
 
 376、source package:jquery 3.6.1
-package:
-jquery
+package: jquery
 
 377、source package:js 0.1.0
-package:
-js
+package: js
 
 378、source package:js-tokens 3.0.2
-package:
-js-tokens
+package: js-tokens
 
 379、source package:jsbn 0.1.1
-package:
-jsbn
+package: jsbn
 
 380、source package:jsesc 1.3.0
-package:
-jsesc
+package: jsesc
 
 381、source package:json v3.7.0
-package:
-json
+package: json
 
 382、source package:json-loader 0.5.7
-package:
-json-loader
+package: json-loader
 
 383、source package:json-schema-traverse 0.4.1
-package:
-json-schema-traverse
+package: json-schema-traverse
 
 384、source package:json-stable-stringify 0.0.1
-package:
-json-stable-stringify
+package: json-stable-stringify
 
 385、source package:json5 2.1.3
-package:
-json5
+package: json5
 
 386、source package:jsonc-parser 3.2.0
-package:
-jsonc-parser
+package: jsonc-parser
 
 387、source package:jsonparse 1.3.1
-package:
-jsonparse
+package: jsonparse
 
 388、source package:jsprim 1.4.1
-package:
-jsprim
+package: jsprim
 
 389、source package:jwt-cpp v0.5.0
-package:
-jwt-cpp
+package: jwt-cpp
 
 390、source package:keypress 0.1.0
-package:
-keypress
+package: keypress
 
 391、source package:kind-of 6.0.3
-package:
-kind-of
+package: kind-of
 
 392、source package:labeled-stream-splicer 2.0.2
-package:
-labeled-stream-splicer
+package: labeled-stream-splicer
 
 393、source package:lazy-cache 1.0.4
-package:
-lazy-cache
+package: lazy-cache
 
 394、source package:lcid 1.0.0
-package:
-lcid
+package: lcid
 
 395、source package:libappimage-dev 0.1.9+dfsg-1_s390x
-package:
-libappimage-dev
+package: libappimage-dev
 
 396、source package:libboost-dev 1.71.0.3_s390x
-package:
-libboost-dev
+package: libboost-dev
 
 397、source package:libboost-filesystem-dev 1.71.0.3_s390x
-package:
-libboost-filesystem-dev
+package: libboost-filesystem-dev
 
 398、source package:libboost-serialization-dev 1.71.0.3_s390x
-package:
-libboost-serialization-dev
+package: libboost-serialization-dev
 
 399、source package:libboost-system-dev 1.71.0.3_s390x
-package:
-libboost-system-dev
+package: libboost-system-dev
 
 400、source package:libdrm-dev 2.4.99-1_s390x
-package:
-libdrm-dev
+package: libdrm-dev
 
 401、source package:libegl1-mesa-dev 8.0.5-4+deb7u2_sparc
-package:
-libegl1-mesa-dev
+package: libegl1-mesa-dev
 
 402、source package:libgbm-dev 8.0.5-4+deb7u2_sparc
-package:
-libgbm-dev
+package: libgbm-dev
 
 403、source package:libglib2.0-dev 2.64.4-1_s390x
-package:
-libglib2.0-dev
+package: libglib2.0-dev
 
 404、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 405、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 406、source package:libjson-c3 0.12.1-1.3_s390x
-package:
-libjson-c3
+package: libjson-c3
 
 407、source package:libjson-rpc-cpp v1.4.1
-package:
-libjson-rpc-cpp
+package: libjson-rpc-cpp
 
 408、source package:liblcms2-dev 2.9-4_s390x
-package:
-liblcms2-dev
+package: liblcms2-dev
 
 409、source package:libportaudio2 19.6.0-1_s390x
-package:
-libportaudio2
+package: libportaudio2
 
 410、source package:libx11-dev 2:1.8.4-2+deb12u1
-package:
-libx11-dev
+package: libx11-dev
 
 411、source package:libx11-xcb-dev 1.6.9-2_s390x
-package:
-libx11-xcb-dev
+package: libx11-xcb-dev
 
 412、source package:libxcb-composite0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-composite0-dev
+package: libxcb-composite0-dev
 
 413、source package:libxcb-cursor-dev 0.1.1-4_s390x
-package:
-libxcb-cursor-dev
+package: libxcb-cursor-dev
 
 414、source package:libxcb-damage0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-damage0-dev
+package: libxcb-damage0-dev
 
 415、source package:libxcb-ewmh-dev 0.4.1-1_s390x
-package:
-libxcb-ewmh-dev
+package: libxcb-ewmh-dev
 
 416、source package:libxcb-image0-dev 0.4.0-1_s390x
-package:
-libxcb-image0-dev
+package: libxcb-image0-dev
 
 417、source package:libxcb-keysyms1-dev 0.4.0-1_s390x
-package:
-libxcb-keysyms1-dev
+package: libxcb-keysyms1-dev
 
 418、source package:libxcb-randr0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-randr0-dev
+package: libxcb-randr0-dev
 
 419、source package:libxcb-record0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-record0-dev
+package: libxcb-record0-dev
 
 420、source package:libxcb-render-util0-dev 0.3.9-1_s390x
-package:
-libxcb-render-util0-dev
+package: libxcb-render-util0-dev
 
 421、source package:libxcb-render0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-render0-dev
+package: libxcb-render0-dev
 
 422、source package:libxcb-res0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-res0-dev
+package: libxcb-res0-dev
 
 423、source package:libxcb-shape0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-shape0-dev
+package: libxcb-shape0-dev
 
 424、source package:libxcb-sync-dev 1.14-2_s390x
-package:
-libxcb-sync-dev
+package: libxcb-sync-dev
 
 425、source package:libxcb-util0 0.3.8-3_s390x
-package:
-libxcb-util0
+package: libxcb-util0
 
 426、source package:libxcb-util0-dev 0.3.8-3_s390x
-package:
-libxcb-util0-dev
+package: libxcb-util0-dev
 
 427、source package:libxcb-util1 0.4.0-1
-package:
-libxcb-util1
+package: libxcb-util1
 
 428、source package:libxcb-xfixes0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xfixes0-dev
+package: libxcb-xfixes0-dev
 
 429、source package:libxcb-xinerama0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xinerama0-dev
+package: libxcb-xinerama0-dev
 
 430、source package:libxcb-xinput-dev 1.14-2_s390x
-package:
-libxcb-xinput-dev
+package: libxcb-xinput-dev
 
 431、source package:libxcb-xkb-dev 1.14-2_s390x
-package:
-libxcb-xkb-dev
+package: libxcb-xkb-dev
 
 432、source package:libxcb-xtest0-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb-xtest0-dev
+package: libxcb-xtest0-dev
 
 433、source package:libxcb1-dev 1.8.1-2+deb7u1_sparc
-package:
-libxcb1-dev
+package: libxcb1-dev
 
 434、source package:libxext-dev 1.3.3-1_s390x
-package:
-libxext-dev
+package: libxext-dev
 
 435、source package:libxfixes-dev 5.0.3-2_s390x
-package:
-libxfixes-dev
+package: libxfixes-dev
 
 436、source package:libxinerama-dev 2:1.1.4-3
-package:
-libxinerama-dev
+package: libxinerama-dev
 
 437、source package:libxkbcommon-dev 0.9.1-1_s390x
-package:
-libxkbcommon-dev
+package: libxkbcommon-dev
 
 438、source package:libxkbcommon-x11-dev 0.9.1-1_s390x
-package:
-libxkbcommon-x11-dev
+package: libxkbcommon-x11-dev
 
 439、source package:libxss-dev 1.2.3-1_s390x
-package:
-libxss-dev
+package: libxss-dev
 
 440、source package:libxss1 1.2.3-1_s390x
-package:
-libxss1
+package: libxss1
 
 441、source package:libxtst-dev 1.2.3-1_s390x
-package:
-libxtst-dev
+package: libxtst-dev
 
 442、source package:liftoff 2.5.0
-package:
-liftoff
+package: liftoff
 
 443、source package:load-json-file 2.0.0
-package:
-load-json-file
+package: load-json-file
 
 444、source package:loader-runner 2.4.0
-package:
-loader-runner
+package: loader-runner
 
 445、source package:loader-utils 2.0.0
-package:
-loader-utils
+package: loader-utils
 
 446、source package:local-pkg 0.4.3
-package:
-local-pkg
+package: local-pkg
 
 447、source package:locales v0.12.1
-package:
-locales
+package: locales
 
 448、source package:locate-path 2.0.0
-package:
-locate-path
+package: locate-path
 
 449、source package:lodash 4.17.21
-package:
-lodash
+package: lodash
 
 450、source package:lodash-es 4.17.21
-package:
-lodash-es
+package: lodash-es
 
 451、source package:lodash-unified 1.0.2
-package:
-lodash-unified
+package: lodash-unified
 
 452、source package:lodash._basecopy 3.0.1
-package:
-lodash._basecopy
+package: lodash._basecopy
 
 453、source package:lodash._basetostring 3.0.1
-package:
-lodash._basetostring
+package: lodash._basetostring
 
 454、source package:lodash._basevalues 3.0.0
-package:
-lodash._basevalues
+package: lodash._basevalues
 
 455、source package:lodash._getnative 3.9.1
-package:
-lodash._getnative
+package: lodash._getnative
 
 456、source package:lodash._isiterateecall 3.0.9
-package:
-lodash._isiterateecall
+package: lodash._isiterateecall
 
 457、source package:lodash._reescape 3.0.0
-package:
-lodash._reescape
+package: lodash._reescape
 
 458、source package:lodash._reevaluate 3.0.0
-package:
-lodash._reevaluate
+package: lodash._reevaluate
 
 459、source package:lodash._reinterpolate 3.0.0
-package:
-lodash._reinterpolate
+package: lodash._reinterpolate
 
 460、source package:lodash._root 3.0.1
-package:
-lodash._root
+package: lodash._root
 
 461、source package:lodash.clonedeep 4.5.0
-package:
-lodash.clonedeep
+package: lodash.clonedeep
 
 462、source package:lodash.escape 3.2.0
-package:
-lodash.escape
+package: lodash.escape
 
 463、source package:lodash.isarguments 3.1.0
-package:
-lodash.isarguments
+package: lodash.isarguments
 
 464、source package:lodash.isarray 3.0.4
-package:
-lodash.isarray
+package: lodash.isarray
 
 465、source package:lodash.keys 3.1.2
-package:
-lodash.keys
+package: lodash.keys
 
 466、source package:lodash.memoize 3.0.4
-package:
-lodash.memoize
+package: lodash.memoize
 
 467、source package:lodash.restparam 3.6.1
-package:
-lodash.restparam
+package: lodash.restparam
 
 468、source package:lodash.template 3.6.2
-package:
-lodash.template
+package: lodash.template
 
 469、source package:lodash.templatesettings 3.1.1
-package:
-lodash.templatesettings
+package: lodash.templatesettings
 
 470、source package:logrus v1.9.3
-package:
-logrus
+package: logrus
 
 471、source package:longest 1.0.1
-package:
-longest
+package: longest
 
 472、source package:loose-envify 1.4.0
-package:
-loose-envify
+package: loose-envify
 
 473、source package:loud-rejection 1.6.0
-package:
-loud-rejection
+package: loud-rejection
 
 474、source package:magic-string 0.27.0
-package:
-magic-string
+package: magic-string
 
 475、source package:make-iterator 1.0.1
-package:
-make-iterator
+package: make-iterator
 
 476、source package:map-cache 0.2.2
-package:
-map-cache
+package: map-cache
 
 477、source package:map-obj 1.0.1
-package:
-map-obj
+package: map-obj
 
 478、source package:map-visit 1.0.0
-package:
-map-visit
+package: map-visit
 
 479、source package:marked 1.2.3
-package:
-marked
+package: marked
 
 480、source package:md5.js 1.3.5
-package:
-md5.js
+package: md5.js
 
 481、source package:mem 1.1.0
-package:
-mem
+package: mem
 
 482、source package:memoize-one 6.0.0
-package:
-memoize-one
+package: memoize-one
 
 483、source package:memory-fs 0.4.1
-package:
-memory-fs
+package: memory-fs
 
 484、source package:meow 3.7.0
-package:
-meow
+package: meow
 
 485、source package:merge2 1.4.1
-package:
-merge2
+package: merge2
 
 486、source package:mesa-utils 9.0.0-1
-package:
-mesa-utils
+package: mesa-utils
 
 487、source package:mesa-va-drivers 20.1.2-1_armel
-package:
-mesa-va-drivers
+package: mesa-va-drivers
 
 488、source package:mesa-vdpau-drivers 20.1.2-1_mipsel
-package:
-mesa-vdpau-drivers
+package: mesa-vdpau-drivers
 
 489、source package:mesa-vulkan-drivers 20.1.2-1_mips64el
-package:
-mesa-vulkan-drivers
+package: mesa-vulkan-drivers
 
 490、source package:micromatch 3.1.10
-package:
-micromatch
+package: micromatch
 
 491、source package:miller-rabin 4.0.1
-package:
-miller-rabin
+package: miller-rabin
 
 492、source package:mime-db 1.40.0
-package:
-mime-db
+package: mime-db
 
 493、source package:mime-types 2.1.24
-package:
-mime-types
+package: mime-types
 
 494、source package:mimic-fn 1.2.0
-package:
-mimic-fn
+package: mimic-fn
 
 495、source package:minimalistic-crypto-utils 1.0.1
-package:
-minimalistic-crypto-utils
+package: minimalistic-crypto-utils
 
 496、source package:minimatch 0.2.14
-package:
-minimatch
+package: minimatch
 
 497、source package:minimist 1.2.5
-package:
-minimist
+package: minimist
 
 498、source package:mitt 3.0.0
-package:
-mitt
+package: mitt
 
 499、source package:mixin-deep 1.3.2
-package:
-mixin-deep
+package: mixin-deep
 
 500、source package:mkdirp 0.5.5
-package:
-mkdirp
+package: mkdirp
 
 501、source package:mlly 1.4.2
-package:
-mlly
+package: mlly
 
 502、source package:module-deps 4.1.1
-package:
-module-deps
+package: module-deps
 
 503、source package:moment 2.29.4
-package:
-moment
+package: moment
 
 504、source package:mqt.qfr 1.10.0
-package:
-mqt.qfr
+package: mqt.qfr
 
 505、source package:ms 2.1.2
-package:
-ms
+package: ms
 
 506、source package:multipipe 0.1.2
-package:
-multipipe
+package: multipipe
 
 507、source package:nan 2.14.0
-package:
-nan
+package: nan
 
 508、source package:nanomatch 1.2.13
-package:
-nanomatch
+package: nanomatch
 
 509、source package:native v1.1.0
-package:
-native
+package: native
 
 510、source package:ncurses-base 6.2-1_all
-package:
-ncurses-base
+package: ncurses-base
 
 511、source package:neo-async 2.6.2
-package:
-neo-async
+package: neo-async
 
 512、source package:netlink v1.7.2
-package:
-netlink
+package: netlink
 
 513、source package:next-tick 1.0.0
-package:
-next-tick
+package: next-tick
 
 514、source package:nlohmann_json nlohmann_json-3.7.3
-package:
-nlohmann_json
+package: nlohmann_json
 
 515、source package:node 8.16.1
-package:
-node
+package: node
 
 516、source package:node-gyp 3.8.0
-package:
-node-gyp
+package: node-gyp
 
 517、source package:node-libs-browser 2.2.1
-package:
-node-libs-browser
+package: node-libs-browser
 
 518、source package:node-sass 4.12.0
-package:
-node-sass
+package: node-sass
 
 519、source package:normalize-path 3.0.0
-package:
-normalize-path
+package: normalize-path
 
 520、source package:npm-run-path 2.0.2
-package:
-npm-run-path
+package: npm-run-path
 
 521、source package:number-is-nan 1.0.1
-package:
-number-is-nan
+package: number-is-nan
 
 522、source package:object-assign 4.1.1
-package:
-object-assign
+package: object-assign
 
 523、source package:object-copy 0.1.0
-package:
-object-copy
+package: object-copy
 
 524、source package:object-visit 1.0.1
-package:
-object-visit
+package: object-visit
 
 525、source package:object.defaults 1.1.0
-package:
-object.defaults
+package: object.defaults
 
 526、source package:object.map 1.0.1
-package:
-object.map
+package: object.map
 
 527、source package:object.pick 1.3.0
-package:
-object.pick
+package: object.pick
 
 528、source package:objx v0.5.2
-package:
-objx
+package: objx
 
 529、source package:orchestrator 0.3.8
-package:
-orchestrator
+package: orchestrator
 
 530、source package:ordered-read-streams 0.1.0
-package:
-ordered-read-streams
+package: ordered-read-streams
 
 531、source package:os-browserify 0.3.0
-package:
-os-browserify
+package: os-browserify
 
 532、source package:os-config 0.2.3
-package:
-os-config
+package: os-config
 
 533、source package:os-homedir 1.0.2
-package:
-os-homedir
+package: os-homedir
 
 534、source package:os-locale 2.1.0
-package:
-os-locale
+package: os-locale
 
 535、source package:os-tmpdir 1.0.2
-package:
-os-tmpdir
+package: os-tmpdir
 
 536、source package:p-finally 1.0.0
-package:
-p-finally
+package: p-finally
 
 537、source package:p-limit 1.3.0
-package:
-p-limit
+package: p-limit
 
 538、source package:p-locate 2.0.0
-package:
-p-locate
+package: p-locate
 
 539、source package:p-try 1.0.0
-package:
-p-try
+package: p-try
 
 540、source package:pako 1.0.11
-package:
-pako
+package: pako
 
 541、source package:parents 1.0.1
-package:
-parents
+package: parents
 
 542、source package:parse-filepath 1.0.2
-package:
-parse-filepath
+package: parse-filepath
 
 543、source package:parse-json 2.2.0
-package:
-parse-json
+package: parse-json
 
 544、source package:parse-node-version 1.0.1
-package:
-parse-node-version
+package: parse-node-version
 
 545、source package:parse-passwd 1.0.0
-package:
-parse-passwd
+package: parse-passwd
 
 546、source package:parse5 3.0.3
-package:
-parse5
+package: parse5
 
 547、source package:pascalcase 0.1.1
-package:
-pascalcase
+package: pascalcase
 
 548、source package:path-browserify 0.0.1
-package:
-path-browserify
+package: path-browserify
 
 549、source package:path-dirname 1.0.2
-package:
-path-dirname
+package: path-dirname
 
 550、source package:path-exists 3.0.0
-package:
-path-exists
+package: path-exists
 
 551、source package:path-is-absolute 1.0.1
-package:
-path-is-absolute
+package: path-is-absolute
 
 552、source package:path-key 2.0.1
-package:
-path-key
+package: path-key
 
 553、source package:path-parse 1.0.7
-package:
-path-parse
+package: path-parse
 
 554、source package:path-platform 0.11.15
-package:
-path-platform
+package: path-platform
 
 555、source package:path-root 0.1.1
-package:
-path-root
+package: path-root
 
 556、source package:path-root-regex 0.1.2
-package:
-path-root-regex
+package: path-root-regex
 
 557、source package:path-to-regexp 1.7.0
-package:
-path-to-regexp
+package: path-to-regexp
 
 558、source package:path-type 2.0.0
-package:
-path-type
+package: path-type
 
 559、source package:pathe 1.1.1
-package:
-pathe
+package: pathe
 
 560、source package:pbkdf2 3.1.1
-package:
-pbkdf2
+package: pbkdf2
 
 561、source package:performance-now 2.1.0
-package:
-performance-now
+package: performance-now
 
 562、source package:picomatch 2.3.1
-package:
-picomatch
+package: picomatch
 
 563、source package:pify 2.3.0
-package:
-pify
+package: pify
 
 564、source package:pinia 2.0.22
-package:
-pinia
+package: pinia
 
 565、source package:pinkie 2.0.4
-package:
-pinkie
+package: pinkie
 
 566、source package:pinkie-promise 2.0.1
-package:
-pinkie-promise
+package: pinkie-promise
 
 567、source package:pipewire-pulse 0.3.71
-package:
-pipewire-pulse
+package: pipewire-pulse
 
 568、source package:pkg-types 1.0.3
-package:
-pkg-types
+package: pkg-types
 
 569、source package:platform/external/fmtlib upstream-master
-package:
-platform/external/fmtlib
+package: platform/external/fmtlib
 
 570、source package:portaudio19-dev 19.6.0-1_s390x
-package:
-portaudio19-dev
+package: portaudio19-dev
 
 571、source package:posix-character-classes 0.1.1
-package:
-posix-character-classes
+package: posix-character-classes
 
 572、source package:prefix-style 2.0.1
-package:
-prefix-style
+package: prefix-style
 
 573、source package:pretty v0.2.1
-package:
-pretty
+package: pretty
 
 574、source package:pretty-hrtime 1.0.3
-package:
-pretty-hrtime
+package: pretty-hrtime
 
 575、source package:private 0.1.8
-package:
-private
+package: private
 
 576、source package:process 0.11.10
-package:
-process
+package: process
 
 577、source package:process-nextick-args 2.0.1
-package:
-process-nextick-args
+package: process-nextick-args
 
 578、source package:promxy v0.0.81
-package:
-promxy
+package: promxy
 
 579、source package:prop-types 15.7.2
-package:
-prop-types
+package: prop-types
 
 580、source package:prr 1.0.1
-package:
-prr
+package: prr
 
 581、source package:psl 1.4.0
-package:
-psl
+package: psl
 
 582、source package:public-encrypt 4.0.3
-package:
-public-encrypt
+package: public-encrypt
 
 583、source package:punycode 2.1.1
-package:
-punycode
+package: punycode
 
 584、source package:python3 3.8.2-3_s390x
-package:
-python3
+package: python3
 
 585、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 586、source package:querystring 0.2.0
-package:
-querystring
+package: querystring
 
 587、source package:querystring-es3 0.2.1
-package:
-querystring-es3
+package: querystring-es3
 
 588、source package:queue-microtask 1.2.3
-package:
-queue-microtask
+package: queue-microtask
 
 589、source package:raf 3.4.1
-package:
-raf
+package: raf
 
 590、source package:randombytes 2.1.0
-package:
-randombytes
+package: randombytes
 
 591、source package:randomfill 1.0.4
-package:
-randomfill
+package: randomfill
 
 592、source package:react 16.9.0
-package:
-react
+package: react
 
 593、source package:react-custom-scrollbars 4.2.1
-package:
-react-custom-scrollbars
+package: react-custom-scrollbars
 
 594、source package:react-dom 16.9.0
-package:
-react-dom
+package: react-dom
 
 595、source package:react-is 16.9.0
-package:
-react-is
+package: react-is
 
 596、source package:react-router 4.3.1
-package:
-react-router
+package: react-router
 
 597、source package:react-router-dom 4.3.1
-package:
-react-router-dom
+package: react-router-dom
 
 598、source package:read-only-stream 2.0.0
-package:
-read-only-stream
+package: read-only-stream
 
 599、source package:read-pkg 2.0.0
-package:
-read-pkg
+package: read-pkg
 
 600、source package:read-pkg-up 2.0.0
-package:
-read-pkg-up
+package: read-pkg-up
 
 601、source package:readable-stream 3.6.0
-package:
-readable-stream
+package: readable-stream
 
 602、source package:readdirp 3.6.0
-package:
-readdirp
+package: readdirp
 
 603、source package:rechoir 0.6.2
-package:
-rechoir
+package: rechoir
 
 604、source package:redent 1.0.0
-package:
-redent
+package: redent
 
 605、source package:regenerate 1.4.0
-package:
-regenerate
+package: regenerate
 
 606、source package:regenerator-runtime 0.13.3
-package:
-regenerator-runtime
+package: regenerator-runtime
 
 607、source package:regex-not 1.0.2
-package:
-regex-not
+package: regex-not
 
 608、source package:regexpu-core 2.0.0
-package:
-regexpu-core
+package: regexpu-core
 
 609、source package:regjsgen 0.2.0
-package:
-regjsgen
+package: regjsgen
 
 610、source package:repeat-element 1.1.3
-package:
-repeat-element
+package: repeat-element
 
 611、source package:repeat-string 1.6.1
-package:
-repeat-string
+package: repeat-string
 
 612、source package:repeating 2.0.1
-package:
-repeating
+package: repeating
 
 613、source package:replace-ext 1.0.0
-package:
-replace-ext
+package: replace-ext
 
 614、source package:require-directory 2.1.1
-package:
-require-directory
+package: require-directory
 
 615、source package:resolve 1.22.1
-package:
-resolve
+package: resolve
 
 616、source package:resolve-dir 1.0.1
-package:
-resolve-dir
+package: resolve-dir
 
 617、source package:resolve-pathname 2.2.0
-package:
-resolve-pathname
+package: resolve-pathname
 
 618、source package:resolve-url 0.2.1
-package:
-resolve-url
+package: resolve-url
 
 619、source package:ret 0.1.15
-package:
-ret
+package: ret
 
 620、source package:reusify 1.0.4
-package:
-reusify
+package: reusify
 
 621、source package:right-align 0.1.3
-package:
-right-align
+package: right-align
 
 622、source package:ripemd160 2.0.2
-package:
-ripemd160
+package: ripemd160
 
 623、source package:rollup 2.79.1
-package:
-rollup
+package: rollup
 
 624、source package:run-parallel 1.2.0
-package:
-run-parallel
+package: run-parallel
 
 625、source package:safe-buffer 5.2.1
-package:
-safe-buffer
+package: safe-buffer
 
 626、source package:safe-regex 1.1.0
-package:
-safe-regex
+package: safe-regex
 
 627、source package:safer-buffer 2.1.2
-package:
-safer-buffer
+package: safer-buffer
 
 628、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 629、source package:sass-graph 2.2.4
-package:
-sass-graph
+package: sass-graph
 
 630、source package:scheduler 0.15.0
-package:
-scheduler
+package: scheduler
 
 631、source package:schema-utils 3.0.0
-package:
-schema-utils
+package: schema-utils
 
 632、source package:scroll-into-view-if-needed 2.2.20
-package:
-scroll-into-view-if-needed
+package: scroll-into-view-if-needed
 
 633、source package:scss-tokenizer 0.2.3
-package:
-scss-tokenizer
+package: scss-tokenizer
 
 634、source package:scule 1.1.1
-package:
-scule
+package: scule
 
 635、source package:sequencify 0.0.7
-package:
-sequencify
+package: sequencify
 
 636、source package:set-value 2.0.1
-package:
-set-value
+package: set-value
 
 637、source package:setimmediate 1.0.5
-package:
-setimmediate
+package: setimmediate
 
 638、source package:sha.js 2.4.11
-package:
-sha.js
+package: sha.js
 
 639、source package:shadered v1.5.3
-package:
-shadered
+package: shadered
 
 640、source package:shasum 1.0.2
-package:
-shasum
+package: shasum
 
 641、source package:shebang-command 1.2.0
-package:
-shebang-command
+package: shebang-command
 
 642、source package:shebang-regex 1.0.0
-package:
-shebang-regex
+package: shebang-regex
 
 643、source package:shell-quote 1.7.2
-package:
-shell-quote
+package: shell-quote
 
 644、source package:simple-concat 1.0.0
-package:
-simple-concat
+package: simple-concat
 
 645、source package:slash 1.0.0
-package:
-slash
+package: slash
 
 646、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 647、source package:smooth-scroll-into-view-if-needed 1.1.23
-package:
-smooth-scroll-into-view-if-needed
+package: smooth-scroll-into-view-if-needed
 
 648、source package:snapdragon 0.8.2
-package:
-snapdragon
+package: snapdragon
 
 649、source package:snapdragon-node 2.1.1
-package:
-snapdragon-node
+package: snapdragon-node
 
 650、source package:snapdragon-util 3.0.1
-package:
-snapdragon-util
+package: snapdragon-util
 
 651、source package:source-list-map 2.0.1
-package:
-source-list-map
+package: source-list-map
 
 652、source package:source-map-resolve 0.5.3
-package:
-source-map-resolve
+package: source-map-resolve
 
 653、source package:source-map-support 0.5.21
-package:
-source-map-support
+package: source-map-support
 
 654、source package:source-map-url 0.4.0
-package:
-source-map-url
+package: source-map-url
 
 655、source package:sourcemap-codec 1.4.8
-package:
-sourcemap-codec
+package: sourcemap-codec
 
 656、source package:sparkles 1.0.1
-package:
-sparkles
+package: sparkles
 
 657、source package:spdx-expression-parse 3.0.1
-package:
-spdx-expression-parse
+package: spdx-expression-parse
 
 658、source package:split-string 3.1.0
-package:
-split-string
+package: split-string
 
 659、source package:sqlclosecheck v0.5.0
-package:
-sqlclosecheck
+package: sqlclosecheck
 
 660、source package:sse v0.1.0
-package:
-sse
+package: sse
 
 661、source package:sshpk 1.16.1
-package:
-sshpk
+package: sshpk
 
 662、source package:static-extend 0.1.2
-package:
-static-extend
+package: static-extend
 
 663、source package:stdout-stream 1.4.1
-package:
-stdout-stream
+package: stdout-stream
 
 664、source package:stream-browserify 2.0.2
-package:
-stream-browserify
+package: stream-browserify
 
 665、source package:stream-combiner2 1.1.1
-package:
-stream-combiner2
+package: stream-combiner2
 
 666、source package:stream-consume 0.1.1
-package:
-stream-consume
+package: stream-consume
 
 667、source package:stream-http 2.8.3
-package:
-stream-http
+package: stream-http
 
 668、source package:stream-splicer 2.0.1
-package:
-stream-splicer
+package: stream-splicer
 
 669、source package:string-width 2.1.1
-package:
-string-width
+package: string-width
 
 670、source package:string_decoder 1.3.0
-package:
-string_decoder
+package: string_decoder
 
 671、source package:strip-ansi 4.0.0
-package:
-strip-ansi
+package: strip-ansi
 
 672、source package:strip-bom 3.0.0
-package:
-strip-bom
+package: strip-bom
 
 673、source package:strip-eof 1.0.0
-package:
-strip-eof
+package: strip-eof
 
 674、source package:strip-indent 1.0.1
-package:
-strip-indent
+package: strip-indent
 
 675、source package:strip-literal 1.3.0
-package:
-strip-literal
+package: strip-literal
 
 676、source package:subarg 1.0.0
-package:
-subarg
+package: subarg
 
 677、source package:sudo 1.9.8p2-1~exp1
-package:
-sudo
+package: sudo
 
 678、source package:supports-color 4.5.0
-package:
-supports-color
+package: supports-color
 
 679、source package:supports-preserve-symlinks-flag 1.0.0
-package:
-supports-preserve-symlinks-flag
+package: supports-preserve-symlinks-flag
 
 680、source package:syntax-error 1.4.0
-package:
-syntax-error
+package: syntax-error
 
 681、source package:sys v0.5.0
-package:
-sys
+package: sys
 
 682、source package:systemjs 6.13.0
-package:
-systemjs
+package: systemjs
 
 683、source package:tapable 0.2.9
-package:
-tapable
+package: tapable
 
 684、source package:testify v1.9.0
-package:
-testify
+package: testify
 
 685、source package:text v0.1.0
-package:
-text
+package: text
 
 686、source package:through2 2.0.5
-package:
-through2
+package: through2
 
 687、source package:tildify 1.2.0
-package:
-tildify
+package: tildify
 
 688、source package:time-stamp 1.1.0
-package:
-time-stamp
+package: time-stamp
 
 689、source package:timers-browserify 2.0.12
-package:
-timers-browserify
+package: timers-browserify
 
 690、source package:tiny-invariant 1.0.6
-package:
-tiny-invariant
+package: tiny-invariant
 
 691、source package:tiny-warning 1.0.3
-package:
-tiny-warning
+package: tiny-warning
 
 692、source package:tinyaes 1.0.4rc1
-package:
-tinyaes
+package: tinyaes
 
 693、source package:tlp 1.5.0-1~bpo11+1
-package:
-tlp
+package: tlp
 
 694、source package:to-arraybuffer 1.0.1
-package:
-to-arraybuffer
+package: to-arraybuffer
 
 695、source package:to-camel-case 1.0.0
-package:
-to-camel-case
+package: to-camel-case
 
 696、source package:to-fast-properties 1.0.3
-package:
-to-fast-properties
+package: to-fast-properties
 
 697、source package:to-no-case 1.0.2
-package:
-to-no-case
+package: to-no-case
 
 698、source package:to-object-path 0.3.0
-package:
-to-object-path
+package: to-object-path
 
 699、source package:to-regex 3.0.2
-package:
-to-regex
+package: to-regex
 
 700、source package:to-regex-range 5.0.1
-package:
-to-regex-range
+package: to-regex-range
 
 701、source package:to-space-case 1.0.0
-package:
-to-space-case
+package: to-space-case
 
 702、source package:toml v1.3.2
-package:
-toml
+package: toml
 
 703、source package:tools v0.6.0
-package:
-tools
+package: tools
 
 704、source package:tortellini 4f6795a
-package:
-tortellini
+package: tortellini
 
 705、source package:trim-newlines 1.0.0
-package:
-trim-newlines
+package: trim-newlines
 
 706、source package:trim-right 1.0.1
-package:
-trim-right
+package: trim-right
 
 707、source package:tty-browserify 0.0.1
-package:
-tty-browserify
+package: tty-browserify
 
 708、source package:typedarray 0.0.6
-package:
-typedarray
+package: typedarray
 
 709、source package:uglify-to-browserify 1.0.2
-package:
-uglify-to-browserify
+package: uglify-to-browserify
 
 710、source package:uglifyjs-webpack-plugin 0.4.6
-package:
-uglifyjs-webpack-plugin
+package: uglifyjs-webpack-plugin
 
 711、source package:umd 3.0.3
-package:
-umd
+package: umd
 
 712、source package:unc-path-regex 0.1.2
-package:
-unc-path-regex
+package: unc-path-regex
 
 713、source package:unimport 1.3.0
-package:
-unimport
+package: unimport
 
 714、source package:union-value 1.0.1
-package:
-union-value
+package: union-value
 
 715、source package:unique-stream 1.0.0
-package:
-unique-stream
+package: unique-stream
 
 716、source package:universal-translator v0.16.0
-package:
-universal-translator
+package: universal-translator
 
 717、source package:unplugin-auto-import 0.11.5
-package:
-unplugin-auto-import
+package: unplugin-auto-import
 
 718、source package:unplugin-vue-components 0.22.12
-package:
-unplugin-vue-components
+package: unplugin-vue-components
 
 719、source package:unset-value 1.0.0
-package:
-unset-value
+package: unset-value
 
 720、source package:upath 1.2.0
-package:
-upath
+package: upath
 
 721、source package:urix 0.1.0
-package:
-urix
+package: urix
 
 722、source package:url 0.11.0
-package:
-url
+package: url
 
 723、source package:use 3.1.1
-package:
-use
+package: use
 
 724、source package:user-home 1.1.1
-package:
-user-home
+package: user-home
 
 725、source package:util 0.11.1
-package:
-util
+package: util
 
 726、source package:util-deprecate 1.0.2
-package:
-util-deprecate
+package: util-deprecate
 
 727、source package:uuid 3.3.3
-package:
-uuid
+package: uuid
 
 728、source package:v-drag 3.0.9
-package:
-v-drag
+package: v-drag
 
 729、source package:v8flags 2.1.1
-package:
-v8flags
+package: v8flags
 
 730、source package:value-equal 0.4.0
-package:
-value-equal
+package: value-equal
 
 731、source package:verror 1.10.0
-package:
-verror
+package: verror
 
 732、source package:vinyl 2.2.0
-package:
-vinyl
+package: vinyl
 
 733、source package:vinyl-buffer 1.0.1
-package:
-vinyl-buffer
+package: vinyl-buffer
 
 734、source package:vinyl-fs 0.3.14
-package:
-vinyl-fs
+package: vinyl-fs
 
 735、source package:vinyl-source-stream 2.0.0
-package:
-vinyl-source-stream
+package: vinyl-source-stream
 
 736、source package:vm-browserify 1.1.2
-package:
-vm-browserify
+package: vm-browserify
 
 737、source package:vue-codemirror 6.1.1
-package:
-vue-codemirror
+package: vue-codemirror
 
 738、source package:vue-demi 0.13.11
-package:
-vue-demi
+package: vue-demi
 
 739、source package:vue-router 4.1.5
-package:
-vue-router
+package: vue-router
 
 740、source package:w3c-keyname 2.2.8
-package:
-w3c-keyname
+package: w3c-keyname
 
 741、source package:warning 4.0.3
-package:
-warning
+package: warning
 
 742、source package:watchpack 1.7.4
-package:
-watchpack
+package: watchpack
 
 743、source package:watchpack-chokidar2 2.0.0
-package:
-watchpack-chokidar2
+package: watchpack-chokidar2
 
 744、source package:webpack 3.12.0
-package:
-webpack
+package: webpack
 
 745、source package:webpack-sources 3.2.3
-package:
-webpack-sources
+package: webpack-sources
 
 746、source package:webpack-virtual-modules 0.6.1
-package:
-webpack-virtual-modules
+package: webpack-virtual-modules
 
 747、source package:window-size 0.1.0
-package:
-window-size
+package: window-size
 
 748、source package:wireplumber 0.4.9-1
-package:
-wireplumber
+package: wireplumber
 
 749、source package:wordwrap 0.0.2
-package:
-wordwrap
+package: wordwrap
 
 750、source package:wrap-ansi 2.1.0
-package:
-wrap-ansi
+package: wrap-ansi
 
 751、source package:x11-utils 7.7~1_sparc
-package:
-x11-utils
+package: x11-utils
 
 752、source package:x11-xserver-utils 7.7~3_sparc
-package:
-x11-xserver-utils
+package: x11-xserver-utils
 
 753、source package:x11proto-record-dev 2020.1-1_all
-package:
-x11proto-record-dev
+package: x11proto-record-dev
 
 754、source package:x11proto-xext-dev 7.3.0-1_all
-package:
-x11proto-xext-dev
+package: x11proto-xext-dev
 
 755、source package:xcb-proto 1.7.1.orig
-package:
-xcb-proto
+package: xcb-proto
 
 756、source package:xdg-utils 1.1.3-4.1
-package:
-xdg-utils
+package: xdg-utils
 
 757、source package:xkb-data 2.5.1-3_all
-package:
-xkb-data
+package: xkb-data
 
 758、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 759、source package:xserver-xorg-input-all 7.7+7_s390x
-package:
-xserver-xorg-input-all
+package: xserver-xorg-input-all
 
 760、source package:xserver-xorg-video-all 7.7+7_s390x
-package:
-xserver-xorg-video-all
+package: xserver-xorg-video-all
 
 761、source package:xtend 4.0.2
-package:
-xtend
+package: xtend
 
 762、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 763、source package:yargs 8.0.2
-package:
-yargs
+package: yargs
 
 
 Open Source Software Licensed under the Expat:
 1、source package:golang-github-adrg-xdg-dev 0.4.0-2
-package:
-golang-github-adrg-xdg-dev
+package: golang-github-adrg-xdg-dev
 
 2、source package:golang-github-disintegration-imaging-dev 1.6.2-2
-package:
-golang-github-disintegration-imaging-dev
+package: golang-github-disintegration-imaging-dev
 
 3、source package:golang-github-smartystreets-goconvey-dev 1.6.4+dfsg-1_all
-package:
-golang-github-smartystreets-goconvey-dev
+package: golang-github-smartystreets-goconvey-dev
 
 4、source package:golang-github-stretchr-testify-dev 1.8.0-1~bpo11+1
-package:
-golang-github-stretchr-testify-dev
+package: golang-github-stretchr-testify-dev
 
 5、source package:golang-github-teambition-rrule-go-dev 1.8.1-1
-package:
-golang-github-teambition-rrule-go-dev
+package: golang-github-teambition-rrule-go-dev
 
 6、source package:golang-gopkg-alecthomas-kingpin.v2-dev 2.2.6-4
-package:
-golang-gopkg-alecthomas-kingpin.v2-dev
+package: golang-gopkg-alecthomas-kingpin.v2-dev
 
 7、source package:intel-media-va-driver-non-free 23.2.3+ds1-1
-package:
-intel-media-va-driver-non-free
+package: intel-media-va-driver-non-free
 
 8、source package:libepoxy-dev 1.5.9-2
-package:
-libepoxy-dev
+package: libepoxy-dev
 
 9、source package:libiniparser-dev 4.1-4_s390x
-package:
-libiniparser-dev
+package: libiniparser-dev
 
 10、source package:libinput-dev 1.6.3-1_s390x
-package:
-libinput-dev
+package: libinput-dev
 
 11、source package:libjson-c-dev 0.16-2
-package:
-libjson-c-dev
+package: libjson-c-dev
 
 12、source package:libmtdev-dev 1.1.6-1_s390x
-package:
-libmtdev-dev
+package: libmtdev-dev
 
 13、source package:libsass-dev 3.6.4-4~exp_s390x
-package:
-libsass-dev
+package: libsass-dev
 
 14、source package:libspdlog-dev 1:1.3.1-1
-package:
-libspdlog-dev
+package: libspdlog-dev
 
 15、source package:libutf8proc-dev 2.7.0-4
-package:
-libutf8proc-dev
+package: libutf8proc-dev
 
 16、source package:libva-dev 2.8.0-1_s390x
-package:
-libva-dev
+package: libva-dev
 
 17、source package:nlohmann-json3-dev 3.9.1-1
-package:
-nlohmann-json3-dev
+package: nlohmann-json3-dev
 
 18、source package:rapidjson-dev 1.1.0-1
-package:
-rapidjson-dev
+package: rapidjson-dev
 
 19、source package:va-driver-all 2.8.0-1_s390x
-package:
-va-driver-all
+package: va-driver-all
 
 20、source package:wayland-protocols 1.9-1
-package:
-wayland-protocols
+package: wayland-protocols
 
 
 Open Source Software Licensed under the BSD-3-Clause:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 2、source package:alsa-topology-conf 1.2.5.1-2
-package:
-alsa-topology-conf
+package: alsa-topology-conf
 
 3、source package:alsa-ucm-conf 1.2.9-1
-package:
-alsa-ucm-conf
+package: alsa-ucm-conf
 
 4、source package:amdefine 1.0.1
-package:
-amdefine
+package: amdefine
 
 5、source package:android-pdfium a56ccce4
-package:
-android-pdfium
+package: android-pdfium
 
 6、source package:apt 2.7.1
-package:
-apt
+package: apt
 
 7、source package:bcrypt-pbkdf 1.0.2
-package:
-bcrypt-pbkdf
+package: bcrypt-pbkdf
 
 8、source package:browserify 14.5.0
-package:
-browserify
+package: browserify
 
 9、source package:charenc 0.0.2
-package:
-charenc
+package: charenc
 
 10、source package:chromium 87.0.4280.88-0.4
-package:
-chromium
+package: chromium
 
 11、source package:cmake v3.27.0-rc5
-package:
-cmake
+package: cmake
 
 12、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 13、source package:crypt 0.0.2
-package:
-crypt
+package: crypt
 
 14、source package:crypto v0.13.0
-package:
-crypto
+package: crypto
 
 15、source package:css-select 1.2.0
-package:
-css-select
+package: css-select
 
 16、source package:css-what 2.1.3
-package:
-css-what
+package: css-what
 
 17、source package:dns v1.1.52
-package:
-dns
+package: dns
 
 18、source package:dnsutils 970203-0.1
-package:
-dnsutils
+package: dnsutils
 
 19、source package:duplexer2 0.1.4
-package:
-duplexer2
+package: duplexer2
 
 20、source package:entities 1.1.2
-package:
-entities
+package: entities
 
 21、source package:errwrap v1.5.0
-package:
-errwrap
+package: errwrap
 
 22、source package:external/github.com/protocolbuffers/protobuf v3.7.0-rc.3
-package:
-external/github.com/protocolbuffers/protobuf
+package: external/github.com/protocolbuffers/protobuf
 
 23、source package:extra-cmake-modules 5.98.0-2
-package:
-extra-cmake-modules
+package: extra-cmake-modules
 
 24、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 25、source package:fsnotify v1.6.0
-package:
-fsnotify
+package: fsnotify
 
 26、source package:go-cmp v0.6.0
-package:
-go-cmp
+package: go-cmp
 
 27、source package:golang 2:1.7~5~bpo8+1
-package:
-golang
+package: golang
 
 28、source package:golang-any 1.7~5~bpo8+1_s390x
-package:
-golang-any
+package: golang-any
 
 29、source package:golang-github-fsnotify-fsnotify-dev 1.6.0-1
-package:
-golang-github-fsnotify-fsnotify-dev
+package: golang-github-fsnotify-fsnotify-dev
 
 30、source package:golang-github-miekg-dns-dev 1.1.50-2
-package:
-golang-github-miekg-dns-dev
+package: golang-github-miekg-dns-dev
 
 31、source package:golang-github-rickb777-date-dev 1.20.1-1
-package:
-golang-github-rickb777-date-dev
+package: golang-github-rickb777-date-dev
 
 32、source package:golang-go 1.7~5~bpo8+1_ppc64el
-package:
-golang-go
+package: golang-go
 
 33、source package:golang-golang-x-sys-dev 0.3.0-1+hurd.1
-package:
-golang-golang-x-sys-dev
+package: golang-golang-x-sys-dev
 
 34、source package:golang-golang-x-xerrors-dev 0.0~git20191204.9bdfabe-1~bpo10+1
-package:
-golang-golang-x-xerrors-dev
+package: golang-golang-x-xerrors-dev
 
 35、source package:golang-google-protobuf-dev 1.28.1-3
-package:
-golang-google-protobuf-dev
+package: golang-google-protobuf-dev
 
 36、source package:gstreamer1.0-plugins-base 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-base
+package: gstreamer1.0-plugins-base
 
 37、source package:gstreamer1.0-plugins-good 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-plugins-good
+package: gstreamer1.0-plugins-good
 
 38、source package:gstreamer1.0-pulseaudio 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-pulseaudio
+package: gstreamer1.0-pulseaudio
 
 39、source package:gstreamer1.0-x 1.4.4-2_kfreebsd-i386
-package:
-gstreamer1.0-x
+package: gstreamer1.0-x
 
 40、source package:hoist-non-react-statics 2.5.5
-package:
-hoist-non-react-statics
+package: hoist-non-react-statics
 
 41、source package:ieee754 1.2.1
-package:
-ieee754
+package: ieee754
 
 42、source package:init 1.65~exp2
-package:
-init
+package: init
 
 43、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 44、source package:js-base64 2.5.1
-package:
-js-base64
+package: js-base64
 
 45、source package:json-schema 0.2.3
-package:
-json-schema
+package: json-schema
 
 46、source package:libcli11-dev 2.1.2+ds-1
-package:
-libcli11-dev
+package: libcli11-dev
 
 47、source package:libgmock-dev 1.9.0.20190831-3
-package:
-libgmock-dev
+package: libgmock-dev
 
 48、source package:libgoogle-glog-dev 0.4.0-1_s390x
-package:
-libgoogle-glog-dev
+package: libgoogle-glog-dev
 
 49、source package:libgstreamer-plugins-base1.0-0 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-0
+package: libgstreamer-plugins-base1.0-0
 
 50、source package:libgstreamer-plugins-base1.0-dev 1.4.4-2_kfreebsd-i386
-package:
-libgstreamer-plugins-base1.0-dev
+package: libgstreamer-plugins-base1.0-dev
 
 51、source package:libgtest-dev 1.9.0.20190831-1_s390x
-package:
-libgtest-dev
+package: libgtest-dev
 
 52、source package:libjpeg-dev 2.0.5-1_all
-package:
-libjpeg-dev
+package: libjpeg-dev
 
 53、source package:libnl-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-3-dev
+package: libnl-3-dev
 
 54、source package:libnl-genl-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-genl-3-dev
+package: libnl-genl-3-dev
 
 55、source package:libnl-route-3-dev 3.4.0-1~bpo9+1_s390x
-package:
-libnl-route-3-dev
+package: libnl-route-3-dev
 
 56、source package:libpcap-dev 1.9.1-4~bpo10+1_s390x
-package:
-libpcap-dev
+package: libpcap-dev
 
 57、source package:libtirpc-common 1.2.6-1_all
-package:
-libtirpc-common
+package: libtirpc-common
 
 58、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 59、source package:locales 2.31-0experimental0_all
-package:
-locales
+package: locales
 
 60、source package:lxqt-build-tools 0.8.0-1
-package:
-lxqt-build-tools
+package: lxqt-build-tools
 
 61、source package:marked 1.2.3
-package:
-marked
+package: marked
 
 62、source package:md5 2.2.1
-package:
-md5
+package: md5
 
 63、source package:mmkv-static 1.2.10
-package:
-mmkv-static
+package: mmkv-static
 
 64、source package:mod v0.8.0
-package:
-mod
+package: mod
 
 65、source package:mount 2.9g-6
-package:
-mount
+package: mount
 
 66、source package:net v0.15.0
-package:
-net
+package: net
 
 67、source package:node 8.16.1
-package:
-node
+package: node
 
 68、source package:normalize-wheel-es 1.2.0
-package:
-normalize-wheel-es
+package: normalize-wheel-es
 
 69、source package:nth-check 1.0.2
-package:
-nth-check
+package: nth-check
 
 70、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 71、source package:passwd 980403-0.3
-package:
-passwd
+package: passwd
 
 72、source package:pflag v1.0.5
-package:
-pflag
+package: pflag
 
 73、source package:protobuf v1.3.2
-package:
-protobuf
+package: protobuf
 
 74、source package:python3-click 8.1.6-1
-package:
-python3-click
+package: python3-click
 
 75、source package:qml-module-qtgraphicaleffects 5.7.1~20161021-3_s390x
-package:
-qml-module-qtgraphicaleffects
+package: qml-module-qtgraphicaleffects
 
 76、source package:qs 6.5.2
-package:
-qs
+package: qs
 
 77、source package:qtermwidget 0.14.1
-package:
-qtermwidget
+package: qtermwidget
 
 78、source package:regenerator-transform 0.10.1
-package:
-regenerator-transform
+package: regenerator-transform
 
 79、source package:regjsparser 0.1.5
-package:
-regjsparser
+package: regjsparser
 
 80、source package:sass 1.55.0
-package:
-sass
+package: sass
 
 81、source package:sha.js 2.4.11
-package:
-sha.js
+package: sha.js
 
 82、source package:source-map 0.6.1
-package:
-source-map
+package: source-map
 
 83、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 84、source package:sys v0.6.0
-package:
-sys
+package: sys
 
 85、source package:syscall_intercept 4b3a3b5
-package:
-syscall_intercept
+package: syscall_intercept
 
 86、source package:term v0.13.0
-package:
-term
+package: term
 
 87、source package:terser 5.15.1
-package:
-terser
+package: terser
 
 88、source package:text v0.13.0
-package:
-text
+package: text
 
 89、source package:tough-cookie 2.4.3
-package:
-tough-cookie
+package: tough-cookie
 
 90、source package:uglify-js 2.8.29
-package:
-uglify-js
+package: uglify-js
 
 91、source package:util-linux 2.5-12
-package:
-util-linux
+package: util-linux
 
 92、source package:uuid v1.3.0
-package:
-uuid
+package: uuid
 
 93、source package:wpasupplicant 2.9.0-12_s390x
-package:
-wpasupplicant
+package: wpasupplicant
 
 94、source package:xdotool 3.20160805.1-4_s390x
-package:
-xdotool
+package: xdotool
 
 95、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 96、source package:xsettingsd 1.0.2-1
-package:
-xsettingsd
+package: xsettingsd
 
 97、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the BSD-2-Clause:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 2、source package:block-stream 0.0.9
-package:
-block-stream
+package: block-stream
 
 3、source package:coost v3.0.0
-package:
-coost
+package: coost
 
 4、source package:domelementtype 1.3.1
-package:
-domelementtype
+package: domelementtype
 
 5、source package:domhandler 2.4.2
-package:
-domhandler
+package: domhandler
 
 6、source package:domutils 1.5.1
-package:
-domutils
+package: domutils
 
 7、source package:doxyqml 0.3.0-1.1.debian
-package:
-doxyqml
+package: doxyqml
 
 8、source package:escope 3.6.0
-package:
-escope
+package: escope
 
 9、source package:esrecurse 4.3.0
-package:
-esrecurse
+package: esrecurse
 
 10、source package:estraverse 5.2.0
-package:
-estraverse
+package: estraverse
 
 11、source package:esutils 2.0.3
-package:
-esutils
+package: esutils
 
 12、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 13、source package:glob 3.1.21
-package:
-glob
+package: glob
 
 14、source package:golang-dbus-dev 5.1.0-1~bpo11+1
-package:
-golang-dbus-dev
+package: golang-dbus-dev
 
 15、source package:golang-github-msteinert-pam-dev 1.1.0-1
-package:
-golang-github-msteinert-pam-dev
+package: golang-github-msteinert-pam-dev
 
 16、source package:golang-gopkg-check.v1-dev 0.0+git20200902.038fdea-1
-package:
-golang-gopkg-check.v1-dev
+package: golang-gopkg-check.v1-dev
 
 17、source package:graceful-fs 1.2.3
-package:
-graceful-fs
+package: graceful-fs
 
 18、source package:libarchive-dev 3.4.0-2~bpo9+1_amd64
-package:
-libarchive-dev
+package: libarchive-dev
 
 19、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 20、source package:libtss2-dev 2.4.0-1_s390x
-package:
-libtss2-dev
+package: libtss2-dev
 
 21、source package:libtss2-tcti-tabrmd0 3.0.0-1
-package:
-libtss2-tcti-tabrmd0
+package: libtss2-tcti-tabrmd0
 
 22、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 23、source package:normalize-package-data 2.5.0
-package:
-normalize-package-data
+package: normalize-package-data
 
 24、source package:sdparm 1.12-1
-package:
-sdparm
+package: sdparm
 
 25、source package:shim-signed 1.39~1+deb11u1
-package:
-shim-signed
+package: shim-signed
 
 26、source package:shim-unsigned 15+1533136590.3beb971-9_i386
-package:
-shim-unsigned
+package: shim-unsigned
 
 27、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 28、source package:tpm2-abrmd 3.0.0-1
-package:
-tpm2-abrmd
+package: tpm2-abrmd
 
 29、source package:tt v1.0.1
-package:
-tt
+package: tt
 
 30、source package:uri-js 4.4.0
-package:
-uri-js
+package: uri-js
 
 31、source package:usb-modeswitch 2.6.1.orig
-package:
-usb-modeswitch
+package: usb-modeswitch
 
 
 Open Source Software Licensed under the MPL-2.0:
 1、source package:browser-desktop 87.0-729282885
-package:
-browser-desktop
+package: browser-desktop
 
 2、source package:dompurify 2.4.1
-package:
-dompurify
+package: dompurify
 
 3、source package:libjwt-dev 1.9.0-4_mips64el
-package:
-libjwt-dev
+package: libjwt-dev
 
 4、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 
 Open Source Software Licensed under the MPL-1.1:
 1、source package:libcairo2-dev 1.16.0-4_s390x
-package:
-libcairo2-dev
+package: libcairo2-dev
 
 2、source package:libchardet 1.0.3
-package:
-libchardet
+package: libchardet
 
 3、source package:libpam-gnome-keyring 3.4.1-5_sparc
-package:
-libpam-gnome-keyring
+package: libpam-gnome-keyring
 
 4、source package:libtag1-dev 1.9.1-2~bpo70+1_sparc
-package:
-libtag1-dev
+package: libtag1-dev
 
 
 Open Source Software Licensed under the AFL-2.1:
 1、source package:python3-dbus 1.2.8-3_s390x
-package:
-python3-dbus
+package: python3-dbus
 
 
 Open Source Software Licensed under the AGPL-1.0-only:
 1、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 
 Open Source Software Licensed under the AGPL-3.0-only:
 1、source package:nging v3.5.2
-package:
-nging
+package: nging
 
 2、source package:sobjectizer 1.2.3
-package:
-sobjectizer
+package: sobjectizer
 
 
 Open Source Software Licensed under the Apache-2.0 or LGPL-3+:
 1、source package:liblucene++-dev 3.0.7-8+b2_s390x
-package:
-liblucene++-dev
+package: liblucene++-dev
 
 
 Open Source Software Licensed under the Apache-2.0-with-GPL2-LGPL2-Exception:
 1、source package:cups 2.4.2-3+deb12u1
-package:
-cups
+package: cups
 
 
 Open Source Software Licensed under the Artistic or GPL-1+:
 1、source package:libfile-mimeinfo-perl 0.33-1
-package:
-libfile-mimeinfo-perl
+package: libfile-mimeinfo-perl
 
 2、source package:perl-openssl-defaults 7
-package:
-perl-openssl-defaults
+package: perl-openssl-defaults
 
 
 Open Source Software Licensed under the Artistic-2.0:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the BSD:
 1、source package:compiler 4.12.0
-package:
-compiler
+package: compiler
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:glide 4.12.0
-package:
-glide
+package: glide
 
 4、source package:libnet-dev 1.2-rc3
-package:
-libnet-dev
+package: libnet-dev
 
 5、source package:libvncserver LibVNCServer-0.9.14
-package:
-libvncserver
+package: libvncserver
 
 6、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 7、source package:node 8.16.1
-package:
-node
+package: node
 
 8、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 9、source package:zip 3.0-9
-package:
-zip
+package: zip
 
 
 Open Source Software Licensed under the BSD-1-Clause:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 
 Open Source Software Licensed under the BSD-3-clause:
 1、source package:tpm2-tools 5.4-1
-package:
-tpm2-tools
+package: tpm2-tools
 
 
 Open Source Software Licensed under the BSD-3-clause or GPL-2:
 1、source package:libcap-dev 2.36-1_mips64el
-package:
-libcap-dev
+package: libcap-dev
 
 2、source package:libcap2-bin 2.36-1_s390x
-package:
-libcap2-bin
+package: libcap2-bin
 
 
 Open Source Software Licensed under the BSD-4-Clause:
 1、source package:unalz 0.65-9
-package:
-unalz
+package: unalz
 
 
 Open Source Software Licensed under the BSD-Source-Code:
 1、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 
 Open Source Software Licensed under the BSL-1.0:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 
 Open Source Software Licensed under the Bitstream-Vera:
 1、source package:fontconfig 2.9.0.orig
-package:
-fontconfig
+package: fontconfig
 
 
 Open Source Software Licensed under the Brian-Gladman-3-Clause:
 1、source package:libzip-dev 1.6.1-3_s390x
-package:
-libzip-dev
+package: libzip-dev
 
 2、source package:libzip4 1.6.1-3_s390x
-package:
-libzip4
+package: libzip4
 
 
 Open Source Software Licensed under the CC-BY-3.0:
 1、source package:spdx-exceptions 2.3.0
-package:
-spdx-exceptions
+package: spdx-exceptions
 
 
 Open Source Software Licensed under the CC-BY-4.0:
 1、source package:caniuse-lite 1.0.30000989
-package:
-caniuse-lite
+package: caniuse-lite
 
 
 Open Source Software Licensed under the CC-BY-SA-4.0:
 1、source package:glob 7.1.4
-package:
-glob
+package: glob
 
 
 Open Source Software Licensed under the CC0-1.0:
 1、source package:spdx-license-ids 3.0.6
-package:
-spdx-license-ids
+package: spdx-license-ids
 
 
 Open Source Software Licensed under the CDDL-1.0:
 1、source package:libraw-dev 0.9.1-1+deb6u1
-package:
-libraw-dev
+package: libraw-dev
 
 
 Open Source Software Licensed under the CPL-1.0:
 1、source package:graphviz 2.8-3+etch1
-package:
-graphviz
+package: graphviz
 
 2、source package:junit 4.11
-package:
-junit
+package: junit
 
 
 Open Source Software Licensed under the EPL-1.0:
 1、source package:aspectjrt 1.9.6
-package:
-aspectjrt
+package: aspectjrt
 
 2、source package:junit 4.13.2
-package:
-junit
+package: junit
 
 
 Open Source Software Licensed under the FTL:
 1、source package:freetype VER-2-10-3
-package:
-freetype
+package: freetype
 
 2、source package:libfreetype-dev 2.13.0+dfsg-1
-package:
-libfreetype-dev
+package: libfreetype-dev
 
 
 Open Source Software Licensed under the Font-exception-2.0:
 1、source package:ttf-unifont 9.0.06-2_all
-package:
-ttf-unifont
+package: ttf-unifont
 
 2、source package:xfonts-wqy 1.0.0~rc1-7
-package:
-xfonts-wqy
+package: xfonts-wqy
 
 
 Open Source Software Licensed under the GFDL-1.2-only:
 1、source package:kdevelop v22.11.80
-package:
-kdevelop
+package: kdevelop
 
 
 Open Source Software Licensed under the GPL+ and GPLv2+ and MIT and Redistributable no modification permitted:
 1、source package:linux-firmware 20230824
-package:
-linux-firmware
+package: linux-firmware
 
 
 Open Source Software Licensed under the GPL-2 or GPL-2+:
 1、source package:ipheth-utils 1.0-5_s390x
-package:
-ipheth-utils
+package: ipheth-utils
 
 
 Open Source Software Licensed under the GPL-2 with Font embedding exception and M+ FONTS License:
 1、source package:fonts-wqy-zenhei 0.9.45-8
-package:
-fonts-wqy-zenhei
+package: fonts-wqy-zenhei
 
 
 Open Source Software Licensed under the GPL-2 with OpenSSL exception:
 1、source package:barrier 2.4.0+dfsg-2
-package:
-barrier
+package: barrier
 
 
 Open Source Software Licensed under the GPL-2+ and LGPL-2+:
 1、source package:xdg-desktop-portal-gtk 1.8.0-1~bpo10+1
-package:
-xdg-desktop-portal-gtk
+package: xdg-desktop-portal-gtk
 
 
 Open Source Software Licensed under the GPL-2+ or AFL-2.1:
 1、source package:dbus 1.9.8-1
-package:
-dbus
+package: dbus
 
 2、source package:dbus-user-session 1.13.8-1_s390x
-package:
-dbus-user-session
+package: dbus-user-session
 
 3、source package:dbus-x11 1.8.22-0+deb8u1_s390x
-package:
-dbus-x11
+package: dbus-x11
 
 4、source package:libdbus-1-dev 1.8.22-0+deb8u1_s390x
-package:
-libdbus-1-dev
+package: libdbus-1-dev
 
 
 Open Source Software Licensed under the GPL-2+ or FTL:
 1、source package:libfreetype6-dev 2.9.1-4_s390x
-package:
-libfreetype6-dev
+package: libfreetype6-dev
 
 
 Open Source Software Licensed under the GPL-2+ or LGPL-2.1 or LGPL-3.0:
 1、source package:libquazip5-dev 0.7.6-6_s390x
-package:
-libquazip5-dev
+package: libquazip5-dev
 
 
 Open Source Software Licensed under the GPL-2+ with OpenSSL exception:
 1、source package:cryptsetup 2:2.6.1-4
-package:
-cryptsetup
+package: cryptsetup
 
 2、source package:cryptsetup-initramfs 2.3.1-1_all
-package:
-cryptsetup-initramfs
+package: cryptsetup-initramfs
 
 3、source package:libcryptsetup12 2.3.1-1_s390x
-package:
-libcryptsetup12
+package: libcryptsetup12
 
 
 Open Source Software Licensed under the GPL-2+ with SSL exception:
 1、source package:remmina 1.4.8+dfsg-2~bpo10+2
-package:
-remmina
+package: remmina
 
 2、source package:remmina-plugin-rdp 1.4.7+dfsg-1_s390x
-package:
-remmina-plugin-rdp
+package: remmina-plugin-rdp
 
 3、source package:remmina-plugin-vnc 1.4.7+dfsg-1_s390x
-package:
-remmina-plugin-vnc
+package: remmina-plugin-vnc
 
 
 Open Source Software Licensed under the GPL-2+ with sane exception:
 1、source package:libsane-dev 1.2.1-4
-package:
-libsane-dev
+package: libsane-dev
 
 
 Open Source Software Licensed under the GPL-2.0 or GPL-3.0 or FIPL-1.0:
 1、source package:libfreeimage-dev 3.18.0+ds2-3_s390x
-package:
-libfreeimage-dev
+package: libfreeimage-dev
 
 
 Open Source Software Licensed under the GPL-2.0+ or LGPL-2.1+:
 1、source package:fcitx5-frontend-gtk3 0.0~git20200606.fc335f1-2_s390x
-package:
-fcitx5-frontend-gtk3
+package: fcitx5-frontend-gtk3
 
 
 Open Source Software Licensed under the GPL-3 with Qt-1.0 exception:
 1、source package:qttools5-dev 5.9.2-4_kfreebsd-i386
-package:
-qttools5-dev
+package: qttools5-dev
 
 2、source package:qttools5-dev-tools 5.9.2-4_kfreebsd-i386
-package:
-qttools5-dev-tools
+package: qttools5-dev-tools
 
 3、source package:qttranslations5-l10n 5.9.2-1
-package:
-qttranslations5-l10n
+package: qttranslations5-l10n
 
 
 Open Source Software Licensed under the GPL-3+ or Less:
 1、source package:less 590-2
-package:
-less
+package: less
 
 
 Open Source Software Licensed under the GPL-3+ with OpenSSL exception:
 1、source package:libdmr-dev 5.7.6.147-1
-package:
-libdmr-dev
+package: libdmr-dev
 
 
 Open Source Software Licensed under the GPL-3.0-with-Qt-1.0-exception:
 1、source package:libqt5webchannel5-dev 5.7.1-2_s390x
-package:
-libqt5webchannel5-dev
+package: libqt5webchannel5-dev
 
 2、source package:qml-module-qtwebchannel 5.9.2-3
-package:
-qml-module-qtwebchannel
+package: qml-module-qtwebchannel
 
 
 Open Source Software Licensed under the GPL-any:
 1、source package:command-not-found 23.04.0-1
-package:
-command-not-found
+package: command-not-found
 
 
 Open Source Software Licensed under the Hylafax:
 1、source package:libtiff-dev 4.1.0+git191117-2~deb10u1_s390x
-package:
-libtiff-dev
+package: libtiff-dev
 
 
 Open Source Software Licensed under the ICU:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 2、source package:x11-xserver-utils 7.7~3_sparc
-package:
-x11-xserver-utils
+package: x11-xserver-utils
 
 3、source package:xkb-data 2.5.1-3_all
-package:
-xkb-data
+package: xkb-data
 
 4、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 5、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the ISC:
 1、source package:abbrev 1.1.1
-package:
-abbrev
+package: abbrev
 
 2、source package:anymatch 3.1.2
-package:
-anymatch
+package: anymatch
 
 3、source package:aproba 1.2.0
-package:
-aproba
+package: aproba
 
 4、source package:are-we-there-yet 1.1.5
-package:
-are-we-there-yet
+package: are-we-there-yet
 
 5、source package:boolbase 1.0.0
-package:
-boolbase
+package: boolbase
 
 6、source package:browserify-sign 4.2.1
-package:
-browserify-sign
+package: browserify-sign
 
 7、source package:cliui 4.1.0
-package:
-cliui
+package: cliui
 
 8、source package:color-support 1.1.3
-package:
-color-support
+package: color-support
 
 9、source package:concat-with-sourcemaps 1.1.0
-package:
-concat-with-sourcemaps
+package: concat-with-sourcemaps
 
 10、source package:console-control-strings 1.1.0
-package:
-console-control-strings
+package: console-control-strings
 
 11、source package:crda 4.14+git20191112.9856751.orig
-package:
-crda
+package: crda
 
 12、source package:d 1.0.1
-package:
-d
+package: d
 
 13、source package:distro-info-data 0.9~bpo60+1
-package:
-distro-info-data
+package: distro-info-data
 
 14、source package:electron-to-chromium 1.3.254
-package:
-electron-to-chromium
+package: electron-to-chromium
 
 15、source package:es5-ext 0.10.53
-package:
-es5-ext
+package: es5-ext
 
 16、source package:es6-symbol 3.1.3
-package:
-es6-symbol
+package: es6-symbol
 
 17、source package:es6-weak-map 2.0.3
-package:
-es6-weak-map
+package: es6-weak-map
 
 18、source package:ext 1.4.0
-package:
-ext
+package: ext
 
 19、source package:fastq 1.13.0
-package:
-fastq
+package: fastq
 
 20、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 21、source package:fs 0.0.1-security
-package:
-fs
+package: fs
 
 22、source package:fs.realpath 1.0.0
-package:
-fs.realpath
+package: fs.realpath
 
 23、source package:fstream 1.0.12
-package:
-fstream
+package: fstream
 
 24、source package:gauge 2.7.4
-package:
-gauge
+package: gauge
 
 25、source package:get-caller-file 1.0.3
-package:
-get-caller-file
+package: get-caller-file
 
 26、source package:glob 7.1.4
-package:
-glob
+package: glob
 
 27、source package:glob-parent 5.1.2
-package:
-glob-parent
+package: glob-parent
 
 28、source package:go-spew v1.1.1
-package:
-go-spew
+package: go-spew
 
 29、source package:go-wav v0.3.2
-package:
-go-wav
+package: go-wav
 
 30、source package:golang-github-nfnt-resize-dev 0.0~git20180221.83c6a99-2_all
-package:
-golang-github-nfnt-resize-dev
+package: golang-github-nfnt-resize-dev
 
 31、source package:graceful-fs 4.2.4
-package:
-graceful-fs
+package: graceful-fs
 
 32、source package:har-schema 2.0.0
-package:
-har-schema
+package: har-schema
 
 33、source package:has-unicode 2.0.1
-package:
-has-unicode
+package: has-unicode
 
 34、source package:hosted-git-info 2.8.8
-package:
-hosted-git-info
+package: hosted-git-info
 
 35、source package:in-publish 2.0.0
-package:
-in-publish
+package: in-publish
 
 36、source package:inflight 1.0.6
-package:
-inflight
+package: inflight
 
 37、source package:inherits 2.0.4
-package:
-inherits
+package: inherits
 
 38、source package:ini 1.3.5
-package:
-ini
+package: ini
 
 39、source package:isexe 2.0.0
-package:
-isexe
+package: isexe
 
 40、source package:json-stringify-safe 5.0.1
-package:
-json-stringify-safe
+package: json-stringify-safe
 
 41、source package:lru-cache 4.1.5
-package:
-lru-cache
+package: lru-cache
 
 42、source package:minimalistic-assert 1.0.1
-package:
-minimalistic-assert
+package: minimalistic-assert
 
 43、source package:minimatch 5.1.6
-package:
-minimatch
+package: minimatch
 
 44、source package:natives 1.1.6
-package:
-natives
+package: natives
 
 45、source package:node 8.16.1
-package:
-node
+package: node
 
 46、source package:node-bin-setup 1.0.6
-package:
-node-bin-setup
+package: node-bin-setup
 
 47、source package:nopt 3.0.6
-package:
-nopt
+package: nopt
 
 48、source package:npmlog 4.1.2
-package:
-npmlog
+package: npmlog
 
 49、source package:once 1.4.0
-package:
-once
+package: once
 
 50、source package:osenv 0.1.5
-package:
-osenv
+package: osenv
 
 51、source package:parse-asn1 5.1.6
-package:
-parse-asn1
+package: parse-asn1
 
 52、source package:pkgconf 1.8.1-2
-package:
-pkgconf
+package: pkgconf
 
 53、source package:pseudomap 1.0.2
-package:
-pseudomap
+package: pseudomap
 
 54、source package:python3-dnspython 2.4.0~rc1-1
-package:
-python3-dnspython
+package: python3-dnspython
 
 55、source package:remove-trailing-separator 1.1.0
-package:
-remove-trailing-separator
+package: remove-trailing-separator
 
 56、source package:require-main-filename 1.0.1
-package:
-require-main-filename
+package: require-main-filename
 
 57、source package:rimraf 2.7.1
-package:
-rimraf
+package: rimraf
 
 58、source package:rollup 2.79.1
-package:
-rollup
+package: rollup
 
 59、source package:semver 5.7.1
-package:
-semver
+package: semver
 
 60、source package:set-blocking 2.0.0
-package:
-set-blocking
+package: set-blocking
 
 61、source package:sigmund 1.0.1
-package:
-sigmund
+package: sigmund
 
 62、source package:signal-exit 3.0.3
-package:
-signal-exit
+package: signal-exit
 
 63、source package:tar 2.2.2
-package:
-tar
+package: tar
 
 64、source package:type 2.1.0
-package:
-type
+package: type
 
 65、source package:vinyl-sourcemaps-apply 0.2.1
-package:
-vinyl-sourcemaps-apply
+package: vinyl-sourcemaps-apply
 
 66、source package:which 1.3.1
-package:
-which
+package: which
 
 67、source package:which-module 2.0.0
-package:
-which-module
+package: which-module
 
 68、source package:wide-align 1.1.3
-package:
-wide-align
+package: wide-align
 
 69、source package:wrappy 1.0.2
-package:
-wrappy
+package: wrappy
 
 70、source package:y18n 3.2.1
-package:
-y18n
+package: y18n
 
 71、source package:yallist 2.1.2
-package:
-yallist
+package: yallist
 
 72、source package:yargs-parser 8.1.0
-package:
-yargs-parser
+package: yargs-parser
 
 
 Open Source Software Licensed under the ImageMagick:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 
 Open Source Software Licensed under the Info-ZIP:
 1、source package:unzip 6.0.orig
-package:
-unzip
+package: unzip
 
 
 Open Source Software Licensed under the LGPL:
 1、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 2、source package:libatspi2.0-dev 2.5.3-2_sparc
-package:
-libatspi2.0-dev
+package: libatspi2.0-dev
 
 3、source package:liblightdm-qt-dev 1.26.0-5_s390x
-package:
-liblightdm-qt-dev
+package: liblightdm-qt-dev
 
 4、source package:lightdm 1.9.9-1
-package:
-lightdm
+package: lightdm
 
 5、source package:slirp4netns 1.2.0-1
-package:
-slirp4netns
+package: slirp4netns
 
 6、source package:smartmontools 7.3-1
-package:
-smartmontools
+package: smartmontools
 
 
 Open Source Software Licensed under the LGPL-2+ and LGPL-2.1+:
 1、source package:ostree 2023.3-2
-package:
-ostree
+package: ostree
 
 
 Open Source Software Licensed under the LGPL-2+ and LGPL-2.1+ and FSFULLR and CC0-1.0 and Janik-permissive and Iconv-PD and Mingw-PD and Old-GLib-Tests-permissive:
 1、source package:libglib2.0-bin 2.76.4-1
-package:
-libglib2.0-bin
+package: libglib2.0-bin
 
 
 Open Source Software Licensed under the LGPL-2.0+ and Expat:
 1、source package:policykit-1 122-4
-package:
-policykit-1
+package: policykit-1
 
 
 Open Source Software Licensed under the LGPL-2.0-or-later:
 1、source package:bubblewrap 0~git160513-2
-package:
-bubblewrap
+package: bubblewrap
 
 2、source package:gvfs-backends 1.44.1-1_s390x
-package:
-gvfs-backends
+package: gvfs-backends
 
 3、source package:gvfs-bin 1.44.1-1_s390x
-package:
-gvfs-bin
+package: gvfs-bin
 
 4、source package:gvfs-fuse 1.44.1-1_s390x
-package:
-gvfs-fuse
+package: gvfs-fuse
 
 5、source package:kcalcore 5:5.85.0-2
-package:
-kcalcore
+package: kcalcore
 
 6、source package:kdeclarative 5.100.0-1
-package:
-kdeclarative
+package: kdeclarative
 
 7、source package:libasound2-dev 1.2.2-2.3_ppc64el
-package:
-libasound2-dev
+package: libasound2-dev
 
 8、source package:libgdk-pixbuf2.0-0 2.40.2-3
-package:
-libgdk-pixbuf2.0-0
+package: libgdk-pixbuf2.0-0
 
 9、source package:libgdk-pixbuf2.0-dev 2.40.0+dfsg-5_s390x
-package:
-libgdk-pixbuf2.0-dev
+package: libgdk-pixbuf2.0-dev
 
 10、source package:libkf5itemviews-dev 5.70.0-1_s390x
-package:
-libkf5itemviews-dev
+package: libkf5itemviews-dev
 
 11、source package:libkf5widgetsaddons-dev 5.70.0-1_s390x
-package:
-libkf5widgetsaddons-dev
+package: libkf5widgetsaddons-dev
 
 12、source package:libmtp-runtime 1.1.9-3~bpo8+1
-package:
-libmtp-runtime
+package: libmtp-runtime
 
 13、source package:libpolkit-agent-1-dev 0.116-2_s390x
-package:
-libpolkit-agent-1-dev
+package: libpolkit-agent-1-dev
 
 14、source package:libpolkit-qt5-1-dev 0.112.0-7_s390x
-package:
-libpolkit-qt5-1-dev
+package: libpolkit-qt5-1-dev
 
 15、source package:librsvg2-bin 2.48.7-1_ppc64el
-package:
-librsvg2-bin
+package: librsvg2-bin
 
 16、source package:platform/external/e2fsprogs lollipop-dev
-package:
-platform/external/e2fsprogs
+package: platform/external/e2fsprogs
 
 17、source package:xdg-desktop-portal 1.8.1-1~bpo10+1
-package:
-xdg-desktop-portal
+package: xdg-desktop-portal
 
 
 Open Source Software Licensed under the LGPL-2.1 or MPL-2.0:
 1、source package:libical-dev 3.0.8-2_mipsel
-package:
-libical-dev
+package: libical-dev
 
 
 Open Source Software Licensed under the LGPL-3 or GPL-2-or-3 with KDE Exception:
 1、source package:qml6-module-qtwebchannel 6.4.2~rc1-3
-package:
-qml6-module-qtwebchannel
+package: qml6-module-qtwebchannel
 
 
 Open Source Software Licensed under the LGPL-3Qt-1.1Exception or GPL-2Qt-1.1Exception:
 1、source package:qml-module-qtwebengine 5.7.1+dfsg-6.1_mipsel
-package:
-qml-module-qtwebengine
+package: qml-module-qtwebengine
 
 2、source package:qtwebengine5-dev 5.7.1+dfsg-6.1_mipsel
-package:
-qtwebengine5-dev
+package: qtwebengine5-dev
 
 
 Open Source Software Licensed under the LGPLv2 with exceptions or GPLv3 with exceptions and GFDL:
 1、source package:libqt6svg6 6.4.1
-package:
-libqt6svg6
+package: libqt6svg6
 
 
 Open Source Software Licensed under the Libpng:
 1、source package:libpng-dev 1.6.37-2_s390x
-package:
-libpng-dev
+package: libpng-dev
 
 2、source package:libsdl2-dev 2.0.9+dfsg1-1_s390x
-package:
-libsdl2-dev
+package: libsdl2-dev
 
 
 Open Source Software Licensed under the Linux-syscall-note:
 1、source package:pinn 0.0
-package:
-pinn
+package: pinn
 
 
 Open Source Software Licensed under the MITNFA:
 1、source package:through2 0.6.5
-package:
-through2
+package: through2
 
 
 Open Source Software Licensed under the MPL-1.1 or GPL-2+ or LGPL-2.1+:
 1、source package:libchardet-dev 1.0.4-1_s390x
-package:
-libchardet-dev
+package: libchardet-dev
 
 2、source package:libchardet1 1.0.4-1_s390x
-package:
-libchardet1
+package: libchardet1
 
 3、source package:libuchardet-dev 0.0.7-1_s390x
-package:
-libuchardet-dev
+package: libuchardet-dev
 
 4、source package:libuchardet0 0.0.7-1_s390x
-package:
-libuchardet0
+package: libuchardet0
 
 
 Open Source Software Licensed under the NAIST-2003:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Net-SNMP:
 1、source package:sudo 1.9.8p2-1~exp1
-package:
-sudo
+package: sudo
 
 
 Open Source Software Licensed under the OFL-1.1:
 1、source package:fonts-intel-one-mono 1.2.1-2
-package:
-fonts-intel-one-mono
+package: fonts-intel-one-mono
 
 2、source package:fonts-lohit-deva 2.95.4.orig
-package:
-fonts-lohit-deva
+package: fonts-lohit-deva
 
 3、source package:fonts-noto 20201225-1
-package:
-fonts-noto
+package: fonts-noto
 
 4、source package:fonts-noto-mono 20200323-1_all
-package:
-fonts-noto-mono
+package: fonts-noto-mono
 
 
 Open Source Software Licensed under the OpenSSL:
 1、source package:libssl1.1 1.1.1~~pre9-1
-package:
-libssl1.1
+package: libssl1.1
 
 2、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the PD:
 1、source package:xz-utils 5.4.1-0.2
-package:
-xz-utils
+package: xz-utils
 
 
 Open Source Software Licensed under the Public Domain:
 1、source package:debianutils 5.8-1
-package:
-debianutils
+package: debianutils
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:grub-efi-amd64-signed 1+2.06+8.1
-package:
-grub-efi-amd64-signed
+package: grub-efi-amd64-signed
 
 4、source package:grub-efi-arm64-signed 1+2.06+8.1
-package:
-grub-efi-arm64-signed
+package: grub-efi-arm64-signed
 
 5、source package:jsonify 0.0.0
-package:
-jsonify
+package: jsonify
 
 6、source package:libatspi2.0-dev 2.5.3-2_sparc
-package:
-libatspi2.0-dev
+package: libatspi2.0-dev
 
 7、source package:libsqlite3-0 3.8.7.1-1_kfreebsd-i386
-package:
-libsqlite3-0
+package: libsqlite3-0
 
 8、source package:libsqlite3-dev 3.8.7.1-1_kfreebsd-i386
-package:
-libsqlite3-dev
+package: libsqlite3-dev
 
 9、source package:sqlite3 3.9.2-1
-package:
-sqlite3
+package: sqlite3
 
 10、source package:tzdata 2023c-7
-package:
-tzdata
+package: tzdata
 
 
 Open Source Software Licensed under the Python-2.0:
 1、source package:python3 3.8.2-3_s390x
-package:
-python3
+package: python3
 
 
 Open Source Software Licensed under the Qt-GPL-exception-1.0:
 1、source package:qtremoteobjects v5.11.0-rc2
-package:
-qtremoteobjects
+package: qtremoteobjects
 
 
 Open Source Software Licensed under the Rdisc:
 1、source package:iputils-ping 20190709-3_s390x
-package:
-iputils-ping
+package: iputils-ping
 
 
 Open Source Software Licensed under the SGI-B-1.1:
 1、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 2、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the SGI-B-2.0:
 1、source package:libegl1-mesa-dev 8.0.5-4+deb7u2_sparc
-package:
-libegl1-mesa-dev
+package: libegl1-mesa-dev
 
 2、source package:libgbm-dev 8.0.5-4+deb7u2_sparc
-package:
-libgbm-dev
+package: libgbm-dev
 
 3、source package:xserver-xorg-core 1.20.8-2_s390x
-package:
-xserver-xorg-core
+package: xserver-xorg-core
 
 4、source package:xwayland 2:23.1.1-1
-package:
-xwayland
+package: xwayland
 
 
 Open Source Software Licensed under the SIL-1.1:
 1、source package:fonts-noto-cjk 20190410+repack1-2.debian
-package:
-fonts-noto-cjk
+package: fonts-noto-cjk
 
 
 Open Source Software Licensed under the SSLeay:
 1、source package:libssl1.1 1.1.1~~pre9-1
-package:
-libssl1.1
+package: libssl1.1
 
 
 Open Source Software Licensed under the Sleepycat:
 1、source package:go-difflib v1.0.0
-package:
-go-difflib
+package: go-difflib
 
 
 Open Source Software Licensed under the The Bugly Software License Version 1.0:
 1、source package:crashreport 3.4.4
-package:
-crashreport
+package: crashreport
 
 2、source package:nativecrashreport 3.9.2
-package:
-nativecrashreport
+package: nativecrashreport
 
 
 Open Source Software Licensed under the Unicode-DFS-2015:
 1、source package:DocxFactory 91131f28
-package:
-DocxFactory
+package: DocxFactory
 
 
 Open Source Software Licensed under the Unicode-DFS-2016:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Unicode-TOU:
 1、source package:node 8.16.1
-package:
-node
+package: node
 
 
 Open Source Software Licensed under the Unlicense:
 1、source package:ncompress 4.2.4.6.orig
-package:
-ncompress
+package: ncompress
 
 2、source package:tortellini 4f6795a
-package:
-tortellini
+package: tortellini
 
 3、source package:tweetnacl 0.14.5
-package:
-tweetnacl
+package: tweetnacl
 
 
 Open Source Software Licensed under the Vim:
 1、source package:vim 8.2.0716.orig
-package:
-vim
+package: vim
 
 
 Open Source Software Licensed under the X11:
 1、source package:libwayland-dev 1.6.0-2_s390x
-package:
-libwayland-dev
+package: libwayland-dev
 
 2、source package:libxcb-image0-dev 0.4.0-1_s390x
-package:
-libxcb-image0-dev
+package: libxcb-image0-dev
 
 3、source package:libxcb-keysyms1-dev 0.4.0-1_s390x
-package:
-libxcb-keysyms1-dev
+package: libxcb-keysyms1-dev
 
 4、source package:libyaml-cpp-dev 0.6.3-9_s390x
-package:
-libyaml-cpp-dev
+package: libyaml-cpp-dev
 
 5、source package:ncurses-base 6.2-1_all
-package:
-ncurses-base
+package: ncurses-base
 
 6、source package:wordwrap 0.0.2
-package:
-wordwrap
+package: wordwrap
 
 
 Open Source Software Licensed under the Xnet:
 1、source package:onboard 1.4.1-5_s390x
-package:
-onboard
+package: onboard
 
 
 Open Source Software Licensed under the Zlib:
 1、source package:avfs 1.1.4-2
-package:
-avfs
+package: avfs
 
 2、source package:ffmpeg 7:6.0-3
-package:
-ffmpeg
+package: ffmpeg
 
 3、source package:libminizip-dev 1.1-8_hurd-i386
-package:
-libminizip-dev
+package: libminizip-dev
 
 4、source package:libsdl2-dev 2.0.9+dfsg1-1_s390x
-package:
-libsdl2-dev
+package: libsdl2-dev
 
 5、source package:libxlsxwriter RELEASE_1.0.0
-package:
-libxlsxwriter
+package: libxlsxwriter
 
 6、source package:node 8.16.1
-package:
-node
+package: node
 
 7、source package:pako 1.0.11
-package:
-pako
+package: pako
 
 8、source package:pigz 2.6-1
-package:
-pigz
+package: pigz
 
 9、source package:unalz 0.65-9
-package:
-unalz
+package: unalz
 
 10、source package:zlib1g 1.2.8.dfsg-5_s390x
-package:
-zlib1g
+package: zlib1g
 
 11、source package:zlib1g-dev 1:1.2.3.3.dfsg-1
-package:
-zlib1g-dev
+package: zlib1g-dev
 
 
 Open Source Software Licensed under the copyleft-next-0.3.0:
 1、source package:crda 4.14+git20191112.9856751.orig
-package:
-crda
+package: crda
 
 
 Open Source Software Licensed under the cryptsetup-OpenSSL-exception:
 1、source package:aria2 1.9.5-1
-package:
-aria2
+package: aria2
 
 2、source package:libcryptsetup-dev 2:2.4.0-1
-package:
-libcryptsetup-dev
+package: libcryptsetup-dev
 
 
 Open Source Software Licensed under the curl:
 1、source package:curl 8.0.1-1~exp1
-package:
-curl
+package: curl
 
 2、source package:libcurl4-openssl-dev 7.68.0-1_s390x
-package:
-libcurl4-openssl-dev
+package: libcurl4-openssl-dev
 
 
 Open Source Software Licensed under the hdparm:
 1、source package:hdparm 9.65+ds-1
-package:
-hdparm
+package: hdparm
 
 
 Open Source Software Licensed under the nolicense:
 1、source package:FreeBSD-Electron v9.0.3
-package:
-FreeBSD-Electron
+package: FreeBSD-Electron
 
 2、source package:LTSLAM 94d7e0f
-package:
-LTSLAM
+package: LTSLAM
 
 3、source package:TSFileEditor 0.2.1
-package:
-TSFileEditor
+package: TSFileEditor
 
 4、source package:asio asio-1-29-0
-package:
-asio
+package: asio
 
 5、source package:chromium-source-tarball 59.0.3071.57
-package:
-chromium-source-tarball
+package: chromium-source-tarball
 
 6、source package:geek-navigation 5a521f2
-package:
-geek-navigation
+package: geek-navigation
 
 7、source package:gentoo 202
-package:
-gentoo
+package: gentoo
 
 8、source package:go-urn v1.1.0
-package:
-go-urn
+package: go-urn
 
 9、source package:imaging v1.6.2
-package:
-imaging
+package: imaging
 
 10、source package:kcrash 5.103.0-1
-package:
-kcrash
+package: kcrash
 
 11、source package:ncnn_paddleocr 9c054d3
-package:
-ncnn_paddleocr
+package: ncnn_paddleocr
 
 12、source package:plasma-workspace v5.25.90
-package:
-plasma-workspace
+package: plasma-workspace
 
 13、source package:platform/external/qt emu-29.0-release
-package:
-platform/external/qt
+package: platform/external/qt
 
 14、source package:qtbase v6.5.1
-package:
-qtbase
+package: qtbase
 
 15、source package:qtxlsxwriter v0.3.0
-package:
-qtxlsxwriter
+package: qtxlsxwriter
 
 16、source package:scriptcommunicator_serial-terminal Release_06_02
-package:
-scriptcommunicator_serial-terminal
+package: scriptcommunicator_serial-terminal
 
 17、source package:socket v0.4.1
-package:
-socket
+package: socket
 
 18、source package:strace v4.14
-package:
-strace
+package: strace
 
 19、source package:v5 v5.1.0
-package:
-v5
+package: v5
 
 20、source package:wlr-protocols d278d20
-package:
-wlr-protocols
+package: wlr-protocols
 
 
 Copy of Licenses


### PR DESCRIPTION
fix: Optimize the typesetting layout of open-source software declarations

调整开源软件声明的排版，删除package后的换行

PMS: BUG-355359

## Summary by Sourcery

Enhancements:
- Refine formatting of GPL 3.0 license body text files for en_US, zh_CN, and zh_TW to optimize visual layout of open-source software declarations.