### PR TITLE
Revert "fix: use QQmlIncubator for asynchronous plugin object creation"

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -168,30 +168,6 @@ void LoadPluginTask::createData()
     Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data finished. elapsed time :" + QString::number(timer.elapsed()));
 }
 
-class DccIncubator : public QQmlIncubator
-{
-public:
-    DccIncubator(PluginManager *pManager, PluginData *plugin, QQmlComponent *component, QQmlContext *context, std::function<void(QQmlIncubator::Status, DccIncubator *)> &&fun)
-        : QQmlIncubator(Asynchronous)
-        , m_pManager(pManager)
-        , m_plugin(plugin)
-        , m_component(component)
-        , m_context(context)
-        , m_fun(std::move(fun))
-    {
-    }
-
-protected:
-    void statusChanged(Status status) override { m_fun(status, this); }
-
-public:
-    PluginManager *m_pManager;
-    PluginData *m_plugin;
-    QQmlComponent *m_component;
-    QQmlContext *m_context;
-    std::function<void(QQmlIncubator::Status, DccIncubator *)> m_fun;
-};
-
 PluginManager::PluginManager(DccManager *parent)
     : QObject(parent)
     , m_manager(parent)
@@ -537,11 +513,16 @@ void PluginManager::createModule(QQmlComponent *component)
     Q_EMIT updatePluginStatus(plugin, ModuleCreate, "create module");
     switch (component->status()) {
     case QQmlComponent::Ready: {
-        DccIncubator *incubator = new DccIncubator(this, plugin, component, nullptr, std::bind(&PluginManager::incubatorStatusChangedModule, this, std::placeholders::_1, std::placeholders::_2));
-        component->create(*incubator, nullptr, nullptr);
-        connect(component, &QQmlComponent::destroyed, this, [incubator]() {
-            delete incubator;
-        });
+        QObject *object = component->create();
+        component->deleteLater();
+        if (!object) {
+            Q_EMIT updatePluginStatus(plugin, ModuleErr | ModuleEnd, " component create module object is null:" + component->errorString());
+            return;
+        }
+        object->setParent(m_rootModule);
+        plugin->module = qobject_cast<DccObject *>(object);
+        Q_EMIT updatePluginStatus(plugin, ModuleEnd, "create module finished");
+        m_manager->addObject(plugin->module);
     } break;
     case QQmlComponent::Error: {
         component->deleteLater();
@@ -563,11 +544,15 @@ void PluginManager::createMain(QQmlComponent *component)
     case QQmlComponent::Ready: {
         QQmlContext *context = new QQmlContext(component->engine());
         context->setContextProperties({ { "dccData", QVariant::fromValue(plugin->data) }, { "dccModule", QVariant::fromValue(plugin->module) } });
-        DccIncubator *incubator = new DccIncubator(this, plugin, component, context, std::bind(&PluginManager::incubatorStatusChangedMain, this, std::placeholders::_1, std::placeholders::_2));
-        component->create(*incubator, context, nullptr);
-        connect(component, &QQmlComponent::destroyed, this, [incubator]() {
-            delete incubator;
-        });
+        QObject *object = component->create(context);
+        component->deleteLater();
+        if (!object) {
+            Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object is null:" + component->errorString());
+            return;
+        }
+        object->setParent(plugin->module ? plugin->module : m_rootModule);
+        plugin->mainObj = qobject_cast<DccObject *>(object);
+        Q_EMIT updatePluginStatus(plugin, MainObjEnd, ": create main finished");
     } break;
     case QQmlComponent::Error: {
         Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object error:" + component->errorString());
@@ -616,67 +601,6 @@ void PluginManager::addMainObject(PluginData *plugin)
         Q_EMIT addObject(plugin->soObj);
     }
     Q_EMIT updatePluginStatus(plugin, MainObjEnd | PluginEnd, "add main object finished");
-}
-
-void PluginManager::incubatorStatusChangedModule(QQmlIncubator::Status status, DccIncubator *incubator)
-{
-    if (isDeleting()) {
-        return;
-    }
-    switch (status) {
-    case QQmlIncubator::Ready: {
-        QObject *obj = incubator->object();
-        incubator->m_component->deleteLater();
-        if (!obj) {
-            Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleErr | ModuleEnd, " component create module object is null:" + incubator->m_component->errorString());
-            return;
-        }
-        if (m_rootModule) {
-            obj->setParent(m_rootModule);
-            incubator->m_plugin->module = qobject_cast<DccObject *>(obj);
-            Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleEnd, "create module finished");
-            m_manager->addObject(incubator->m_plugin->module);
-        } else {
-            obj->deleteLater();
-            Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleErr | ModuleEnd, " component create module object error:" + incubator->m_component->errorString());
-        }
-    } break;
-    case QQmlIncubator::Error: {
-        Q_EMIT updatePluginStatus(incubator->m_plugin, ModuleErr | ModuleEnd, " component create module object error:" + incubator->m_component->errorString());
-        incubator->m_component->deleteLater();
-    } break;
-    default:
-        break;
-    }
-}
-
-void PluginManager::incubatorStatusChangedMain(QQmlIncubator::Status status, DccIncubator *incubator)
-{
-    if (isDeleting()) {
-        return;
-    }
-    switch (status) {
-    case QQmlIncubator::Ready: {
-        QObject *obj = incubator->object();
-        incubator->m_component->deleteLater();
-        if (!obj) {
-            incubator->m_context->deleteLater();
-            Q_EMIT updatePluginStatus(incubator->m_plugin, MainObjErr | MainObjEnd, " component create main object is null:" + incubator->m_component->errorString());
-            return;
-        }
-        incubator->m_context->setParent(obj);
-        obj->setParent(incubator->m_plugin->module ? incubator->m_plugin->module : nullptr);
-        incubator->m_plugin->mainObj = qobject_cast<DccObject *>(obj);
-        Q_EMIT updatePluginStatus(incubator->m_plugin, MainObjEnd, ": create main finished");
-    } break;
-    case QQmlIncubator::Error: {
-        Q_EMIT updatePluginStatus(incubator->m_plugin, MainObjErr | MainObjEnd, " component create main object error:" + incubator->m_component->errorString());
-        incubator->m_component->deleteLater();
-        incubator->m_context->deleteLater();
-    } break;
-    default:
-        break;
-    }
 }
 
 void PluginManager::moduleLoading()

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -3,11 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
-#include "dccobject.h"
-
 #include <QObject>
 #include <QQmlContext>
-#include <QQmlIncubator>
 #include <QStringList>
 #include <QVector>
 
@@ -18,7 +15,6 @@ namespace dccV25 {
 class DccObject;
 class DccManager;
 struct PluginData;
-class DccIncubator;
 
 class PluginManager : public QObject
 {
@@ -60,9 +56,6 @@ private Q_SLOTS:
     void createMain(QQmlComponent *component);
     void addMainObject(PluginData *plugin);
 
-    void incubatorStatusChangedModule(QQmlIncubator::Status status, DccIncubator *incubator);
-    void incubatorStatusChangedMain(QQmlIncubator::Status status, DccIncubator *incubator);
-
     void moduleLoading();
     void mainLoading();
 
@@ -73,8 +66,8 @@ private Q_SLOTS:
 
 private:
     DccManager *m_manager;
-    QList<PluginData *> m_plugins;    // cache for other plugin
-    QPointer<DccObject> m_rootModule; // root module from MainWindow
+    QList<PluginData *> m_plugins; // cache for other plugin
+    DccObject *m_rootModule;       // root module from MainWindow
     QThreadPool *m_threadPool;
     bool m_isDeleting;
     bool m_modulePhaseFinished;


### PR DESCRIPTION
Reverts linuxdeepin/dde-control-center#3172

## Summary by Sourcery

Revert asynchronous plugin QML object creation and restore direct QQmlComponent-based creation for plugin modules and main objects.

Enhancements:
- Remove the custom DccIncubator helper and related incubator status handlers in PluginManager, simplifying plugin object lifecycle management.
- Adjust PluginManager root module tracking from a QPointer<DccObject> to a raw DccObject* to align with the reverted creation flow.