### PR TITLE
refactor: simplify plugin loading by removing async loading

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -440,22 +440,21 @@ void PluginManager::loadModule(PluginData *plugin)
         return;
     }
     QQmlComponent *component = new QQmlComponent(m_manager->engine(), m_manager->engine());
-    component->setProperty("PluginData", QVariant::fromValue(plugin));
-    connect(component, &QQmlComponent::statusChanged, this, &PluginManager::moduleLoading);
     switch (plugin->version()) {
     case T_V1_0: {
         const QString qmlPath = plugin->path + "/" + plugin->name + ".qml";
         Q_EMIT updatePluginStatus(plugin, ModuleLoad, ": load module " + qmlPath);
-        component->loadUrl(qmlPath, QQmlComponent::Asynchronous);
+        component->loadUrl(qmlPath);
     } break;
     case T_V1_1:
     default: {
         QString typeName = plugin->name;
         typeName[0] = typeName[0].toUpper();
         Q_EMIT updatePluginStatus(plugin, ModuleLoad, ": load module " + typeName);
-        component->loadFromModule(plugin->name, typeName, QQmlComponent::Asynchronous);
+        component->loadFromModule(plugin->name, typeName);
     } break;
     }
+    createModule(component, plugin);
 }
 
 void PluginManager::loadPluginData(PluginData *plugin)
@@ -486,30 +485,28 @@ void PluginManager::loadMain(PluginData *plugin)
         return;
     }
     QQmlComponent *component = new QQmlComponent(m_manager->engine(), m_manager->engine());
-    component->setProperty("PluginData", QVariant::fromValue(plugin));
-    connect(component, &QQmlComponent::statusChanged, this, &PluginManager::mainLoading);
     switch (plugin->version()) {
     case T_V1_0: {
         const QString qmlPath = plugin->path + "/" + ((plugin->type & T_ShortMain) ? "main.qml" : plugin->name + "Main.qml");
         Q_EMIT updatePluginStatus(plugin, MainObjLoad, ": load Main " + qmlPath);
-        component->loadUrl(qmlPath, QQmlComponent::Asynchronous);
+        component->loadUrl(qmlPath);
     } break;
     case T_V1_1:
     default: {
         QString typeName = plugin->name + "Main";
         typeName[0] = typeName[0].toUpper();
         Q_EMIT updatePluginStatus(plugin, MainObjLoad, ": load Main " + typeName);
-        component->loadFromModule(plugin->name, typeName, QQmlComponent::Asynchronous);
+        component->loadFromModule(plugin->name, typeName);
     } break;
     }
+    createMain(component, plugin);
 }
 
-void PluginManager::createModule(QQmlComponent *component)
+void PluginManager::createModule(QQmlComponent *component, PluginData *plugin)
 {
     if (isDeleting()) {
         return;
     }
-    PluginData *plugin = component->property("PluginData").value<PluginData *>();
     Q_EMIT updatePluginStatus(plugin, ModuleCreate, "create module");
     switch (component->status()) {
     case QQmlComponent::Ready: {
@@ -533,12 +530,11 @@ void PluginManager::createModule(QQmlComponent *component)
     }
 }
 
-void PluginManager::createMain(QQmlComponent *component)
+void PluginManager::createMain(QQmlComponent *component, PluginData *plugin)
 {
     if (isDeleting()) {
         return;
     }
-    PluginData *plugin = component->property("PluginData").value<PluginData *>();
     Q_EMIT updatePluginStatus(plugin, MainObjCreate, "create main");
     switch (component->status()) {
     case QQmlComponent::Ready: {
@@ -547,9 +543,11 @@ void PluginManager::createMain(QQmlComponent *component)
         QObject *object = component->create(context);
         component->deleteLater();
         if (!object) {
+            delete context;
             Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object is null:" + component->errorString());
             return;
         }
+        context->setParent(object);
         object->setParent(plugin->module ? plugin->module : m_rootModule);
         plugin->mainObj = qobject_cast<DccObject *>(object);
         Q_EMIT updatePluginStatus(plugin, MainObjEnd, ": create main finished");
@@ -601,22 +599,6 @@ void PluginManager::addMainObject(PluginData *plugin)
         Q_EMIT addObject(plugin->soObj);
     }
     Q_EMIT updatePluginStatus(plugin, MainObjEnd | PluginEnd, "add main object finished");
-}
-
-void PluginManager::moduleLoading()
-{
-    QQmlComponent *component = qobject_cast<QQmlComponent *>(sender());
-    if (!component || component->status() == QQmlComponent::Loading)
-        return;
-    createModule(component);
-}
-
-void PluginManager::mainLoading()
-{
-    QQmlComponent *component = qobject_cast<QQmlComponent *>(sender());
-    if (!component || component->status() == QQmlComponent::Loading)
-        return;
-    createMain(component);
 }
 
 void PluginManager::onModulePhaseFinished()

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -52,12 +52,9 @@ private Q_SLOTS:
     void loadModule(PluginData *plugin);
     void loadPluginData(PluginData *plugin);
     void loadMain(PluginData *plugin);
-    void createModule(QQmlComponent *component);
-    void createMain(QQmlComponent *component);
+    void createModule(QQmlComponent *component, PluginData *plugin);
+    void createMain(QQmlComponent *component, PluginData *plugin);
     void addMainObject(PluginData *plugin);
-
-    void moduleLoading();
-    void mainLoading();
 
     void onModulePhaseFinished();
     void onHideModuleChanged(const QSet<QString> &hideModule);


### PR DESCRIPTION
1. Remove asynchronous loading mode from QQmlComponent operations
2. Eliminate statusChanged signal connections and their handlers (moduleLoading/mainLoading)
3. Change loadUrl and loadFromModule calls from Asynchronous to synchronous mode
4. Directly invoke createModule/createMain after component loading instead of waiting for status signals
5. Modify createModule and createMain signatures to accept PluginData pointer directly instead of extracting from component property
6. Remove property-based plugin data storage on components, passing data explicitly as parameters
7. Simplify code flow by making loading and creation sequential rather than signal-driven

This change eliminates race conditions and complexity from async loading while making the code more straightforward and maintainable. The synchronous loading ensures component status is immediately available without waiting for signals.

Influence:
1. Test plugin loading with various plugin types (V1_0 and V1_1)
2. Verify module creation succeeds for all installed plugins
3. Test main object loading and creation flow
4. Check error handling when component loading fails
5. Verify plugin manager cleanup during destruction
6. Test with plugins that have missing or invalid QML files
7. Verify memory management of QQmlComponent objects

refactor: 简化插件加载流程，移除异步加载机制

1. 从 QQmlComponent 操作中移除异步加载模式
2. 删除 statusChanged 信号连接及其处理函数（moduleLoading/mainLoading）
3. 将 loadUrl 和 loadFromModule 调用从异步模式改为同步模式
4. 在组件加载后直接调用 createModule/createMain，不再等待状态信号
5. 修改 createModule 和 createMain 的函数签名，直接接受 PluginData 指针 而非从组件属性中提取
6. 移除组件上的属性存储方式，改为显式参数传递插件数据
7. 简化代码流程，使加载和创建变为顺序执行而非信号驱动

此变更消除了异步加载带来的竞态条件和复杂性，使代码更加简洁易维护。同步加
载确保组件状态立即可用，无需等待信号。

Influence:
1. 测试各类插件（V1_0 和 V1_1）的加载流程
2. 验证所有已安装插件的模块创建是否成功
3. 测试主对象加载和创建流程
4. 检查组件加载失败时的错误处理
5. 验证插件管理器在销毁时的清理行为
6. 测试缺失或无效 QML 文件的插件场景
7. 验证 QQmlComponent 对象的内存管理

## Summary by Sourcery

Refactor the plugin manager to load QML components synchronously and create plugin modules/main objects directly after loading instead of via statusChanged signals.

Enhancements:
- Switch plugin module and main QML loading from asynchronous to synchronous QQmlComponent operations.
- Pass PluginData explicitly into createModule and createMain instead of storing it on QQmlComponent properties.
- Remove statusChanged-based loading helpers and simplify the plugin loading flow to sequential function calls.