### PR TITLE
perf(wallpaper): optimize wallpaper thumbnail loading with QImageRead…

### DIFF
--- a/src/dde-control-center/plugin/dccimageprovider.cpp
+++ b/src/dde-control-center/plugin/dccimageprovider.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccimageprovider.h"
 
+#include <QImageReader>
 #include <QMetaObject>
 #include <QThread>
 #include <QThreadPool>
@@ -73,13 +74,25 @@ public:
         else
             path = url.toString();
 
-        QImage img;
-        if (!img.load(path)) {
+        QImageReader reader(path);
+        if (!reader.canRead()) {
             Q_EMIT imageLoaded(m_cacheKey, QImage());
             return;
         }
 
-        img = img.scaled(m_requestedSize, Qt::KeepAspectRatioByExpanding, Qt::SmoothTransformation);
+        const QSize nativeSize = reader.size();
+        if (nativeSize.isValid() && m_requestedSize.isValid()) {
+            QSize scaledSize = nativeSize.scaled(m_requestedSize, Qt::KeepAspectRatioByExpanding);
+            scaledSize = scaledSize.boundedTo(nativeSize);
+            reader.setScaledSize(scaledSize);
+        }
+
+        QImage img;
+        if (!reader.read(&img)) {
+            Q_EMIT imageLoaded(m_cacheKey, QImage());
+            return;
+        }
+
         if (img.width() > m_requestedSize.width() || img.height() > m_requestedSize.height()) {
             const QRect dest(QPoint(0, 0), m_requestedSize);
             const QRect src(img.rect().center() - dest.center(), m_requestedSize);

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -76,7 +76,8 @@ DccObject {
                     Image {
                         id: image
                         anchors.fill: parent
-                        source: dccData.model.wallpaperMap[dccData.model.currentSelectScreen]
+                        source: "image://DccImage/" + dccData.model.wallpaperMap[dccData.model.currentSelectScreen]
+                        sourceSize: Qt.size(197, 110)
                         mipmap: true
                         visible: false
                         fillMode: Image.PreserveAspectCrop


### PR DESCRIPTION
…er scaling

1. Use QImageReader::setScaledSize() to decode images at target size directly
2. Remove redundant full-image scaling after load, reducing memory usage
3. Add image validity check before processing to handle invalid files gracefully
4. Update WallpaperPage to use DccImage provider with proper sourceSize

Log: Optimize wallpaper thumbnail loading by scaling during decode instead of after

perf(wallpaper): 优化壁纸缩略图加载性能

1. 使用 QImageReader::setScaledSize() 在解码时直接缩放到目标尺寸
2. 移除加载后的全图缩放操作，减少内存占用
3. 添加图片有效性检查，优雅处理无效文件
4. 更新 WallpaperPage 使用 DccImage provider 并设置正确的 sourceSize

Log: 通过解码时缩放优化壁纸缩略图加载性能
PMS: BUG-358691

## Summary by Sourcery

Optimize wallpaper thumbnail loading by scaling images during decode and wiring QML wallpaper previews through the DccImage provider.

New Features:
- Support loading and scaling wallpapers via QImageReader with optional decode-time scaling based on requested size.

Bug Fixes:
- Handle unreadable or invalid image files gracefully by emitting an empty image instead of proceeding with processing.

Enhancements:
- Reduce memory usage and post-processing by removing redundant full-image scaling after load and relying on decode-time scaling.
- Update the wallpaper preview in WallpaperPage to use the DccImage image provider with an explicit thumbnail source size for consistent rendering.