### PR TITLE
feat: add event logger integration for control center

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,6 +178,17 @@ endif()
 find_package(GTest REQUIRED)
 find_package(Threads REQUIRED)
 
+# Check if dde-api eventlogger.hpp exists
+# Unset cache to force re-detection every time
+unset(DDE_API_EVENTLOGGER_INCLUDE_DIR CACHE)
+find_path(DDE_API_EVENTLOGGER_INCLUDE_DIR NAMES dde-api/eventlogger.hpp PATHS /usr/include)
+if(DDE_API_EVENTLOGGER_INCLUDE_DIR)
+    set(HAVE_DDE_API_EVENTLOGGER ON)
+    message(STATUS "Found dde-api eventlogger.hpp: ${DDE_API_EVENTLOGGER_INCLUDE_DIR}")
+else()
+    message(STATUS "dde-api eventlogger.hpp not found, event logging will be disabled")
+endif()
+
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "sw_64")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
 endif()

--- a/debian/control
+++ b/debian/control
@@ -51,7 +51,7 @@ Depends:
  qml6-module-qtquick-effects,
  libdtk6declarative(>> 6.7.36),
  netselect,
-Recommends: uos-license-content,
+Recommends: uos-license-content, dde-api(>>6.0.38),
 Conflicts: dde-control-center-dock
 Replaces: dde-control-center-dock
 Description: New control center for Deepin Desktop Environment,

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -69,6 +69,10 @@ target_link_libraries(${Control_Center_Name} PRIVATE
     ${Control_Center_Libraries}
 )
 
+if (HAVE_DDE_API_EVENTLOGGER)
+    target_compile_definitions(${Control_Center_Name} PRIVATE HAVE_DDE_API_EVENTLOGGER)
+endif()
+
 file(GLOB_RECURSE DCC_Translation_QML_FILES ${DCC_PROJECT_ROOT_DIR}/qml/*.qml ${DCC_PROJECT_ROOT_DIR}/src/*.qml)
 file(GLOB_RECURSE DCC_Translation_SOURCE_FILES ${DCC_PROJECT_ROOT_DIR}/src/*.cpp ${DCC_PROJECT_ROOT_DIR}/src/*.h)
 dcc_handle_plugin_translation(NAME ${Control_Center_Name} SOURCE_DIR ${DCC_PROJECT_ROOT_DIR} QML_FILES ${DCC_Translation_QML_FILES} SOURCE_FILES ${DCC_Translation_SOURCE_FILES})

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -32,6 +32,13 @@
 #include <QTranslator>
 #include <QWindow>
 
+#ifdef HAVE_DDE_API_EVENTLOGGER
+#include <dde-api/eventlogger.hpp>
+
+// Event ID for control center page stay (10-digit number)
+constexpr qint64 EVENT_LOGGER_CONTROL_CENTER_STAY = 1000600012;
+#endif
+
 DCORE_USE_NAMESPACE
 
 namespace dccV25 {
@@ -60,6 +67,9 @@ DccManager::DccManager(QObject *parent)
     , m_imageProvider(nullptr)
     , m_sidebarWidth(-1)
     , m_showTimer(nullptr)
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    , m_pageStayTimer(nullptr)
+#endif
 {
     m_hideObjects->setName("_hide");
     m_noAddObjects->setName("_noAdd");
@@ -74,6 +84,16 @@ DccManager::DccManager(QObject *parent)
     QJSEngine::setObjectOwnership(m_hideObjects, QQmlEngine::CppOwnership);
     QJSEngine::setObjectOwnership(m_noAddObjects, QQmlEngine::CppOwnership);
     QJSEngine::setObjectOwnership(m_noParentObjects, QQmlEngine::CppOwnership);
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    DDE_EventLogger::EventLogger::instance().init("org.deepin.dde.control-center", false);
+    qCInfo(dccLog) << "EventLogger initialized";
+
+    m_pageStayTimer = new QTimer(this);
+    m_pageStayTimer->setSingleShot(true);
+    m_pageStayTimer->setInterval(2000); // 2 seconds
+    connect(m_pageStayTimer, &QTimer::timeout, this, &DccManager::onPageStayTimeout);
+#endif
 
     initConfig();
     connect(m_plugins, &PluginManager::addObject, this, &DccManager::addObject);
@@ -899,6 +919,21 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     m_navModel->setNavigationObject(m_currentObjects);
     qCInfo(dccLog) << "trigger object:" << triggeredObj->name() << " active object:" << m_activeObject->name() << " parent:" << (void *)triggeredObj->parentItem();
 
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    // Reset and start page stay timer when page changes
+    if (m_pageStayTimer) {
+        m_pageStayTimer->stop();
+        // Build page tags directly from current objects
+        m_lastPageTags.clear();
+        for (auto *obj : m_currentObjects) {
+            if (obj != m_root) {
+                m_lastPageTags.append(obj->name());
+            }
+        }
+        m_pageStayTimer->start();
+    }
+#endif
+
     // 触发父项变更
     if (auto *parentItem = triggeredObj->parentItem(); !(triggeredObj->pageType() & DccObject::Menu) && parentItem) {
         Q_EMIT activeItemChanged(parentItem, indicatorShown);
@@ -1166,6 +1201,32 @@ void DccManager::doGetAllModule(const QDBusMessage message) const
     doc.setArray(arr);
     QString json = doc.toJson(QJsonDocument::Compact);
     QDBusConnection::sessionBus().send(message.createReply(json));
+}
+
+void DccManager::onPageStayTimeout()
+{
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    qCInfo(dccLog) << "onPageStayTimeout triggered, m_lastPageTags:" << m_lastPageTags;
+    if (m_lastPageTags.isEmpty()) {
+        qCWarning(dccLog) << "onPageStayTimeout: m_lastPageTags is empty, skipping log";
+        return;
+    }
+
+    // Build the tag list as JSON array string
+    QJsonArray tagArray;
+    for (const auto &tag : m_lastPageTags) {
+        tagArray.append(tag);
+    }
+    QJsonDocument doc;
+    doc.setArray(tagArray);
+    QString tagJson = doc.toJson(QJsonDocument::Compact);
+
+    // Log page tag event with format: {"control_center_tag": ["display", "displayMultipleDisplays"]}
+    DDE_EventLogger::EventLogger::instance().writeEventLog(
+        EVENT_LOGGER_CONTROL_CENTER_STAY, "control_center_tag", "control_center_tag", tagJson);
+
+    qCInfo(dccLog) << "EventLogger: page stay - tags:" << tagJson;
+#endif
 }
 
 } // namespace dccV25

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -118,6 +118,7 @@ private Q_SLOTS:
     void clearData();
     void waitLoadFinished() const;
     void doGetAllModule(const QDBusMessage message) const;
+    void onPageStayTimeout();
 
 private:
     DccObject *m_root;
@@ -145,6 +146,11 @@ private:
     QDBusMessage m_showMessage;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
+
+#ifdef HAVE_DDE_API_EVENTLOGGER
+    QTimer *m_pageStayTimer;
+    QStringList m_lastPageTags;
+#endif
 };
 } // namespace dccV25
 #endif // DCCMANAGER_H


### PR DESCRIPTION
Add EventLogger integration to log user page navigation behavior. When user stays on a page for 2 seconds, the page navigation path is logged with format: {"control_center_tag": ["display", "displayMultipleDisplays"]}.

The feature is optional and depends on dde-api eventlogger.hpp header. If the header is not found, the feature is disabled at compile time.

Log: 添加控制中心事件日志功能
PMS: TASK-388657