### PR TITLE
chore: update changelog to 6.1.82

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,27 @@
+dde-control-center (6.1.82) unstable; urgency=medium
+
+  * feat: add event logger integration for control center
+  * perf(wallpaper): optimize wallpaper thumbnail loading with
+    QImageReader scaling
+  * refactor: simplify plugin loading by removing async loading
+  * Revert "fix: use QQmlIncubator for asynchronous plugin object
+    creation"
+  * fix: Optimize the typesetting layout of open-source software
+    declarations
+  * feat(notification): add app notification search functionality
+  * fix(display): use screen dimensions instead of currentResolution for
+    Qt screen matching
+  * fix: use QQmlIncubator for asynchronous plugin object creation
+  * docs: update v25 dcc interface documentation
+  * i18n: Updates for project Deepin Desktop Environment (#3170)
+  * fix: prevent control center from not closing properly
+  * fix: Window size not correctly restored after maximisation
+  * fix: optimize page visibility management in DccWindow
+  * fix(datetime): add real-time display for timezone information
+  * i18n: Updates for project Deepin Desktop Environment (#3127)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 23 Apr 2026 21:46:05 +0800
+
 dde-control-center (6.1.81) unstable; urgency=medium
 
   * feat: improve DccRepeater parent object assignment


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.82

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.82
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh debian/changelog entries to document release 6.1.82.