### PR TITLE
fix: Optimize the logic for restoring default keyboard shortcuts

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -198,7 +198,7 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
 
     connect(m_shortcutModel, &ShortcutModel::delCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::addCustomInfo, sourceModel, &ShortcutListModel::reset);
-    connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::reset);
+    connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::onUpdateShortcut);
     connect(m_shortcutModel, &ShortcutModel::windowSwitchChanged, sourceModel, &ShortcutListModel::reset);
 
     m_shortcutSearchModel->setSourceModel(sourceModel);

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -75,9 +75,6 @@ void KeyboardWorker::resetAll() {
             qDebug() << Q_FUNC_INFO << reply->error();
         }
 
-        // reset 之后主动更新快捷键。。。
-        refreshShortcut();
-
         // Reset completed, restore flag and emit signal
         m_isResetting = false;
         Q_EMIT onResetFinished();

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -116,32 +116,32 @@ ShortcutModel::~ShortcutModel()
     m_searchList.clear();
 }
 
-QList<ShortcutInfo *> ShortcutModel::systemInfo() const
+const QList<ShortcutInfo *>& ShortcutModel::systemInfo() const
 {
     return m_systemInfos;
 }
 
-QList<ShortcutInfo *> ShortcutModel::windowInfo() const
+const QList<ShortcutInfo *>& ShortcutModel::windowInfo() const
 {
     return m_windowInfos;
 }
 
-QList<ShortcutInfo *> ShortcutModel::workspaceInfo() const
+const QList<ShortcutInfo *>& ShortcutModel::workspaceInfo() const
 {
     return m_workspaceInfos;
 }
 
-QList<ShortcutInfo *> ShortcutModel::assistiveToolsInfo() const
+const QList<ShortcutInfo *>& ShortcutModel::assistiveToolsInfo() const
 {
     return m_assistiveToolsInfos;
 }
 
-QList<ShortcutInfo *> ShortcutModel::customInfo() const
+const QList<ShortcutInfo *>& ShortcutModel::customInfo() const
 {
     return m_customInfos;
 }
 
-QList<ShortcutInfo *> ShortcutModel::infos() const
+const QList<ShortcutInfo *>& ShortcutModel::infos() const
 {
     return m_infos;
 }
@@ -412,7 +412,76 @@ void ShortcutModel::onWindowSwitchChanged(bool value)
      }
 
      return newList;
- }
+}
+
+int ShortcutModel::indexOfShortcut(ShortcutInfo *info)
+{
+    if (!info)
+        return -1;
+
+    int row = 0;
+    const QList<ShortcutInfo *> *targetList = nullptr;
+    do
+    {
+        static const QString sectionSystem = tr("System");
+        static const QString sectionWindow = tr("Window");
+        static const QString sectionWorkspace = tr("Workspace");
+        static const QString sectionAssistiveTools = tr("AssistiveTools");
+        static const QString sectionCustom = tr("Custom");
+        const QString &section = info->sectionName;
+
+        const auto& systemInfoList = systemInfo();
+        if (section == sectionSystem)
+        {
+            targetList = &systemInfoList;
+            break;
+        }
+        row += systemInfoList.size();
+
+        const auto& windowInfoList = windowInfo();
+        if (section == sectionWindow)
+        {
+            targetList = &windowInfoList;
+            break;
+        }
+        row += windowInfoList.size();
+
+        const auto& workspaceInfoList = workspaceInfo();
+        if (section == sectionWorkspace)
+        {
+            targetList = &workspaceInfoList;
+            break;
+        }
+        row += workspaceInfoList.size();
+
+        const auto& assistiveToolsInfoList = assistiveToolsInfo();
+        if (section == sectionAssistiveTools)
+        {
+            targetList = &assistiveToolsInfoList;
+            break;
+        }
+        row += assistiveToolsInfoList.size();
+
+        const auto& customInfoList = customInfo();
+        if (section == sectionCustom)
+        {
+            targetList = &customInfoList;
+            break;
+        }
+    } while (false);
+    
+    if (!targetList)
+        return -1;
+
+    int idx = targetList->indexOf(info);
+    if (idx >= 0)
+    {
+        row += idx;
+        return row;
+    }
+
+    return -1;
+}
 
 ShortcutInfo *ShortcutModel::currentInfo() const
 {
@@ -597,6 +666,19 @@ void ShortcutListModel::reset()
 {
     beginResetModel();
     endResetModel();
+}
+
+void ShortcutListModel::onUpdateShortcut(ShortcutInfo *info)
+{
+    if (!m_model || !info)
+        return;
+
+    int row = m_model->indexOfShortcut(info);
+    if (row >= 0)
+    {
+        QModelIndex modelIndex = index(row);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {Qt::DisplayRole, KeySequenceRole});
+    }
 }
 
 int ShortcutListModel::rowCount(const QModelIndex &) const

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -59,12 +59,12 @@ public:
         AssistiveTools,
     };
 
-    QList<ShortcutInfo *> systemInfo() const;
-    QList<ShortcutInfo *> windowInfo() const;
-    QList<ShortcutInfo *> workspaceInfo() const;
-    QList<ShortcutInfo *> assistiveToolsInfo() const;
-    QList<ShortcutInfo *> customInfo() const;
-    QList<ShortcutInfo *> infos() const;
+    const QList<ShortcutInfo *>& systemInfo() const;
+    const QList<ShortcutInfo *>& windowInfo() const;
+    const QList<ShortcutInfo *>& workspaceInfo() const;
+    const QList<ShortcutInfo *>& assistiveToolsInfo() const;
+    const QList<ShortcutInfo *>& customInfo() const;
+    const QList<ShortcutInfo *>& infos() const;
 
     inline int count()
     {
@@ -94,6 +94,8 @@ public:
     bool containsSystemShortcutName(const QString &name) const;
 
     static QStringList formatKeys(const QString &shortcut);
+    int indexOfShortcut(ShortcutInfo *info);
+
 Q_SIGNALS:
     void listChanged(QList<ShortcutInfo *>, InfoType);
     void addCustomInfo(ShortcutInfo *info);
@@ -131,6 +133,7 @@ private:
 
 class ShortcutListModel : public QAbstractListModel
 {
+    Q_OBJECT
 public:
     explicit ShortcutListModel(QObject *parent = nullptr);
 
@@ -150,11 +153,13 @@ public:
     void setSouceModel(ShortcutModel *model);
     ShortcutModel *souceModel();
 
-    void reset();
-
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
+
+public Q_SLOTS:
+    void reset();
+    void onUpdateShortcut(ShortcutInfo *info);
 
 private:
     ShortcutModel *m_model = nullptr;

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -163,6 +163,13 @@ DccObject {
                             showEditButtons: shortcutSettingsBody.isEditing && model.isCustom
                             showWarnning: model.accels.length > 0 && shortcutSettingsBody.conflictAccels === model.accels
 
+                            Connections{
+                                target: model
+                                function onKeySequenceChanged() {
+                                    edit.keys= model.keySequence
+                                }
+                            }
+
                             onRequestKeys: {
                                 if (shortcutView.editItem) {
                                     shortcutView.editItem.restore()


### PR DESCRIPTION
fix: Optimize the logic for restoring default keyboard shortcuts

每个快捷键更改都会reset整个数据源，导致界面中视图频繁刷新。修复方案是获取所修改快捷键在数据model中的QModelIndex，局部刷新视图

PMS: BUG-357571

## Summary by Sourcery

Optimize keyboard shortcut restoration to update only affected list items instead of reloading the entire shortcut list.

Bug Fixes:
- Prevent unnecessary full model resets when a single shortcut is changed, reducing UI flicker and improving shortcut editing responsiveness.

Enhancements:
- Expose const reference accessors for shortcut info lists to avoid redundant list copies.
- Add APIs to locate and update a specific shortcut entry in the list model, enabling targeted dataChanged signals.
- Synchronize the shortcut editor UI with key sequence changes via a QML connection instead of forcing a full refresh.