### PR TITLE
build: add dde-api-dev build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,7 +36,8 @@ Build-Depends:
  libwayland-dev,
  libssl-dev,
  libdde-shell-dev(>= 1.99.20),
- libdpkg-dev
+ libdpkg-dev,
+ dde-api-dev(>>6.0.38)
 Standards-Version: 4.5.0
 Homepage: https://github.com/linuxdeepin/dde-control-center
 
@@ -51,7 +52,7 @@ Depends:
  qml6-module-qtquick-effects,
  libdtk6declarative(>> 6.7.36),
  netselect,
-Recommends: uos-license-content, dde-api(>>6.0.38),
+Recommends: uos-license-content,
 Conflicts: dde-control-center-dock
 Replaces: dde-control-center-dock
 Description: New control center for Deepin Desktop Environment,


### PR DESCRIPTION
Add dde-api-dev(>>6.0.38) to Build-Depends in debian/control to ensure the required development headers are available during build.

build: 添加 dde-api-dev 构建依赖

在 debian/control 的 Build-Depends 中添加 dde-api-dev(>>6.0.38)， 确保构建时有必要的开发头文件。

PMS: TASK-388657

## Summary by Sourcery

Build:
- Declare dde-api-dev (>> 6.0.38) in debian/control Build-Depends to satisfy build-time header requirements.