### PR TITLE
chore: update changelog to 6.1.83

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-control-center (6.1.83) unstable; urgency=medium
+
+  * build: add dde-api-dev build dependency
+  * i18n: Updates for project Deepin Desktop Environment (#3179)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 24 Apr 2026 13:18:28 +0800
+
 dde-control-center (6.1.82) unstable; urgency=medium
 
   * feat: add event logger integration for control center


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.83

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.83
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog to version 6.1.83 for the master branch.