### PR TITLE
fix: Make the selected region visible when entering the Regional format pop-up window.

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -112,8 +112,7 @@ Loader {
 
                             Component.onCompleted: {
                             if (currentIndex >= 0 && currentIndex < count) {
-                                let delegateHeight = 40;
-                                contentY = currentIndex * delegateHeight;
+                                positionViewAtIndex(currentIndex, ListView.Contain);
 
                                 Qt.callLater(function() {
                                     if (currentItem && currentItem.model) {


### PR DESCRIPTION
fix: Make the selected region visible when entering the Regional format pop-up window.

根据固定的行高计算当前ListView的可视区域，无法自适应字号的改变。修复方案使用ListView的positionViewAtIndex方法将目标项滚动至顶部

PMS: BUG-357581

## Summary by Sourcery

Bug Fixes:
- Fix incorrect initial scroll offset in the Regional format selection list that failed to show the currently selected region when font size or item height changed.