### PR TITLE
feat: use multi-field event logger output

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -178,15 +178,13 @@ endif()
 find_package(GTest REQUIRED)
 find_package(Threads REQUIRED)
 
-# Check if dde-api eventlogger.hpp exists
-# Unset cache to force re-detection every time
-unset(DDE_API_EVENTLOGGER_INCLUDE_DIR CACHE)
-find_path(DDE_API_EVENTLOGGER_INCLUDE_DIR NAMES dde-api/eventlogger.hpp PATHS /usr/include)
-if(DDE_API_EVENTLOGGER_INCLUDE_DIR)
+# Check if dde-api provides EventLogger (header-only)
+find_package(DDEAPI QUIET)
+if(DDEAPI_FOUND)
     set(HAVE_DDE_API_EVENTLOGGER ON)
-    message(STATUS "Found dde-api eventlogger.hpp: ${DDE_API_EVENTLOGGER_INCLUDE_DIR}")
+    message(STATUS "Found DDEAPI: EventLogger available")
 else()
-    message(STATUS "dde-api eventlogger.hpp not found, event logging will be disabled")
+    message(STATUS "DDEAPI not found, event logging will be disabled")
 endif()
 
 if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "sw_64")

--- a/debian/control
+++ b/debian/control
@@ -37,7 +37,7 @@ Build-Depends:
  libssl-dev,
  libdde-shell-dev(>= 1.99.20),
  libdpkg-dev,
- dde-api-dev(>>6.0.38)
+ dde-api-dev (>> 6.0.39)
 Standards-Version: 4.5.0
 Homepage: https://github.com/linuxdeepin/dde-control-center
 

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -71,6 +71,7 @@ target_link_libraries(${Control_Center_Name} PRIVATE
 
 if (HAVE_DDE_API_EVENTLOGGER)
     target_compile_definitions(${Control_Center_Name} PRIVATE HAVE_DDE_API_EVENTLOGGER)
+    target_link_libraries(${Control_Center_Name} PRIVATE DDEAPI::EventLogger)
 endif()
 
 file(GLOB_RECURSE DCC_Translation_QML_FILES ${DCC_PROJECT_ROOT_DIR}/qml/*.qml ${DCC_PROJECT_ROOT_DIR}/src/*.qml)

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -87,7 +87,6 @@ DccManager::DccManager(QObject *parent)
     QJSEngine::setObjectOwnership(m_noParentObjects, QQmlEngine::CppOwnership);
 
 #ifdef HAVE_DDE_API_EVENTLOGGER
-    DDE_EventLogger::EventLogger::instance().init("org.deepin.dde.control-center", false);
     qCInfo(dccLog) << "EventLogger initialized";
 
     m_pageStayTimer = new QTimer(this);
@@ -1237,20 +1236,17 @@ void DccManager::onPageStayTimeout()
         return;
     }
 
-    // Build the tag list as JSON array string
     QJsonArray tagArray;
     for (const auto &tag : m_lastPageTags) {
         tagArray.append(tag);
     }
-    QJsonDocument doc;
-    doc.setArray(tagArray);
-    QString tagJson = doc.toJson(QJsonDocument::Compact);
 
-    // Log page tag event with format: {"control_center_tag": ["display", "displayMultipleDisplays"]}
     DDE_EventLogger::EventLogger::instance().writeEventLog(
-        EVENT_LOGGER_CONTROL_CENTER_STAY, "control_center_tag", "control_center_tag", tagJson);
+        DDE_EventLogger::EventLoggerData(EVENT_LOGGER_CONTROL_CENTER_STAY, "control_center_config", {
+            {"control_center_tag", tagArray}
+        }));
 
-    qCInfo(dccLog) << "EventLogger: page stay - tags:" << tagJson;
+    qCInfo(dccLog) << "EventLogger: page stay - tags:" << QJsonDocument(tagArray).toJson(QJsonDocument::Compact);
 #endif
 }
 


### PR DESCRIPTION
Update control center event logging to use multi-field output and normalize the dde-api-dev packaging dependency declaration. Keep the control center event reporting and build dependency configuration aligned.

feat: 使用多字段事件日志输出

将控制中心事件日志更新为多字段输出，并规范 dde-api-dev 的打包依赖声明格式。
保持控制中心事件上报与构建依赖配置的一致性。

PMS: TASK-388657

## Summary by Sourcery

Update control center page stay event logging to use the multi-field event logger format and align the Debian packaging dependency declaration for dde-api-dev.

New Features:
- Switch control center page stay events to the multi-field EventLoggerData format for structured tag reporting.

Build:
- Normalize the dde-api-dev dependency declaration format in Debian packaging metadata to stay consistent with build requirements.