### PR TITLE
fix: add tooltips to automatically elided text

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -264,11 +264,10 @@ Loader {
                                     Layout.fillWidth: true
                                     Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
                                     Layout.rightMargin: 10
-                                    contentItem: Label {
+                                    contentItem: DccLabel {
                                         width: parent.width
                                         horizontalAlignment: Text.AlignRight
                                         text: repeater.getValue(index)
-                                        elide: Text.ElideRight
                                     }
                                 }
                             }


### PR DESCRIPTION
Change Label to DccLabel, to add tooltips to automatically elided text

给区域格式弹窗中自动省略的长文本增加鼠标悬浮提示

Log: 修复区域格式弹窗中文案省略时无悬浮提示的问题
PMS: BUG-357575
Influence: 区域格式弹框中长日期、长时间等内容过长自动省略时，增加tooltips提示

## Summary by Sourcery

Bug Fixes:
- Ensure long, auto-elided text in the region format dialog shows a tooltip on hover.