### PR TITLE
fix: fix activeTimer crash in control center

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -67,6 +67,7 @@ DccManager::DccManager(QObject *parent)
     , m_imageProvider(nullptr)
     , m_sidebarWidth(-1)
     , m_showTimer(nullptr)
+    , m_showFallbackTimer(nullptr)
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -97,10 +98,15 @@ DccManager::DccManager(QObject *parent)
 
     initConfig();
     connect(m_plugins, &PluginManager::addObject, this, &DccManager::addObject);
-    connect(m_plugins, &PluginManager::loadAllFinished, this, &DccManager::tryShow, Qt::QueuedConnection);
+    connect(m_plugins, &PluginManager::loadAllFinished, this, &DccManager::handleShowReady, Qt::QueuedConnection);
     m_showTimer = new QTimer(this);
+    m_showTimer->setInterval(60);
+    m_showTimer->setSingleShot(true);
     connect(m_showTimer, &QTimer::timeout, this, &DccManager::tryShow);
-    m_showTimer->start(5000); // 防止插件卡死不显示界面
+    m_showFallbackTimer = new QTimer(this);
+    m_showFallbackTimer->setSingleShot(true);
+    connect(m_showFallbackTimer, &QTimer::timeout, this, &DccManager::tryShowFallback);
+    m_showFallbackTimer->start(5000); // 防止插件卡死不显示界面
 }
 
 DccManager::~DccManager()
@@ -749,89 +755,116 @@ void DccManager::handleScreenAdded(QScreen *screen)
     m_window->requestActivate();
 }
 
+QString DccManager::parseShowPageUrl(const QString &url, QString &cmd) const
+{
+    const int i = url.indexOf('?');
+    cmd = i != -1 ? url.mid(i + 1) : QString();
+    return url.mid(0, i).split('/', Qt::SkipEmptyParts).join('/'); // 移除多余的/
+}
+
+void DccManager::replyShowPageRequest(const QString &url, const QDBusMessage &message, bool found) const
+{
+    if (message.type() == QDBusMessage::InvalidMessage) {
+        return;
+    }
+
+    if (found) {
+        QDBusConnection::sessionBus().send(message.createReply());
+    } else {
+        QDBusConnection::sessionBus().send(message.createErrorReply(QDBusError::InvalidArgs, QString("not found url:") + url));
+    }
+}
+
+void DccManager::startPendingShow(const QString &url, const QDBusMessage &message)
+{
+    m_showUrl = url;
+    m_showMessage = message;
+    m_showTimer->start();
+}
+
 void DccManager::waitShowPage(const QString &url, const QDBusMessage message)
 {
     qCInfo(dccLog()) << "show page:" << url;
     clearShowParam();
+    m_showFallbackTimer->stop();
     if (m_plugins->isDeleting()) {
         return;
     }
+
     DccObject *obj = nullptr;
     QString cmd;
     if (url.isEmpty()) {
         obj = m_root;
-        DccManager::showPage(obj, QString());
+        showPage(obj, QString());
     } else {
-        int i = url.indexOf('?');
-        cmd = i != -1 ? url.mid(i + 1) : QString();
-        QString path = url.mid(0, i).split('/', Qt::SkipEmptyParts).join('/'); // 移除多余的/
-        auto objs = findObjects(path, true);
+        const QString path = parseShowPageUrl(url, cmd);
+        const auto objs = findObjects(path, true);
         obj = objs.isEmpty() ? nullptr : objs.first();
         if (obj) {
-            DccManager::showPage(obj, cmd);
+            showPage(obj, cmd);
         } else if (!m_plugins->loadFinished()) {
-            m_showUrl = url;
-            m_showMessage = message;
-            if (!m_showTimer) {
-                m_showTimer = new QTimer(this);
-                connect(m_showTimer, &QTimer::timeout, this, &DccManager::tryShow);
-            }
-            m_showTimer->start(50);
+            startPendingShow(url, message);
             return;
         }
     }
-    if (message.type() != QDBusMessage::InvalidMessage) {
-        if (obj) {
-            QDBusConnection::sessionBus().send(message.createReply());
-        } else {
-            QDBusConnection::sessionBus().send(message.createErrorReply(QDBusError::InvalidArgs, QString("not found url:") + url));
-        }
-    }
+
+    replyShowPageRequest(url, message, obj);
 }
 
 void DccManager::clearShowParam()
 {
-    if (m_showTimer) {
-        m_showTimer->stop();
-        m_showTimer->deleteLater();
-        m_showTimer = nullptr;
-    }
+    m_showTimer->stop();
     if (!m_showUrl.isEmpty()) {
         m_showUrl.clear();
         m_showMessage = QDBusMessage();
     }
 }
 
+void DccManager::handleShowReady()
+{
+    if (!m_showUrl.isEmpty()) {
+        tryShow();
+    } else if (m_showFallbackTimer->isActive() && !m_activeObject) {
+        tryShowFallback();
+    }
+}
+
 void DccManager::tryShow()
 {
-    if (m_showUrl.isEmpty() && m_showTimer) {
-        clearShowParam();
-        showPage(m_root, QString());
-        return;
-    }
     if (m_showUrl.isEmpty()) {
-        clearShowParam();
         return;
     }
-    int i = m_showUrl.indexOf('?');
-    QString cmd = i != -1 ? m_showUrl.mid(i + 1) : QString();
-    QString path = m_showUrl.mid(0, i).split('/', Qt::SkipEmptyParts).join('/'); // 移除多余的/
+
+    QString cmd;
+    const QString path = parseShowPageUrl(m_showUrl, cmd);
     DccObject *obj = findObject(path);
     if (obj) {
+        const QString url = m_showUrl;
+        const QDBusMessage message = m_showMessage;
+        clearShowParam();
         showPage(obj, cmd);
-        if (m_showMessage.type() != QDBusMessage::InvalidMessage) {
-            QDBusConnection::sessionBus().send(m_showMessage.createReply());
-        }
-        clearShowParam();
+        replyShowPageRequest(url, message, true);
     } else if (m_plugins->loadFinished()) {
-        if (m_showMessage.type() != QDBusMessage::InvalidMessage) {
-            QDBusConnection::sessionBus().send(m_showMessage.createErrorReply(QDBusError::InvalidArgs, QString("not found url:") + m_showUrl));
-        }
+        const QString url = m_showUrl;
+        const QDBusMessage message = m_showMessage;
         clearShowParam();
+        replyShowPageRequest(url, message, false);
         if (!m_activeObject) {
             showPage(m_root, QString());
         }
+    } else if (!m_plugins->isDeleting()) {
+        m_showTimer->start();
     }
+}
+
+void DccManager::tryShowFallback()
+{
+    if (m_plugins->isDeleting() || !m_showUrl.isEmpty() || m_activeObject) {
+        return;
+    }
+
+    m_showFallbackTimer->stop();
+    showPage(m_root, QString());
 }
 
 void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
@@ -839,6 +872,7 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     if (m_plugins->isDeleting() || !obj) {
         return;
     }
+    m_showFallbackTimer->stop();
     qCInfo(dccLog) << "ShowPage:" << obj << " have cmd:" << !cmd.isEmpty();
     // 禁用首页
     if (obj == m_root) {

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -100,13 +100,18 @@ private:
     const DccObject *findParent(const DccObject *obj);
     bool eventFilter(QObject *watched, QEvent *event) override;
     bool isIndicatorShown(const QString &cmd) const;
+    QString parseShowPageUrl(const QString &url, QString &cmd) const;
+    void replyShowPageRequest(const QString &url, const QDBusMessage &message, bool found) const;
+    void startPendingShow(const QString &url, const QDBusMessage &message);
 
 private Q_SLOTS:
     void saveSize();
     void handleScreenAdded(QScreen *screen);
     void waitShowPage(const QString &url, const QDBusMessage message);
     void clearShowParam();
+    void handleShowReady();
     void tryShow();
+    void tryShowFallback();
     void doShowPage(QPointer<DccObject> obj, const QString &cmd);
     void updateModuleConfig(const QString &key);
     void onVisible(bool visible);
@@ -142,6 +147,7 @@ private:
     int m_sidebarWidth;
     // DBus调用时，对应项还没加载完成，此处保存跳转参数
     QTimer *m_showTimer;
+    QTimer *m_showFallbackTimer;
     QString m_showUrl;
     QDBusMessage m_showMessage;
 

--- a/src/plugin-personalization/operation/x11worker.cpp
+++ b/src/plugin-personalization/operation/x11worker.cpp
@@ -100,8 +100,8 @@ void X11Worker::setMovedWindowOpacity(bool value)
         m_personalizationDBusProxy->unloadEffect(EffectMoveWindowArg);
     }
 
-    //设置kwin接口后, 等待50ms给kwin反应，根据isEffectLoaded返回值确定真实状态
-    QTimer::singleShot(50, [this] {
+    //设置kwin接口后, 等待55ms给kwin反应，根据isEffectLoaded返回值确定真实状态
+    QTimer::singleShot(55, this, [this] {
         bool isLoaded =  m_personalizationDBusProxy->isEffectLoaded(EffectMoveWindowArg);
         qCDebug(DdcPersonnalizationX11Worker) << "Moved window switch WM, load effect translucency: " << isLoaded;
         m_model->setIsMoveWindow(isLoaded);


### PR DESCRIPTION
Fix the crash issue caused by improper timer management in DccManager.
The original code deleted and recreated m_showTimer in clearShowParam()
and waitShowPage(), causing dangling pointer issues and potential
crashes with activeTimers. Changed m_showTimer to be created once with
setSingleShot(true) in the constructor, using stop/start instead of
delete/recreate. Also fixed timer lambda capture in x11worker to include
proper context.

Log: Fixed control center crash due to activeTimer issues

Influence:
1. Test control center startup to ensure no crash
2. Verify page display timeout mechanism works correctly
3. Test plugin loading scenarios and tryShow() behavior
4. Verify clearShowParam() doesn't cause timer issues
5. Test waitShowPage() with different plugin load states
6. Test personalization module Move Window feature

fix: 修复控制中心activeTimer导致的崩溃问题

修复DccManager中定时器管理不当导致的崩溃问题。原代码在clearShowParam()
和waitShowPage()中删除并重新创建m_showTimer，导致野指针问题和activeTimer
相关的潜在崩溃。改为在构造函数中一次性创建并设置setSingleShot(true)的定
时器，使用stop/start替代删除/重建操作。同时修复了x11worker中的lambda捕获
问题。

Log: 修复控制中心activeTimer崩溃问题

Influence:
1. 测试控制中心启动，确保不会崩溃
2. 验证页面显示超时机制正常工作
3. 测试各种插件加载场景和tryShow()行为
4. 验证clearShowParam()不会引起定时器问题
5. 测试waitShowPage()在不同插件加载状态下的表现
6. 测试个性化模块的窗口移动功能

PMS: BUG-353781

## Summary by Sourcery

Stabilize control center page display timing and fix timer-related crashes.

Bug Fixes:
- Prevent crashes by managing DccManager's show timer as a single-shot instance that is stopped and restarted instead of deleted and recreated.
- Avoid dangling timer callbacks in the personalization X11 worker by associating the single-shot timer with the QObject context.