### PR TITLE
fix: fix the issue of slow default recovery of system shortcut keys

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -198,7 +198,7 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
 
     connect(m_shortcutModel, &ShortcutModel::delCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::addCustomInfo, sourceModel, &ShortcutListModel::reset);
-    connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::reset);
+    connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::onUpdateShortcut);
     connect(m_shortcutModel, &ShortcutModel::windowSwitchChanged, sourceModel, &ShortcutListModel::reset);
 
     m_shortcutSearchModel->setSourceModel(sourceModel);

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -75,9 +75,6 @@ void KeyboardWorker::resetAll() {
             qDebug() << Q_FUNC_INFO << reply->error();
         }
 
-        // reset 之后主动更新快捷键。。。
-        refreshShortcut();
-
         // Reset completed, restore flag and emit signal
         m_isResetting = false;
         Q_EMIT onResetFinished();

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -412,7 +412,36 @@ void ShortcutModel::onWindowSwitchChanged(bool value)
      }
 
      return newList;
- }
+}
+
+int ShortcutModel::indexOfShortcut(ShortcutInfo *info)
+{
+    if (!info)
+        return -1;
+
+    static const QStringList sections = {
+        tr("System"), tr("Window"), tr("Workspace"), 
+        tr("AssistiveTools"), tr("Custom")
+    };
+
+    const QList<ShortcutInfo *> lists[] = {
+        m_systemInfos, m_windowInfos, m_workspaceInfos,
+        m_assistiveToolsInfos, m_customInfos
+    };
+
+    int row = 0;
+    for (int i = 0; i < 5; i++)
+    {
+        if (info->sectionName == sections[i])
+        {
+            int idx = lists[i].indexOf(info);
+            return idx >= 0 ? row + idx : -1;
+        }
+        row += lists[i].size();
+    }
+
+    return -1;
+}
 
 ShortcutInfo *ShortcutModel::currentInfo() const
 {
@@ -597,6 +626,19 @@ void ShortcutListModel::reset()
 {
     beginResetModel();
     endResetModel();
+}
+
+void ShortcutListModel::onUpdateShortcut(ShortcutInfo *info)
+{
+    if (!m_model || !info)
+        return;
+
+    int row = m_model->indexOfShortcut(info);
+    if (row >= 0)
+    {
+        QModelIndex modelIndex = index(row);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {Qt::DisplayRole, KeySequenceRole});
+    }
 }
 
 int ShortcutListModel::rowCount(const QModelIndex &) const

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -94,6 +94,8 @@ public:
     bool containsSystemShortcutName(const QString &name) const;
 
     static QStringList formatKeys(const QString &shortcut);
+    int indexOfShortcut(ShortcutInfo *info);
+
 Q_SIGNALS:
     void listChanged(QList<ShortcutInfo *>, InfoType);
     void addCustomInfo(ShortcutInfo *info);
@@ -131,6 +133,7 @@ private:
 
 class ShortcutListModel : public QAbstractListModel
 {
+    Q_OBJECT
 public:
     explicit ShortcutListModel(QObject *parent = nullptr);
 
@@ -150,11 +153,13 @@ public:
     void setSouceModel(ShortcutModel *model);
     ShortcutModel *souceModel();
 
-    void reset();
-
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
+
+public Q_SLOTS:
+    void reset();
+    void onUpdateShortcut(ShortcutInfo *info);
 
 private:
     ShortcutModel *m_model = nullptr;

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -163,6 +163,13 @@ DccObject {
                             showEditButtons: shortcutSettingsBody.isEditing && model.isCustom
                             showWarnning: model.accels.length > 0 && shortcutSettingsBody.conflictAccels === model.accels
 
+                            Connections{
+                                target: model
+                                function onKeySequenceChanged() {
+                                    edit.keys= model.keySequence
+                                }
+                            }
+
                             onRequestKeys: {
                                 if (shortcutView.editItem) {
                                     shortcutView.editItem.restore()


### PR DESCRIPTION
Avoid frequent resetting of the data model and change to local refreshing of the ListView

避免频繁重置model刷新整个ListView,修改为局部刷新

Log: 优化多个系统快捷键同时恢复默认时性能较慢的问题
PMS: BUG-357571
Influence: 1. 可正常修改快捷键；2. 多个系统快捷键同时恢复默认，能正确恢复默认且响应时间正常

## Summary by Sourcery

Optimize shortcut key reset handling to avoid full list resets and improve performance when restoring multiple system shortcuts to default.

Bug Fixes:
- Ensure shortcut list updates only the affected item instead of resetting the entire ListView when a shortcut changes.
- Fix slow response when restoring multiple system shortcut keys to their default values.

Enhancements:
- Expose a model method to locate shortcut indices and a corresponding list-model slot for targeted data updates.
- Update QML bindings so edited shortcut key sequences stay in sync with model changes.