### PR TITLE
fix: fix the issue of slow default recovery of system shortcut keys

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -198,7 +198,7 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
 
     connect(m_shortcutModel, &ShortcutModel::delCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::addCustomInfo, sourceModel, &ShortcutListModel::reset);
-    connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::reset);
+    connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::onUpdateShortcut);
     connect(m_shortcutModel, &ShortcutModel::windowSwitchChanged, sourceModel, &ShortcutListModel::reset);
 
     m_shortcutSearchModel->setSourceModel(sourceModel);

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -74,9 +74,6 @@ void KeyboardWorker::resetAll() {
         if (reply->isError()) {
             qDebug() << Q_FUNC_INFO << reply->error();
         }
-
-        // reset 之后主动更新快捷键。。。
-        refreshShortcut();
 
         // Reset completed, restore flag and emit signal
         m_isResetting = false;

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -412,7 +412,28 @@ void ShortcutModel::onWindowSwitchChanged(bool value)
      }
 
      return newList;
- }
+}
+
+int ShortcutModel::indexOfShortcut(ShortcutInfo *info)
+{
+    if (!info)
+        return -1;
+
+    const QList<ShortcutInfo*> *lists[] = {
+        &m_systemInfos, &m_windowInfos, &m_workspaceInfos,
+        &m_assistiveToolsInfos, &m_customInfos
+    };
+
+    int row = 0;
+    for (const auto *list : lists) {
+        const int idx = list->indexOf(info);
+        if (idx >= 0)
+            return row + idx;
+        row += list->size();
+    }
+
+    return -1;
+}
 
 ShortcutInfo *ShortcutModel::currentInfo() const
 {
@@ -597,6 +618,19 @@ void ShortcutListModel::reset()
 {
     beginResetModel();
     endResetModel();
+}
+
+void ShortcutListModel::onUpdateShortcut(ShortcutInfo *info)
+{
+    if (!m_model || !info)
+        return;
+
+    int row = m_model->indexOfShortcut(info);
+    if (row >= 0)
+    {
+        QModelIndex modelIndex = index(row);
+        Q_EMIT dataChanged(modelIndex, modelIndex, {Qt::DisplayRole, KeySequenceRole});
+    }
 }
 
 int ShortcutListModel::rowCount(const QModelIndex &) const

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -94,6 +94,8 @@ public:
     bool containsSystemShortcutName(const QString &name) const;
 
     static QStringList formatKeys(const QString &shortcut);
+    int indexOfShortcut(ShortcutInfo *info);
+
 Q_SIGNALS:
     void listChanged(QList<ShortcutInfo *>, InfoType);
     void addCustomInfo(ShortcutInfo *info);
@@ -131,6 +133,7 @@ private:
 
 class ShortcutListModel : public QAbstractListModel
 {
+    Q_OBJECT
 public:
     explicit ShortcutListModel(QObject *parent = nullptr);
 
@@ -150,11 +153,13 @@ public:
     void setSouceModel(ShortcutModel *model);
     ShortcutModel *souceModel();
 
-    void reset();
-
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
     QHash<int, QByteArray> roleNames() const override;
+
+public Q_SLOTS:
+    void reset();
+    void onUpdateShortcut(ShortcutInfo *info);
 
 private:
     ShortcutModel *m_model = nullptr;

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -163,6 +163,13 @@ DccObject {
                             showEditButtons: shortcutSettingsBody.isEditing && model.isCustom
                             showWarnning: model.accels.length > 0 && shortcutSettingsBody.conflictAccels === model.accels
 
+                            Connections{
+                                target: model
+                                function onKeySequenceChanged() {
+                                    edit.keys= model.keySequence
+                                }
+                            }
+
                             onRequestKeys: {
                                 if (shortcutView.editItem) {
                                     shortcutView.editItem.restore()


### PR DESCRIPTION
Avoid frequent resetting of the data model and change to local refreshing of the ListView

避免频繁重置model刷新整个ListView,修改为局部刷新

Log: 优化多个系统快捷键同时恢复默认时性能较慢的问题
PMS: BUG-357571
Influence: 1. 可正常修改快捷键；2. 多个系统快捷键同时恢复默认，能正确恢复默认且响应时间正常

## Summary by Sourcery

Optimize shortcut key reset handling to update only affected shortcuts instead of resetting the entire list, improving performance when restoring defaults.

Bug Fixes:
- Ensure shortcut list and QML editor reflect updated key sequences correctly when individual shortcuts change.
- Fix slow response when multiple system shortcuts are restored to defaults by avoiding full model refreshes.

Enhancements:
- Introduce per-shortcut update support in the list model and wire it to shortcut change notifications instead of global resets.