### PR TITLE
fix: Optimize the issue of slow entry into the Bluetooth interface

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
@@ -54,7 +54,7 @@ Rectangle {
 
                 content: Rectangle {
                     width: parent.width
-                    implicitHeight: Math.max(50, status.implicitHeight + 10)
+                    implicitHeight: Math.max(50, deviceRow.statusItem.implicitHeight + 10)
                     color: "transparent"
                     MouseArea {
                         anchors.fill: parent
@@ -68,14 +68,15 @@ Rectangle {
                     }
 
                     RowLayout {
+                        id: deviceRow
+                        property alias statusItem: status
                         width: parent.width
                         anchors.fill: parent
-                        Layout.fillWidth: true
-                        Layout.fillHeight: true
 
                         ColumnLayout {
                             id: status
                             Layout.fillHeight: true
+                            Layout.fillWidth: true
                             spacing: 0
                             Layout.leftMargin: 10
                             implicitHeight: Math.max(myDeviceName.implicitHeight, loader.implicitHeight) + 10
@@ -131,32 +132,40 @@ Rectangle {
                             }
                         }
 
-                        D.LineEdit {
-                            id: nameEdit
-                            visible: false
-                            text: model.name
+                        Loader {
+                            id: nameEditLoader
+                            active: false
+                            visible: active
                             Layout.fillWidth: true
                             Layout.fillHeight: true
                             Layout.topMargin: 10
                             Layout.bottomMargin: 10
 
-                            onEditingFinished: {
-                                nameEdit.visible = false
-                                status.visible = true
-                                itemCtl.hoverEnabled = true
+                            sourceComponent: D.LineEdit {
+                                id: nameEdit
+                                text: model.name
 
-                                console.log("set device name ", model.id, nameEdit.text)
-                                dccData.work().setDeviceAlias(model.id, nameEdit.text)
+                                onEditingFinished: {
+                                    nameEditLoader.active = false
+                                    deviceRow.statusItem.visible = true
+                                    itemCtl.hoverEnabled = true
 
-                            }
-                            onVisibleChanged: {
-                                if (visible) {
-                                    text = model.name
+                                    console.log("set device name ", model.id, nameEdit.text)
+                                    dccData.work().setDeviceAlias(model.id, nameEdit.text)
                                 }
-                            }
-                            Keys.onPressed: function(event) {
-                                if (event.key === Qt.Key_Return) {
-                                    nameEdit.forceActiveFocus(false); // 结束编辑
+                                onVisibleChanged: {
+                                    if (visible) {
+                                        text = model.name
+                                    }
+                                }
+                                Keys.onPressed: function(event) {
+                                    if (event.key === Qt.Key_Return) {
+                                        nameEdit.forceActiveFocus(false); // 结束编辑
+                                    }
+                                }
+                                Component.onCompleted: {
+                                    nameEdit.forceActiveFocus(true)
+                                    nameEdit.selectAll()
                                 }
                             }
                         }
@@ -193,135 +202,130 @@ Rectangle {
                                 }
                             }
 
-                            D.ActionButton {
-                                id: moreBtn
-                                palette.windowText: D.ColorSelector.textColor
-                                visible: showMoreBtn
+                            Loader {
+                                active: showMoreBtn
                                 Layout.alignment: Qt.AlignRight
-                                icon.name: "bluetooth_option"
-                                icon.width: 16
-                                icon.height: 16
 
-                                implicitHeight: 30
-                                implicitWidth: 30
+                                sourceComponent: D.ActionButton {
+                                    id: moreBtn
+                                    palette.windowText: D.ColorSelector.textColor
+                                    icon.name: "bluetooth_option"
+                                    icon.width: 16
+                                    icon.height: 16
+                                    implicitHeight: 30
+                                    implicitWidth: 30
+                                    flat: !hovered
 
-                                flat: !hovered
+                                    property bool menuShown: false
 
-                                property bool menuShown: false
-
-                                background: Rectangle {
-                                    property D.Palette pressedColor: D.Palette {
-                                        normal: Qt.rgba(0, 0, 0, 0.2)
-                                        normalDark: Qt.rgba(1, 1, 1, 0.25)
+                                    background: Rectangle {
+                                        property D.Palette pressedColor: D.Palette {
+                                            normal: Qt.rgba(0, 0, 0, 0.2)
+                                            normalDark: Qt.rgba(1, 1, 1, 0.25)
+                                        }
+                                        property D.Palette hoveredColor: D.Palette {
+                                            normal: Qt.rgba(0, 0, 0, 0.1)
+                                            normalDark: Qt.rgba(1, 1, 1, 0.1)
+                                        }
+                                        radius: DS.Style.control.radius
+                                        color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                                        border {
+                                            color: parent.palette.highlight
+                                            width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                        }
                                     }
-                                    property D.Palette hoveredColor: D.Palette {
-                                        normal: Qt.rgba(0, 0, 0, 0.1)
-                                        normalDark: Qt.rgba(1, 1, 1, 0.1)
-                                    }
-                                    radius: DS.Style.control.radius
-                                    color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
-                                    border {
-                                        color: parent.palette.highlight
-                                        width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
-                                    }
-                                }
 
-                                D.Menu {
-                                    id: contextMenu
-                                    implicitWidth: 150
+                                    D.Menu {
+                                        id: contextMenu
+                                        implicitWidth: 150
 
-                                    D.MenuItem {
-                                        id: connectDev
-                                        padding: 0
-                                        text: model.connectStatus === 2 ? qsTr("Disconnect") : qsTr("Connect")
-                                        enabled: model.connectStatus === 2 || model.connectStatus === 0
-                                        onTriggered: {
-                                            if (model.connectStatus === 2) {
-                                                dccData.work().disconnectDevice(model.id)
-                                            } else {
-                                                dccData.work().connectDevice(model.id, model.adapterId)
+                                        D.MenuItem {
+                                            id: connectDev
+                                            padding: 0
+                                            text: model.connectStatus === 2 ? qsTr("Disconnect") : qsTr("Connect")
+                                            enabled: model.connectStatus === 2 || model.connectStatus === 0
+                                            onTriggered: {
+                                                if (model.connectStatus === 2) {
+                                                    dccData.work().disconnectDevice(model.id)
+                                                } else {
+                                                    dccData.work().connectDevice(model.id, model.adapterId)
+                                                }
+                                            }
+                                        }
+                                        D.MenuItem {
+                                            id: sendFile
+                                            padding: 0
+                                            text: qsTr("Send Files")
+                                            visible: itemCtl.showSendFile
+                                            height : sendFile.visible ? implicitHeight : 0
+                                            topPadding: sendFile.visible ? undefined : 0
+                                            bottomPadding: sendFile.visible ? undefined : 0
+
+                                            onTriggered: {
+                                                fileDlg.open()
+                                            }
+
+                                        }
+
+                                        D.MenuItem {
+                                            id: rename
+                                            text: qsTr("Rename")
+                                            padding: 0
+                                            onTriggered: {
+                                                nameEditLoader.active = true
+                                                deviceRow.statusItem.visible = false
+                                                itemCtl.hoverEnabled = false
+                                            }
+                                        }
+
+                                        D.MenuSeparator {
+                                        }
+
+                                        D.MenuItem {
+                                            id: removeDev
+                                            text: qsTr("Remove Device")
+                                            enabled: model.connectStatus === 2 || model.connectStatus === 0
+                                            padding: 0
+                                            onTriggered: {
+                                                dccData.work().ignoreDevice(model.id, model.adapterId)
                                             }
                                         }
                                     }
-                                    D.MenuItem {
-                                        id: sendFile
-                                        padding: 0
-                                        text: qsTr("Send Files")
-                                        visible: itemCtl.showSendFile
-                                        height : sendFile.visible ? implicitHeight : 0
-                                        topPadding: sendFile.visible ? undefined : 0
-                                        bottomPadding: sendFile.visible ? undefined : 0
 
-                                        onTriggered: {
-                                            fileDlg.open()
-                                        }
-
-                                    }
-
-                                    D.MenuItem {
-                                        id: rename
-                                        text: qsTr("Rename")
-                                        padding: 0
-                                        onTriggered: {
-                                            nameEdit.visible = true
-
-                                            status.visible = false
-                                            itemCtl.hoverEnabled = false
-
-                                            nameEdit.forceActiveFocus(true)
-                                            nameEdit.selectAll()
+                                    FileDialog {
+                                        id: fileDlg
+                                        title: qsTr("Select file")
+                                        fileMode: FileDialog.OpenFiles
+                                        folder: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
+                                        onAccepted: {
+                                            console.log(" Select file : ", fileDlg.files)
+                                            dccData.work().showBluetoothTransDialog(model.address, fileDlg.files)
                                         }
                                     }
 
-                                    D.MenuSeparator {
-                                    }
-
-                                    D.MenuItem {
-                                        id: removeDev
-                                        text: qsTr("Remove Device")
-                                        enabled: model.connectStatus === 2 || model.connectStatus === 0
-                                        padding: 0
-                                        onTriggered: {
-                                            dccData.work().ignoreDevice(model.id, model.adapterId)
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        hoverEnabled: true
+                                        onEntered: {
+                                            moreBtn.menuShown = contextMenu.visible
                                         }
-                                    }
-                                }
-
-                                FileDialog {
-                                    id: fileDlg
-                                    title: qsTr("Select file")
-                                    fileMode: FileDialog.OpenFiles
-                                    folder: StandardPaths.writableLocation(StandardPaths.DocumentsLocation)
-                                    onAccepted: {
-                                        console.log(" Select file : ", fileDlg.files)
-                                        dccData.work().showBluetoothTransDialog(model.address, fileDlg.files)
-
-                                    }
-                                }
-
-                                MouseArea {
-                                    anchors.fill: parent
-                                    hoverEnabled: true
-                                    onEntered: {
-                                        moreBtn.menuShown = contextMenu.visible
-                                    }
-                                    onClicked: {
-                                        console.log(" contextMenu 单击事件 ");
-                                        if (moreBtn.menuShown) {
-                                            moreBtn.menuShown = false
-                                            return
+                                        onClicked: {
+                                            console.log(" contextMenu 单击事件 ");
+                                            if (moreBtn.menuShown) {
+                                                moreBtn.menuShown = false
+                                                return
+                                            }
+                                            // 在点击位置下方显示菜单
+                                            // 获取按钮的全局位置，确保菜单在按钮的正下方显示
+                                            var buttonGlobalX = moreBtn.x + moreBtn.width / 2 - contextMenu.width
+                                            var buttonGlobalY = moreBtn.y + moreBtn.height + 5
+                                            contextMenu.popup(buttonGlobalX, buttonGlobalY)
+                                            moreBtn.menuShown = true
                                         }
-                                        // 在点击位置下方显示菜单
-                                        // 获取按钮的全局位置，确保菜单在按钮的正下方显示
-                                        var buttonGlobalX = moreBtn.x + moreBtn.width / 2 - contextMenu.width
-                                        var buttonGlobalY = moreBtn.y + moreBtn.height + 5
-                                        contextMenu.popup(buttonGlobalX, buttonGlobalY)
-                                        moreBtn.menuShown = true
                                     }
                                 }
                             }
                         }
-
                     }
                 }
             }

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -20,7 +20,7 @@ DccObject{
                 // 初始化状态记录
                 lastPoweredState = model.powered
                 if (model.powered && !model.discovering) {
-                    deferDiscoverTimer.restart()
+                    dccData.work().setAdapterDiscoverable(model.id)
                 }
            }
         }
@@ -52,17 +52,6 @@ DccObject{
         repeat: false
         onTriggered: {
             if (model.powered && refreshEnable && !model.discovering) {
-                dccData.work().setAdapterDiscoverable(model.id)
-            }
-        }
-    }
-
-    Timer {
-        id: deferDiscoverTimer
-        interval: 300
-        repeat: false
-        onTriggered: {
-            if (model.powered && !model.discovering) {
                 dccData.work().setAdapterDiscoverable(model.id)
             }
         }
@@ -126,11 +115,8 @@ DccObject{
         }
 
         Component.onCompleted: {
-            if (typeof DccApp !== 'undefined' && DccApp.activeObject && DccApp.activeObject.name === "bluetooth") {
-                if (model.powered && !model.discovering) {
-                    deferDiscoverTimer.restart()
-                }
-            }
+            console.log(" blueToothSwitch  checked changed")
+            dccData.work().setAdapterDiscoverable(model.id)
         }
     }
 
@@ -154,10 +140,19 @@ DccObject{
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: BlueToothDeviceListView {
+            id: deviceListView
             showMoreBtn: false
             showConnectStatus: false
             showPowerStatus: false
-            deviceModel: model.otherDevice
+
+            Timer {
+                interval: 300
+                repeat: false
+                running: true
+                onTriggered: {
+                    deviceListView.deviceModel = model.otherDevice
+                }
+            }
 
             onClicked: function (index, checked) {
             }


### PR DESCRIPTION
Other Bluetooth devices have more data and have initialized unnecessary controls. Optimization plan:
1. Add Timer and delay setting data model;
2. Use Loader to delay initialization of required controls;

其他蓝牙设备的数据较多，且初始化了一些不需要的控件。优化方案：
1. 添加Timer，延迟设置其他设备的数据model；
2. 使用Loader， 延迟初始化需要的控件；

Log: 优化进入蓝牙界面较慢的问题
PMS: BUG-312521
Influence: 1. 可正常进入控制中心-设备-蓝牙界面；2. 进入蓝牙界面，响应速度正常；3.可正常刷新其他设备数据；4.已连接设备的UI效果正常；

Revert "fix: Fix the Bluetooth interface opening slowly"

This reverts commit 4f9f7f81fbc583e2ea8f0e0a92bdf2c667c2d4c9.

## Summary by Sourcery

Optimize Bluetooth device list initialization and other-device discovery behavior to improve responsiveness when opening the Bluetooth interface.

Bug Fixes:
- Resolve delayed responsiveness when entering the Bluetooth interface by deferring heavy control initialization and device model binding.

Enhancements:
- Lazy-load the device rename editor and context action button in the Bluetooth device list to avoid unnecessary control creation.
- Adjust Bluetooth device item layout to compute row height from the status column and ensure proper width filling.
- Simplify other-device discovery handling by removing the extra defer timer and triggering discovery directly on state changes and initialization.
- Delay binding of the other-device list model via a short timer to stagger data setup for other Bluetooth devices.

Chores:
- Update Bluetooth device list view file copyright years to 2024 - 2026.