### PR TITLE
fix: Modify the translation of the 'Confirm' button in the 'Date and time setting' window

### DIFF
--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -1187,7 +1187,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Confirm</source>
-        <translation>确认</translation>
+        <translation>确定</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -1184,7 +1184,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Confirm</source>
-        <translation>確認</translation>
+        <translation>確定</translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -1184,7 +1184,7 @@ UnionTech Software Technology Co., Ltd. is committed to research and improve the
     </message>
     <message>
         <source>Confirm</source>
-        <translation>確認</translation>
+        <translation>確定</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
Log: 修改日期和时间设置弹窗的确认按钮的中繁文案
PMS: BUG-358583
Influence: 日期和时间设置弹窗的确认按钮的中繁文案是否正确

## Summary by Sourcery

Bug Fixes:
- Correct the Confirm button label in the date and time settings dialog for Simplified and Traditional Chinese translations.