### PR TITLE
fix: adjust the layout of the custom Repeat time control

### DIFF
--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -298,9 +298,14 @@ DccObject {
             parentName: "power/general/shutdownGroup"
             visible: (dccData.model.scheduledShutdownState && dccData.model.shutdownRepetition === 3)
             weight: 4
-            pageType: DccObject.Editor
+            pageType: DccObject.Item
             page: RowLayout {
-                Label {
+                DccLabel {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 40
+                    Layout.leftMargin: 14
+                    horizontalAlignment: Text.AlignRight
+                    verticalAlignment: Text.AlignVCenter
                     text: {
                         var str = ""
                         var days = dccData.model.customShutdownWeekDays
@@ -314,6 +319,7 @@ DccObject {
                     }
                 }
                 D.ToolButton {
+                    Layout.rightMargin: 8
                     icon.name: "action_edit"
                     icon.width: 12
                     icon.height: 12


### PR DESCRIPTION
1. Limit the width of the layout to the available width of the DccEditorItem
2. Adjust the sub Label control to DccLabel, which will automatically elide and align right

1. 限制所在布局的宽度为对应DccEditorItem的可用宽度
2. 调整子Label控件为DccLabel，超出宽度后自动省略，并使文本居右显示

Log: 调整定时关机的自定义重复时间的布局
PMS: BUG-359013
Influence: 调整字号、窗口大小，自定义重复时间的文案可在宽度不够时自动省略，且右侧修改按钮不溢出布局

## Summary by Sourcery

Adjust the custom shutdown repeat time editor layout to respect the available editor width and improve label behavior.

Bug Fixes:
- Prevent the custom repeat time text from overflowing its layout when font size or window size changes.

Enhancements:
- Use a right-aligned, eliding label for the custom repeat time text so long content is truncated gracefully within the available space.