### PR TITLE
refactor: split PluginManager into DccPluginLoader and DccPluginManager

### DIFF
--- a/src/dde-control-center/controlcenterdbusadaptor.cpp
+++ b/src/dde-control-center/controlcenterdbusadaptor.cpp
@@ -1,9 +1,10 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "controlcenterdbusadaptor.h"
 
 #include "dccmanager.h"
+#include "dccobject_p.h"
 
 #include <QCoreApplication>
 #include <QDBusConnection>
@@ -17,8 +18,6 @@
 #include <QWindow>
 
 using namespace dccV25;
-static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.DBusAdaptor");
-
 const QString DBusProperties = "org.freedesktop.DBus.Properties";
 const QString DBusPropertiesChanged = "PropertiesChanged";
 

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -42,7 +42,6 @@ constexpr qint64 EVENT_LOGGER_CONTROL_CENTER_STAY = 1000600012;
 DCORE_USE_NAMESPACE
 
 namespace dccV25 {
-static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.manager");
 
 const QString WidthConfig = QStringLiteral("width");
 const QString HeightConfig = QStringLiteral("height");
@@ -58,7 +57,7 @@ DccManager::DccManager(QObject *parent)
     , m_hideObjects(new DccObject(this))
     , m_noAddObjects(new DccObject(this))
     , m_noParentObjects(new DccObject(this))
-    , m_plugins(new PluginManager(this))
+    , m_plugins(new DccPluginManager(this))
     , m_window(nullptr)
     , m_dconfig(DConfig::create("org.deepin.dde.control-center", "org.deepin.dde.control-center", QString(), this))
     , m_engine(nullptr)
@@ -96,8 +95,8 @@ DccManager::DccManager(QObject *parent)
 #endif
 
     initConfig();
-    connect(m_plugins, &PluginManager::addObject, this, &DccManager::addObject);
-    connect(m_plugins, &PluginManager::loadAllFinished, this, &DccManager::handleShowReady, Qt::QueuedConnection);
+    connect(m_plugins, &DccPluginManager::addObject, this, &DccManager::addObject);
+    connect(m_plugins, &DccPluginManager::loadAllFinished, this, &DccManager::handleShowReady, Qt::QueuedConnection);
     m_showTimer = new QTimer(this);
     m_showTimer->setInterval(60);
     m_showTimer->setSingleShot(true);
@@ -379,7 +378,7 @@ QString DccManager::searchProxy(const QString &json) const
             setDelayedReply(true);
             QObject::connect(
                     m_plugins,
-                    &PluginManager::loadAllFinished,
+                    &DccPluginManager::loadAllFinished,
                     this,
                     [this, json, message]() {
                         const auto &ret = this->search(json);
@@ -1165,11 +1164,9 @@ void DccManager::clearData()
 #ifdef DCC_ENABLE_MEMORY_MANAGEMENT
     // TODO: delete m_engine会有概率崩溃
     m_window = nullptr;
-    qCDebug(dccLog()) << "delete root begin";
     DccObject *root = m_root;
     m_root = nullptr;
     Q_EMIT rootChanged(m_root);
-    qCDebug(dccLog()) << "delete root end";
 
     qCDebug(dccLog()) << "delete clearData hide:" << m_hideObjects->getChildren().size() << "noAdd:" << m_noAddObjects->getChildren().size() << "noParent" << m_noParentObjects->getChildren().size();
     delete m_noParentObjects;
@@ -1180,7 +1177,9 @@ void DccManager::clearData()
     delete m_engine;
     qCDebug(dccLog()) << "clear QmlEngine";
     m_engine = nullptr;
+    qCDebug(dccLog()) << "delete root begin";
     delete root;
+    qCDebug(dccLog()) << "delete root end";
 #endif
 }
 
@@ -1190,7 +1189,7 @@ void DccManager::waitLoadFinished() const
         QEventLoop loop;
         QTimer timer;
         connect(&timer, &QTimer::timeout, &loop, &QEventLoop::quit);
-        connect(m_plugins, &PluginManager::loadAllFinished, &loop, &QEventLoop::quit);
+        connect(m_plugins, &DccPluginManager::loadAllFinished, &loop, &QEventLoop::quit);
         timer.start(5000);
         loop.exec();
     }

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -23,7 +23,7 @@ QT_END_NAMESPACE
 namespace dccV25 {
 class NavigationModel;
 class SearchModel;
-class PluginManager;
+class DccPluginManager;
 class DccImageProvider;
 
 class DccManager : public DccApp, protected QDBusContext
@@ -135,7 +135,7 @@ private:
     QVector<DccObject *> m_currentObjects;   // 当前显示的页面路径，从根页面到当前页面
     QVector<DccObject *> m_triggeredObjects; // 用户交互触发的对象路径，从根菜单到当前子控件
 
-    PluginManager *m_plugins;
+    DccPluginManager *m_plugins;
     QPointer<QWindow> m_window;
     Dtk::Core::DConfig *m_dconfig;
     QSet<QString> m_hideModule;

--- a/src/dde-control-center/dccpluginloader.cpp
+++ b/src/dde-control-center/dccpluginloader.cpp
@@ -1,0 +1,458 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dccpluginloader.h"
+
+#include "dccfactory.h"
+#include "dccmanager.h"
+#include "dccobject.h"
+#include "dccobject_p.h"
+#include "pluginmanager.h"
+
+#include <DIconTheme>
+
+#include <QDebug>
+#include <QDir>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QPluginLoader>
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QThread>
+
+namespace dccV25 {
+
+DccPluginLoader::DccPluginLoader(const QString &name, const QString &path, DccPluginManager *manager)
+    : QObject(manager)
+    , m_path(path)
+    , m_status(PluginBegin)
+    , m_type(T_Unknown)
+    , m_factory(nullptr)
+    , m_module(nullptr)
+    , m_mainObj(nullptr)
+    , m_soObj(nullptr)
+    , m_data(nullptr)
+    , m_pManager(manager)
+{
+    setObjectName(name);
+}
+
+DccPluginLoader::~DccPluginLoader()
+{
+    if (m_data) {
+        qCDebug(dccLog) << "delete so data" << name();
+        delete m_data;
+        m_data = nullptr;
+    }
+}
+
+QString DccPluginLoader::path() const
+{
+    return m_path;
+}
+
+DccPluginLoader::StatusFlags DccPluginLoader::status() const
+{
+    return m_status.load();
+}
+
+DccPluginLoader::TypeFlags DccPluginLoader::type() const
+{
+    return m_type;
+}
+
+DccObject *DccPluginLoader::module() const
+{
+    return m_module;
+}
+
+DccObject *DccPluginLoader::mainObj() const
+{
+    return m_mainObj;
+}
+
+DccObject *DccPluginLoader::soObj() const
+{
+    return m_soObj;
+}
+
+QObject *DccPluginLoader::data() const
+{
+    return m_data;
+}
+
+DccFactory *DccPluginLoader::factory() const
+{
+    return m_factory;
+}
+
+void DccPluginLoader::setLog(const QString &log)
+{
+    m_log.append(log);
+}
+
+bool DccPluginLoader::isFinished() const
+{
+    return m_status.load() & PluginEnd;
+}
+
+bool DccPluginLoader::hasError() const
+{
+    return m_status.load() & PluginErrMask;
+}
+
+bool DccPluginLoader::isVisibleToApp() const
+{
+    return !m_module || m_module->isVisibleToApp();
+}
+
+void DccPluginLoader::setType(TypeFlags type)
+{
+    m_type = type;
+}
+
+void DccPluginLoader::transitionStatus(StatusFlags status)
+{
+    StatusFlags oldStatus = m_status;
+    m_status = m_status.load() | status;
+    const static QMetaEnum statusFlagsMeta = QMetaEnum::fromType<StatusFlags>();
+    QString statusName = statusFlagsMeta.valueToKeys(status);
+    if (status & PluginErrMask) {
+        qCWarning(dccLog) << name() << ": status" << QString::number(m_status.load(), 16) << statusName << m_log.join("\n");
+    } else if (m_log.isEmpty()) {
+        qCDebug(dccLog) << name() << ": status" << QString::number(m_status.load(), 16) << statusName;
+    } else {
+        qCDebug(dccLog) << name() << ": status" << QString::number(m_status.load(), 16) << statusName << m_log.join("\n");
+    }
+    m_log.clear();
+    if (oldStatus != m_status) {
+        Q_EMIT statusChanged(this, status);
+    }
+}
+
+void DccPluginLoader::updateVisible(bool visibleToApp)
+{
+    if (!visibleToApp) {
+        return;
+    }
+    if ((m_status.load() & PluginEnd) && (!(m_status.load() & (DataEnd | DataErr)))) {
+        // 加载完成，没检查MetaData也没错误，不在hideModule中，则需要重新加载
+        StatusFlags status = m_status.load() & ~PluginEnd;
+        m_status = PluginBegin;
+        transitionStatus(status);
+    }
+}
+
+bool DccPluginLoader::updateType()
+{
+    QString qrcPath;
+    switch (m_type & T_V_MASK) {
+    case T_V1_1: {
+        if (QFile::exists(m_path + "/qmldir")) {
+            m_type |= T_HasModule | T_HasMain;
+            qrcPath = ":/qt/qml/" + name();
+            QQmlEngine *engine = m_pManager->engine();
+            if (engine) {
+                auto paths = engine->importPathList();
+                QDir pluginDir(m_path);
+                pluginDir.cdUp();
+                QString qmlPlugin = pluginDir.absolutePath();
+                if (!paths.contains(qmlPlugin)) {
+                    engine->addImportPath(qmlPlugin);
+                }
+            }
+        }
+    } break;
+    case T_V1_0: {
+        QDir dir(m_path);
+        if (dir.exists("main.qml")) {
+            m_type |= T_ShortMain | T_HasMain;
+        } else if (dir.exists(name() + "Main.qml")) {
+            m_type |= T_HasMain;
+        }
+        if (dir.exists(name() + ".qml")) {
+            m_type |= T_HasModule;
+        }
+        qrcPath = m_path;
+    } break;
+    default: {
+        // Try to determine version
+        m_type = T_V1_1;
+        if (updateType()) {
+            return true;
+        }
+        m_type = T_V1_0;
+        if (updateType()) {
+            return true;
+        }
+        m_type = T_Unknown;
+        return false;
+    } break;
+    }
+
+    if (m_type & T_DataMask) {
+        QStringList paths = Dtk::Gui::DIconTheme::dciThemeSearchPaths();
+        paths.append(qrcPath);
+        Dtk::Gui::DIconTheme::setDciThemeSearchPaths(paths);
+        return true;
+    }
+    return false;
+}
+
+bool DccPluginLoader::loadMetaData()
+{
+    if (!updateType()) {
+        return false;
+    }
+
+    // Install translator for this plugin
+    DccManager::installTranslator(name());
+
+    // Skip hidden modules (this should be checked by the caller)
+    if (m_pManager->hidden(name())) {
+        setLog("module is hidden");
+        return false;
+    }
+    return true;
+}
+
+bool DccPluginLoader::loadModule()
+{
+    if (!(m_type & T_HasModule)) {
+        setLog("module qml not exists");
+        return true;
+    }
+
+    QQmlComponent component(m_pManager->engine());
+    switch (version()) {
+    case T_V1_0: {
+        const QString qmlPath = m_path + "/" + name() + ".qml";
+        setLog("create module " + qmlPath);
+        component.loadUrl(qmlPath);
+    } break;
+    case T_V1_1:
+    default: {
+        QString typeName = name();
+        typeName[0] = typeName[0].toUpper();
+        setLog("create module " + typeName);
+        component.loadFromModule(name(), typeName);
+    } break;
+    }
+    transitionStatus(ModuleCreate);
+    switch (component.status()) {
+    case QQmlComponent::Ready: {
+        QObject *object = component.create();
+        if (!object) {
+            setLog("component create module object is null:" + component.errorString());
+            return true;
+        }
+        object->setParent(m_pManager->rootModule());
+        m_module = qobject_cast<DccObject *>(object);
+        connect(m_module, &DccObject::visibleToAppChanged, this, &DccPluginLoader::updateVisible);
+        if (m_module && !m_module->isVisibleToApp()) {
+            setLog("create module finished, module is hidden");
+            return false;
+        }
+    } break;
+    case QQmlComponent::Error: {
+        setLog("component create module object error:" + component.errorString());
+        transitionStatus(ModuleErr);
+    } break;
+    default:
+        break;
+    }
+    return true;
+}
+
+void DccPluginLoader::loadData()
+{
+    if (m_factory) {
+        return;
+    }
+
+    const QString soPath = m_path + "/" + name() + ".so";
+    if (!QFile::exists(soPath)) {
+        return;
+    }
+
+    QPluginLoader loader(soPath);
+    if (!loader.load()) {
+        setLog("prepare factory load failed:" + loader.errorString());
+        transitionStatus(DataErr);
+        return;
+    }
+
+    const auto &meta = loader.metaData();
+    const auto iid = meta["IID"].toString();
+    if (iid.isEmpty() || iid != QString(qobject_interface_iid<DccFactory *>())) {
+        setLog("prepare factory iid error:" + iid);
+        transitionStatus(DataErr);
+        loader.unload();
+        return;
+    }
+
+    QObject *instance = loader.instance();
+    if (!instance) {
+        setLog("prepare factory instance failed:" + loader.errorString());
+        transitionStatus(DataErr);
+        loader.unload();
+        return;
+    }
+
+    DccFactory *factory = qobject_cast<DccFactory *>(instance);
+    if (!factory) {
+        setLog("prepare factory cast failed.");
+        transitionStatus(DataErr);
+        loader.unload();
+        return;
+    }
+
+    m_factory = factory;
+}
+
+void DccPluginLoader::createData()
+{
+    if (!m_factory) {
+        setLog(": create data skipped");
+        transitionStatus(DataErr);
+        return;
+    }
+    m_data = m_factory->create();
+}
+
+void DccPluginLoader::createDccObject()
+{
+    if (m_factory) {
+        m_soObj = m_factory->dccObject();
+    }
+}
+
+void DccPluginLoader::moveThread()
+{
+    QThread *thread = this->thread();
+    if (m_factory && m_factory->thread() != thread) {
+        m_factory->moveToThread(thread);
+    }
+    if (m_data && m_data->thread() != thread) {
+        m_data->moveToThread(thread);
+    }
+    if (m_soObj && m_soObj->thread() != thread) {
+        m_soObj->moveToThread(thread);
+    }
+}
+
+void DccPluginLoader::updateParent()
+{
+    if (m_data && m_data->parent() != this) {
+        m_data->setParent(this);
+    }
+    if (m_soObj && m_soObj->parent() != this) {
+        m_soObj->setParent(this);
+    }
+}
+
+void DccPluginLoader::loadMain()
+{
+    if (!(m_type & T_HasMain)) {
+        setLog("main qml not exists");
+        transitionStatus(MainObjErr);
+        return;
+    }
+
+    QQmlComponent component(m_pManager->engine());
+    switch (version()) {
+    case T_V1_0: {
+        const QString qmlPath = m_path + "/" + ((m_type & T_ShortMain) ? "main.qml" : name() + "Main.qml");
+        setLog("create Main " + qmlPath);
+        component.loadUrl(qmlPath);
+    } break;
+    case T_V1_1:
+    default: {
+        QString typeName = name() + "Main";
+        typeName[0] = typeName[0].toUpper();
+        setLog("create Main " + typeName);
+        component.loadFromModule(name(), typeName);
+    } break;
+    }
+    transitionStatus(MainObjCreate);
+
+    switch (component.status()) {
+    case QQmlComponent::Ready: {
+        QQmlContext *context = new QQmlContext(component.engine());
+        context->setContextProperties({ { "dccData", QVariant::fromValue(m_data) }, { "dccModule", QVariant::fromValue(m_module) } });
+        QObject *object = component.create(context);
+        if (!object) {
+            delete context;
+            setLog(" component create main object is null:" + component.errorString());
+            transitionStatus(MainObjErr);
+            return;
+        }
+        context->setParent(object); // Context will be deleted when object is deleted
+        object->setParent(m_module ? m_module : m_pManager->rootModule());
+        m_mainObj = qobject_cast<DccObject *>(object);
+    } break;
+    case QQmlComponent::Error: {
+        setLog(" component create main object error:" + component.errorString());
+        transitionStatus(MainObjErr);
+    } break;
+    default:
+        break;
+    }
+}
+
+void DccPluginLoader::addMainObject()
+{
+    transitionStatus(MainObjAdd);
+
+    if (!m_mainObj) {
+        m_mainObj = m_soObj;
+    }
+
+    if (m_mainObj) {
+        if (m_mainObj->name().isEmpty() || (m_module && m_mainObj->name() == m_module->name())) {
+            // Plugin root item name is empty, associate with {name}.qml, don't add to tree
+            if (m_module) {
+                QQmlComponent *page = m_mainObj->page();
+                if (page) {
+                    m_module->setPage(page);
+                }
+                connect(m_mainObj, &DccObject::pageChanged, m_module, &DccObject::setPage);
+                connect(m_mainObj, &DccObject::displayNameChanged, m_module, &DccObject::setDisplayName);
+                connect(m_mainObj, &DccObject::descriptionChanged, m_module, &DccObject::setDescription);
+                connect(m_mainObj, &DccObject::iconChanged, m_module, &DccObject::setIcon);
+                connect(m_mainObj, &DccObject::badgeChanged, m_module, &DccObject::setBadge);
+                connect(m_mainObj, &DccObject::visibleChanged, m_module, &DccObject::setVisible);
+                connect(m_mainObj, &DccObject::active, m_module, &DccObject::active);
+                connect(m_mainObj, &DccObject::deactive, m_module, &DccObject::deactive);
+            }
+        }
+    } else {
+        setLog("The plugin isn't main DccObject");
+        transitionStatus(MainObjErr);
+    }
+}
+
+void DccPluginLoader::cancel()
+{
+    setLog("cancelled");
+    transitionStatus(PluginEnd);
+}
+
+void DccPluginLoader::reset()
+{
+    // Reset status to begin state
+    m_status = PluginBegin;
+    m_module = nullptr;
+    m_mainObj = nullptr;
+    m_soObj = nullptr;
+    m_data = nullptr;
+    // Don't reset factory - it can be reused
+}
+
+uint DccPluginLoader::version() const
+{
+    return m_type & T_V_MASK;
+}
+
+} // namespace dccV25

--- a/src/dde-control-center/dccpluginloader.h
+++ b/src/dde-control-center/dccpluginloader.h
@@ -1,0 +1,135 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QObject>
+#include <QQmlEngine>
+#include <QString>
+
+namespace dccV25 {
+
+class DccObject;
+class DccFactory;
+class DccPluginManager;
+
+class DccPluginLoader : public QObject
+{
+    Q_OBJECT
+
+public:
+    // Status bit flags for state machine
+    enum Status {
+        // metaData 0xFF000000
+        PluginBegin = 0x10000000,
+        PluginEnd = 0x20000000,
+        MetaDataLoad = 0x02000000,
+        MetaDataEnd = 0x04000000,
+        MetaDataErr = 0x08000000,
+        // module 0x00FF0000
+        ModuleLoad = 0x00010000,
+        ModuleCreate = 0x00020000,
+        ModuleEnd = 0x00400000,
+        ModuleErr = 0x00800000,
+        // data 0x0000FF00
+        DataBegin = 0x00000100,
+        DataLoad = 0x00000200,
+        DataEnd = 0x00004000,
+        DataErr = 0x00008000,
+        // mainObj 0x000000FF
+        MainObjLoad = 0x00000001,
+        MainObjCreate = 0x00000002,
+        MainObjAdd = 0x00000004,
+        MainObjEnd = 0x00000040,
+        MainObjErr = 0x00000080,
+
+        PluginErrMask = MetaDataErr | ModuleErr | DataErr | MainObjErr,
+        PluginEndMask = PluginEnd | MetaDataEnd | ModuleEnd | DataEnd | MainObjEnd,
+    };
+    Q_DECLARE_FLAGS(StatusFlags, Status)
+    Q_FLAG(StatusFlags)
+
+    // Plugin version and capabilities
+    enum Type {
+        T_Unknown = 0,
+        T_V1_0 = 0x01000000,
+        T_V1_1 = 0x02000000,
+        T_V_MASK = 0xFF000000,
+
+        T_HasModule = 0x00000001,
+        T_HasMain = 0x00000002,
+        T_DataMask = 0x00000003,
+        T_ShortMain = 0x00000004, // main module named main.qml
+    };
+    Q_DECLARE_FLAGS(TypeFlags, Type)
+    Q_FLAG(TypeFlags)
+
+    explicit DccPluginLoader(const QString &name, const QString &path, DccPluginManager *manager);
+    ~DccPluginLoader() override;
+
+    // Properties
+    inline QString name() const { return objectName(); };
+
+    QString path() const;
+    StatusFlags status() const;
+    TypeFlags type() const;
+    DccObject *module() const;
+    DccObject *mainObj() const;
+    DccObject *soObj() const;
+    QObject *data() const;
+    DccFactory *factory() const;
+    void setLog(const QString &log);
+    // State query methods
+    bool isFinished() const;
+    bool hasError() const;
+    bool isVisibleToApp() const;
+
+    // Dependency injection
+    void setType(TypeFlags type);
+
+    // Loading methods
+    void reset(); // Reset status and restart loading
+    bool loadMetaData();
+    bool loadModule();
+    void loadData(); // For async loading in worker thread
+    void createData();
+    void createDccObject();
+    void moveThread();
+    void updateParent();
+    void loadMain();
+    void addMainObject();
+    void cancel();
+
+    // Utility
+    uint version() const;
+    void transitionStatus(StatusFlags status);
+
+private:
+    // Private helper methods
+    bool updateType();
+
+public Q_SLOTS:
+    void updateVisible(bool visibleToApp);
+
+Q_SIGNALS:
+    void statusChanged(DccPluginLoader *loader, StatusFlags status);
+
+private:
+    QString m_path;
+    std::atomic<StatusFlags> m_status;
+    TypeFlags m_type;
+    DccFactory *m_factory;
+    DccObject *m_module;
+    DccObject *m_mainObj;
+    DccObject *m_soObj;
+    QObject *m_data;
+
+    DccPluginManager *m_pManager;
+    QStringList m_log;
+};
+
+} // namespace dccV25
+
+Q_DECLARE_METATYPE(dccV25::DccPluginLoader *)
+Q_DECLARE_OPERATORS_FOR_FLAGS(dccV25::DccPluginLoader::StatusFlags)
+Q_DECLARE_OPERATORS_FOR_FLAGS(dccV25::DccPluginLoader::TypeFlags)

--- a/src/dde-control-center/navigationmodel.cpp
+++ b/src/dde-control-center/navigationmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "navigationmodel.h"
@@ -8,7 +8,6 @@
 #include <QLoggingCategory>
 
 namespace dccV25 {
-// static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.NavigationModel");
 
 enum NavType {
     Separator,

--- a/src/dde-control-center/plugin/dccmodel.cpp
+++ b/src/dde-control-center/plugin/dccmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccmodel.h"
@@ -10,7 +10,6 @@
 #include <QLoggingCategory>
 
 namespace dccV25 {
-// static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.model");
 
 enum DccModelRole {
     DccItemRole = Qt::UserRole + 300,
@@ -99,7 +98,6 @@ QModelIndex DccModel::index(const DccObject *object)
 
 QModelIndex DccModel::index(int row, int column, const QModelIndex &parentIndex) const
 {
-    // qWarning() << __FUNCTION__ << __LINE__ << row << column << parentIndex;
     if (row < 0 || row >= m_root->getChildren().size()) {
         return QModelIndex();
     }
@@ -143,7 +141,6 @@ int DccModel::rowCount(const QModelIndex &) const
 
 int DccModel::columnCount(const QModelIndex &parent) const
 {
-    // qCWarning(dccLog) << __FUNCTION__ << __LINE__;
     if (!parent.isValid())
         return 0;
 
@@ -152,7 +149,6 @@ int DccModel::columnCount(const QModelIndex &parent) const
 
 QVariant DccModel::data(const QModelIndex &index, int role) const
 {
-    // qCWarning(dccLog) << __FUNCTION__ << index << role;
     if (!index.isValid())
         return QVariant();
     DccObject *item = static_cast<DccObject *>(index.internalPointer());

--- a/src/dde-control-center/plugin/dccobject.cpp
+++ b/src/dde-control-center/plugin/dccobject.cpp
@@ -13,7 +13,7 @@
 #include <QTimer>
 
 namespace dccV25 {
-static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.object");
+Q_LOGGING_CATEGORY(dccLog, "dde.dcc.main");
 
 DccObject::Private *DccObject::Private::FromObject(const DccObject *obj)
 {

--- a/src/dde-control-center/plugin/dccobject_p.h
+++ b/src/dde-control-center/plugin/dccobject_p.h
@@ -6,7 +6,9 @@
 
 #include "dccobject.h"
 
+#include <QLoggingCategory>
 #include <QVector>
+
 #define DCC_HIDDEN 0x80000000
 #define DCC_DISABLED 0x40000000
 #define DCC_CONFIG_HIDDEN 0x20000000
@@ -24,6 +26,8 @@
 #define DCC_CANSEARCH 0x04000000 // 不参与搜索
 
 namespace dccV25 {
+Q_DECLARE_LOGGING_CATEGORY(dccLog);
+
 class DccObject::Private
 {
 public:

--- a/src/dde-control-center/plugin/dccquickdbusinterface.cpp
+++ b/src/dde-control-center/plugin/dccquickdbusinterface.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccquickdbusinterface.h"
 
+#include "dccobject_p.h"
 #include "dccquickdbusinterface_p.h"
 
 #include <QDBusArgument>
@@ -16,7 +17,6 @@
 #include <QLoggingCategory>
 
 namespace dccV25 {
-static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.quickDBus");
 static const QString &PropertiesInterface = QStringLiteral("org.freedesktop.DBus.Properties");
 static const QString &PropertiesChanged = QStringLiteral("PropertiesChanged");
 

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -6,8 +6,8 @@
 
 #include "dccfactory.h"
 #include "dccmanager.h"
-
-#include <DIconTheme>
+#include "dccobject_p.h"
+#include "dccpluginloader.h"
 
 #include <QDebug>
 #include <QDir>
@@ -26,635 +26,129 @@
 #include <QtConcurrentRun>
 
 namespace dccV25 {
-static Q_LOGGING_CATEGORY(dccLog, "dde.dcc.plugin");
 
 const static QString TranslateReadDir = QStringLiteral(TRANSLATE_READ_DIR);
 
-enum PluginStatus {
-    // metaData 0xFF000000
-    PluginBegin = 0x10000000,
-    PluginEnd = 0x20000000,
-    MetaDataLoad = 0x02000000,
-    MetaDataEnd = 0x04000000,
-    MetaDataErr = 0x08000000,
-    // module 0x00FF0000
-    ModuleLoad = 0x00010000,
-    ModuleCreate = 0x00020000,
-    ModuleEnd = 0x00400000,
-    ModuleErr = 0x00800000,
-    // data 0x0000FF00
-    DataBegin = 0x00000100,
-    DataLoad = 0x00000200,
-    DataEnd = 0x00004000,
-    DataErr = 0x00008000,
-    // mainObj 0x000000FF
-    MainObjLoad = 0x00000001,
-    MainObjCreate = 0x00000002,
-    MainObjAdd = 0x00000004,
-    MainObjEnd = 0x00000040,
-    MainObjErr = 0x00000080,
-
-    PluginErrMask = MetaDataErr | ModuleErr | DataErr | MainObjErr,
-    PluginEndMask = PluginEnd | MetaDataEnd | ModuleEnd | DataEnd | MainObjEnd,
-};
-
-enum PluginType {
-    T_Unknown = 0,
-    T_V1_0 = 0x01000000,
-    T_V1_1 = 0x02000000,
-    T_V_MASK = 0xFF000000,
-
-    T_HasMoudule = 0x00000001,
-    T_HasMain = 0x00000002,
-    T_DataMask = 0x00000003,
-    T_ShortMain = 0x00000004, // main模块名为main.qml
-};
-
-struct PluginData
-{
-    QString name;
-    QString path;
-    uint type;
-    DccFactory *factory;
-
-    DccObject *module;
-    DccObject *mainObj;
-    DccObject *soObj;
-    QObject *data;
-    QThread *thread;
-    uint status;
-
-    PluginData(const QString &_name, const QString &_path)
-        : name(_name)
-        , path(_path)
-        , type(T_Unknown)
-        , factory(nullptr)
-        , module(nullptr)
-        , mainObj(nullptr)
-        , soObj(nullptr)
-        , data(nullptr)
-        , thread(nullptr)
-        , status(PluginBegin)
-    {
-    }
-
-    inline uint version() { return type & T_V_MASK; }
-};
-
-class LoadPluginTask : public QRunnable
+// Run async data loading in thread pool
+class LoadDataTask : public QRunnable
 {
 public:
-    explicit LoadPluginTask(PluginData *data, PluginManager *pManager)
+    explicit LoadDataTask(DccPluginLoader *loader, DccPluginManager *manager)
         : QRunnable()
-        , m_pManager(pManager)
-        , m_data(data)
+        , m_loader(loader)
+        , m_manager(manager)
     {
     }
 
-protected:
-    void run() override;
-    void createData();
+    void run() override
+    {
+        if (m_manager->isDeleting()) {
+            return;
+        }
+        QElapsedTimer timer;
+        timer.start();
+        m_loader->loadData();
+        m_loader->setLog("load data finished. elapsed time :" + QString::number(timer.elapsed()));
+        m_loader->transitionStatus(DccPluginLoader::DataLoad);
+        if (m_manager->isDeleting()) {
+            return;
+        }
+        m_loader->createData();
+        if (m_manager->isDeleting()) {
+            return;
+        }
+        m_loader->moveThread();
+        m_loader->setLog("create data finished. elapsed time :" + QString::number(timer.elapsed()));
+        m_loader->transitionStatus(DccPluginLoader::DataEnd);
+    }
 
-protected:
-    PluginManager *m_pManager;
-    PluginData *m_data;
+private:
+    DccPluginLoader *m_loader;
+    DccPluginManager *m_manager;
 };
 
-void LoadPluginTask::run()
-{
-    m_data->thread = QThread::currentThread();
-    createData();
-    m_data->thread = nullptr;
-}
-
-void LoadPluginTask::createData()
-{
-    Q_EMIT m_pManager->updatePluginStatus(m_data, DataBegin, "create data begin");
-    QElapsedTimer timer;
-    timer.start();
-    QObject *dataObj = nullptr;
-    DccObject *soObj = nullptr;
-    if (m_pManager->isDeleting()) {
-        return;
-    }
-    if (!m_data->factory) {
-        Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data skipped");
-        return;
-    } else {
-        Q_EMIT m_pManager->updatePluginStatus(m_data, DataLoad, QString());
-        dataObj = m_data->factory->create();
-        if (dataObj && dataObj->parent()) {
-            dataObj->setParent(nullptr);
-        }
-        soObj = m_data->factory->dccObject();
-        if (soObj && soObj->parent()) {
-            soObj->setParent(nullptr);
-        }
-    }
-    if (dataObj) {
-        m_data->data = dataObj;
-    }
-    if (soObj) {
-        m_data->soObj = soObj;
-    }
-    if (m_data->data) {
-        m_data->data->moveToThread(m_pManager->thread());
-    }
-    if (m_data->soObj) {
-        m_data->soObj->moveToThread(m_pManager->thread());
-    }
-    Q_EMIT m_pManager->updatePluginStatus(m_data, DataEnd, ": create data finished. elapsed time :" + QString::number(timer.elapsed()));
-}
-
-PluginManager::PluginManager(DccManager *parent)
+DccPluginManager::DccPluginManager(DccManager *parent)
     : QObject(parent)
     , m_manager(parent)
     , m_rootModule(nullptr)
     , m_threadPool(nullptr)
     , m_isDeleting(false)
-    , m_modulePhaseFinished(false)
 {
-    qRegisterMetaType<PluginData>("PluginData");
-    connect(this, &PluginManager::pluginEndStatusChanged, this, &PluginManager::loadPlugin);
-    connect(this, &PluginManager::updatePluginStatus, this, &PluginManager::onUpdatePluginStatus);
-    connect(this, &PluginManager::modulePhaseFinished, this, &PluginManager::onModulePhaseFinished);
-    connect(m_manager, &DccManager::hideModuleChanged, this, &PluginManager::onHideModuleChanged);
+    connect(m_manager, &DccManager::hideModuleChanged, this, &DccPluginManager::onHideModuleChanged);
 }
 
-PluginManager::~PluginManager()
+DccPluginManager::~DccPluginManager()
 {
-    for (auto &&data : m_plugins) {
-        if (data->data && !data->thread) {
-            qCDebug(dccLog()) << "delete so" << data->name;
-            delete data->data;
-            data->data = nullptr;
-        }
-    }
     cancelLoad();
-    for (auto &&data : m_plugins) {
-        if (data->data) {
-            qCDebug(dccLog()) << "delete so" << data->name;
-            delete data->data;
-            data->data = nullptr;
-        }
-        data->factory = nullptr;
-        delete data;
-    }
+    qDeleteAll(m_plugins);
     m_plugins.clear();
 }
 
-bool PluginManager::compareVersion(const QString &targetVersion, const QString &baseVersion)
-{
-    QStringList version1 = baseVersion.split(".");
-    QStringList version2 = targetVersion.split(".");
-
-    if (version1.size() != version2.size()) {
-        return false;
-    }
-
-    for (int i = 0; i < version1.size(); ++i) {
-        // 相等判断下一个子版本号
-        if (version1[i] == version2[i])
-            continue;
-
-        // 转成整形比较
-        if (version1[i].toInt() > version2[i].toInt()) {
-            return false;
-        } else {
-            return true;
-        }
-    }
-
-    return true;
-}
-
-bool PluginManager::updatePluginType(PluginData *plugin)
-{
-    QString qrcPath;
-    switch (plugin->type) {
-    case T_V1_1: {
-        if (QFile::exists(plugin->path + "/qmldir")) {
-            plugin->type |= T_HasMoudule | T_HasMain;
-            qrcPath = ":/qt/qml/" + plugin->name;
-            auto paths = m_engine->importPathList();
-            QDir pluginDir(plugin->path);
-            pluginDir.cdUp();
-            QString qmlPlugin = pluginDir.absolutePath();
-            if (!paths.contains(qmlPlugin)) {
-                m_engine->addImportPath(qmlPlugin);
-            }
-        }
-    } break;
-    case T_V1_0: {
-        QDir dir(plugin->path);
-        if (dir.exists("main.qml")) {
-            plugin->type |= T_ShortMain | T_HasMain;
-        } else if (dir.exists(plugin->name + "Main.qml")) {
-            plugin->type |= T_HasMain;
-        }
-        if (dir.exists(plugin->name + ".qml")) {
-            plugin->type |= T_HasMoudule;
-        }
-        qrcPath = plugin->path;
-    } break;
-    default: { // 尝试枚举版本
-        plugin->type = T_V1_1;
-        if (updatePluginType(plugin)) {
-            return true;
-        }
-        plugin->type = T_V1_0;
-        if (updatePluginType(plugin)) {
-            return true;
-        }
-        plugin->type = T_Unknown;
-        return false;
-    } break;
-    }
-    if (plugin->type & T_DataMask) {
-        QStringList paths = Dtk::Gui::DIconTheme::dciThemeSearchPaths();
-        paths.append(qrcPath);
-        Dtk::Gui::DIconTheme::setDciThemeSearchPaths(paths);
-        return true;
-    }
-    return false;
-}
-
-bool PluginManager::preparePluginFactory(PluginData *plugin)
-{
-    if (!plugin || plugin->factory) {
-        return plugin && plugin->factory;
-    }
-
-    const QString soPath = plugin->path + "/" + plugin->name + ".so";
-    if (!QFile::exists(soPath)) {
-        return true;
-    }
-
-    QPluginLoader loader(soPath);
-    if (!loader.load()) {
-        qCWarning(dccLog()) << plugin->name << ": prepare factory load failed" << loader.errorString();
-        return false;
-    }
-
-    const auto &meta = loader.metaData();
-    const auto iid = meta["IID"].toString();
-    if (iid.isEmpty() || iid != QString(qobject_interface_iid<DccFactory *>())) {
-        qCWarning(dccLog()) << plugin->name << ": prepare factory iid error" << iid;
-        loader.unload();
-        return false;
-    }
-
-    QObject *instance = loader.instance();
-    if (!instance) {
-        qCWarning(dccLog()) << plugin->name << ": prepare factory instance failed" << loader.errorString();
-        loader.unload();
-        return false;
-    }
-
-    DccFactory *factory = qobject_cast<DccFactory *>(instance);
-    if (!factory) {
-        qCWarning(dccLog()) << plugin->name << ": prepare factory cast failed";
-        loader.unload();
-        return false;
-    }
-
-    plugin->factory = factory;
-    return true;
-}
-
-bool PluginManager::allModulesFinished() const
-{
-    for (auto &&plugin : m_plugins) {
-        uint status = plugin->status;
-        bool moduleFinished = (status & ModuleEnd) || (status & ModuleErr) || (status & PluginEnd);
-        if (!moduleFinished) {
-            return false;
-        }
-    }
-    return !m_plugins.isEmpty();
-}
-
-QThreadPool *PluginManager::threadPool()
+QThreadPool *DccPluginManager::threadPool()
 {
     if (!m_threadPool) {
-        m_threadPool = new QThreadPool(this);
+        m_threadPool = new QThreadPool(); // No parent to avoid double-delete
     }
     return m_threadPool;
 }
 
-void PluginManager::loadPlugin(PluginData *plugin)
+// 根据状态执行插件流程
+void DccPluginManager::loadPlugin(DccPluginLoader *loader)
 {
     if (isDeleting()) {
         return;
     }
-    if (plugin->status & PluginEnd) {
+    if (loader->status() & DccPluginLoader::PluginEnd) {
         if (loadFinished()) {
             Q_EMIT loadAllFinished();
             cancelLoad();
         }
-    } else if (plugin->status & MainObjEnd) {
-        addMainObject(plugin);
-        Q_EMIT updatePluginStatus(plugin, PluginEnd, QString());
-    } else if ((plugin->status & (DataEnd | MainObjLoad)) == DataEnd) {
-        if (plugin->data) {
-            plugin->data->setParent(this);
+    } else if (loader->status() & DccPluginLoader::MainObjEnd) {
+        loader->addMainObject();
+        if (loader->mainObj()) {
+            Q_EMIT addObject(loader->mainObj());
         }
-        if (plugin->soObj) {
-            plugin->soObj->setParent(this);
+        if (loader->soObj()) {
+            Q_EMIT addObject(loader->soObj());
         }
-        loadMain(plugin);
-    } else if ((plugin->status & (ModuleEnd | DataBegin)) == ModuleEnd) {
-        if (!m_modulePhaseFinished && allModulesFinished()) {
-            Q_EMIT modulePhaseFinished();
-            return;
+        loader->transitionStatus(DccPluginLoader::PluginEnd);
+    } else if ((loader->status() & (DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad)) == DccPluginLoader::DataEnd) {
+        loader->transitionStatus(DccPluginLoader::MainObjLoad);
+        loader->createDccObject();
+        loader->updateParent();
+        loader->loadMain();
+        loader->transitionStatus(DccPluginLoader::MainObjEnd);
+    } else if ((loader->status() & (DccPluginLoader::ModuleEnd | DccPluginLoader::DataBegin)) == DccPluginLoader::ModuleEnd) {
+        loader->transitionStatus(DccPluginLoader::DataBegin);
+        if (loader->module()) {
+            Q_EMIT addObject(loader->module());
         }
-        if (m_modulePhaseFinished) {
-            loadPluginData(plugin);
-        }
-    } else if ((plugin->status & (MetaDataEnd | ModuleLoad)) == MetaDataEnd) {
-        if (!preparePluginFactory(plugin)) {
-            Q_EMIT updatePluginStatus(plugin, DataErr | PluginEnd, ": factory preparation failed, plugin skipped");
-            return;
-        }
-        DccManager::installTranslator(plugin->name);
-        loadModule(plugin);
-    } else {
-        loadMetaData(plugin);
-    }
-}
-
-void PluginManager::onUpdatePluginStatus(PluginData *plugin, uint status, const QString &log)
-{
-    if (isDeleting()) {
-        return;
-    }
-    uint oldStatus = plugin->status;
-    plugin->status |= status;
-    if (status & PluginErrMask) {
-        qCWarning(dccLog()) << plugin->name << ": status" << QString::number(plugin->status, 16) << log;
-    } else {
-        qCDebug(dccLog()) << plugin->name << ": status" << QString::number(plugin->status, 16) << log;
-    }
-    if ((oldStatus != plugin->status) && (status & PluginEndMask)) {
-        Q_EMIT pluginEndStatusChanged(plugin);
-    }
-}
-
-void PluginManager::loadMetaData(PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    updatePluginType(plugin);
-    if (m_manager->hideModule().contains(plugin->name)) {
-        // 跳过隐藏的模块,需要动态加载回来
-        Q_EMIT updatePluginStatus(plugin, PluginEnd | MetaDataEnd, QString());
-        return;
-    }
-    // metadata
-#if 0 // 文件夹有版本信息，不需要用metadata.json判断
-    const QString metadataPath = plugin->path + "/metadata.json";
-    QFile metadataFile(metadataPath);
-    if (!metadataFile.open(QIODevice::ReadOnly)) {
-        Q_EMIT updatePluginStatus(plugin, MetaDataErr | PluginEnd, "Couldn't open " + metadataFile.fileName());
-        return;
-    }
-    QJsonParseError error;
-    const QJsonObject metaData = QJsonDocument::fromJson(metadataFile.readAll()).object();
-    metadataFile.close();
-    if (error.error) {
-        Q_EMIT updatePluginStatus(plugin, MetaDataErr | PluginEnd, "error parsing json data:" + error.errorString());
-        return;
-    }
-    if (!compareVersion(metaData.value("Version").toString(), "1.0")) {
-        Q_EMIT updatePluginStatus(plugin, MetaDataErr | PluginEnd, "plugin's version is too low:" + metaData.value("Version").toString());
-        return;
-    }
-#endif
-    Q_EMIT updatePluginStatus(plugin, MetaDataEnd, QString());
-}
-
-void PluginManager::loadModule(PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    if (!(plugin->type & T_HasMoudule)) {
-        Q_EMIT updatePluginStatus(plugin, ModuleErr | ModuleEnd, "module qml not exists");
-        return;
-    }
-    QQmlComponent *component = new QQmlComponent(m_manager->engine(), m_manager->engine());
-    switch (plugin->version()) {
-    case T_V1_0: {
-        const QString qmlPath = plugin->path + "/" + plugin->name + ".qml";
-        Q_EMIT updatePluginStatus(plugin, ModuleLoad, ": load module " + qmlPath);
-        component->loadUrl(qmlPath);
-    } break;
-    case T_V1_1:
-    default: {
-        QString typeName = plugin->name;
-        typeName[0] = typeName[0].toUpper();
-        Q_EMIT updatePluginStatus(plugin, ModuleLoad, ": load module " + typeName);
-        component->loadFromModule(plugin->name, typeName);
-    } break;
-    }
-    createModule(component, plugin);
-}
-
-void PluginManager::loadPluginData(PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    if (plugin->module) {
-        disconnect(plugin->module, nullptr, this, nullptr);
-        if (plugin->module->isVisibleToApp()) {
-            threadPool()->start(new LoadPluginTask(plugin, this));
+        threadPool()->start(new LoadDataTask(loader, this));
+    } else if ((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) {
+        loader->transitionStatus(DccPluginLoader::ModuleLoad);
+        if (loader->loadModule()) {
+            loader->transitionStatus(DccPluginLoader::ModuleEnd);
         } else {
-            connect(plugin->module, &DccObject::visibleToAppChanged, this, &PluginManager::onVisibleToAppChanged);
-            Q_EMIT updatePluginStatus(plugin, PluginEnd, QString());
+            loader->transitionStatus(DccPluginLoader::ModuleEnd | DccPluginLoader::PluginEnd);
         }
     } else {
-        threadPool()->start(new LoadPluginTask(plugin, this));
-    }
-}
-
-void PluginManager::loadMain(PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    if (!(plugin->type & T_HasMain)) {
-        Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, "main qml not exists");
-        return;
-    }
-    QQmlComponent *component = new QQmlComponent(m_manager->engine(), m_manager->engine());
-    switch (plugin->version()) {
-    case T_V1_0: {
-        const QString qmlPath = plugin->path + "/" + ((plugin->type & T_ShortMain) ? "main.qml" : plugin->name + "Main.qml");
-        Q_EMIT updatePluginStatus(plugin, MainObjLoad, ": load Main " + qmlPath);
-        component->loadUrl(qmlPath);
-    } break;
-    case T_V1_1:
-    default: {
-        QString typeName = plugin->name + "Main";
-        typeName[0] = typeName[0].toUpper();
-        Q_EMIT updatePluginStatus(plugin, MainObjLoad, ": load Main " + typeName);
-        component->loadFromModule(plugin->name, typeName);
-    } break;
-    }
-    createMain(component, plugin);
-}
-
-void PluginManager::createModule(QQmlComponent *component, PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    Q_EMIT updatePluginStatus(plugin, ModuleCreate, "create module");
-    switch (component->status()) {
-    case QQmlComponent::Ready: {
-        QObject *object = component->create();
-        component->deleteLater();
-        if (!object) {
-            Q_EMIT updatePluginStatus(plugin, ModuleErr | ModuleEnd, " component create module object is null:" + component->errorString());
-            return;
-        }
-        object->setParent(m_rootModule);
-        plugin->module = qobject_cast<DccObject *>(object);
-        Q_EMIT updatePluginStatus(plugin, ModuleEnd, "create module finished");
-        m_manager->addObject(plugin->module);
-    } break;
-    case QQmlComponent::Error: {
-        component->deleteLater();
-        Q_EMIT updatePluginStatus(plugin, ModuleErr | ModuleEnd, " component create module object error:" + component->errorString());
-    } break;
-    default:
-        break;
-    }
-}
-
-void PluginManager::createMain(QQmlComponent *component, PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    Q_EMIT updatePluginStatus(plugin, MainObjCreate, "create main");
-    switch (component->status()) {
-    case QQmlComponent::Ready: {
-        QQmlContext *context = new QQmlContext(component->engine());
-        context->setContextProperties({ { "dccData", QVariant::fromValue(plugin->data) }, { "dccModule", QVariant::fromValue(plugin->module) } });
-        QObject *object = component->create(context);
-        component->deleteLater();
-        if (!object) {
-            delete context;
-            Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object is null:" + component->errorString());
-            return;
-        }
-        context->setParent(object);
-        object->setParent(plugin->module ? plugin->module : m_rootModule);
-        plugin->mainObj = qobject_cast<DccObject *>(object);
-        Q_EMIT updatePluginStatus(plugin, MainObjEnd, ": create main finished");
-    } break;
-    case QQmlComponent::Error: {
-        Q_EMIT updatePluginStatus(plugin, MainObjErr | MainObjEnd, " component create main object error:" + component->errorString());
-        component->deleteLater();
-    } break;
-    default:
-        break;
-    }
-}
-
-void PluginManager::addMainObject(PluginData *plugin)
-{
-    if (isDeleting()) {
-        return;
-    }
-    Q_EMIT updatePluginStatus(plugin, MainObjAdd, "add main object");
-    if (!plugin->mainObj) {
-        plugin->mainObj = plugin->soObj;
-    }
-    if (plugin->mainObj) {
-        if (plugin->mainObj->name().isEmpty() || (plugin->module && plugin->mainObj->name() == plugin->module->name())) {
-            // 插件根项name为空时，关联{name}.qml,不加树
-            if (plugin->module) {
-                QQmlComponent *page = plugin->mainObj->page();
-                if (page) {
-                    plugin->module->setPage(page);
-                }
-                connect(plugin->mainObj, &DccObject::pageChanged, plugin->module, &DccObject::setPage);
-                connect(plugin->mainObj, &DccObject::displayNameChanged, plugin->module, &DccObject::setDisplayName);
-                connect(plugin->mainObj, &DccObject::descriptionChanged, plugin->module, &DccObject::setDescription);
-                connect(plugin->mainObj, &DccObject::iconChanged, plugin->module, &DccObject::setIcon);
-                connect(plugin->mainObj, &DccObject::badgeChanged, plugin->module, &DccObject::setBadge);
-                connect(plugin->mainObj, &DccObject::visibleChanged, plugin->module, &DccObject::setVisible);
-                connect(plugin->mainObj, &DccObject::active, plugin->module, &DccObject::active);
-                connect(plugin->mainObj, &DccObject::deactive, plugin->module, &DccObject::deactive);
-            }
+        if (loader->loadMetaData()) {
+            loader->transitionStatus(DccPluginLoader::MetaDataEnd);
         } else {
-        }
-    } else {
-        Q_EMIT updatePluginStatus(plugin, MainObjErr, "The plugin isn't main DccObject");
-    }
-    if (plugin->mainObj) {
-        Q_EMIT addObject(plugin->mainObj);
-    }
-    if (plugin->soObj) {
-        Q_EMIT addObject(plugin->soObj);
-    }
-    Q_EMIT updatePluginStatus(plugin, MainObjEnd | PluginEnd, "add main object finished");
-}
-
-void PluginManager::onModulePhaseFinished()
-{
-    if (isDeleting()) {
-        return;
-    }
-    m_modulePhaseFinished = true;
-    for (auto &&plugin : m_plugins) {
-        if (plugin->status & ModuleEnd) {
-            loadPlugin(plugin);
+            loader->transitionStatus(DccPluginLoader::MetaDataEnd | DccPluginLoader::PluginEnd);
         }
     }
 }
 
-void PluginManager::onHideModuleChanged(const QSet<QString> &hideModule)
-{
-    for (auto &&plugin : m_plugins) {
-        if ((plugin->status & PluginEnd) && (((plugin->status & (MetaDataEnd | MetaDataErr | ModuleLoad)) == MetaDataEnd) && (!hideModule.contains(plugin->name)))) {
-            // 加载完成，没检查MetaData也没错误，不在hideModule中，则需要重新加载
-            plugin->status &= ~PluginEnd;
-            loadPlugin(plugin);
-        }
-    }
-}
-
-void PluginManager::onVisibleToAppChanged(bool visibleToApp)
-{
-    if (!visibleToApp) {
-        return;
-    }
-    DccObject *obj = qobject_cast<DccObject *>(sender());
-    if (!obj) {
-        return;
-    }
-    for (auto &&plugin : m_plugins) {
-        if (plugin->module == obj && (plugin->status & PluginEnd) && (!(plugin->status & (DataEnd | DataErr)))) {
-            // 加载完成，没检查MetaData也没错误，不在hideModule中，则需要重新加载
-            plugin->status &= ~PluginEnd;
-            loadPlugin(plugin);
-        }
-    }
-}
-
-void PluginManager::loadModules(DccObject *root, bool async, const QStringList &dirs, QQmlEngine *engine)
+void DccPluginManager::loadModules(DccObject *root, bool async, const QStringList &dirs, QQmlEngine *engine)
 {
     Q_UNUSED(async)
     if (!root)
         return;
     m_rootModule = root;
-    qCDebug(dccLog()) << "plugin dir:" << dirs;
     m_engine = engine;
+    qCDebug(dccLog()) << "plugin dir:" << dirs;
+
     QFileInfoList pluginList;
     for (const auto &dir : dirs) {
         QDir plugindir(dir);
@@ -665,60 +159,101 @@ void PluginManager::loadModules(DccObject *root, bool async, const QStringList &
             pluginList += plugindir.entryInfoList(QDir::Dirs | QDir::NoDotAndDotDot);
         }
     }
+
     const QStringList groupPlugins({ "system", "device" }); // 优先加载只是组的插件
+    QList<DccPluginLoader *> loaders;
+
     for (auto &lib : pluginList) {
         const QString &filepath = lib.absoluteFilePath();
         auto filename = lib.fileName();
-        PluginData *plugin = new PluginData(lib.baseName(), filepath);
+        DccPluginLoader *loader = new DccPluginLoader(lib.baseName(), filepath, this);
+
+        // Set version type based on path
+        DccPluginLoader::TypeFlags type = DccPluginLoader::T_Unknown;
         if (filepath.contains("_v1.1")) {
-            plugin->type = T_V1_1;
+            type = DccPluginLoader::T_V1_1;
         } else if (filepath.contains("_v1.0")) {
-            plugin->type = T_V1_0;
-        } else {
-            plugin->type = T_Unknown;
+            type = DccPluginLoader::T_V1_0;
         }
+        loader->setType(type);
+
+        // Connect signals
+        connect(loader, &DccPluginLoader::statusChanged, this, &DccPluginManager::onPluginStatusChanged, Qt::QueuedConnection);
+
         if (groupPlugins.contains(filename)) {
-            m_plugins.prepend(plugin);
+            loaders.prepend(loader);
         } else {
-            m_plugins.append(plugin);
+            loaders.append(loader);
         }
     }
-    for (const auto &plugin : m_plugins) {
-        loadPlugin(plugin);
+
+    m_plugins = loaders;
+
+    // Start loading all plugins
+    for (auto &&loader : m_plugins) {
+        loadPlugin(loader);
     }
 }
 
-void PluginManager::cancelLoad()
+void DccPluginManager::cancelLoad()
 {
     if (m_threadPool) {
-        m_threadPool->clear();
-        // 等待所有正在运行的任务完成,避免析构时的竞态条件
-        m_threadPool->waitForDone();
-        for (auto &&plugin : m_plugins) {
-            if (plugin->thread) {
-                qCWarning(dccLog()) << plugin->name << ": status" << QString::number(plugin->status, 16) << "thread exit timeout";
-            }
-        }
         qCWarning(dccLog()) << "delete threadPool";
+        m_threadPool->clear();
+        m_threadPool->waitForDone();
         delete m_threadPool;
         qCWarning(dccLog()) << "delete threadPool finish";
         m_threadPool = nullptr;
     }
 }
 
-bool PluginManager::loadFinished() const
+bool DccPluginManager::loadFinished() const
 {
-    uint status = PluginEnd;
-    for (auto &&plugin : m_plugins) {
-        status &= plugin->status;
+    for (auto &&loader : m_plugins) {
+        if (!loader->isFinished()) {
+            return false;
+        }
     }
-
-    return (status & PluginEnd) && (!m_plugins.isEmpty());
+    return !m_plugins.isEmpty();
 }
 
-void PluginManager::beginDelete()
+void DccPluginManager::beginDelete()
 {
-    m_isDeleting = true;
+    m_isDeleting.store(true);
 }
-}; // namespace dccV25
-Q_DECLARE_METATYPE(dccV25::PluginData *)
+
+QQmlEngine *DccPluginManager::engine()
+{
+    return m_engine;
+}
+
+DccObject *DccPluginManager::rootModule()
+{
+    return m_rootModule;
+}
+
+bool DccPluginManager::hidden(const QString &name)
+{
+    return m_manager->hideModule().contains(name);
+}
+
+void DccPluginManager::onPluginStatusChanged(DccPluginLoader *loader, uint status)
+{
+    if (isDeleting()) {
+        return;
+    }
+    if ((status & DccPluginLoader::PluginEndMask)) {
+        loadPlugin(loader);
+    }
+}
+
+void DccPluginManager::onHideModuleChanged(const QSet<QString> &hideModule)
+{
+    for (auto &&loader : m_plugins) {
+        if ((loader->status() & DccPluginLoader::PluginEnd) && !loader->module() && !hideModule.contains(loader->name())) {
+            loader->updateVisible(true);
+        }
+    }
+}
+
+} // namespace dccV25

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -8,25 +8,31 @@
 #include <QStringList>
 #include <QVector>
 
+#include <atomic>
+
 class QQmlComponent;
 class QThreadPool;
 
 namespace dccV25 {
 class DccObject;
 class DccManager;
-struct PluginData;
+class DccPluginLoader;
 
-class PluginManager : public QObject
+class DccPluginManager : public QObject
 {
     Q_OBJECT
 public:
-    explicit PluginManager(DccManager *parent);
-    ~PluginManager();
+    explicit DccPluginManager(DccManager *parent);
+    ~DccPluginManager();
     void loadModules(DccObject *root, bool async, const QStringList &dirs, QQmlEngine *engine);
     bool loadFinished() const;
     void beginDelete();
 
-    inline bool isDeleting() const { return m_isDeleting; }
+    QQmlEngine *engine();
+    DccObject *rootModule();
+    bool hidden(const QString &name);
+
+    inline bool isDeleting() const { return m_isDeleting.load(); }
 
 public Q_SLOTS:
     void cancelLoad();
@@ -34,40 +40,23 @@ public Q_SLOTS:
 Q_SIGNALS:
     void addObject(DccObject *obj);
     void loadAllFinished();
-    void modulePhaseFinished();
-
-    void pluginEndStatusChanged(PluginData *plugin);
-    void updatePluginStatus(PluginData *plugin, uint status, const QString &log);
 
 private:
-    bool compareVersion(const QString &targetVersion, const QString &baseVersion);
-    bool updatePluginType(PluginData *plugin);
-    bool preparePluginFactory(PluginData *plugin);
-    bool allModulesFinished() const;
     QThreadPool *threadPool();
 
 private Q_SLOTS:
-    void loadPlugin(PluginData *plugin);
-    void loadMetaData(PluginData *plugin);
-    void loadModule(PluginData *plugin);
-    void loadPluginData(PluginData *plugin);
-    void loadMain(PluginData *plugin);
-    void createModule(QQmlComponent *component, PluginData *plugin);
-    void createMain(QQmlComponent *component, PluginData *plugin);
-    void addMainObject(PluginData *plugin);
+    void loadPlugin(DccPluginLoader *loader);
 
-    void onModulePhaseFinished();
+private Q_SLOTS:
+    void onPluginStatusChanged(DccPluginLoader *loader, uint status);
     void onHideModuleChanged(const QSet<QString> &hideModule);
-    void onVisibleToAppChanged(bool visibleToApp);
-    void onUpdatePluginStatus(PluginData *plugin, uint status, const QString &log);
 
 private:
     DccManager *m_manager;
-    QList<PluginData *> m_plugins; // cache for other plugin
-    DccObject *m_rootModule;       // root module from MainWindow
+    QList<DccPluginLoader *> m_plugins; // cache for other plugin
+    DccObject *m_rootModule;            // root module from MainWindow
     QThreadPool *m_threadPool;
-    bool m_isDeleting;
-    bool m_modulePhaseFinished;
+    std::atomic<bool> m_isDeleting;
     QQmlEngine *m_engine;
 };
 

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -62,18 +62,13 @@ DisplayModulePrivate::DisplayModulePrivate(DisplayModule *parent)
     , m_primary(nullptr)
     , m_maxGlobalScale(1.0)
 {
-    QMetaObject::invokeMethod(
-            q_ptr,
-            [this]() {
-                init();
-            },
-            Qt::QueuedConnection);
+    m_model = new DisplayModel(q_ptr);
+    m_worker = new DisplayWorker(m_model, q_ptr);
+    init();
 }
 
 void DisplayModulePrivate::init()
 {
-    m_model = new DisplayModel(q_ptr);
-    m_worker = new DisplayWorker(m_model, q_ptr);
     m_worker->active();
     q_ptr->connect(m_model, &DisplayModel::monitorListChanged, [this]() {
         updateMonitorList();


### PR DESCRIPTION
Extract plugin loading state machine from PluginData into DccPluginLoader class with signal-driven auto-advancing states. Simplify PluginManager (renamed to DccPluginManager) to only handle scheduling, thread pool and lifecycle management. Fix display module unnecessary delayed initialization and adjust root/engine deletion order in cleanup.

将PluginData中的插件加载逻辑提取为DccPluginLoader类，使用信号驱动状态机自动推进。 简化PluginManager（重命名为DccPluginManager）为调度协调角色，仅管理线程池和生命周期。 修复DisplayModule不必要的延迟初始化，调整清理时root/engine的删除顺序。

Log: 重构插件加载架构，分离加载逻辑与调度管理
Influence: 1. 控制中心各模块正常加载和显示；2. 插件隐藏/取消隐藏功能正常；3. 异步数据加载正常；4. 模块切换和页面导航正常