### PR TITLE
fix: clear shortcut conflict warning state on page leave

### DIFF
--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -34,6 +34,14 @@ DccObject {
         ScrollBar.vertical: viewScrollbar
     }
 
+    Connections {
+        target: shortcutSettingsView
+        function onDeactive() {
+            shortcutSettingsBody.conflictAccels = ""
+            shortcutSettingsBody.isEditing = false
+        }
+    }
+
     DccObject {
         id: shortcutSettingsBody
         property bool isEditing: false


### PR DESCRIPTION
1. Add Connections to listen for deactive signal on shortcutSettingsView
2. Clear conflictAccels and isEditing when leaving the shortcuts page
1. 监听快捷键页面的 deactive 信号
2. 离开快捷键页面时清除 conflictAccels 和 isEditing 状态 
Log: 修复快捷键冲突警告图标在返回后重新进入时仍然存在的问题 
PMS: BUG-359155 
Influence: 修复用户录制快捷键触发冲突后直接返回，再次进入时警告图标仍然残留的问题

## Summary by Sourcery

Bug Fixes:
- Clear shortcut conflict and editing state when leaving the shortcuts page so warning icons do not persist after navigating away and back.