### PR TITLE
fix: resolve shortcut conflict UI state

### DIFF
--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -315,8 +315,15 @@ DccObject {
                                     MouseArea {
                                         anchors.fill: parent
                                         onClicked: {
-                                            edit.modifyShortcut(shortcutSettingsBody.conflictAccels)
+                                            var newAccels = shortcutSettingsBody.conflictAccels
+                                            edit.modifyShortcut(newAccels)
                                             shortcutSettingsBody.conflictAccels = ""
+
+                                            // Fix: hide conflict warning and reset edit state after replacing
+                                            edit.keys = dccData.formatKeys(newAccels)
+                                            conflictText.visible = false
+                                            shortcutView.editItem = null
+                                            shortcutView.conflictText = null
                                         }
                                     }
                                 }


### PR DESCRIPTION
1. Fixed shortcut conflict resolution by updating UI state after replacing conflicting keys
2. Added logic to hide conflict warning text and reset edit state when conflict is resolved
3. Ensured edit.keys is properly formatted after conflict resolution using dccData.formatKeys
4. Cleaned up trailing whitespace in ToolTip section for code consistency

Log: Fixed shortcut conflict resolution UI state and warning display

PMS: BUG-359143

Influence:
1. Test shortcut conflict detection and resolution workflow
2. Verify conflict warning message appears and disappears correctly
3. Test editing shortcuts when conflicts exist
4. Verify edit state resets properly after conflict resolution
5. Test that formatted keys display correctly after conflict resolution
6. Verify tooltip behavior with long shortcut names

fix: 修复快捷键冲突的UI状态

1. 通过替换冲突键后更新UI状态来修复快捷键冲突解决
2. 添加逻辑以在解决冲突时隐藏冲突警告文本并重置编辑状态
3. 确保使用dccData.formatKeys在冲突解决后正确格式化edit.keys
4. 清理工具提示部分的尾随空白以保持代码一致性

Log: 修复快捷键冲突解决UI状态和警告显示

PMS: BUG-359143

Influence:
1. 测试快捷键冲突检测和解决工作流程
2. 验证冲突警告消息正确显示和消失
3. 测试存在冲突时编辑快捷键的功能
4. 验证冲突解决后编辑状态正确重置
5. 测试冲突解决后格式化键的正确显示
6. 验证长快捷键名称的工具提示行为

## Summary by Sourcery

Update shortcut conflict resolution to correctly refresh UI state and warning visibility after applying replacement shortcuts.

Bug Fixes:
- Ensure shortcut conflict resolution updates the edited shortcut keys, hides the conflict warning, and clears edit state after applying conflicting accelerators.

Enhancements:
- Normalize formatted shortcut keys using dccData.formatKeys when resolving conflicts for consistent key display.