### PR TITLE
feat(wallpaper): adapt new wallpaper protocol and support live wallpaper

### DIFF
--- a/src/plugin-personalization/CMakeLists.txt
+++ b/src/plugin-personalization/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${LIB_NAME} MODULE
 if (Enable_TreelandSupport)
 qt6_generate_wayland_protocol_client_sources(${LIB_NAME} FILES
     ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-personalization-manager-v1.xml
+    ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-wallpaper-manager-unstable-v1.xml
 )
 
 target_compile_definitions(${LIB_NAME} PRIVATE Enable_Treeland)

--- a/src/plugin-personalization/operation/personalizationexport.hpp
+++ b/src/plugin-personalization/operation/personalizationexport.hpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -31,4 +31,11 @@ public:
     };
 
     Q_ENUM(ModuleType)
+
+    enum WallpaperType {
+        Type_Image,
+        Type_Video
+    };
+
+    Q_ENUM(WallpaperType)
 };

--- a/src/plugin-personalization/operation/personalizationmodel.cpp
+++ b/src/plugin-personalization/operation/personalizationmodel.cpp
@@ -21,18 +21,21 @@ PersonalizationModel::PersonalizationModel(QObject *parent)
     m_customWallpaperSortModel = new WallpaperSortModel(this);
     m_sysWallpaperSortModel = new WallpaperSortModel(this);
     m_solidWallpaperSortModel = new WallpaperSortModel(this);
+    m_liveWallpaperSortModel = new WallpaperSortModel(this);
     m_screenSaverSortModel = new WallpaperSortModel(this);
     m_picScreenSaverSortModel = new WallpaperSortModel(this);
 
     m_customWallpaperModel = new WallpaperModel(this);
     m_sysWallpaperModel = new WallpaperModel(this);
     m_solidWallpaperModel = new WallpaperModel(this);
+    m_liveWallpaperModel = new WallpaperModel(this);
     m_screenSaverModel = new WallpaperModel(this);
     m_picScreenSaverModel = new WallpaperModel(this);
 
     m_customWallpaperSortModel->setSourceModel(m_customWallpaperModel);
     m_sysWallpaperSortModel->setSourceModel(m_sysWallpaperModel);
     m_solidWallpaperSortModel->setSourceModel(m_solidWallpaperModel);
+    m_liveWallpaperSortModel->setSourceModel(m_liveWallpaperModel);
     m_screenSaverSortModel->setSourceModel(m_screenSaverModel);
     m_picScreenSaverSortModel->setSourceModel(m_picScreenSaverModel);
     m_miniEffect = 0;
@@ -148,6 +151,7 @@ void PersonalizationModel::setWallpaperMap(const QVariantMap &map)
     if (m_wallpaperMap == map)
         return;
     m_wallpaperMap = map;
+    Q_EMIT wallpaperMapChanged(map);
 }
 
 void PersonalizationModel::setWallpaperSlideShowMap(const QVariantMap &map)

--- a/src/plugin-personalization/operation/personalizationmodel.h
+++ b/src/plugin-personalization/operation/personalizationmodel.h
@@ -50,6 +50,7 @@ class PersonalizationModel : public QObject
     Q_PROPERTY(WallpaperSortModel *customWallpaperModel MEMBER m_customWallpaperSortModel CONSTANT)
     Q_PROPERTY(WallpaperSortModel *sysWallpaperModel MEMBER m_sysWallpaperSortModel CONSTANT)
     Q_PROPERTY(WallpaperSortModel *solidWallpaperModel MEMBER m_solidWallpaperSortModel CONSTANT)
+    Q_PROPERTY(WallpaperSortModel *liveWallpaperModel MEMBER m_liveWallpaperSortModel CONSTANT)
 
     Q_PROPERTY(WallpaperSortModel *screenSaverModel MEMBER m_screenSaverSortModel CONSTANT)
     Q_PROPERTY(WallpaperSortModel *picScreenSaverModel MEMBER m_picScreenSaverSortModel CONSTANT)
@@ -68,6 +69,7 @@ public:
     inline WallpaperModel *getCustomWallpaperModel() const { return m_customWallpaperModel; }
     inline WallpaperModel *getSysWallpaperModel() const { return m_sysWallpaperModel; }
     inline WallpaperModel *getSolidWallpaperModel() const { return m_solidWallpaperModel; }
+    inline WallpaperModel *getLiveWallpaperModel() const { return m_liveWallpaperModel; }
     inline WallpaperModel *getScreenSaverModel() const { return m_screenSaverModel; }
     inline WallpaperModel *getPicScreenSaverModel() const { return m_picScreenSaverModel; }
 
@@ -176,12 +178,14 @@ private:
     WallpaperSortModel *m_customWallpaperSortModel;
     WallpaperSortModel *m_sysWallpaperSortModel;
     WallpaperSortModel *m_solidWallpaperSortModel;
+    WallpaperSortModel *m_liveWallpaperSortModel;
     WallpaperSortModel *m_screenSaverSortModel;
     WallpaperSortModel *m_picScreenSaverSortModel;
 
     WallpaperModel *m_customWallpaperModel;
     WallpaperModel *m_sysWallpaperModel;
     WallpaperModel *m_solidWallpaperModel;
+    WallpaperModel *m_liveWallpaperModel;
     WallpaperModel *m_screenSaverModel;
     WallpaperModel *m_picScreenSaverModel;
 

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "personalizationworker.h"
@@ -692,24 +692,17 @@ void PersonalizationWorker::setCursorTheme(const QString &id)
     }
 }
 
-void PersonalizationWorker::setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option)
-{
-    if (option == PersonalizationExport::Option_Desktop) {
-        setBackgroundForMonitor(screen, url, isDark);
-    } else if (option == PersonalizationExport::Option_Lock) {
-        setLockBackForMonitor(screen, url, isDark);
-    } else if (option == PersonalizationExport::Option_All) {
-        setBackgroundForMonitor(screen, url, isDark);
-        setLockBackForMonitor(screen, url, isDark);
-    }
-}
-
-void PersonalizationWorker::setBackgroundForMonitor(const QString &, const QString &, bool )
+void PersonalizationWorker::setWallpaperForMonitor(const QString &, const QString &, bool , PersonalizationExport::WallpaperSetOption, PersonalizationExport::WallpaperType)
 {
 
 }
 
-void PersonalizationWorker::setLockBackForMonitor(const QString &, const QString &, bool)
+void PersonalizationWorker::setBackgroundForMonitor(const QString &, const QString &, bool, PersonalizationExport::WallpaperType type)
+{
+
+}
+
+void PersonalizationWorker::setLockBackForMonitor(const QString &, const QString &, bool, PersonalizationExport::WallpaperType type)
 {
 
 }

--- a/src/plugin-personalization/operation/personalizationworker.h
+++ b/src/plugin-personalization/operation/personalizationworker.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef PERSONALIZATIONWORKER_H
@@ -67,9 +67,9 @@ public Q_SLOTS:
     virtual void setAppearanceTheme(const QString &id, bool keepAuto = false);
     virtual void setIconTheme(const QString &id);
     virtual void setCursorTheme(const QString &id);
-    virtual void setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option);
-    virtual void setBackgroundForMonitor(const QString &screenName, const QString &url, bool isDark);
-    virtual void setLockBackForMonitor(const QString &screenName, const QString &url, bool isDark);
+    virtual void setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image);
+    virtual void setBackgroundForMonitor(const QString &screenName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image);
+    virtual void setLockBackForMonitor(const QString &screenName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image);
 
 signals:
     void personalizationChanged(const QString &propertyName, const QString &value);

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,14 +12,17 @@
 #include <QLoggingCategory>
 #include <QDebug>
 #include <QDir>
-#include "utils.hpp"
+#include <QScreen>
 
+#include "utils.hpp"
+#include <qpa/qplatformnativeinterface.h>
 #include <private/qguiapplication_p.h>
 #include <private/qwaylandintegration_p.h>
 #include <private/qwaylandwindow_p.h>
 #include "treelandworker.h"
 #include "operation/personalizationworker.h"
 #include "operation/model/thememodel.h"
+#include "operation/personalizationexport.hpp"
 
 #define TYPEWALLPAPER           "wallpaper"
 #define TYPEGREETERBACKGROUND   "greeterbackground"
@@ -41,27 +44,41 @@ TreeLandWorker::TreeLandWorker(PersonalizationModel *model, QObject *parent)
 
 }
 
+TreeLandWorker::~TreeLandWorker()
+{
+#ifdef Enable_Treeland
+    qDeleteAll(m_wallpaperContexts);
+    m_wallpaperContexts.clear();
+    
+    qDeleteAll(m_wallpapers);
+    m_wallpapers.clear();
+    
+    qDeleteAll(m_lockWallpapers);
+    m_lockWallpapers.clear();
+#endif
+}
+
 #ifdef Enable_Treeland
 
-void TreeLandWorker::setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option)
+void TreeLandWorker::setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option, PersonalizationExport::WallpaperType type)
 {
     if (checkWallpaperLockStatus()) {
         return;
     }
 
     if (option == PersonalizationExport::Option_Desktop) {
-        setBackgroundForMonitor(screen, url, isDark);
+        setBackgroundForMonitor(screen, url, isDark, type);
     } else if (option == PersonalizationExport::Option_Lock) {
-        setLockBackForMonitor(screen, url, isDark);
+        setLockBackForMonitor(screen, url, isDark, type);
     } else if (option == PersonalizationExport::Option_All) {
-        setBackgroundForMonitor(screen, url, isDark);
-        setLockBackForMonitor(screen, url, isDark);
+        setBackgroundForMonitor(screen, url, isDark, type);
+        setLockBackForMonitor(screen, url, isDark, type);
     }
 }
 
-void TreeLandWorker::setBackgroundForMonitor(const QString &monitorName, const QString &url, bool isDark)
+void TreeLandWorker::setBackgroundForMonitor(const QString &monitorName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type)
 {
-    setWallpaper(monitorName, url, isDark, PersonalizationWallpaperContext::options_background);
+    setWallpaper(monitorName, url, isDark, WallpaperContext::wallpaper_role_desktop, type);
 }
 
 QString TreeLandWorker::getBackgroundForMonitor(const QString &monitorName)
@@ -72,9 +89,9 @@ QString TreeLandWorker::getBackgroundForMonitor(const QString &monitorName)
     return QString();
 }
 
-void TreeLandWorker::setLockBackForMonitor(const QString &monitorName, const QString &url, bool isDark)
+void TreeLandWorker::setLockBackForMonitor(const QString &monitorName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type)
 {
-    setWallpaper(monitorName, url, isDark, PersonalizationWallpaperContext::options_lockscreen);
+    setWallpaper(monitorName, url, isDark, WallpaperContext::wallpaper_role_lockscreen, type);
 }
 
 QString TreeLandWorker::getLockBackForMonitor(const QString &monitorName)
@@ -241,14 +258,6 @@ void TreeLandWorker::onWallpaperUrlsChanged()
 
 void TreeLandWorker::init()
 {
-    if (m_wallpaperContext.isNull()) {
-        m_wallpaperContext.reset(new PersonalizationWallpaperContext(m_personalizationManager->get_wallpaper_context()));
-        connect(m_wallpaperContext.get(),
-            &PersonalizationWallpaperContext::metadataChanged,
-            this,
-            &TreeLandWorker::wallpaperMetaDataChanged);
-        m_wallpaperContext->get_metadata();
-    }
     if (m_appearanceContext.isNull()) { 
         m_appearanceContext.reset(new PersonalizationAppearanceContext(m_personalizationManager->get_appearance_context(), this->m_model));
     }
@@ -260,44 +269,72 @@ void TreeLandWorker::init()
     }
 }
 
-void TreeLandWorker::wallpaperMetaDataChanged(const QString &data)
+void TreeLandWorker::initWallpaperContext()
 {
-    QJsonDocument json_doc = QJsonDocument::fromJson(data.toLocal8Bit());
-
-    if (!json_doc.isNull()) {
-        QJsonObject json = json_doc.object();
-
-        for (auto it = json.begin(); it != json.end(); ++it) {
-            QJsonObject context = it.value().toObject();
-            if (context.isEmpty())
-                continue;
-
-            WallpaperMetaData *wallpaper = nullptr;
-            if (m_wallpapers.contains(it.key())) {
-                wallpaper = m_wallpapers.value(it.key());
-            } else {
-                wallpaper = new WallpaperMetaData();
-                m_wallpapers.insert(it.key(), wallpaper);
-            }
-            wallpaper->isDark = context["isDark"].toBool();
-            wallpaper->url = context["url"].toString();
-            wallpaper->monitorName = context["monitorName"].toString();
-        }
+    auto screens = qApp->screens();
+    for (auto screen : screens) {
+        getOrCreateWallpaperContext(screen->name());
     }
-
-    onWallpaperUrlsChanged();
 }
 
-void TreeLandWorker::setWallpaper(const QString &monitorName, const QString &url, bool isDark, uint32_t option)
+WallpaperContext *TreeLandWorker::getOrCreateWallpaperContext(const QString &monitorName)
 {
-    qCDebug(DdcPersonnalizationTreelandWorker) << "setWallpaper:" << monitorName << "url:" << url << "isDark:" << isDark << "option:" << option;
+    if (m_wallpaperContexts.contains(monitorName)) {
+        return m_wallpaperContexts.value(monitorName);
+    }
+
+    auto *native = QGuiApplication::platformNativeInterface();
+    auto screens = qApp->screens();
+    for (auto screen : screens) {
+        if (screen->name() == monitorName) {
+            struct wl_output *output = reinterpret_cast<wl_output *>(
+                native->nativeResourceForScreen("output", screen));
+            
+            if (output) {
+                auto *wallpaperObj = m_wallpaperManager->get_treeland_wallpaper(output, nullptr);
+                if (wallpaperObj) {
+                    auto *ctx = new WallpaperContext(wallpaperObj);
+                    m_wallpaperContexts.insert(monitorName, ctx);
+                    
+                    connect(ctx, &WallpaperContext::wallpaperChanged, this, 
+                        [this, monitorName](WallpaperContext::wallpaper_role role, WallpaperContext::wallpaper_source_type type, const QString &fileSource) {
+                            qCDebug(DdcPersonnalizationTreelandWorker) << "Wallpaper changed for" << monitorName << "role:" << role << "source:" << fileSource;
+                            
+                            if (role == WallpaperContext::wallpaper_role_desktop) {
+                                if (!m_wallpapers.contains(monitorName)) {
+                                    m_wallpapers.insert(monitorName, new WallpaperMetaData);
+                                }
+                                auto *meta = m_wallpapers.value(monitorName);
+                                meta->url = isURI(fileSource) ? fileSource : enCodeURI(fileSource, "file://");
+                                meta->monitorName = monitorName;
+                                onWallpaperUrlsChanged();
+                            } else if (role == WallpaperContext::wallpaper_role_lockscreen) {
+                                if (!m_lockWallpapers.contains(monitorName)) {
+                                    m_lockWallpapers.insert(monitorName, new WallpaperMetaData);
+                                }
+                                auto *meta = m_lockWallpapers.value(monitorName);
+                                meta->url = fileSource;
+                                meta->monitorName = monitorName;
+                            }
+                        });
+                    
+                    return ctx;
+                }
+            }
+            break;
+        }
+    }
+    
+    return nullptr;
+}
+
+void TreeLandWorker::setWallpaper(const QString &monitorName, const QString &url, bool isDark, uint32_t role, uint32_t type)
+{
+    qCDebug(DdcPersonnalizationTreelandWorker) << "setWallpaper:" << monitorName << "url:" << url << "isDark:" << isDark << "role:" << role << "type:" << type;
 
     if (checkWallpaperLockStatus()) {
         return;
     }
-
-    if (!m_wallpaperContext)
-        return;
 
     QString dest;
     if (QFile::exists(url)) {
@@ -310,56 +347,34 @@ void TreeLandWorker::setWallpaper(const QString &monitorName, const QString &url
     if (dest.isEmpty())
         return;
 
-    QFile file(dest);
-    if (file.open(QIODevice::ReadOnly)) {
+    // Update wallpaper metadata
+    if (!m_wallpapers.contains(monitorName)) {
+        m_wallpapers.insert(monitorName, new WallpaperMetaData);
+    }
 
-        QMap<QString, WallpaperMetaData *> wallpapers;
+    auto meta_data = m_wallpapers.value(monitorName);
 
-        if (option == PersonalizationWallpaperContext::options_background) {
-            wallpapers = m_wallpapers;
+    if (meta_data != nullptr) {
+        meta_data->isDark = isDark;
+        meta_data->url = url;
+        meta_data->monitorName = monitorName;
+    }
+
+    if (m_wallpaperManager && m_wallpaperManager->isActive()) {
+        qCDebug(DdcPersonnalizationTreelandWorker) << "Using new wallpaper manager protocol";
+
+        auto *wallpaperCtx = getOrCreateWallpaperContext(monitorName);
+        if (wallpaperCtx) {
+            if (type == WallpaperContext::wallpaper_source_type_video) {
+                qCDebug(DdcPersonnalizationTreelandWorker) << "Setting video wallpaper:" << dest;
+                wallpaperCtx->setVideoSource(dest, static_cast<WallpaperContext::wallpaper_role>(role));
+            } else {
+                qCDebug(DdcPersonnalizationTreelandWorker) << "Setting image wallpaper:" << dest;
+                wallpaperCtx->setImageSource(dest, static_cast<WallpaperContext::wallpaper_role>(role));
+            }
         } else {
-            wallpapers = m_lockWallpapers;
+            qCWarning(DdcPersonnalizationTreelandWorker) << "Failed to get wallpaper context for:" << monitorName;
         }
-
-        if (!m_wallpapers.contains(monitorName)) {
-            m_wallpapers.insert(monitorName, new WallpaperMetaData);
-        }
-
-        auto meta_data = m_wallpapers.value(monitorName);
-
-        if (meta_data != nullptr) {
-            meta_data->isDark = isDark;
-            meta_data->url = url;
-            meta_data->monitorName = monitorName;
-
-            m_wallpaperContext->set_on(PersonalizationWallpaperContext::options(option));
-            m_wallpaperContext->set_isdark(isDark);
-
-            QMapIterator<QString, WallpaperMetaData *> it(m_wallpapers);
-
-            QJsonObject json;
-            while (it.hasNext()) {
-                it.next();
-                QJsonObject content;
-                content.insert("isDark", it.value()->isDark);
-                content.insert("url", it.value()->url);
-                content.insert("monitorName", it.value()->monitorName);
-
-                json[it.key()] = content;
-            }
-
-            QJsonDocument json_doc(json);
-
-            m_wallpaperContext->set_fd(file.handle(), json_doc.toJson(QJsonDocument::Compact));
-            m_wallpaperContext->set_output(monitorName);
-            m_wallpaperContext->commit();
-
-            if (option == PersonalizationWallpaperContext::options_background) {
-                onWallpaperUrlsChanged();
-            }
-        }
-
-        file.close();
     }
 }
 
@@ -456,7 +471,8 @@ void TreeLandWorker::doSetByType(const QString &type, const QString &value)
     if (type == TYPEWALLPAPER) {
         auto screens = qApp->screens();
         for (const auto screen : screens) {
-            setWallpaper(screen->name(), value, false, PersonalizationWallpaperContext::options_background);
+            // FIXME(mhduiy): only set image, only set to desktop
+            setWallpaper(screen->name(), value, false, WallpaperContext::wallpaper_role_desktop, WallpaperContext::wallpaper_source_type_image);
         }
     } else if(type == TYPEICON) {
         setIconTheme(value);
@@ -487,6 +503,17 @@ void TreeLandWorker::active()
         connect(m_personalizationManager.get(), &PersonalizationManager::activeChanged, this, [this]() {
             if (m_personalizationManager->isActive()) {
                 init();
+            } else {
+                // clear();
+            }
+        });
+    }
+
+    if (m_wallpaperManager.isNull()) {
+        m_wallpaperManager.reset(new WallpaperManager(this));
+        connect(m_wallpaperManager.get(), &WallpaperManager::activeChanged, this, [this]() {
+            if (m_wallpaperManager->isActive()) {
+                initWallpaperContext();
             } else {
                 // clear();
             }
@@ -640,6 +667,91 @@ void PersonalizationFontContext::treeland_personalization_font_context_v1_monosp
 void PersonalizationFontContext::treeland_personalization_font_context_v1_font_size(uint32_t)
 {
 
+}
+
+WallpaperManager::WallpaperManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<WallpaperManager>(1)
+{
+    if (QGuiApplication::platformName() == QLatin1String("wayland")) {
+        QtWaylandClient::QWaylandIntegration *waylandIntegration = static_cast<QtWaylandClient::QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration());
+        if (!waylandIntegration) {
+            qWarning() << "waylandIntegration is nullptr!!!";
+            return;
+        }
+        m_waylandDisplay = waylandIntegration->display();
+        if (!m_waylandDisplay) {
+            qWarning() << "waylandDisplay is nullptr!!!";
+            return;
+        }
+
+        addListener();
+    }
+    setParent(parent);
+}
+
+void WallpaperManager::addListener()
+{
+    if (!m_waylandDisplay) {
+        qWarning() << "waylandDisplay is nullptr!, skip addListener";
+        return;
+    }
+    m_waylandDisplay->addRegistryListener(&handleListenerGlobal, this);
+}
+
+void WallpaperManager::removeListener()
+{
+    if (!m_waylandDisplay) {
+        qWarning() << "waylandDisplay is nullptr!, skip removeListener";
+        return;
+    }
+    m_waylandDisplay->removeListener(&handleListenerGlobal, this);
+}
+
+void WallpaperManager::handleListenerGlobal(void *data, wl_registry *registry, uint32_t id, const QString &interface, uint32_t version)
+{
+    if (interface == treeland_wallpaper_manager_v1_interface.name) {
+        WallpaperManager *manager = static_cast<WallpaperManager *>(data);
+        if (!manager) {
+            qWarning() << "WallpaperManager is nullptr!!!";
+            return;
+        }
+
+        manager->init(registry, id, version);
+    }
+}
+
+// WallpaperContext implementation
+WallpaperContext::WallpaperContext(struct ::treeland_wallpaper_v1 *context)
+    : QWaylandClientExtensionTemplate<WallpaperContext>(1)
+    , QtWayland::treeland_wallpaper_v1(context)
+{
+
+}
+
+void WallpaperContext::setImageSource(const QString &filePath, wallpaper_role role)
+{
+    qCDebug(DdcPersonnalizationTreelandWorker) << "setImageSource:" << filePath << "role:" << role;
+    Q_EMIT wallpaperChanged(role, WallpaperContext::wallpaper_source_type_image, filePath);
+    set_image_source(filePath, static_cast<uint32_t>(role));
+}
+
+void WallpaperContext::setVideoSource(const QString &filePath, wallpaper_role role)
+{
+    qCDebug(DdcPersonnalizationTreelandWorker) << "setVideoSource:" << filePath << "role:" << role;
+    Q_EMIT wallpaperChanged(role, WallpaperContext::wallpaper_source_type_video, filePath);
+    set_video_source(filePath, static_cast<uint32_t>(role));
+}
+
+void WallpaperContext::treeland_wallpaper_v1_changed(uint32_t role, uint32_t source_type, const QString &file_source)
+{
+    qCDebug(DdcPersonnalizationTreelandWorker) << "wallpaper changed:" << file_source << "role:" << role << "type:" << source_type;
+    Q_EMIT wallpaperChanged(static_cast<wallpaper_role>(role), static_cast<wallpaper_source_type>(source_type), file_source);
+}
+
+void WallpaperContext::treeland_wallpaper_v1_failed(const QString &file_source, uint32_t error)
+{
+    qCWarning(DdcPersonnalizationTreelandWorker) << "wallpaper failed:" << file_source << "error:" << error;
+    Q_EMIT wallpaperFailed(file_source, error);
 }
 
 #endif

--- a/src/plugin-personalization/operation/treelandworker.h
+++ b/src/plugin-personalization/operation/treelandworker.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,12 +10,15 @@
 
 #include <private/qwaylanddisplay_p.h>
 
+#include "operation/personalizationexport.hpp"
 #include "operation/personalizationmodel.h"
 #include "personalizationworker.h"
 
 #ifdef Enable_Treeland
 #include "wayland-treeland-personalization-manager-v1-client-protocol.h"
 #include "qwayland-treeland-personalization-manager-v1.h"
+#include "wayland-treeland-wallpaper-manager-unstable-v1-client-protocol.h"
+#include "qwayland-treeland-wallpaper-manager-unstable-v1.h"
 #include "keyfile.h"
 #endif
 
@@ -24,6 +27,8 @@ class PersonalizationAppearanceContext;
 class PersonalizationWallpaperContext;
 class PersonalizationCursorContext;
 class PersonalizationFontContext;
+class WallpaperManager;
+class WallpaperContext;
 
 class TreeLandWorker : public PersonalizationWorker
 {
@@ -37,13 +42,14 @@ public:
     };
 
     TreeLandWorker(PersonalizationModel *model, QObject *parent = nullptr);
+    ~TreeLandWorker();
 
 #ifdef Enable_Treeland
-    void setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option) override;
-    void setBackgroundForMonitor(const QString &monitorName, const QString &url, bool isDark) override;
+    void setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option, PersonalizationExport::WallpaperType type) override;
+    void setBackgroundForMonitor(const QString &monitorName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image) override;
     QString getBackgroundForMonitor(const QString &monitorName);
 
-    void setLockBackForMonitor(const QString &monitorName, const QString &url, bool isDark) override;
+    void setLockBackForMonitor(const QString &monitorName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image) override;
     QString getLockBackForMonitor(const QString &monitorName);
 
     void setDefault(const QJsonObject &value) override;
@@ -83,6 +89,7 @@ public:
 
     void active() override;
     void init();
+    void initWallpaperContext();
 
 public slots:
     void onWallpaperUrlsChanged() override;
@@ -94,8 +101,8 @@ signals:
     void CursorThemeChanged(const QString &id);
 
 private:
-    void wallpaperMetaDataChanged(const QString &data);
-    void setWallpaper(const QString &monitorName, const QString &url, bool isDark, uint32_t type);
+    WallpaperContext *getOrCreateWallpaperContext(const QString &monitorName);
+    void setWallpaper(const QString &monitorName, const QString &url, bool isDark, uint32_t role, uint32_t type);
     void handleGlobalTheme(const QString &themeId);
     void applyGlobalTheme(KeyFile &theme, const QString &themeName, const QString &defaultTheme, const QString &themePath);
     void doSetByType(const QString &type, const QString &value);
@@ -103,9 +110,10 @@ private:
 private:
     QScopedPointer<PersonalizationManager> m_personalizationManager;
     QScopedPointer<PersonalizationAppearanceContext> m_appearanceContext;
-    QScopedPointer<PersonalizationWallpaperContext> m_wallpaperContext;
     QScopedPointer<PersonalizationCursorContext> m_cursorContext;
     QScopedPointer<PersonalizationFontContext> m_fontContext;
+    QScopedPointer<WallpaperManager> m_wallpaperManager;
+    QMap<QString, WallpaperContext *> m_wallpaperContexts;
 
     QMap<QString, WallpaperMetaData *> m_wallpapers;
     QMap<QString, WallpaperMetaData *> m_lockWallpapers;
@@ -204,5 +212,41 @@ protected:
 
 private:
     PersonalizationModel *m_model;
+};
+
+class WallpaperManager : public QWaylandClientExtensionTemplate<WallpaperManager>,
+                         public QtWayland::treeland_wallpaper_manager_v1
+{
+    Q_OBJECT
+public:
+    explicit WallpaperManager(QObject *parent = nullptr);
+
+private:
+    void addListener();
+    void removeListener();
+
+    static void handleListenerGlobal(void *data, wl_registry *registry, uint32_t id, const QString &interface, uint32_t version);
+
+private:
+    QtWaylandClient::QWaylandDisplay *m_waylandDisplay = nullptr;
+};
+
+class WallpaperContext : public QWaylandClientExtensionTemplate<WallpaperContext>,
+                         public QtWayland::treeland_wallpaper_v1
+{
+    Q_OBJECT
+public:
+    explicit WallpaperContext(struct ::treeland_wallpaper_v1 *context);
+
+    void setImageSource(const QString &filePath, wallpaper_role role);
+    void setVideoSource(const QString &filePath, wallpaper_role role);
+
+Q_SIGNALS:
+    void wallpaperChanged(wallpaper_role role, wallpaper_source_type type, const QString &fileSource);
+    void wallpaperFailed(const QString &fileSource, uint32_t error);
+
+protected:
+    void treeland_wallpaper_v1_changed(uint32_t role, uint32_t source_type, const QString &file_source) override;
+    void treeland_wallpaper_v1_failed(const QString &file_source, uint32_t error) override;
 };
 #endif

--- a/src/plugin-personalization/operation/wallpaperprovider.cpp
+++ b/src/plugin-personalization/operation/wallpaperprovider.cpp
@@ -12,6 +12,7 @@
 #include <QUrl>
 #include <QDir>
 #include <QHash>
+#include <QProcess>
 #include <QtConcurrent/QtConcurrent>
 #include <algorithm>
 
@@ -23,6 +24,7 @@ Q_LOGGING_CATEGORY(DdcPersonalizationWallpaperWorker, "dcc-personalization-wallp
 
 #define SYS_WALLPAPER_DIR "/usr/share/wallpapers/deepin"
 #define SYS_SOLIDE_WALLPAPER_DIR "/usr/share/wallpapers/deepin-solidwallpapers"
+#define SYS_LIVE_WALLPAPER_DIR "/usr/share/wallpapers/live-wallpapers"
 #define CUSTOM_SOLIDE_WALLPAPER_DIR "/var/cache/wallpapers/custom-solidwallpapers"
 #define CUSTOM_WALLPAPER_DIR "/var/cache/wallpapers/custom-wallpapers"
 
@@ -112,6 +114,10 @@ void WallpaperProvider::setWallpaper(const QList<WallpaperItemPtr> &items, Wallp
             m_wallpaperList[WallpaperType::Wallpaper_Solid] = items;
             m_model->getSolidWallpaperModel()->resetData(items);
             break;
+        case WallpaperType::Wallpaper_Live:
+            m_wallpaperList[WallpaperType::Wallpaper_Live] = items;
+            m_model->getLiveWallpaperModel()->resetData(items);
+            break;
         default:
             break;
     }
@@ -133,6 +139,10 @@ void WallpaperProvider::pushWallpaper(WallpaperItemPtr item, WallpaperType type)
         case WallpaperType::Wallpaper_Solid:
             m_wallpaperList[WallpaperType::Wallpaper_Solid].append(item);
             m_model->getSolidWallpaperModel()->appendItem(item);
+            break;
+        case WallpaperType::Wallpaper_Live:
+            m_wallpaperList[WallpaperType::Wallpaper_Live].append(item);
+            m_model->getLiveWallpaperModel()->appendItem(item);
             break;
         default:
             break;
@@ -277,6 +287,7 @@ void InterfaceWorker::startListBackground(WallpaperType type)
             getCustomBackground();
             getSysBackground();
             getSolodBackground();
+            getLiveBackground();
             break;
         case WallpaperType::Wallpaper_Sys:
             getSysBackground();
@@ -286,6 +297,9 @@ void InterfaceWorker::startListBackground(WallpaperType type)
             break;
         case WallpaperType::Wallpaper_Solid:
             getSolodBackground();
+            break;
+        case WallpaperType::Wallpaper_Live:
+            getLiveBackground();
             break;
         default:
             break;
@@ -387,4 +401,44 @@ QStringList InterfaceWorker::fetchWallpaper(const QString &dir)
     }
 
     return walls;
+}
+
+void InterfaceWorker::getLiveBackground()
+{
+    CHECK_RETURN_RUNNING
+    QList<WallpaperItemPtr> wallpapers;
+    
+    QDir dir(SYS_LIVE_WALLPAPER_DIR);
+    if (!dir.exists()) {
+        qCWarning(DdcPersonalizationWallpaperWorker) << "Live wallpaper dir not exists:" << SYS_LIVE_WALLPAPER_DIR;
+        Q_EMIT pushBackground(wallpapers, WallpaperType::Wallpaper_Live);
+        return;
+    }
+
+    QStringList nameFilters;
+    nameFilters << "*.mp4" << "*.MP4" << "*.mov" << "*.MOV" << "*.avi" << "*.AVI";
+    QFileInfoList fileInfoList = dir.entryInfoList(nameFilters, QDir::Files);
+    
+    for (const auto &fileInfo : fileInfoList) {
+        CHECK_RETURN_RUNNING
+        
+        QString videoPath = fileInfo.absoluteFilePath();
+        QUrl url = QUrl::fromLocalFile(videoPath);
+        
+        WallpaperItemPtr ptr(new WallpaperItem{
+            url.toString(),
+            url.toString(),
+            url.toString(),
+            false,
+            fileInfo.lastModified().toMSecsSinceEpoch(),
+            false,
+            false
+        });
+        
+        if (ptr)
+            wallpapers.append(ptr);
+    }
+    
+    qCDebug(DdcPersonalizationWallpaperWorker) << "Found" << wallpapers.size() << "live wallpapers";
+    Q_EMIT pushBackground(wallpapers, WallpaperType::Wallpaper_Live);
 }

--- a/src/plugin-personalization/operation/wallpaperprovider.h
+++ b/src/plugin-personalization/operation/wallpaperprovider.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 
@@ -18,6 +18,7 @@ enum WallpaperType{
     Wallpaper_Sys,
     Wallpaper_Custom,
     Wallpaper_Solid,
+    Wallpaper_Live,
     Wallpaper_Unknown
 };
 
@@ -31,6 +32,7 @@ public:
     void getSysBackground();
     void getCustomBackground();
     void getSolodBackground();
+    void getLiveBackground();
     QStringList fetchWallpaper(const QString &dir);
 
 signals:

--- a/src/plugin-personalization/operation/x11worker.cpp
+++ b/src/plugin-personalization/operation/x11worker.cpp
@@ -3,7 +3,9 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "x11worker.h"
+#include "operation/personalizationexport.hpp"
 #include "operation/personalizationworker.h"
+#include "operation/wallpaperprovider.h"
 
 #include <QLoggingCategory>
 #include <QTimer>
@@ -126,8 +128,12 @@ void X11Worker::setMiniEffect(int effect)
     }
 }
 
-void X11Worker::setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option)
+void X11Worker::setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option, PersonalizationExport::WallpaperType type)
 {
+    if (type != PersonalizationExport::Type_Image) {
+        return;
+    }
+
     if (checkWallpaperLockStatus()) {
         return;
     }
@@ -142,7 +148,7 @@ void X11Worker::setWallpaperForMonitor(const QString &screen, const QString &url
     }
 }
 
-void X11Worker::setBackgroundForMonitor(const QString &screenName, const QString &url, bool isDark)
+void X11Worker::setBackgroundForMonitor(const QString &screenName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type)
 {
     Q_UNUSED(isDark)
     qCDebug(DdcPersonnalizationX11Worker) << "setMonitorBackground " << screenName << url;
@@ -152,7 +158,7 @@ void X11Worker::setBackgroundForMonitor(const QString &screenName, const QString
     m_personalizationDBusProxy->SetCurrentWorkspaceBackgroundForMonitor(url, screenName);
 }
 
-void X11Worker::setLockBackForMonitor(const QString &screenName, const QString &url, bool isDark)
+void X11Worker::setLockBackForMonitor(const QString &screenName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type)
 {
     Q_UNUSED(isDark)
     qCDebug(DdcPersonnalizationX11Worker) << "setGreeterBackground " << screenName << url;

--- a/src/plugin-personalization/operation/x11worker.h
+++ b/src/plugin-personalization/operation/x11worker.h
@@ -1,9 +1,10 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
+#include "operation/personalizationexport.hpp"
 #include "operation/personalizationworker.h"
 
 class X11Worker : public PersonalizationWorker
@@ -18,9 +19,9 @@ public Q_SLOTS:
     void setWindowEffect(int value) override;
     void setMovedWindowOpacity(bool value) override;
     void setMiniEffect(int effect) override;
-    virtual void setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option) override;
-    void setBackgroundForMonitor(const QString &screenName, const QString &url, bool isDark) override;
-    void setLockBackForMonitor(const QString &screenName, const QString &url, bool isDark) override;
+    virtual void setWallpaperForMonitor(const QString &screen, const QString &url, bool isDark, PersonalizationExport::WallpaperSetOption option, PersonalizationExport::WallpaperType type) override;
+    void setBackgroundForMonitor(const QString &screenName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image) override;
+    void setLockBackForMonitor(const QString &screenName, const QString &url, bool isDark, PersonalizationExport::WallpaperType type = PersonalizationExport::Type_Image) override;
 
 private Q_SLOTS:
     void onMiniEffectChanged(bool value);

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -254,7 +254,12 @@ DccObject {
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: WallpaperSelectView {
-            // model: dccData.model.wallpaperModel
+            model: dccData.model.liveWallpaperModel
+            currentItem: dccData.model.wallpaperMap[dccData.model.currentSelectScreen]
+            enableContextMenu: false
+            onWallpaperSelected: (url, isDark, option) => {
+                                    dccData.worker.setWallpaperForMonitor(dccData.model.currentSelectScreen, url, isDark, option, PersonalizationExport.Type_Video)
+                                 }
         }
     }
 
@@ -262,7 +267,7 @@ DccObject {
         name: "solidColor"
         parentName: "personalization/wallpaper"
         displayName: qsTr("Solid color wallpaper")
-        weight: 600
+        weight: 700
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: WallpaperSelectView {


### PR DESCRIPTION
Adapt treeland-wallpaper-manager-unstable-v1 protocol, replace the old personalization wallpaper context with WallpaperManager/WallpaperContext. Add partial support for live(video) wallpapers including model, provider and QML page.

适配新的treeland-wallpaper-manager-unstable-v1壁纸协议，使用WallpaperManager/ WallpaperContext替代旧的PersonalizationWallpaperContext。部分支持动态(视频)壁纸， 包括model、provider和QML页面。

Log: 适配新wallpaper协议并部分支持动态壁纸
PMS: STORY-39897

## Summary by Sourcery

Switch to the new treeland wallpaper Wayland protocol and extend the personalization pipeline to distinguish wallpaper source types, including live video wallpapers.

New Features:
- Support live (video) wallpapers in the personalization UI, models, and provider, including a dedicated live wallpaper list and selection page.
- Introduce a WallpaperType API and plumb wallpaper type through the personalization workers so callers can specify image vs video wallpapers.
- Implement Wayland wallpaper manager/context clients using the treeland-wallpaper-manager-unstable-v1 protocol for per-monitor desktop and lockscreen wallpapers.

Enhancements:
- Replace the legacy PersonalizationWallpaperContext-based implementation with a new WallpaperManager/WallpaperContext abstraction tied to Wayland outputs.
- Update X11 and Treeland workers to the extended wallpaper-setting interface while keeping X11 limited to static image wallpapers.