### PR TITLE
fix: Fix extra taskbar icons when opening developer mode disclaimer

### DIFF
--- a/src/plugin-commoninfo/qml/DevelopModePage.qml
+++ b/src/plugin-commoninfo/qml/DevelopModePage.qml
@@ -112,7 +112,7 @@ DccObject {
                     active: dccData.mode().needShowModalDialog
                     sourceComponent: Window {
                         id: modalDialog
-                        flags: Qt.Window
+                        flags: Qt.Tool | Qt.FramelessWindowHint
                         modality: Qt.ApplicationModal
                         color: "transparent"
                         opacity: 0.0


### PR DESCRIPTION
fix: Fix extra taskbar icons when opening developer mode disclaimer

1. Change modal dialog window flags from Qt.Window to Qt.Tool | Qt.FramelessWindowHint
2. Qt.Tool windows do not appear in the taskbar, preventing extra icon entries

Influence: When entering developer mode, the taskbar should only show the control center icon, not extra modal dialog icons

fix: 修复开启开发者模式免责声明时任务栏出现多余图标

1. 将模态对话框窗口标志从 Qt.Window 改为 Qt.Tool | Qt.FramelessWindowHint
2. Qt.Tool 窗口不会在任务栏显示，避免出现多余的图标条目

Influence: 进入开发者模式时，任务栏应只显示控制中心图标，不应出现多余的模态对话框图标

PMS: BUG-359493

## Summary by Sourcery

Bug Fixes:
- Prevent the developer mode disclaimer modal from appearing as an additional taskbar icon by changing its window flags.