### PR TITLE
fix: reset search state on notification page destruction

### DIFF
--- a/src/plugin-notification/qml/NotificationMain.qml
+++ b/src/plugin-notification/qml/NotificationMain.qml
@@ -129,6 +129,11 @@ DccObject {
         property bool searchVisible: false
 
         page: RowLayout {
+
+            Component.onDestruction:   {
+                appNotifyTitle.searchVisible = false
+            }
+
             Timer {
                 id: searchTimer
                 interval: 100


### PR DESCRIPTION
1. Added Component.onDestruction handler to reset searchVisible flag
2. Ensures search state is properly cleaned up when notification page is destroyed
3. Prevents inconsistent UI state when navigating away from notification settings

Log: Fixed search state not resetting when leaving notification page

Influence:
1. Test navigating away from notification settings while search is active
2. Verify search field properly disappears when leaving the page
3. Test repeated enter/leave operations on notification page
4. Verify no UI glitches or stuck search states

fix: 通知页面销毁时重置搜索状态

1. 添加 Component.onDestruction 事件处理重置 searchVisible 标志
2. 确保通知页面被销毁时搜索状态被正确清理
3. 防止离开通知设置页面时出现 UI 状态不一致

Log: 修复离开通知页面时搜索状态未重置的问题

Influence:
1. 在搜索状态下测试离开通知设置页面
2. 验证离开页面时搜索框正确隐藏
3. 测试多次进入/离开通知页面的操作
4. 验证无 UI 卡顿或搜索状态卡死问题

PMS: BUG-359713
Change-Id: I7f6d64ffc35e4340c6a29244f593d682d578cdf3

## Summary by Sourcery

Bug Fixes:
- Clear the notification title search visibility flag on page destruction to prevent the search field remaining visible after leaving the page.