### PR TITLE
fix: Fix Tab key cycling in control center settings pages

### DIFF
--- a/src/dde-control-center/plugin/SecondPage.qml
+++ b/src/dde-control-center/plugin/SecondPage.qml
@@ -245,7 +245,7 @@ Item {
             clip: true
             hoverEnabled: true
             focus: true
-            activeFocusOnTab: true
+            activeFocusOnTab: false
             anchors {
                 fill: parent
                 topMargin: 50


### PR DESCRIPTION
## Bug
PMS: BUG-359461

控制中心设置子页面中，Tab键无法在设置控件间循环切换。当Tab到最后一个控件后继续按Tab，焦点不会回到第一个控件，而是卡在最后一个控件。Shift+Tab反向一直正常。

## Root Cause
StackView设置了activeFocusOnTab: true，导致它成为Tab焦点链的一个节点。当Tab离开右侧设置区域后循环回来时，StackView的焦点记忆机制会恢复到最后一个获得焦点的子控件，形成死循环。

## Fix
将StackView的activeFocusOnTab设为false，使Tab焦点链绕过StackView，直接在左侧ListView和右侧设置控件之间导航，实现正常的循环Tab切换。

Shift+Tab不受影响，反向焦点链天然正确循环。

## Test
在控制中心任意设置子页面（如电源管理→使用电源），连续按Tab验证所有控件都能循环聚焦。