### PR TITLE
fix: add first letter search support for apps list

### DIFF
--- a/src/plugin-notification/operation/appslistmodel.cpp
+++ b/src/plugin-notification/operation/appslistmodel.cpp
@@ -52,6 +52,7 @@ bool AppsListModel::filterAcceptsRow(int source_row, const QModelIndex &source_p
     QModelIndex appNameIndex = sourceModel()->index(source_row, 0, source_parent);
     QString appName = sourceModel()->data(appNameIndex, AppNameRole).toString();
     QString transliterated = sourceModel()->data(appNameIndex, TransliteratedRole).toString();
+    QString firstLetter = sourceModel()->data(appNameIndex, FirstLetterRole).toString();
 
-    return appName.contains(filterRegularExpression()) || transliterated.contains(filterRegularExpression());
+    return appName.contains(filterRegularExpression()) || transliterated.contains(filterRegularExpression()) || firstLetter.contains(filterRegularExpression());
 }

--- a/src/plugin-notification/operation/appssourcemodel.cpp
+++ b/src/plugin-notification/operation/appssourcemodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "appssourcemodel.h"
@@ -27,6 +27,7 @@ QHash<int, QByteArray> AppsSourceModel::roleNames() const
     names[ShowNotificationCenterRole] = "ShowNotificationCenter";
     names[LockScreenShowNotificationRole] = "LockScreenShowNotification";
     names[TransliteratedRole] = "Transliterated";
+    names[FirstLetterRole] = "FirstLetter";
     return names;
 }
 
@@ -89,6 +90,11 @@ QVariant AppsSourceModel::data(const QModelIndex &index, int role) const
         if (firstChar.isDigit()) return QString("#%1").arg(transliterated);
         else if (!firstChar.isLetter()) return QString("&%1").arg(transliterated);
         return transliterated;
+    }
+    case FirstLetterRole: {
+        const auto decodedFirstLetters = Dtk::Core::firstLetters(index.data(AppNameRole).toString(), Dtk::Core::TS_NoneTone);
+        if (decodedFirstLetters.isEmpty()) return QString();
+        return decodedFirstLetters.join(QString()).toLower();
     }
     default:
         break;

--- a/src/plugin-notification/operation/appssourcemodel.h
+++ b/src/plugin-notification/operation/appssourcemodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef APPSSOURCEMODEL_H
@@ -20,7 +20,8 @@ enum AppsSourceModelRole
     ShowNotificationDesktopRole,
     ShowNotificationCenterRole,
     LockScreenShowNotificationRole,
-    TransliteratedRole
+    TransliteratedRole,
+    FirstLetterRole
 };
 
 class AppsSourceModel : public QAbstractItemModel


### PR DESCRIPTION
1. Added a new role FirstLetterRole in the model to extract and store first letters of app names
2. Modified the filter logic to also match against the first letter of app names in the notification apps list
3. Used Dtk::Core::firstLetters to convert Chinese characters to their pinyin initial letters for consistent search behavior
4. Updated role names and filter acceptance to enable character-by- letter searching

Log: Added ability to search apps by their first letter (pinyin initials) in the notification settings

Influence:
1. Test searching for apps using first letters (e.g., "wx" should find WeChat)
2. Verify mixed search with full names and first letters
3. Test empty and invalid input scenarios for the search field
4. Ensure performance is not degraded with large app lists
5. Verify the first letter extraction works for multi-character app names

fix: 为应用列表添加首字母搜索支持

1. 在模型中新增 FirstLetterRole，提取并存储应用名称的首字母
2. 修改过滤逻辑，使其也匹配应用名称的首字母
3. 使用 Dtk::Core::firstLetters 将中文字符转换为拼音首字母，确保搜索一 致性
4. 更新角色名称和过滤条件，实现按字母搜索功能

Log: 新增在通知设置中通过首字母搜索应用的功能

Influence:
1. 使用首字母搜索应用（如 "wx" 应找到微信）
2. 测试完整名称和首字母混合搜索
3. 测试搜索框为空或无效输入的情况
4. 确保大量应用列表时性能不受影响
5. 验证多字应用名称的首字母提取功能

PMS: BUG-359709
Change-Id: I6fce81841baf52c858564e96df99e8310cfd75d5

## Summary by Sourcery

Add first-letter based search support for notification apps list, including pinyin initials for Chinese app names.

New Features:
- Expose a FirstLetter role in the apps source model to store initial letters of app names, including pinyin initials for Chinese characters.
- Extend the notification apps list filtering to match against stored first letters in addition to full names and transliterated names.