### PR TITLE
fix: adjust path calculation for handle alignment

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -50,7 +50,7 @@ Depends:
  qml6-module-qt-labs-qmlmodels,
  qml6-module-qtquick-dialogs,
  qml6-module-qtquick-effects,
- libdtk6declarative(>> 6.7.36),
+ libdtk6declarative(>> 6.7.40),
  netselect,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock

--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -156,7 +156,7 @@ DccObject {
                     Slider {
                         id: slider
                         anchors.fill: parent
-                        handleType: -2
+                        handleType: Slider.HandleType.NoArrowType
                         highlightedPassedGroove: true
                         value: dccData.model().microphoneFeedback
                     }


### PR DESCRIPTION
When handleType is NoHandleType, the x-coordinate calculation now calculates based on sliderGroove to correct the visual alignment of the slider path.

Log: adjust path calculation for handle alignment
PMS: BUG-358623
Influence: 检查输入设备的反馈音量显示是否正确，同时关注静音场景（PMS:350837）

## Summary by Sourcery

Bug Fixes:
- Correct microphone feedback slider path alignment by using the NoArrowType handle configuration.