### PR TITLE
chore: update changelog to 6.1.85

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.1.85) unstable; urgency=medium
+
+  * fix: Fix Tab key cycling in control center settings pages
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 08 May 2026 16:44:10 +0800
+
 dde-control-center (6.1.84) unstable; urgency=medium
 
   * refactor: split PluginManager into DccPluginLoader and


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.85

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.85
- 目标分支: master
