### PR TITLE
fix: reset AlertToolTip visible after fade-out to free layout space

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -258,6 +258,11 @@ DccObject {
                             timeout: 3000
                             visible: false
 
+                            on_ExpiredChanged: {
+                                if (_expired && visible)
+                                    visible = false
+                            }
+
                             function show(msg) {
                                 text = msg;
                                 visible = true;                                


### PR DESCRIPTION
After the AlertToolTip is automatically hidden, reset the visible state to prevent layout anomalies

AlertToolTip自动隐藏后，重置visible状态，防止布局异常

Log: reset AlertToolTip visible state
PMS: BUG-354177
Influence: 错误提示的显示样式和位置是否正确；生物认证数据项整体布局是否正确；