### PR TITLE
fix(display): adjust layout on scale change in extend mode

### DIFF
--- a/src/plugin-display/operation/dccscreen.cpp
+++ b/src/plugin-display/operation/dccscreen.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccscreen.h"
@@ -123,6 +123,9 @@ void DccScreenPrivate::setMonitors(QList<Monitor *> monitors)
     q_ptr->connect(monitor(), &Monitor::currentModeChanged, q_ptr, &DccScreen::currentModeChanged);
     q_ptr->connect(monitor(), &Monitor::enableChanged, q_ptr, &DccScreen::enableChanged);
     q_ptr->connect(monitor(), &Monitor::rotateChanged, q_ptr, &DccScreen::rotateChanged);
+    q_ptr->connect(monitor(), &Monitor::scaleChanged, q_ptr, &DccScreen::scaleChanged);
+    q_ptr->connect(monitor(), &Monitor::scaleChanged, q_ptr, &DccScreen::widthChanged);
+    q_ptr->connect(monitor(), &Monitor::scaleChanged, q_ptr, &DccScreen::heightChanged);
     q_ptr->connect(monitor(), &Monitor::xChanged, q_ptr, &DccScreen::xChanged);
     q_ptr->connect(monitor(), &Monitor::yChanged, q_ptr, &DccScreen::yChanged);
     q_ptr->connect(monitor(), &Monitor::wChanged, q_ptr, &DccScreen::widthChanged);

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -62,6 +62,7 @@ DisplayModulePrivate::DisplayModulePrivate(DisplayModule *parent)
     , m_primary(nullptr)
     , m_maxGlobalScale(1.0)
 {
+    qRegisterMetaType<QHash<Monitor *, QPair<int, int>>>("QHash<Monitor *, QPair<int, int>>");
     m_model = new DisplayModel(q_ptr);
     m_worker = new DisplayWorker(m_model, q_ptr);
     init();
@@ -137,6 +138,9 @@ void DisplayModulePrivate::updateVirtualScreens()
         q_ptr->connect(screen, &DccScreen::rotateChanged, q_ptr, &DisplayModule::applyChanged, Qt::QueuedConnection);
         q_ptr->connect(screen, &DccScreen::currentModeChanged, q_ptr, &DisplayModule::applyChanged, Qt::QueuedConnection);
         q_ptr->connect(screen, &DccScreen::wallpaperChanged, q_ptr, &DisplayModule::wallpaperChanged);
+        q_ptr->connect(screen, &DccScreen::scaleChanged, q_ptr, [this, screen]() {
+            updateScale(screen);
+        });
         m_virtualScreens << screen;
     }
     if (changed) {
@@ -279,9 +283,13 @@ QString DisplayModulePrivate::displayMode() const
     return m_displayMode;
 }
 
-void DisplayModulePrivate::setScreenPosition(QList<ScreenData *> screensData)
+void DisplayModulePrivate::setScreenPosition(const QList<ScreenData *> &screensData)
 {
-    qRegisterMetaType<QHash<Monitor *, QPair<int, int>>>("QHash<Monitor *, QPair<int, int>>");
+    m_worker->setMonitorPosition(buildMonitorPosition(screensData));
+}
+
+QHash<Monitor *, QPair<int, int>> DisplayModulePrivate::buildMonitorPosition(const QList<ScreenData *> &screensData)
+{
     QHash<Monitor *, QPair<int, int>> monitorPosition;
     int lstX = 1000000, lstY = 1000000;
     for (auto item : screensData) {
@@ -303,7 +311,40 @@ void DisplayModulePrivate::setScreenPosition(QList<ScreenData *> screensData)
     for (auto it = monitorPosition.cbegin(); it != monitorPosition.cend(); ++it) {
         qDebug() << "applySettings 处理之后:" << it.key()->name() << it.value() << it.key()->w() << it.key()->h();
     }
-    m_worker->setMonitorPosition(monitorPosition);
+    return monitorPosition;
+}
+
+void DisplayModulePrivate::updateScale(DccScreen *item)
+{
+    if (!item || m_model->displayMode() != EXTEND_MODE) {
+        return;
+    }
+    QList<ScreenData *> tmpListItems;
+    ScreenData *pwItem = nullptr;
+    for (auto obj : m_virtualScreens) {
+        if (obj) {
+            ScreenData *tmpItem = new ScreenData(obj);
+            tmpListItems.append(tmpItem);
+            if (obj == item) {
+                pwItem = tmpItem;
+            }
+        }
+    }
+    if (tmpListItems.size() < 2 || !pwItem) {
+        qDeleteAll(tmpListItems);
+        return;
+    }
+    ConcatScreen *concatScreen = new ConcatScreen(tmpListItems, pwItem);
+    concatScreen->executemultiScreenAlgo(true);
+    delete concatScreen;
+
+    auto monitorPosition = buildMonitorPosition(tmpListItems);
+    m_worker->updateMonitorPosition(monitorPosition);
+    qDeleteAll(tmpListItems);
+    // 设置过快会导致treeland崩溃
+    QTimer::singleShot(300, q_ptr, [this, monitorPosition] {
+        m_worker->setMonitorPosition(monitorPosition);
+    });
 }
 
 DisplayModule::DisplayModule(QObject *parent)
@@ -572,6 +613,7 @@ void DisplayModule::executemultiScreenAlgo(QList<QObject *> listItems, QObject *
         }
     }
     if (tmpListItems.size() < 2 || !pwItem) {
+        qDeleteAll(tmpListItems);
         return;
     }
     ConcatScreen *concatScreen = new ConcatScreen(tmpListItems, pwItem);

--- a/src/plugin-display/operation/private/displaymodule_p.h
+++ b/src/plugin-display/operation/private/displaymodule_p.h
@@ -1,16 +1,19 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DISPLAYMODULE_P_H
 #define DISPLAYMODULE_P_H
 
+#include <QHash>
 #include <QObject>
+#include <QPair>
 
 namespace dccV25 {
 class DisplayWorker;
 class DisplayModel;
 class DisplayModule;
 class DccScreen;
+class Monitor;
 class ScreenData;
 
 class DisplayModulePrivate
@@ -29,7 +32,9 @@ public:
     void updateMaxGlobalScale();
     DccScreen *primary() const;
     QString displayMode() const;
-    void setScreenPosition(QList<ScreenData *> screensData);
+    void setScreenPosition(const QList<ScreenData *> &screensData);
+    void updateScale(DccScreen *item);
+    QHash<Monitor *, QPair<int, int>> buildMonitorPosition(const QList<ScreenData *> &screensData);
 
 public:
     DisplayModule *q_ptr;

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -554,7 +554,15 @@ void DisplayWorker::setMonitorBrightness(Monitor *mon, const double brightness)
     }
 }
 
-void DisplayWorker::setMonitorPosition(QHash<Monitor *, QPair<int, int>> monitorPosition)
+void DisplayWorker::updateMonitorPosition(const QHash<Monitor *, QPair<int, int>> &monitorPosition)
+{
+    for (auto it(monitorPosition.cbegin()); it != monitorPosition.cend(); ++it) {
+        it.key()->setX(it.value().first);
+        it.key()->setY(it.value().second);
+    }
+}
+
+void DisplayWorker::setMonitorPosition(const QHash<Monitor *, QPair<int, int>> monitorPosition)
 {
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -59,7 +59,8 @@ public Q_SLOTS:
 #endif
     void setMonitorResolution(Monitor *mon, const int mode);
     void setMonitorBrightness(Monitor *mon, const double brightness);
-    void setMonitorPosition(QHash<Monitor *, QPair<int, int>> monitorPosition);
+    void updateMonitorPosition(const QHash<Monitor *, QPair<int, int>> &monitorPosition);
+    void setMonitorPosition(const QHash<Monitor *, QPair<int, int> > monitorPosition);
     void setUiScale(const double value);
     void setIndividualScaling(Monitor *m, const double scaling);
     void setTouchScreenAssociation(const QString &monitor, const QString &touchscreenUUID);


### PR DESCRIPTION
1. Connect Monitor::scaleChanged signal through DccScreen to trigger layout recalculation when a monitor's scale changes
2. Add updateScale() to rerun ConcatScreen multi-screen algorithm and recompute monitor positions after scale change
3. Extract buildMonitorPosition() from setScreenPosition() to share monitor position calculation logic between the two methods
4. Add updateMonitorPosition() in DisplayWorker to update Monitor coordinates locally without backend commit
5. Move qRegisterMetaType to constructor to avoid repeated registration
6. Use two-step position update (immediate local update + 300ms delayed backend commit) to prevent treeland crash from rapid config changes

Log: 扩展模式下修改屏幕缩放后自动重排多屏布局

Influence:
1. 多屏扩展模式下修改某个屏幕的缩放比例，验证各屏幕位置是否 自动重新排列
2. 快速连续修改缩放比例，验证是否出现treeland崩溃

fix(display): 扩展模式下缩放变化时调整屏幕布局

1. 将Monitor::scaleChanged信号通过DccScreen传递，在缩放变化时触发 布局重算
2. 新增updateScale()方法，通过ConcatScreen多屏算法重新计算各显示器 位置
3. 从setScreenPosition()中提取buildMonitorPosition()，共享显示器位置 计算逻辑
4. 在DisplayWorker中新增updateMonitorPosition()，仅本地更新Monitor坐标
5. 将qRegisterMetaType移至构造函数，避免每次调用时重复注册
6. 采用两步位置更新（立即本地更新 + 延迟300ms后端提交），防止treeland 因快速配置变更崩溃

Log: 扩展模式下修改屏幕缩放后自动重排多屏布局

Influence:
1. 多屏扩展模式下修改某个屏幕的缩放比例，验证各屏幕位置是否 自动重新排列
2. 快速连续修改缩放比例，验证是否出现treeland崩溃

PMS: BUG-304077