### PR TITLE
fix: normalize space symbol checks

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -144,6 +144,19 @@ static inline QString unEscapSpace(const QString &space)
     return space.at(0).isSpace() ? DatetimeModel::tr("Space") : space;
 }
 
+static inline bool isSpaceSymbol(const QString &value)
+{
+    if (value.isEmpty())
+        return false;
+
+    return value == DatetimeModel::tr("Space") || value.at(0).isSpace();
+}
+
+static inline QString normalizedSymbol(const QString &value)
+{
+    return isSpaceSymbol(value) ? DatetimeModel::tr("Space") : value;
+}
+
 // 将显示用的符号转换回实际的字符
 // 如果用户选择了 "Space"，返回区域对应的实际空格字符
 static inline QString escapSpace(const QString &displaySymbol, const QLocale &locale, bool grouping)
@@ -1435,8 +1448,9 @@ bool DatetimeModel::hasSymbolConflict() const
 
 bool DatetimeModel::symbolsConflict(const QString &decimal, const QString &separator) const
 {
-    // 检查两个符号是否非空且相同
-    return !decimal.isEmpty() && !separator.isEmpty() && decimal == separator;
+    // 所有空白类字符在符号逻辑中都视为同一个 "Space" 符号
+    return !decimal.isEmpty() && !separator.isEmpty()
+            && normalizedSymbol(decimal) == normalizedSymbol(separator);
 }
 
 QStringList DatetimeModel::getAllSupportedSymbols() const
@@ -1494,7 +1508,7 @@ QString DatetimeModel::resolveDecimalSymbol(const QString &decimal, const QStrin
     } else if (separator == ".") {
         // 点→逗号：当分隔符是点时，小数点改为逗号
         return ",";
-    } else if (separator == " " || separator == tr("Space")) {
+    } else if (isSpaceSymbol(separator)) {
         // 空格→点：当分隔符是空格时，小数点改为点
         return ".";
     } else if (separator == "'") {
@@ -1532,7 +1546,7 @@ QStringList DatetimeModel::getFilteredDecimalSymbols() const
         symbols.removeAll(currentSeparator);
         
         // 如果当前分隔符是空格字符，也要排除实际的空格字符
-        if (currentSeparator.contains(' ')) {
+        if (isSpaceSymbol(currentSeparator)) {
             symbols.removeAll(" ");
         }
     }
@@ -1555,9 +1569,9 @@ QStringList DatetimeModel::getFilteredSeparatorSymbols() const
     QString currentSeparator = m_work->digitGroupingSymbol();
     
     // 检查小数点是否为空格（空字符串或空格字符）
-    bool isDecimalSpace = currentDecimal.isEmpty() || currentDecimal.contains(' ');
+    bool isDecimalSpace = currentDecimal.isEmpty() || isSpaceSymbol(currentDecimal);
     // 检查分隔符是否为空格
-    bool isSeparatorSpace = currentSeparator.isEmpty() || currentSeparator.contains(' ');
+    bool isSeparatorSpace = currentSeparator.isEmpty() || isSpaceSymbol(currentSeparator);
     
     // 场景1：小数点为空格，分隔符也为空格 → 冲突！需要自动调整小数点
     if (isDecimalSpace && isSeparatorSpace) {
@@ -1591,7 +1605,7 @@ QStringList DatetimeModel::getFilteredSeparatorSymbols() const
             symbols.removeAll(currentDecimal);
             
             // 如果当前小数点是空格字符，也要排除实际的空格字符
-            if (currentDecimal.contains(' ')) {
+            if (isSpaceSymbol(currentDecimal)) {
                 symbols.removeAll(" ");
             }
         } else {


### PR DESCRIPTION
1. Normalize space-like symbols before conflict checks to treat translated "Space" and blanks consistently.
2. Reuse a shared space-symbol helper when resolving decimal and grouping separators.
3. Prevent filtered symbol lists from missing space conflicts caused by localized display values.

Log: Fix the inconsistency in handling space symbols, which causes the separators and decimal points to display as blank.

fix: 统一空格符号判断逻辑

1. 在冲突检测前统一归一化空格类符号，保证翻译后的“Space”和空白字符被一致处理。
2. 通过复用空格符号辅助方法，统一小数点和分组分隔符的解析逻辑。
3. 避免本地化显示值导致过滤后的符号列表遗漏空格冲突。

Log: 修复空格符号处理不一致导致分隔符和小数点显示为空白。
PMS: BUG-359911