### PR TITLE
fix: persist display scale after logout and re-login

### DIFF
--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -85,10 +85,10 @@ void DisplayWorker::active()
         //                               "AllowEnableMultiScaleRatio",
         //                               false));
 
-        QDBusPendingCallWatcher *scalewatcher = new QDBusPendingCallWatcher(m_displayInter->GetScaleFactor());
+        QDBusPendingCallWatcher *scalewatcher = new QDBusPendingCallWatcher(m_displayInter->GetScaleFactor(), this);
         connect(scalewatcher, &QDBusPendingCallWatcher::finished, this, &DisplayWorker::onGetScaleFinished);
 
-        QDBusPendingCallWatcher *screenscaleswatcher = new QDBusPendingCallWatcher(m_displayInter->GetScreenScaleFactors());
+        QDBusPendingCallWatcher *screenscaleswatcher = new QDBusPendingCallWatcher(m_displayInter->GetScreenScaleFactors(), this);
         connect(screenscaleswatcher, &QDBusPendingCallWatcher::finished, this, &DisplayWorker::onGetScreenScalesFinished);
 
         onMonitorsBrightnessChanged(m_displayInter->brightness());


### PR DESCRIPTION
1. Set `this` as parent for two QDBusPendingCallWatcher objects in DisplayWorker::active()
2. Without a parent, the watcher cannot be moved to the correct thread during thread switches, causing its connected slots to never execute, so scale factors are not saved
3. Affects GetScaleFactor and GetScreenScaleFactors watchers

PMS: BUG-360835

Influence:
1. Switch display scale, log out and re-login, verify the scale setting is correctly preserved
2. Set different scale factors per monitor, log out and re-login to verify each monitor keeps its scale

fix: 修复切换缩放后注销再登录缩放恢复为100%的问题

1. 为 DisplayWorker::active() 中的两个 QDBusPendingCallWatcher 对象设置 this 作为 parent
2. 未设置 parent 时，切换线程后 watcher 无法找到目标线程， 导致连接的槽函数永远不会执行，缩放比例未能正确保存
3. 影响 GetScaleFactor 和 GetScreenScaleFactors 的 watcher

PMS: BUG-360835

Influence:
1. 切换缩放比例后注销再重新登录，验证缩放设置是否被正确保持
2. 多显示器场景下分别设置不同缩放比例后注销再登录验证