### PR TITLE
fix: update event logger ID for control center page stay

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -36,7 +36,7 @@
 #include <dde-api/eventlogger.hpp>
 
 // Event ID for control center page stay (10-digit number)
-constexpr qint64 EVENT_LOGGER_CONTROL_CENTER_STAY = 1000600012;
+constexpr qint64 EVENT_LOGGER_CONTROL_CENTER_STAY = 1000610008;
 #endif
 
 DCORE_USE_NAMESPACE


### PR DESCRIPTION
Update EVENT_LOGGER_CONTROL_CENTER_STAY from 1000600012 to 1000610008 to align with the latest event tracking system.

Log: Update the event logger ID for control center page stay tracking.

fix: 更新控制中心页面停留事件日志ID

将 EVENT_LOGGER_CONTROL_CENTER_STAY 从 1000600012 更新为 1000610008， 以匹配最新的事件追踪系统。

Log: 更新控制中心页面停留事件日志ID。
PMS: BUG-360911