### PR TITLE
feat(factory): upgrade DccFactory to v2.0 with lifecycle and DBus data channel

### DIFF
--- a/include/dccfactory.h
+++ b/include/dccfactory.h
@@ -1,43 +1,104 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DCCFACTORY_H
 #define DCCFACTORY_H
 
 #include <QObject>
+#include <QVariantMap>
 
 namespace dccV25 {
-#define DccFactory_iid "org.deepin.dde.dcc-factory/v1.0"
+#define DccFactory_iid "org.deepin.dde.dcc-factory/v2.0"
 class DccObject;
 
-class DccFactory : public QObject
+class DccFactory_20 : public QObject
 {
     Q_OBJECT
 public:
     using QObject::QObject;
 
-    // 作为数据返回，会导出为dccData供main.qml使用
+    // 注册类型，在主线程中调用
+    virtual void registerType() { };
+
+    // 作为数据返回，会导出为dccData供main.qml使用，在子线程中调用
     virtual QObject *create(QObject * = nullptr) { return nullptr; }
 
-    // 未提供qml的，可在此自己加载qml返回DccObject对象
+    // 激活，在主线程中调用
+    virtual void active() { };
+
+    // 未提供qml的，可在此自己加载qml返回DccObject对象，在主线程中调用
     virtual DccObject *dccObject(QObject * = nullptr) { return nullptr; }
+
+    //////////^^^^初始化流程按以上函数顺序调用^^^^//////////////////
+
+    // 获取数据，DBus触发，在子线程中调用（注意加锁），建议支持批量获取
+    virtual const QVariantMap get(const QVariantMap &param) { return QVariantMap(); }
+
+    // 设置数据，DBus触发，在子线程中调用（注意加锁），建议支持批量设置，返回为空表示设置成功，否则返回错误信息
+    virtual const QVariantMap set(const QVariantMap &param) { return QVariantMap(); }
+
+Q_SIGNALS:
+    // 模块中有设置项变化时，发出该信号
+    // 命名valuesChanged() 待定
+    void propertiesChanged(const QVariantMap &properties);
 };
 } // namespace dccV25
-Q_DECLARE_INTERFACE(dccV25::DccFactory, DccFactory_iid)
+Q_DECLARE_INTERFACE(dccV25::DccFactory_20, DccFactory_iid)
 
-#define DCC_FACTORY_CLASS(classname)                                      \
-    namespace {                                                           \
-    class Q_DECL_EXPORT classname##DccFactory : public dccV25::DccFactory \
-    {                                                                     \
-        Q_OBJECT                                                          \
-        Q_PLUGIN_METADATA(IID DccFactory_iid)                             \
-        Q_INTERFACES(dccV25::DccFactory)                                  \
-    public:                                                               \
-        using dccV25::DccFactory::DccFactory;                             \
-        QObject *create(QObject *parent = nullptr) override               \
-        {                                                                 \
-            return new classname(parent);                                 \
-        }                                                                 \
-    };                                                                    \
+#define DCC_FACTORY_CLASS(classname)                                         \
+    namespace {                                                              \
+    class Q_DECL_EXPORT classname##DccFactory : public dccV25::DccFactory_20 \
+    {                                                                        \
+        Q_OBJECT                                                             \
+        Q_PLUGIN_METADATA(IID DccFactory_iid)                                \
+        Q_INTERFACES(dccV25::DccFactory_20);                                 \
+                                                                             \
+    public:                                                                  \
+        using dccV25::DccFactory_20::DccFactory_20;                          \
+        QObject *create(QObject *parent = nullptr) override                  \
+        {                                                                    \
+            return new classname(parent);                                    \
+        }                                                                    \
+    };                                                                       \
+    }
+
+#define DCC_FULL_FACTORY_CLASS(classname)                                                                          \
+    namespace {                                                                                                    \
+    class Q_DECL_EXPORT classname##DccFactory : public dccV25::DccFactory_20                                       \
+    {                                                                                                              \
+        Q_OBJECT                                                                                                   \
+        Q_PLUGIN_METADATA(IID DccFactory_iid)                                                                      \
+        Q_INTERFACES(dccV25::DccFactory_20);                                                                       \
+                                                                                                                   \
+    public:                                                                                                        \
+        using dccV25::DccFactory_20::DccFactory_20;                                                                \
+        void registerType() override                                                                               \
+        {                                                                                                          \
+            classname::registerType();                                                                             \
+        }                                                                                                          \
+        QObject *create(QObject *parent = nullptr) override                                                        \
+        {                                                                                                          \
+            if (!m_object) {                                                                                       \
+                m_object = new classname(parent);                                                                  \
+                connect(m_object, &classname::propertiesChanged, this, &classname##DccFactory::propertiesChanged); \
+            }                                                                                                      \
+            return m_object;                                                                                       \
+        }                                                                                                          \
+        void active() override                                                                                     \
+        {                                                                                                          \
+            m_object->active();                                                                                    \
+        }                                                                                                          \
+        const QVariantMap get(const QVariantMap &param) override                                                           \
+        {                                                                                                          \
+            return m_object->get(param);                                                                           \
+        }                                                                                                          \
+        const QVariantMap set(const QVariantMap &param) override                                                           \
+        {                                                                                                          \
+            return m_object->set(param);                                                                           \
+        }                                                                                                          \
+                                                                                                                   \
+    private:                                                                                                       \
+        classname *m_object = nullptr;                                                                             \
+    };                                                                                                             \
     }
 #endif // DCCFACTORY_H

--- a/src/dde-control-center/controlcenterdbusadaptor.cpp
+++ b/src/dde-control-center/controlcenterdbusadaptor.cpp
@@ -96,6 +96,16 @@ void ControlCenterDBusAdaptor::Toggle()
     parent()->toggle();
 }
 
+QVariantMap ControlCenterDBusAdaptor::Get(const QString &module, const QVariantMap &param)
+{
+    return parent()->get(module, param);
+}
+
+QVariantMap ControlCenterDBusAdaptor::Set(const QString &module, const QVariantMap &param)
+{
+    return parent()->set(module, param);
+}
+
 QString ControlCenterDBusAdaptor::GetAllModule()
 {
     return parent()->GetAllModule();
@@ -142,7 +152,7 @@ DBusControlCenterGrandSearchService::DBusControlCenterGrandSearchService(DccMana
     : QDBusAbstractAdaptor(parent)
     , m_autoExitTimer(new QTimer(this))
 {
-    m_autoExitTimer->setInterval(10000);
+    m_autoExitTimer->setInterval(60000);
     m_autoExitTimer->setSingleShot(true);
     connect(m_autoExitTimer, &QTimer::timeout, this, [this]() {
         // 当主界面show出来之后不再执行自动退出

--- a/src/dde-control-center/controlcenterdbusadaptor.h
+++ b/src/dde-control-center/controlcenterdbusadaptor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
@@ -47,9 +47,14 @@ public Q_SLOTS: // METHODS
     void ShowHome();
     void ShowPage(const QString &url);
     void Toggle();
+    QVariantMap Get(const QString &module, const QVariantMap &param);
+    QVariantMap Set(const QString &module, const QVariantMap &param); // 成功返回空，错误以DBus的错误返回
     QString GetAllModule();
     Q_DECL_DEPRECATED_X("Use ShowPage") void ShowPage(const QString &module, const QString &page);
     Q_DECL_DEPRECATED_X("Use ShowPage") void ShowModule(const QString &module);
+
+Q_SIGNALS:
+    void PropertiesChanged(const QString &module, const QVariantMap &properties);
 
 private:
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/dde-control-center/dccfactoryadapter.h
+++ b/src/dde-control-center/dccfactoryadapter.h
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include "dccfactory.h"
+#include "dccfactoryold.h"
+
+namespace dccV25 {
+
+// 适配器类：兼容旧版 DccFactory，适配到 DccFactory_20
+// 用于 DccPluginLoader 中统一处理新旧版本工厂
+class DccFactoryAdapter : public DccFactory_20
+{
+public:
+    // 包装旧版 DccFactory
+    explicit DccFactoryAdapter(DccFactory *oldFactory, QObject *parent = nullptr)
+        : DccFactory_20(parent)
+        , m_oldFactory(oldFactory)
+    {
+    }
+
+    // 旧工厂不存在时的安全检查
+    bool hasOldFactory() const { return m_oldFactory != nullptr; }
+
+    // ===== DccFactory_20 接口实现 =====
+
+    // 注册类型（转发给旧工厂）
+    void registerType() override
+    {
+        if (m_oldFactory) {
+            // 旧工厂没有 registerType，但可能有 qmlRegisterType 等调用
+            // 这里可以添加兼容性处理
+        }
+    }
+
+    // 创建数据对象（转发）
+    QObject *create(QObject *parent = nullptr) override
+    {
+        if (m_oldFactory) {
+            return m_oldFactory->create(parent);
+        }
+        return nullptr;
+    }
+
+    // 激活（转发给数据对象）
+    void active() override
+    {
+        if (m_data) {
+            // 通知数据对象激活
+            QMetaObject::invokeMethod(m_data, "active", Qt::AutoConnection);
+        }
+    }
+
+    // 创建 DccObject（转发）
+    DccObject *dccObject(QObject *parent = nullptr) override
+    {
+        if (m_oldFactory) {
+            return m_oldFactory->dccObject(parent);
+        }
+        return nullptr;
+    }
+
+    // 获取数据（新版接口，旧工厂不支持，返回空）
+    const QVariantMap get(const QVariantMap &param) override
+    {
+        Q_UNUSED(param)
+        // 旧工厂不支持 get，返回空结果
+        return QVariantMap();
+    }
+
+    // 设置数据（新版接口，旧工厂不支持，返回空）
+    const QVariantMap set(const QVariantMap &param) override
+    {
+        Q_UNUSED(param)
+        // 旧工厂不支持 set，返回空结果
+        return QVariantMap();
+    }
+
+    // ===== 数据对象管理 =====
+
+    // 设置数据对象（用于 active 调用）
+    void setDataObject(QObject *data) { m_data = data; }
+
+    QObject *dataObject() const { return m_data; }
+
+private:
+    DccFactory *m_oldFactory;  // 包装的旧工厂
+    QObject *m_data = nullptr; // 创建的数据对象
+};
+
+} // namespace dccV25

--- a/src/dde-control-center/dccfactoryold.h
+++ b/src/dde-control-center/dccfactoryold.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+#include <QObject>
+
+namespace dccV25 {
+#define DccFactory_iid_v10 "org.deepin.dde.dcc-factory/v1.0"
+class DccObject;
+
+class DccFactory : public QObject
+{
+    Q_OBJECT
+public:
+    using QObject::QObject;
+
+    // 作为数据返回，会导出为dccData供main.qml使用
+    virtual QObject *create(QObject * = nullptr) { return nullptr; }
+
+    // 未提供qml的，可在此自己加载qml返回DccObject对象
+    virtual DccObject *dccObject(QObject * = nullptr) { return nullptr; }
+};
+} // namespace dccV25
+Q_DECLARE_INTERFACE(dccV25::DccFactory, DccFactory_iid_v10)

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -415,6 +415,22 @@ bool DccManager::action(const QString &json)
     return true;
 }
 
+QVariantMap DccManager::get(const QString &module, const QVariantMap &param)
+{
+    auto message = this->message();
+    setDelayedReply(true);
+    QMetaObject::invokeMethod(m_plugins, &DccPluginManager::get, Qt::QueuedConnection, module, param, message);
+    return QVariantMap();
+}
+
+QVariantMap DccManager::set(const QString &module, const QVariantMap &param)
+{
+    auto message = this->message();
+    setDelayedReply(true);
+    QMetaObject::invokeMethod(m_plugins, &DccPluginManager::set, Qt::QueuedConnection, module, param, message);
+    return QVariantMap();
+}
+
 QString DccManager::GetAllModule()
 {
     auto message = this->message();
@@ -461,6 +477,7 @@ void DccManager::cacheImage(const QString &id, const QSize &thumbnailSize)
 
 void DccManager::show()
 {
+    m_plugins->switchToFullMode();
     QWindow *w = DccManager::mainWindow();
     if (!w) {
         return;

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -81,6 +81,8 @@ public Q_SLOTS:
     QString searchProxy(const QString &json) const;
     bool stop(const QString &json);
     bool action(const QString &json);
+    QVariantMap get(const QString &module, const QVariantMap &param);
+    QVariantMap set(const QString &module, const QVariantMap &param);
     QString GetAllModule();
     void onDccObjectDestroyed(DccObject *obj);
 

--- a/src/dde-control-center/dccpluginloader.cpp
+++ b/src/dde-control-center/dccpluginloader.cpp
@@ -5,6 +5,8 @@
 #include "dccpluginloader.h"
 
 #include "dccfactory.h"
+#include "dccfactoryadapter.h"
+#include "dccfactoryold.h"
 #include "dccmanager.h"
 #include "dccobject.h"
 #include "dccobject_p.h"
@@ -82,7 +84,7 @@ QObject *DccPluginLoader::data() const
     return m_data;
 }
 
-DccFactory *DccPluginLoader::factory() const
+DccFactory_20 *DccPluginLoader::factory() const
 {
     return m_factory;
 }
@@ -285,13 +287,6 @@ void DccPluginLoader::loadData()
 
     const auto &meta = loader.metaData();
     const auto iid = meta["IID"].toString();
-    if (iid.isEmpty() || iid != QString(qobject_interface_iid<DccFactory *>())) {
-        setLog("prepare factory iid error:" + iid);
-        transitionStatus(DataErr);
-        loader.unload();
-        return;
-    }
-
     QObject *instance = loader.instance();
     if (!instance) {
         setLog("prepare factory instance failed:" + loader.errorString());
@@ -300,15 +295,25 @@ void DccPluginLoader::loadData()
         return;
     }
 
-    DccFactory *factory = qobject_cast<DccFactory *>(instance);
-    if (!factory) {
-        setLog("prepare factory cast failed.");
-        transitionStatus(DataErr);
-        loader.unload();
+    // 优先尝试新版工厂 (v2.0)
+    DccFactory_20 *factory20 = qobject_cast<DccFactory_20 *>(instance);
+    if (factory20) {
+        m_factory = factory20;
         return;
     }
 
-    m_factory = factory;
+    // 尝试旧版工厂 (v1.0)，使用适配器包装
+    DccFactory *factory10 = qobject_cast<DccFactory *>(instance);
+    if (factory10) {
+        setLog("using adapter for old factory");
+        m_factory = new DccFactoryAdapter(factory10, this);
+        return;
+    }
+
+    // 未知 IID
+    setLog("prepare factory iid error, unknown iid:" + iid);
+    transitionStatus(DataErr);
+    loader.unload();
 }
 
 void DccPluginLoader::createData()

--- a/src/dde-control-center/dccpluginloader.h
+++ b/src/dde-control-center/dccpluginloader.h
@@ -7,10 +7,11 @@
 #include <QQmlEngine>
 #include <QString>
 
+#include "dccfactory.h"
+
 namespace dccV25 {
 
 class DccObject;
-class DccFactory;
 class DccPluginManager;
 
 class DccPluginLoader : public QObject
@@ -77,7 +78,7 @@ public:
     DccObject *mainObj() const;
     DccObject *soObj() const;
     QObject *data() const;
-    DccFactory *factory() const;
+    DccFactory_20 *factory() const;
     void setLog(const QString &log);
     // State query methods
     bool isFinished() const;
@@ -86,6 +87,10 @@ public:
 
     // Dependency injection
     void setType(TypeFlags type);
+
+    // 新增: 标记该模块是否有待处理的 DBus get/set 请求
+    inline bool hasPendingDataRequest() const { return m_pendingDataRequest; }
+    inline void setPendingDataRequest(bool pending) { m_pendingDataRequest = pending; }
 
     // Loading methods
     void reset(); // Reset status and restart loading
@@ -118,7 +123,7 @@ private:
     QString m_path;
     std::atomic<StatusFlags> m_status;
     TypeFlags m_type;
-    DccFactory *m_factory;
+    DccFactory_20 *m_factory;
     DccObject *m_module;
     DccObject *m_mainObj;
     DccObject *m_soObj;
@@ -126,6 +131,7 @@ private:
 
     DccPluginManager *m_pManager;
     QStringList m_log;
+    bool m_pendingDataRequest = false;
 };
 
 } // namespace dccV25

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QDir>
 #include <QElapsedTimer>
+#include <QEventLoop>
 #include <QFileInfo>
 #include <QLoggingCategory>
 #include <QPluginLoader>
@@ -22,8 +23,11 @@
 #include <QRunnable>
 #include <QSet>
 #include <QSettings>
+#include <QTimer>
 #include <QtConcurrent>
 #include <QtConcurrentRun>
+
+#include <QDBusConnection>
 
 namespace dccV25 {
 
@@ -67,6 +71,85 @@ private:
     DccPluginManager *m_manager;
 };
 
+// DataRequestTask - DBus get/set 请求任务
+class DataRequestTask : public QRunnable
+{
+public:
+    DataRequestTask(DccPluginLoader *loader, const QVariantMap &param,
+                    const QDBusMessage &message, bool isGet,
+                    DccPluginManager *manager)
+        : m_loader(loader), m_param(param), m_message(message)
+        , m_isGet(isGet), m_manager(manager)
+    {
+        setAutoDelete(true);
+    }
+
+    void run() override
+    {
+        // 如果还未到达 DataEnd，需要等待加载
+        if (!(m_loader->status() & DccPluginLoader::DataEnd)) {
+            // 设置标志
+            m_loader->setPendingDataRequest(true);
+
+            // 等待 DataEnd
+            waitForDataEnd();
+        }
+        qWarning()<<__LINE__<<__FUNCTION__<<m_loader->name()<<m_isGet<<m_param;
+        // 回复 DBus
+        if (m_loader->status() & DccPluginLoader::DataEnd) {
+            QVariantMap result;
+            if (auto *factory = m_loader->factory()) {
+                if (m_isGet) {
+                    result = factory->get(m_param);
+                } else {
+                    result = factory->set(m_param);
+                }
+            }
+            QDBusConnection::sessionBus().send(m_message.createReply(result));
+        } else {
+            // 超时或加载失败
+            QDBusConnection::sessionBus().send(
+                m_message.createErrorReply("org.deepin.dde.ControlCenter1.Error.Timeout",
+                                          "Plugin load timeout: " + m_loader->name()));
+        }
+    }
+
+private:
+    void waitForDataEnd()
+    {
+        QEventLoop loop;
+        QTimer timeout;
+        timeout.setSingleShot(true);
+        timeout.setInterval(10000);  // 10秒超时
+
+        QObject context;
+
+        auto conn = QObject::connect(m_loader, &DccPluginLoader::statusChanged,
+                                    &context, [&](DccPluginLoader *, uint status) {
+            if (status & DccPluginLoader::DataEnd) {
+                loop.quit();
+            } else if (status & DccPluginLoader::PluginErrMask) {
+                loop.quit();
+            }
+        }, Qt::QueuedConnection);
+
+        QObject::connect(&timeout, &QTimer::timeout, &context, [&]{ loop.quit(); });
+        timeout.start();
+
+        // 发射信号触发状态机继续（Qt::QueuedConnection 自动在主线程执行 loadPlugin）
+        Q_EMIT m_manager->requestAdvancePlugin(m_loader);
+
+        loop.exec();
+        QObject::disconnect(conn);
+    }
+
+    DccPluginLoader *m_loader;
+    QVariantMap m_param;
+    QDBusMessage m_message;
+    bool m_isGet;
+    DccPluginManager *m_manager;
+};
+
 DccPluginManager::DccPluginManager(DccManager *parent)
     : QObject(parent)
     , m_manager(parent)
@@ -75,6 +158,10 @@ DccPluginManager::DccPluginManager(DccManager *parent)
     , m_isDeleting(false)
 {
     connect(m_manager, &DccManager::hideModuleChanged, this, &DccPluginManager::onHideModuleChanged);
+
+    // 连接 requestAdvancePlugin 信号到 loadPlugin（只需绑定一次）
+    connect(this, &DccPluginManager::requestAdvancePlugin,
+            this, &DccPluginManager::loadPlugin, Qt::QueuedConnection);
 }
 
 DccPluginManager::~DccPluginManager()
@@ -112,26 +199,32 @@ void DccPluginManager::loadPlugin(DccPluginLoader *loader)
             Q_EMIT addObject(loader->soObj());
         }
         loader->transitionStatus(DccPluginLoader::PluginEnd);
-    } else if ((loader->status() & (DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad)) == DccPluginLoader::DataEnd) {
+    } else if ((loader->status() & (DccPluginLoader::ModuleEnd | DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad)) == (DccPluginLoader::ModuleEnd | DccPluginLoader::DataEnd)) {
         loader->transitionStatus(DccPluginLoader::MainObjLoad);
         loader->createDccObject();
         loader->updateParent();
         loader->loadMain();
         loader->transitionStatus(DccPluginLoader::MainObjEnd);
-    } else if ((loader->status() & (DccPluginLoader::ModuleEnd | DccPluginLoader::DataBegin)) == DccPluginLoader::ModuleEnd) {
+    } else if (((loader->status() & (DccPluginLoader::ModuleEnd | DccPluginLoader::DataBegin)) == DccPluginLoader::ModuleEnd)
+               || ((m_loadMode == OnlyData && loader->hasPendingDataRequest())
+                   && ((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::DataBegin)) == DccPluginLoader::MetaDataEnd))) {
         loader->transitionStatus(DccPluginLoader::DataBegin);
-        if (loader->module()) {
-            Q_EMIT addObject(loader->module());
-        }
         threadPool()->start(new LoadDataTask(loader, this));
-    } else if ((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) {
+    } else if (((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) && m_loadMode != OnlyData) {
+        // MetaDataEnd 状态
+        // if (m_loadMode == OnlyData && !loader->hasPendingDataRequest()) {
+        //     // OnlyData 模式且非 DBus 目标：停在 MetaDataEnd，等待 requestAdvancePlugin 信号
+        //     return;
+        // }
+        // 否则继续加载（OnlyData+DBus目标 或 Full模式）
         loader->transitionStatus(DccPluginLoader::ModuleLoad);
         if (loader->loadModule()) {
+            Q_EMIT addObject(loader->module());
             loader->transitionStatus(DccPluginLoader::ModuleEnd);
         } else {
             loader->transitionStatus(DccPluginLoader::ModuleEnd | DccPluginLoader::PluginEnd);
         }
-    } else {
+    } else if (!(loader->status() & DccPluginLoader::MetaDataEnd)) {
         if (loader->loadMetaData()) {
             loader->transitionStatus(DccPluginLoader::MetaDataEnd);
         } else {
@@ -237,6 +330,58 @@ DccObject *DccPluginManager::rootModule()
 bool DccPluginManager::hidden(const QString &name)
 {
     return m_manager->hideModule().contains(name);
+}
+
+void DccPluginManager::get(const QString &module, const QVariantMap &param, const QDBusMessage &message)
+{
+    DccPluginLoader *loader = findLoader(module);
+    if (!loader) {
+        QDBusConnection::sessionBus().send(
+            message.createErrorReply("org.deepin.dde.ControlCenter1.Error.NotFound",
+                                    "Module not found: " + module));
+        return;
+    }
+
+    // 统一由 DataRequestTask 处理（等待 + 执行）
+    threadPool()->start(new DataRequestTask(loader, param, message, true, this));
+}
+
+void DccPluginManager::set(const QString &module, const QVariantMap &param, const QDBusMessage &message)
+{
+    DccPluginLoader *loader = findLoader(module);
+    if (!loader) {
+        QDBusConnection::sessionBus().send(
+            message.createErrorReply("org.deepin.dde.ControlCenter1.Error.NotFound",
+                                    "Module not found: " + module));
+        return;
+    }
+
+    threadPool()->start(new DataRequestTask(loader, param, message, false, this));
+}
+
+DccPluginLoader *DccPluginManager::findLoader(const QString &module) const
+{
+    for (auto *loader : m_plugins) {
+        if (loader->name() == module) {
+            return loader;
+        }
+    }
+    return nullptr;
+}
+
+void DccPluginManager::switchToFullMode()
+{
+    if (m_loadMode == Full) return;
+    m_loadMode = Full;
+    qCInfo(dccLog) << "Switching to full load mode";
+
+    // 从各插件当前状态继续推进
+    for (auto &&loader : m_plugins) {
+        if (loader->isFinished()) continue;
+        // 重置标志，避免影响全量加载
+        loader->setPendingDataRequest(false);
+        loadPlugin(loader);
+    }
 }
 
 void DccPluginManager::onPluginStatusChanged(DccPluginLoader *loader, uint status)

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
+#include <qdbusmessage.h>
+
 #include <QObject>
 #include <QQmlContext>
 #include <QStringList>
@@ -14,6 +16,12 @@ class QQmlComponent;
 class QThreadPool;
 
 namespace dccV25 {
+
+enum LoadMode {
+    OnlyData,  // 按需：只加载 Data，跳过 Module
+    Full       // 全量：完整加载到 PluginEnd
+};
+
 class DccObject;
 class DccManager;
 class DccPluginLoader;
@@ -35,14 +43,19 @@ public:
     inline bool isDeleting() const { return m_isDeleting.load(); }
 
 public Q_SLOTS:
+    void get(const QString &module, const QVariantMap &param, const QDBusMessage &message);
+    void set(const QString &module, const QVariantMap &param, const QDBusMessage &message);
+    void switchToFullMode();
     void cancelLoad();
 
 Q_SIGNALS:
     void addObject(DccObject *obj);
     void loadAllFinished();
+    void requestAdvancePlugin(DccPluginLoader *loader);
 
 private:
     QThreadPool *threadPool();
+    DccPluginLoader *findLoader(const QString &module) const;
 
 private Q_SLOTS:
     void loadPlugin(DccPluginLoader *loader);
@@ -58,6 +71,7 @@ private:
     QThreadPool *m_threadPool;
     std::atomic<bool> m_isDeleting;
     QQmlEngine *m_engine;
+    LoadMode m_loadMode = OnlyData;
 };
 
 } // namespace dccV25

--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -14,7 +14,7 @@ Popup {
     popupType: Popup.Window
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
-    PopupHandle.enableBlurWindow: true
+    // PopupHandle.enableBlurWindow: true
 
     required property var viewModel
     property int currentIndex: -1

--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -16,7 +16,7 @@ Popup {
     popupType: Popup.Window
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
 
-    PopupHandle.enableBlurWindow: true
+    // PopupHandle.enableBlurWindow: true
 
     property int maxVisibleItems: 10
     property int highlightedIndex: 0

--- a/src/plugin-defaultapp/operation/defappmodel.cpp
+++ b/src/plugin-defaultapp/operation/defappmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "defappmodel.h"
@@ -13,7 +13,6 @@
 DefAppModel::DefAppModel(QObject *parent)
     : QObject(parent)
 {
-    qmlRegisterType<CategoryModel>("org.deepin.dcc.defApp", 1, 0, "CategoryModel");
     for (int i = 0; i < Count; i++) {
         m_categoryModel[i] = new CategoryModel(new Category(this));
     }
@@ -48,6 +47,22 @@ DefAppModel::~DefAppModel()
     }
 }
 
-DCC_FACTORY_CLASS(DefAppModel)
+void DefAppModel::registerType()
+{
+    qmlRegisterType<CategoryModel>("org.deepin.dcc.defApp", 1, 0, "CategoryModel");
+}
+
+void DefAppModel::active() { }
+
+const QVariantMap DefAppModel::get(const QVariantMap &param)
+{
+    return QVariantMap();
+}
+
+const QVariantMap DefAppModel::set(const QVariantMap &param)
+{
+    return QVariantMap();
+}
+DCC_FULL_FACTORY_CLASS(DefAppModel)
 
 #include "defappmodel.moc"

--- a/src/plugin-defaultapp/operation/defappmodel.h
+++ b/src/plugin-defaultapp/operation/defappmodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DEFAPPMODEL_H
@@ -30,6 +30,13 @@ public:
         Terminal,
         Count,
     };
+    // from DccFactory
+    static void registerType();
+    void active();
+    const QVariantMap get(const QVariantMap &param);
+    const QVariantMap set(const QVariantMap &param);
+Q_SIGNALS:
+    void propertiesChanged(const QVariantMap &properties);
 
 public Q_SLOTS:
 

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -696,6 +696,67 @@ void DisplayModule::resetBackup()
     d->m_worker->resetBackup();
 }
 
+const QVariantMap DisplayModule::get(const QVariantMap &param)
+{
+    QVariantMap result;
+    for (auto it = param.constBegin(); it != param.constEnd(); ++it) {
+        const QString &key = it.key();
+        const QVariant &value = it.value();
+        Q_UNUSED(value);
+
+        if (key == "displayMode") {
+            result[key] = displayMode();
+        } else if (key == "globalScale") {
+            result[key] = globalScale();
+        } else if (key == "maxGlobalScale") {
+            result[key] = maxGlobalScale();
+        } else if (key == "colorTemperatureEnabled") {
+            result[key] = colorTemperatureEnabled();
+        } else if (key == "colorTemperatureMode") {
+            result[key] = colorTemperatureMode();
+        } else if (key == "colorTemperature") {
+            result[key] = colorTemperature();
+        } else if (key == "autoBacklightEnabled") {
+            result[key] = autoBacklightEnabled();
+        } else if (key == "isX11") {
+            result[key] = isX11();
+        }
+    }
+    return result;
+}
+
+const QVariantMap DisplayModule::set(const QVariantMap &param)
+{
+    QVariantMap errors;
+    for (auto it = param.constBegin(); it != param.constEnd(); ++it) {
+        const QString &key = it.key();
+        const QVariant &value = it.value();
+
+        if (key == "displayMode") {
+            setDisplayMode(value.toString());
+        } else if (key == "globalScale") {
+            setGlobalScale(value.toReal());
+        } else if (key == "colorTemperatureEnabled") {
+            setColorTemperatureEnabled(value.toBool());
+        } else if (key == "colorTemperatureMode") {
+            setColorTemperatureMode(value.toInt());
+        } else if (key == "colorTemperature") {
+            setColorTemperature(value.toInt());
+        } else if (key == "autoBacklightEnabled") {
+            setAutoBacklightEnabled(value.toBool());
+        } else {
+            errors[key] = QString("unsupported property: %1").arg(key);
+        }
+    }
+    return errors;  // 空表示成功
+}
+
+void DisplayModule::active()
+{
+    Q_D(DisplayModule);
+    d->init();
+}
+
 void DisplayModule::adsorptionScreen(QList<QObject *> listItems, QObject *pw, qreal scale)
 {
     QQuickItem *tmpPw = dynamic_cast<QQuickItem *>(pw);
@@ -805,7 +866,7 @@ void DisplayModule::applyChanged()
     qDeleteAll(tmpListItems);
 }
 
-DCC_FACTORY_CLASS(DisplayModule)
+DCC_FULL_FACTORY_CLASS(DisplayModule)
 
 } // namespace dccV25
 

--- a/src/plugin-display/operation/displaymodule.h
+++ b/src/plugin-display/operation/displaymodule.h
@@ -36,6 +36,11 @@ public:
     explicit DisplayModule(QObject *parent = nullptr);
     ~DisplayModule() override;
 
+    static void registerType()
+    {
+        // 注册自定义类型（如果需要）
+    }
+
     // 逻辑屏幕 去除禁用的
     QList<DccScreen *> virtualScreens() const;
     // 物理屏幕
@@ -64,6 +69,11 @@ public:
     bool isConcatScreenMode() const;
 
 public Q_SLOTS:
+    // DBus get/set 接口
+    const QVariantMap get(const QVariantMap &param);
+    const QVariantMap set(const QVariantMap &param);
+    void active();
+
     void saveChanges();
     void resetBackup();
 
@@ -93,6 +103,8 @@ Q_SIGNALS:
     void builtinMonitorNameChanged();
     void screensFormRectChanged();
     void isConcatScreenModeChanged();
+    // DBus get/set 变化信号
+    void propertiesChanged(const QVariantMap &properties);
 
 private:
     QScopedPointer<DisplayModulePrivate> d_ptrDisplayModule;


### PR DESCRIPTION
1. Rename DccFactory to DccFactory_20, bump IID to v2.0
2. Add registerType() for QML type registration in main thread
3. Add active() for post-creation activation in main thread
4. Add get/set virtual methods for DBus-triggered data access in worker thread
5. Add DCC_FULL_FACTORY_CLASS macro with singleton create and full lifecycle delegation to classname::registerType/active/get/set
6. Preserve v1.0 interface in dccfactoryold.h for backward compatibility
7. Wire DBus get/set slots in ControlCenterDBusAdaptor and DccManager (async dispatch pending)
8. Migrate DefAppModel plugin as first v2.0 adopter, move qmlRegisterType into static registerType()

Influence:
1. Verify existing v1.0 plugins still load via old interface
2. Verify DefAppModel QML types register correctly on startup

feat(factory): 升级 DccFactory 至 v2.0，支持生命周期管理与 DBus 数据通道

1. 将 DccFactory 重命名为 DccFactory_20，IID 升级为 v2.0
2. 新增 registerType() 用于在主线程中注册 QML 类型
3. 新增 active() 用于在主线程中执行创建后激活
4. 新增 get/set 虚函数用于在子线程中响应 DBus 数据请求
5. 新增 DCC_FULL_FACTORY_CLASS 宏，支持单例创建及完整生命周期 委托至 classname::registerType/active/get/set
6. 在 dccfactoryold.h 中保留 v1.0 接口以向后兼容
7. 在 ControlCenterDBusAdaptor 和 DccManager 中接入 DBus get/set （异步分发待实现）
8. 迁移 DefAppModel 插件作为首个 v2.0 适配示例，将 qmlRegisterType 移入静态 registerType()

Influence:
1. 验证已有的 v1.0 插件仍能通过旧接口正常加载
2. 验证 DefAppModel 的 QML 类型在启动时正确注册