### PR TITLE
fix: set plugin install dir to system path in debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,11 +135,11 @@ if (CMAKE_BUILD_TYPE STREQUAL "Debug")
 endif()
 
 add_definitions(-DTRANSLATE_READ_DIR="${DCC_TRANSLATE_READ_DIR}")
-# 插件安装目录
-set(DCC_PLUGINS_INSTALL_DIR ${DCC_DEBUG_LIBDIR}/${DCC_PLUGINS_DIR} CACHE STRING "Install dir for dde-control-center plugins")
-# 插件读取目录
+# 插件安装目录 (始终安装到系统目录)
+set(DCC_PLUGINS_INSTALL_DIR ${DCC_INSTALL_DIR}/${DCC_PLUGINS_DIR} CACHE STRING "Install dir for dde-control-center plugins")
+# 插件读取目录 (Debug模式读取构建目录, Release模式读取系统目录)
 set(MODULE_READ_DIR "${DCC_DEBUG_LIBDIR}" CACHE STRING "Dir to find dde-control-center modules")
-set(PLUGINS_READ_DIR "${DCC_PLUGINS_INSTALL_DIR}" CACHE STRING "Dir to find dde-control-center plugins")
+set(PLUGINS_READ_DIR "${DCC_DEBUG_LIBDIR}/${DCC_PLUGINS_DIR}" CACHE STRING "Dir to find dde-control-center plugins")
 
 GNUInstallDirs_get_absolute_install_dir(
     MODULE_READ_FULL_DIR


### PR DESCRIPTION
1. Change plugin installation directory from debug libdir to system
install dir for all build types
2. Update plugin read directory to point to debug build directory in
debug mode for development convenience
3. This fixes cmake install failure in debug build due to incorrect
installation path

Influence:
1. Test debug build compilation and installation with cmake install
2. Verify plugins are correctly installed to system directory
3. Test plugin loading in debug mode, ensuring it reads from build
directory
4. Test release build remains unaffected

fix: 修复Debug模式下插件安装目录问题

1. 将所有构建类型的插件安装目录从debug库目录改为系统安装目录
2. 更新调试模式下插件读取目录为构建目录，方便开发调试
3. 修复Debug模式下cmake install失败的问题

Influence:
1. 测试Debug模式下的编译和cmake install安装
2. 验证插件正确安装到系统目录
3. 测试Debug模式下插件加载，确保从构建目录读取
4. 测试Release模式不受影响

## Summary by Sourcery

Align plugin install and read paths so debug builds install plugins to the system directory while still loading them from the build tree for development.

Bug Fixes:
- Fix cmake install failures in Debug builds caused by installing plugins to the debug lib directory instead of the system install directory.

Build:
- Change plugin installation directory for all build types to the system install directory instead of the debug lib directory.
- Adjust plugin read directory configuration so Debug builds load plugins from the build output directory and Release builds load from the system directory.