### PR TITLE
refactor: decouple MouseDBusProxy from MouseWorker dependency

### DIFF
--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "mousedbusproxy.h"
@@ -36,9 +36,19 @@ const QString PowerService = QStringLiteral("org.deepin.dde.Power1");
 const QString PowerPath = QStringLiteral("/org/deepin/dde/Power1");
 const QString PowerInterface = QStringLiteral("org.deepin.dde.Power1");
 
-MouseDBusProxy::MouseDBusProxy(MouseWorker *worker, QObject *parent)
+MouseDBusProxy::MouseDBusProxy(QObject *parent)
     : QObject(parent)
-    , m_worker(worker)
+    , m_dbusMouseProperties(nullptr)
+    , m_dbusTouchPadProperties(nullptr)
+    , m_dbusTrackPointProperties(nullptr)
+    , m_dbusDevicesProperties(nullptr)
+    , m_dbusGestureProperties(nullptr)
+    , m_dbusMouse(nullptr)
+    , m_dbusTouchPad(nullptr)
+    , m_dbusTrackPoint(nullptr)
+    , m_dbusDevices(nullptr)
+    , m_dbusGesture(nullptr)
+    , m_appearance(nullptr)
 {
     init();
 }
@@ -54,13 +64,13 @@ void MouseDBusProxy::active()
     bool adaptiveAccelProfile = m_dbusMouseProperties->call("Get", MouseInterface, "AdaptiveAccelProfile").arguments().at(0).value<QDBusVariant>().variant().toBool();
     double motionAcceleration = m_dbusMouseProperties->call("Get", MouseInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
 
-    m_worker->setMouseExist(exist);
-    m_worker->setLeftHandState(leftHanded);
-    m_worker->setMouseNaturalScrollState(naturalScroll);
-    m_worker->setDouClick(doubleClick);
-    m_worker->setDisTouchPad(disableTpad);
-    m_worker->setAccelProfile(adaptiveAccelProfile);
-    m_worker->setMouseMotionAcceleration(motionAcceleration);
+    Q_EMIT mouseExistChanged(exist);
+    Q_EMIT leftHandStateChanged(leftHanded);
+    Q_EMIT mouseNaturalScrollStateChanged(naturalScroll);
+    Q_EMIT douClickChanged(doubleClick);
+    Q_EMIT disTouchPadChanged(disableTpad);
+    Q_EMIT accelProfileChanged(adaptiveAccelProfile);
+    Q_EMIT mouseMotionAccelerationChanged(motionAcceleration);
 
     // initial touchpad settings
     motionAcceleration = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
@@ -73,38 +83,36 @@ void MouseDBusProxy::active()
     int palmMinWidth = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "PalmMinWidth").arguments().at(0).value<QDBusVariant>().variant().toInt();
     bool palmMinZ = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "PalmMinZ").arguments().at(0).value<QDBusVariant>().variant().toBool();
 
-    m_worker->setTouchpadMotionAcceleration(motionAcceleration);
-    m_worker->setTpadEnabled(touchpadEnabled);
-    m_worker->setTapClick(tapClick);
-    m_worker->setTpadExist(exist);
-    m_worker->setTouchNaturalScrollState(naturalScroll);
-    m_worker->setDisTyping(disableIfTyping);
-    m_worker->setPalmDetect(palmDetect);
-    m_worker->setPalmMinWidth(palmMinWidth);
-    m_worker->setPalmMinz(palmMinZ);
+    Q_EMIT touchpadMotionAccelerationChanged(motionAcceleration);
+    Q_EMIT tpadEnabledChanged(touchpadEnabled);
+    Q_EMIT tapClickChanged(tapClick);
+    Q_EMIT tpadExistChanged(exist);
+    Q_EMIT touchNaturalScrollStateChanged(naturalScroll);
+    Q_EMIT disTypingChanged(disableIfTyping);
+    Q_EMIT palmDetectChanged(palmDetect);
+    Q_EMIT palmMinWidthChanged(palmMinWidth);
+    Q_EMIT palmMinzChanged(palmMinZ);
 
-    // initial redpoint settings
     motionAcceleration = m_dbusTrackPointProperties->call("Get", TrackpointInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
     exist = m_dbusTouchPadProperties->call("Get", TrackpointInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
 
-    m_worker->setTrackPointMotionAcceleration(motionAcceleration);
-    m_worker->setRedPointExist(exist);
+    Q_EMIT trackPointMotionAccelerationChanged(motionAcceleration);
+    Q_EMIT redPointExistChanged(exist);
 
     // initial device properties
     uint wheelSpeed  = m_dbusDevicesProperties->call("Get", InputDevicesInterface, "WheelSpeed").arguments().at(0).value<QDBusVariant>().variant().toUInt();
-
-    m_worker->setScrollSpeed(wheelSpeed);
+    Q_EMIT scrollSpeedChanged(wheelSpeed);
 
     // initial lid is present
     bool lidIsPresent = getLidIsPresent();
-    m_worker->setLidIsPresent(lidIsPresent);
+    Q_EMIT lidIsPresentChanged(lidIsPresent);
 
     QVariant gestureInfos = m_dbusGestureProperties->call("Get", GestureInterface, "Infos").arguments().at(0).value<QDBusVariant>().variant();
     parseGesturesData(qvariant_cast<QDBusArgument>(gestureInfos));
 
     listCursor();
     auto cursorSize = m_appearance->property("CursorSize").toInt();
-    m_worker->setCursorSize(cursorSize);
+    Q_EMIT cursorSizeChanged(cursorSize);
 }
 
 void MouseDBusProxy::deactive()
@@ -205,57 +213,6 @@ void MouseDBusProxy::init()
                                        GesturePath,
                                        GestureInterface,
                                        QDBusConnection::sessionBus());
-
-    // set Mouse settings from dde-control-center
-    connect(m_worker,
-            &MouseWorker::requestSetLeftHandState,
-            this,
-            &MouseDBusProxy::setLeftHandState);
-    connect(m_worker,
-            &MouseWorker::requestSetMouseNaturalScrollState,
-            this,
-            &MouseDBusProxy::setMouseNaturalScrollState);
-    connect(m_worker, &MouseWorker::requestSetDouClick, this, &MouseDBusProxy::setDouClick);
-    connect(m_worker,
-            &MouseWorker::requestSetDisTouchPad,
-            this,
-            &MouseDBusProxy::setDisableTouchPadWhenMouseExist);
-    connect(m_worker, &MouseWorker::requestSetAccelProfile, this, &MouseDBusProxy::setAccelProfile);
-    connect(m_worker,
-            &MouseWorker::requestSetMouseMotionAcceleration,
-            this,
-            &MouseDBusProxy::setMouseMotionAcceleration);
-
-    // set Touchpad settings from dde-control-center
-    connect(m_worker,
-            &MouseWorker::requestSetTouchNaturalScrollState,
-            this,
-            &MouseDBusProxy::setTouchNaturalScrollState);
-    connect(m_worker, &MouseWorker::requestSetDisTyping, this, &MouseDBusProxy::setDisTyping);
-    connect(m_worker,
-            &MouseWorker::requestSetTouchpadMotionAcceleration,
-            this,
-            &MouseDBusProxy::setTouchpadMotionAcceleration);
-    connect(m_worker, &MouseWorker::requestSetTapClick, this, &MouseDBusProxy::setTapClick);
-    connect(m_worker, &MouseWorker::requestSetPalmDetect, this, &MouseDBusProxy::setPalmDetect);
-    connect(m_worker, &MouseWorker::requestSetPalmMinWidth, this, &MouseDBusProxy::setPalmMinWidth);
-    connect(m_worker, &MouseWorker::requestSetPalmMinz, this, &MouseDBusProxy::setPalmMinz);
-
-    // set Redpoint settings from dde-control-center
-    connect(m_worker,
-            &MouseWorker::requestSetTrackPointMotionAcceleration,
-            this,
-            &MouseDBusProxy::setTrackPointMotionAcceleration);
-
-    // set Device properties from dde-control-center
-    connect(m_worker, &MouseWorker::requestSetScrollSpeed, this, &MouseDBusProxy::setScrollSpeed);
-    connect(m_worker,
-            &MouseWorker::requestSetTouchpadEnabled,
-            this,
-            &MouseDBusProxy::setTouchpadEnabled);
-
-    connect(m_worker, &MouseWorker::requestSetGesture, this, &MouseDBusProxy::setGesture);
-    connect(m_worker, &MouseWorker::requestSetCursorSize, this, &MouseDBusProxy::setCursorSize);
 }
 
 void MouseDBusProxy::parseGesturesData(const QDBusArgument &argument)
@@ -418,19 +375,19 @@ void MouseDBusProxy::onMousePathPropertiesChanged(QDBusMessage msg)
         QStringList keys = changedProps.keys();
         for (int i = 0; i < keys.size(); i++) {
             if (keys.at(i) == "Exist") {
-                m_worker->setMouseExist(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT mouseExistChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "LeftHanded") {
-                m_worker->setLeftHandState(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT leftHandStateChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "NaturalScroll") {
-                m_worker->setMouseNaturalScrollState(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT mouseNaturalScrollStateChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "DoubleClick") {
-                m_worker->setDouClick(changedProps.value(keys.at(i)).toInt());
+                Q_EMIT douClickChanged(changedProps.value(keys.at(i)).toInt());
             } else if(keys.at(i) == "DisableTpad") {
-                m_worker->setDisTouchPad(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT disTouchPadChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "AdaptiveAccelProfile") {
-                m_worker->setAccelProfile(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT accelProfileChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "MotionAcceleration") {
-                m_worker->setMouseMotionAcceleration(changedProps.value(keys.at(i)).toDouble());
+                Q_EMIT mouseMotionAccelerationChanged(changedProps.value(keys.at(i)).toDouble());
             }
         }
     }
@@ -448,25 +405,25 @@ void MouseDBusProxy::onTouchpadPathPropertiesChanged(QDBusMessage msg)
         QStringList keys = changedProps.keys();
         for (int i = 0; i < keys.size(); i++) {
             if (keys.at(i) == "Exist") {
-                m_worker->setTpadExist(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT tpadExistChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "TPadEnable") {
-                m_worker->setTpadEnabled(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT tpadEnabledChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "NaturalScroll") {
-                m_worker->setTouchNaturalScrollState(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT touchNaturalScrollStateChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "DisableIfTyping") {
-                m_worker->setDisTyping(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT disTypingChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "DoubleClick") {
-                m_worker->setDouClick(changedProps.value(keys.at(i)).toInt());
+                Q_EMIT douClickChanged(changedProps.value(keys.at(i)).toInt());
             } else if(keys.at(i) == "MotionAcceleration") {
-                m_worker->setTouchpadMotionAcceleration(changedProps.value(keys.at(i)).toDouble());
+                Q_EMIT touchpadMotionAccelerationChanged(changedProps.value(keys.at(i)).toDouble());
             } else if(keys.at(i) == "TapClick") {
-                m_worker->setTapClick(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT tapClickChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "PalmDetect") {
-                m_worker->setPalmDetect(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT palmDetectChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "PalmMinWidth") {
-                m_worker->setPalmMinWidth(changedProps.value(keys.at(i)).toInt());
+                Q_EMIT palmMinWidthChanged(changedProps.value(keys.at(i)).toInt());
             } else if(keys.at(i) == "PalmMinZ") {
-                m_worker->setPalmMinz(changedProps.value(keys.at(i)).toInt());
+                Q_EMIT palmMinzChanged(changedProps.value(keys.at(i)).toInt());
             }
         }
     }
@@ -484,9 +441,9 @@ void MouseDBusProxy::onTrackpointPathPropertiesChanged(QDBusMessage msg)
         QStringList keys = changedProps.keys();
         for (int i = 0; i < keys.size(); i++) {
             if (keys.at(i) == "Exist") {
-                m_worker->setRedPointExist(changedProps.value(keys.at(i)).toBool());
+                Q_EMIT redPointExistChanged(changedProps.value(keys.at(i)).toBool());
             } else if(keys.at(i) == "MotionAcceleration") {
-                m_worker->setTrackPointMotionAcceleration(changedProps.value(keys.at(i)).toDouble());
+                Q_EMIT trackPointMotionAccelerationChanged(changedProps.value(keys.at(i)).toDouble());
             }
         }
     }
@@ -504,7 +461,7 @@ void MouseDBusProxy::onInputDevicesPathPropertiesChanged(QDBusMessage msg)
         QStringList keys = changedProps.keys();
         for (int i = 0; i < keys.size(); i++) {
             if (keys.at(i) == "WheelSpeed") {
-                m_worker->setScrollSpeed(changedProps.value(keys.at(i)).toUInt());
+                Q_EMIT scrollSpeedChanged(changedProps.value(keys.at(i)).toUInt());
             }
         }
     }
@@ -541,7 +498,7 @@ void MouseDBusProxy::onAppearancePropertiesChanged(QDBusMessage msg)
         for (int i = 0; i < keys.size(); i++) {
             if (keys.at(i) == "CursorSize") {
                 int cursorSize = changedProps.value(keys.at(i)).toInt();
-                m_worker->setCursorSize(cursorSize);
+                Q_EMIT cursorSizeChanged(cursorSize);
             } else if (keys.at(i) == "CursorTheme") {
                 listCursor();
             }
@@ -581,8 +538,7 @@ void MouseDBusProxy::onGetGestureAvaiableActionsFinished(QDBusPendingCallWatcher
         }
     }
 
-    m_worker->setGestureData(data);
-    m_worker->initFingerGestures();
+    Q_EMIT gestureDataChanged(data);
     w->deleteLater();
 }
 
@@ -608,7 +564,7 @@ void MouseDBusProxy::listCursor()
                         for (const auto &size : availableSizesValue) {
                             availableSizes.append(size.toInt(-1));
                         }
-                        m_worker->setAvailableCursorSizes(availableSizes);
+                        Q_EMIT availableCursorSizesChanged(availableSizes);
                         break;
                     }
                 }

--- a/src/plugin-mouse/operation/mousedbusproxy.h
+++ b/src/plugin-mouse/operation/mousedbusproxy.h
@@ -1,11 +1,12 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef MOUSEDBUSPROXY_H
 #define MOUSEDBUSPROXY_H
 
-#include "mouseworker.h"
+#include "gesturedata.h"
 
+#include <QDBusArgument>
 #include <QDBusMessage>
 #include <QDBusPendingCallWatcher>
 #include <QObject>
@@ -17,11 +18,36 @@ class MouseDBusProxy : public QObject
 {
     Q_OBJECT
 public:
-    explicit MouseDBusProxy(MouseWorker *worker, QObject *parent = nullptr);
+    explicit MouseDBusProxy(QObject *parent = nullptr);
     void deactive();
     void init();
 
     void parseGesturesData(const QDBusArgument &argument);
+
+Q_SIGNALS:
+    void mouseExistChanged(bool exist);
+    void tpadExistChanged(bool exist);
+    void tpadEnabledChanged(bool enabled);
+    void redPointExistChanged(bool exist);
+    void leftHandStateChanged(bool state);
+    void mouseNaturalScrollStateChanged(bool state);
+    void touchNaturalScrollStateChanged(bool state);
+    void disTypingChanged(bool state);
+    void disTouchPadChanged(bool state);
+    void tapClickChanged(bool state);
+    void douClickChanged(int value);
+    void mouseMotionAccelerationChanged(double value);
+    void accelProfileChanged(bool state);
+    void touchpadMotionAccelerationChanged(double value);
+    void trackPointMotionAccelerationChanged(double value);
+    void palmDetectChanged(bool palmDetect);
+    void palmMinWidthChanged(int palmMinWidth);
+    void palmMinzChanged(int palmMinz);
+    void scrollSpeedChanged(uint speed);
+    void gestureDataChanged(const GestureData &data);
+    void cursorSizeChanged(int cursorSize);
+    void availableCursorSizesChanged(QList<int> sizes);
+    void lidIsPresentChanged(bool lidIsPresent);
 
 public Q_SLOTS:
     void active();
@@ -68,7 +94,6 @@ public Q_SLOTS:
     void onGetGestureAvaiableActionsFinished(QDBusPendingCallWatcher *w);
 
 private:
-    MouseWorker  *m_worker;
     QDBusInterface *m_dbusMouseProperties;
     QDBusInterface *m_dbusTouchPadProperties;
     QDBusInterface *m_dbusTrackPointProperties;

--- a/src/plugin-mouse/operation/mouseworker.cpp
+++ b/src/plugin-mouse/operation/mouseworker.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "mouseworker.h"
@@ -11,13 +11,79 @@ const QString Service = "org.deepin.dde.InputDevices1";
 MouseWorker::MouseWorker(MouseModel *model, QObject *parent)
     : QObject(parent)
     , m_model(model)
+    , m_mouseProxy(new MouseDBusProxy(this))
     , m_treelandWorker(new TreeLandWorker(this))
 {
-    MouseDBusProxy *proxy = new MouseDBusProxy(this, this);
-    QMetaObject::invokeMethod(proxy, "active", Qt::QueuedConnection);
+    bindProxySignals();
+    bindRequestSignals();
+    QMetaObject::invokeMethod(m_mouseProxy, "active", Qt::QueuedConnection);
 #ifdef Enable_Treeland
     m_treelandWorker->active();
 #endif
+}
+
+void MouseWorker::active()
+{
+}
+
+void MouseWorker::deactive()
+{
+}
+
+void MouseWorker::init()
+{
+}
+
+void MouseWorker::bindProxySignals()
+{
+    connect(m_mouseProxy, &MouseDBusProxy::mouseExistChanged, this, &MouseWorker::setMouseExist);
+    connect(m_mouseProxy, &MouseDBusProxy::tpadExistChanged, this, &MouseWorker::setTpadExist);
+    connect(m_mouseProxy, &MouseDBusProxy::tpadEnabledChanged, this, &MouseWorker::setTpadEnabled);
+    connect(m_mouseProxy, &MouseDBusProxy::leftHandStateChanged, this, &MouseWorker::setLeftHandState);
+    connect(m_mouseProxy, &MouseDBusProxy::mouseNaturalScrollStateChanged, this, &MouseWorker::setMouseNaturalScrollState);
+    connect(m_mouseProxy, &MouseDBusProxy::touchNaturalScrollStateChanged, this, &MouseWorker::setTouchNaturalScrollState);
+    connect(m_mouseProxy, &MouseDBusProxy::disTypingChanged, this, &MouseWorker::setDisTyping);
+    connect(m_mouseProxy, &MouseDBusProxy::disTouchPadChanged, this, &MouseWorker::setDisTouchPad);
+    connect(m_mouseProxy, &MouseDBusProxy::tapClickChanged, this, &MouseWorker::setTapClick);
+    connect(m_mouseProxy, &MouseDBusProxy::douClickChanged, this, &MouseWorker::setDouClick);
+    connect(m_mouseProxy, &MouseDBusProxy::mouseMotionAccelerationChanged, this, &MouseWorker::setMouseMotionAcceleration);
+    connect(m_mouseProxy, &MouseDBusProxy::accelProfileChanged, this, &MouseWorker::setAccelProfile);
+    connect(m_mouseProxy, &MouseDBusProxy::touchpadMotionAccelerationChanged, this, &MouseWorker::setTouchpadMotionAcceleration);
+    connect(m_mouseProxy, &MouseDBusProxy::redPointExistChanged, this, &MouseWorker::setRedPointExist);
+    connect(m_mouseProxy, &MouseDBusProxy::trackPointMotionAccelerationChanged, this, &MouseWorker::setTrackPointMotionAcceleration);
+    connect(m_mouseProxy, &MouseDBusProxy::palmDetectChanged, this, &MouseWorker::setPalmDetect);
+    connect(m_mouseProxy, &MouseDBusProxy::palmMinWidthChanged, this, &MouseWorker::setPalmMinWidth);
+    connect(m_mouseProxy, &MouseDBusProxy::palmMinzChanged, this, &MouseWorker::setPalmMinz);
+    connect(m_mouseProxy, &MouseDBusProxy::scrollSpeedChanged, this, &MouseWorker::setScrollSpeed);
+    connect(m_mouseProxy, &MouseDBusProxy::gestureDataChanged, this, [this](const GestureData &data) {
+        setGestureData(data);
+        initFingerGestures();
+    });
+    connect(m_mouseProxy, &MouseDBusProxy::cursorSizeChanged, this, &MouseWorker::setCursorSize);
+    connect(m_mouseProxy, &MouseDBusProxy::availableCursorSizesChanged, this, &MouseWorker::setAvailableCursorSizes);
+    connect(m_mouseProxy, &MouseDBusProxy::lidIsPresentChanged, this, &MouseWorker::setLidIsPresent);
+}
+
+void MouseWorker::bindRequestSignals()
+{
+    connect(this, &MouseWorker::requestSetPalmDetect, m_mouseProxy, &MouseDBusProxy::setPalmDetect);
+    connect(this, &MouseWorker::requestSetPalmMinWidth, m_mouseProxy, &MouseDBusProxy::setPalmMinWidth);
+    connect(this, &MouseWorker::requestSetPalmMinz, m_mouseProxy, &MouseDBusProxy::setPalmMinz);
+    connect(this, &MouseWorker::requestSetDouClick, m_mouseProxy, &MouseDBusProxy::setDouClick);
+    connect(this, &MouseWorker::requestSetScrollSpeed, m_mouseProxy, &MouseDBusProxy::setScrollSpeed);
+    connect(this, &MouseWorker::requestSetLeftHandState, m_mouseProxy, &MouseDBusProxy::setLeftHandState);
+    connect(this, &MouseWorker::requestSetMouseNaturalScrollState, m_mouseProxy, &MouseDBusProxy::setMouseNaturalScrollState);
+    connect(this, &MouseWorker::requestSetTouchNaturalScrollState, m_mouseProxy, &MouseDBusProxy::setTouchNaturalScrollState);
+    connect(this, &MouseWorker::requestSetDisTyping, m_mouseProxy, &MouseDBusProxy::setDisTyping);
+    connect(this, &MouseWorker::requestSetDisTouchPad, m_mouseProxy, &MouseDBusProxy::setDisableTouchPadWhenMouseExist);
+    connect(this, &MouseWorker::requestSetTapClick, m_mouseProxy, &MouseDBusProxy::setTapClick);
+    connect(this, &MouseWorker::requestSetMouseMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setMouseMotionAcceleration);
+    connect(this, &MouseWorker::requestSetAccelProfile, m_mouseProxy, &MouseDBusProxy::setAccelProfile);
+    connect(this, &MouseWorker::requestSetTouchpadMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setTouchpadMotionAcceleration);
+    connect(this, &MouseWorker::requestSetTrackPointMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setTrackPointMotionAcceleration);
+    connect(this, &MouseWorker::requestSetTouchpadEnabled, m_mouseProxy, &MouseDBusProxy::setTouchpadEnabled);
+    connect(this, &MouseWorker::requestSetGesture, m_mouseProxy, &MouseDBusProxy::setGesture);
+    connect(this, &MouseWorker::requestSetCursorSize, m_mouseProxy, &MouseDBusProxy::setCursorSize);
 }
 
 void MouseWorker::initFingerGestures()

--- a/src/plugin-mouse/operation/mouseworker.h
+++ b/src/plugin-mouse/operation/mouseworker.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef MOUSEWORKER_H
@@ -11,6 +11,7 @@
 
 using namespace DCC_MOUSE;
 namespace DCC_NAMESPACE {
+class MouseDBusProxy;
 class MouseWorker : public QObject
 {
     Q_OBJECT
@@ -86,6 +87,9 @@ Q_SIGNALS:
     void requestSetCursorSize(const int cursorSize);
 
 private:
+    void bindProxySignals();
+    void bindRequestSignals();
+
     int converToDouble(int value);
     int converToDoubleModel(int value);
     double converToMotionAcceleration(int value);
@@ -93,6 +97,7 @@ private:
 
 private:
     MouseModel *m_model;
+    MouseDBusProxy *m_mouseProxy;
     TreeLandWorker *m_treelandWorker;
 };
 }


### PR DESCRIPTION
1. Remove direct dependency of MouseDBusProxy on MouseWorker, using
signals instead
2. Move signal connections from MouseDBusProxy constructor to
MouseWorker::bindProxySignals and bindRequestSignals
3. Add new signals in MouseDBusProxy for all changed properties
4. MouseWorker now uses signals to interact with MouseDBusProxy, making
it platform-agnostic
5. This restructuring prepares for Wayland adaptation where platform-
specific logic should be isolated
6. MouseDBusProxy now only handles DBus communication, not business
logic

Log: Restructured plugin-mouse code to better separate platform-specific
code from business logic

Influence:
1. Test mouse settings (left-handed, natural scroll, double-click) are
applied correctly
2. Test touchpad settings (enable/disable, tap-to-click, natural scroll)
work as expected
3. Test TrackPoint settings (motion acceleration) are properly synced
4. Test gesture data initialization and finger gesture paths are correct
5. Test cursor size and wheel speed settings are saved and loaded
6. Verify no regression in lid presence detection behavior

refactor: 解耦 MouseDBusProxy 对 MouseWorker 的直接依赖

1. 移除 MouseDBusProxy 对 MouseWorker 的直接依赖，改用信号机制
2. 将信号连接从 MouseDBusProxy 构造函数移入
MouseWorker::bindProxySignals 和 bindRequestSignals
3. 在 MouseDBusProxy 中添加所有属性变更的信号
4. MouseWorker 现在通过信号与 MouseDBusProxy 交互，不再关心平台具体实现
5. 重构为适配 Wayland 做准备，将平台相关代码隔离在 MouseDBusProxy 中
6. MouseDBusProxy 仅负责 DBus 通信，不处理业务逻辑

Log: 重构 plugin-mouse 代码结构，更好地分离平台相关代码和业务逻辑

Influence:
1. 测试鼠标设置（左手模式、自然滚动、双击速度）是否正确应用
2. 测试触摸板设置（启用/禁用、轻触点击、自然滚动）是否正常工作
3. 测试指点杆设置（运动加速度）是否正确同步
4. 测试手势数据初始化和手指手势路径是否正确
5. 测试光标大小和滚轮速度设置是否保存和加载
6. 验证盖子检测功能没有回归问题
