### PR TITLE
feat: add auto brightness toggle

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -52,6 +52,7 @@ Depends:
  qml6-module-qtquick-effects,
  libdtk6declarative(>> 6.7.40),
  netselect,
+ dde-daemon (>> 6.1.88)
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock
 Replaces: dde-control-center-dock

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -85,6 +85,9 @@ void DisplayModulePrivate::init()
     q_ptr->connect(m_model, &DisplayModel::colorTemperatureChanged, q_ptr, &DisplayModule::colorTemperatureChanged);
     q_ptr->connect(m_model, &DisplayModel::customColorTempTimePeriodChanged, q_ptr, &DisplayModule::customColorTempTimePeriodChanged);
     q_ptr->connect(m_model, &DisplayModel::adjustCCTmodeChanged, q_ptr, &DisplayModule::colorTemperatureModeChanged);
+    q_ptr->connect(m_model, &DisplayModel::autoBacklightSupportedChanged, q_ptr, &DisplayModule::autoBacklightSupportedChanged);
+    q_ptr->connect(m_model, &DisplayModel::autoBacklightEnabledChanged, q_ptr, &DisplayModule::autoBacklightEnabledChanged);
+    q_ptr->connect(m_model, &DisplayModel::builtinMonitorNameChanged, q_ptr, &DisplayModule::builtinMonitorNameChanged);
     updateMonitorList();
     updatePrimary();
     updateDisplayMode();
@@ -553,6 +556,32 @@ void DisplayModule::setCustomColorTempTimePeriod(const QString &timePeriod)
 
     Q_D(DisplayModule);
     d->m_worker->setCustomColorTempTimePeriod(startTime.toString(DEFAULT_TIME_FORMAT) + "-" + endTime.toString(DEFAULT_TIME_FORMAT));
+}
+
+bool DisplayModule::autoBacklightSupported() const
+{
+    Q_D(const DisplayModule);
+    return d->m_model->autoBacklightSupported();
+}
+
+bool DisplayModule::autoBacklightEnabled() const
+{
+    Q_D(const DisplayModule);
+    return d->m_model->autoBacklightEnabled();
+}
+
+void DisplayModule::setAutoBacklightEnabled(bool enabled)
+{
+    Q_D(DisplayModule);
+    if (autoBacklightEnabled() != enabled) {
+        Q_EMIT d->m_model->requestSetAutoBacklightEnable(enabled);
+    }
+}
+
+QString DisplayModule::builtinMonitorName() const
+{
+    Q_D(const DisplayModule);
+    return d->m_model->builtinMonitorName();
 }
 
 void DisplayModule::saveChanges()

--- a/src/plugin-display/operation/displaymodule.h
+++ b/src/plugin-display/operation/displaymodule.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DISPLAYMODULE_H
@@ -27,6 +27,9 @@ class DisplayModule : public QObject
     Q_PROPERTY(int colorTemperatureMode READ colorTemperatureMode WRITE setColorTemperatureMode NOTIFY colorTemperatureModeChanged FINAL)
     Q_PROPERTY(int colorTemperature READ colorTemperature WRITE setColorTemperature NOTIFY colorTemperatureChanged FINAL)
     Q_PROPERTY(QString customColorTempTimePeriod READ customColorTempTimePeriod WRITE setCustomColorTempTimePeriod NOTIFY customColorTempTimePeriodChanged FINAL)
+    Q_PROPERTY(bool autoBacklightSupported READ autoBacklightSupported NOTIFY autoBacklightSupportedChanged FINAL)
+    Q_PROPERTY(bool autoBacklightEnabled READ autoBacklightEnabled WRITE setAutoBacklightEnabled NOTIFY autoBacklightEnabledChanged FINAL)
+    Q_PROPERTY(QString builtinMonitorName READ builtinMonitorName NOTIFY builtinMonitorNameChanged FINAL)
 public:
     explicit DisplayModule(QObject *parent = nullptr);
     ~DisplayModule() override;
@@ -51,6 +54,10 @@ public:
     void setColorTemperature(int pos);
     QString customColorTempTimePeriod() const;
     void setCustomColorTempTimePeriod(const QString &timePeriod);
+    bool autoBacklightSupported() const;
+    bool autoBacklightEnabled() const;
+    void setAutoBacklightEnabled(bool enabled);
+    QString builtinMonitorName() const;
 
 public Q_SLOTS:
     void saveChanges();
@@ -75,6 +82,9 @@ Q_SIGNALS:
     void colorTemperatureChanged();
     void customColorTempTimePeriodChanged();
     void wallpaperChanged();
+    void autoBacklightSupportedChanged();
+    void autoBacklightEnabledChanged();
+    void builtinMonitorNameChanged();
 
 private:
     QScopedPointer<DisplayModulePrivate> d_ptrDisplayModule;

--- a/src/plugin-display/operation/private/displaydbusproxy.cpp
+++ b/src/plugin-display/operation/private/displaydbusproxy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "displaydbusproxy.h"
@@ -56,6 +56,22 @@ void DisplayDBusProxy::setAmbientLightAdjustBrightness(bool value)
 bool DisplayDBusProxy::hasAmbientLightSensor()
 {
     return qvariant_cast<bool>(m_dBusPowerInter->property("HasAmbientLightSensor"));
+}
+
+// auto brightness
+bool DisplayDBusProxy::autoBrightnessSupported()
+{
+    return qvariant_cast<bool>(m_dBusDisplayInter->property("AutoBrightnessSupported"));
+}
+
+bool DisplayDBusProxy::autoBrightnessEnabled()
+{
+    return qvariant_cast<bool>(m_dBusDisplayInter->property("AutoBrightnessEnabled"));
+}
+
+void DisplayDBusProxy::setAutoBrightnessEnabled(bool enabled)
+{
+    m_dBusDisplayInter->setProperty("AutoBrightnessEnabled", enabled);
 }
 
 QString DisplayDBusProxy::wallpaperURls() const
@@ -307,6 +323,22 @@ QDBusPendingReply<> DisplayDBusProxy::SetColorTemperature(int in0)
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0);
     return m_dBusDisplayInter->asyncCallWithArgumentList(QStringLiteral("SetColorTemperature"), argumentList);
+}
+
+QDBusPendingReply<> DisplayDBusProxy::SetAutoBrightnessEnabled(bool in0)
+{
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(in0);
+    return m_dBusDisplayInter->asyncCallWithArgumentList(QStringLiteral("SetAutoBrightnessEnabled"), argumentList);
+}
+
+QString DisplayDBusProxy::GetBuiltinMonitorName()
+{
+    QDBusMessage reply = m_dBusDisplayInter->call(QStringLiteral("GetBuiltinMonitor"));
+    if (reply.type() == QDBusMessage::ReplyMessage && reply.arguments().size() > 0) {
+        return reply.arguments().at(0).toString();
+    }
+    return QString();
 }
 
 QDBusPendingReply<> DisplayDBusProxy::SetCustomColorTempTimePeriod(const QString &in0)

--- a/src/plugin-display/operation/private/displaydbusproxy.h
+++ b/src/plugin-display/operation/private/displaydbusproxy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DISPLAYDBUSPROXY_H
@@ -88,6 +88,14 @@ public:
     Q_PROPERTY(bool HasAmbientLightSensor READ hasAmbientLightSensor NOTIFY HasAmbientLightSensorChanged)
     bool hasAmbientLightSensor();
 
+    // auto brightness
+    Q_PROPERTY(bool AutoBrightnessSupported READ autoBrightnessSupported NOTIFY AutoBrightnessSupportedChanged)
+    bool autoBrightnessSupported();
+
+    Q_PROPERTY(bool AutoBrightnessEnabled READ autoBrightnessEnabled WRITE setAutoBrightnessEnabled NOTIFY AutoBrightnessEnabledChanged)
+    bool autoBrightnessEnabled();
+    void setAutoBrightnessEnabled(bool enabled);
+
     Q_PROPERTY(QString WallpaperURls READ wallpaperURls NOTIFY WallpaperURlsChanged FINAL)
     QString wallpaperURls() const;
 
@@ -113,6 +121,8 @@ public Q_SLOTS: // METHODS
     QDBusPendingReply<> SetBrightness(const QString &in0, double in1);
     QDBusPendingReply<> SetColorTemperature(int in0);
     QDBusPendingReply<> SetCustomColorTempTimePeriod(const QString &in0);
+    QDBusPendingReply<> SetAutoBrightnessEnabled(bool in0);
+    QString GetBuiltinMonitorName();
     QDBusPendingReply<> SetMethodAdjustCCT(int in0);
     QDBusPendingReply<> SetPrimary(const QString &in0);
     QDBusPendingReply<> SwitchMode(uchar in0, const QString &in1);
@@ -152,6 +162,10 @@ Q_SIGNALS: // SIGNALS
     // power
     void AmbientLightAdjustBrightnessChanged(bool value) const;
     void HasAmbientLightSensorChanged(bool value) const;
+
+    // auto brightness
+    void AutoBrightnessSupportedChanged(bool value) const;
+    void AutoBrightnessEnabledChanged(bool value) const;
     void WallpaperURlsChanged(const QString &value) const;
     void WorkspaceSwitched(int oldIndex,int newIndex);
 

--- a/src/plugin-display/operation/private/displaymodel.cpp
+++ b/src/plugin-display/operation/private/displaymodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -156,6 +156,30 @@ void DisplayModel::setAutoLightAdjust(bool ala)
     m_isAutoLightAdjust = ala;
 
     Q_EMIT autoLightAdjustSettingChanged(m_isAutoLightAdjust);
+}
+
+void DisplayModel::setAutoBacklightSupported(bool supported)
+{
+    if (m_autoBacklightSupported == supported)
+        return;
+    m_autoBacklightSupported = supported;
+    Q_EMIT autoBacklightSupportedChanged(supported);
+}
+
+void DisplayModel::setAutoBacklightEnabled(bool enabled)
+{
+    if (m_autoBacklightEnabled == enabled)
+        return;
+    m_autoBacklightEnabled = enabled;
+    Q_EMIT autoBacklightEnabledChanged(enabled);
+}
+
+void DisplayModel::setBuiltinMonitorName(const QString &name)
+{
+    if (m_builtinMonitorName == name)
+        return;
+    m_builtinMonitorName = name;
+    Q_EMIT builtinMonitorNameChanged(name);
 }
 
 bool DisplayModel::redshiftIsValid() const

--- a/src/plugin-display/operation/private/displaymodel.h
+++ b/src/plugin-display/operation/private/displaymodel.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DISPLAYMODEL_H
@@ -65,6 +65,15 @@ public:
     inline bool isAudtoLightAdjust() const { return m_isAutoLightAdjust; }
     void setAutoLightAdjust(bool);
 
+    inline bool autoBacklightSupported() const { return m_autoBacklightSupported; }
+    void setAutoBacklightSupported(bool supported);
+
+    inline bool autoBacklightEnabled() const { return m_autoBacklightEnabled; }
+    void setAutoBacklightEnabled(bool enabled);
+
+    inline QString builtinMonitorName() const { return m_builtinMonitorName; }
+    void setBuiltinMonitorName(const QString &name);
+
     inline BrightnessMap brightnessMap() const { return m_brightnessMap; }
     void setBrightnessMap(const BrightnessMap &brightnessMap);
 
@@ -107,6 +116,10 @@ Q_SIGNALS:
     void redshiftVaildChanged(const bool isvalid) const;
     void autoLightAdjustSettingChanged(bool setting) const;
     void autoLightAdjustVaildChanged(bool isvalid) const;
+    void autoBacklightSupportedChanged(bool supported) const;
+    void autoBacklightEnabledChanged(bool enabled) const;
+    void builtinMonitorNameChanged(const QString &name) const;
+    void requestSetAutoBacklightEnable(bool enabled) const;
     void touchscreenListChanged() const;
     void touchscreenMapChanged() const;
     void maxBacklightBrightnessChanged(uint value);
@@ -150,6 +163,9 @@ private:
     bool m_RefreshRateEnable {false};
     bool m_isAutoLightAdjust {false};
     bool m_AutoLightAdjustIsValid {false};
+    bool m_autoBacklightSupported {false};
+    bool m_autoBacklightEnabled {false};
+    QString m_builtinMonitorName;
     bool m_allowEnableMultiScaleRatio;
     bool m_resolutionRefreshEnable;
     bool m_brightnessEnable;

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -108,6 +108,9 @@ void DisplayWorker::active()
         m_model->setmaxBacklightBrightness(m_displayInter->maxBacklightBrightness());
         m_model->setAutoLightAdjustIsValid(m_displayInter->hasAmbientLightSensor());
 
+        // 初始化自动亮度
+        initAutoBacklight();
+
         bool isRedshiftValid = true;
         QDBusReply<bool> reply = m_displayInter->SupportSetColorTemperatureSync();
         if (QDBusError::NoError == reply.error().type())
@@ -960,6 +963,45 @@ void DisplayWorker::updateControl()
 void DisplayWorker::setAmbientLightAdjustBrightness(bool able)
 {
     m_displayInter->setAmbientLightAdjustBrightness(able);
+}
+
+void DisplayWorker::initAutoBacklight()
+{
+    if (!m_displayInter)
+        return;
+
+    // 读取自动亮度支持状态
+    bool supported = m_displayInter->autoBrightnessSupported();
+    m_model->setAutoBacklightSupported(supported);
+
+    // 读取自动亮度启用状态
+    bool enabled = m_displayInter->autoBrightnessEnabled();
+    m_model->setAutoBacklightEnabled(enabled);
+
+    // 获取内置屏幕名称
+    QString builtinName = m_displayInter->GetBuiltinMonitorName();
+    if (!builtinName.isEmpty()) {
+        m_model->setBuiltinMonitorName(builtinName);
+    }
+
+    // 连接信号
+    connect(m_displayInter, &DisplayDBusProxy::AutoBrightnessSupportedChanged, m_model, &DisplayModel::setAutoBacklightSupported);
+    connect(m_displayInter, &DisplayDBusProxy::AutoBrightnessEnabledChanged, m_model, &DisplayModel::setAutoBacklightEnabled);
+    connect(m_model, &DisplayModel::requestSetAutoBacklightEnable, this, &DisplayWorker::setAutoBacklightEnabled);
+}
+
+void DisplayWorker::setAutoBacklightEnabled(const bool value)
+{
+    if (!m_displayInter)
+        return;
+
+    QDBusPendingReply<> reply = m_displayInter->SetAutoBrightnessEnabled(value);
+    reply.waitForFinished();
+    if (reply.isError()) {
+        qCWarning(DdcDisplayWorker) << "Set auto brightness enabled failed, error: " << reply.error().message();
+    } else {
+        qCInfo(DdcDisplayWorker) << "Set `AutoBrightnessEnabled`, value: " << value;
+    }
 }
 
 void DisplayWorker::setTouchScreenAssociation(const QString &monitor, const QString &touchscreenUUID)

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -67,6 +67,7 @@ public Q_SLOTS:
     void setMonitorResolutionBySize(Monitor *mon, const int width, const int height);
     void setAmbientLightAdjustBrightness(bool);
     void setCurrentFillMode(Monitor *mon, const QString fillMode);
+    void setAutoBacklightEnabled(const bool value);
 
     void backupConfig();
     void clearBackup();
@@ -99,6 +100,7 @@ private:
     void wlOutputRemoved(WQt::Output *output);
 
     void updateControl();
+    void initAutoBacklight();
 
 Q_SIGNALS:
     void requestUpdateModeList();

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -577,6 +577,7 @@ DccObject {
         }
     }
     DccObject {
+        id: brightnessGroup
         name: "brightnessGroup"
         parentName: "display"
         displayName: qsTr("Brightness")
@@ -584,27 +585,41 @@ DccObject {
         visible: screen.screenItems.length > 1
         pageType: DccObject.Item
         page: DccGroupView {}
-        DccObject {
-            name: "brightness"
-            parentName: "display/brightnessGroup"
-            displayName: qsTr("Brightness")
-            weight: 10
-            pageType: DccObject.Editor
-            onParentItemChanged: item => { if (item) item.implicitHeight = 36 }
-            page: Item {
+
+        function getBuiltinScreenIndex() {
+            for (var i = 0; i < screen.screenItems.length; i++) {
+                if (screen.screenItems[i].name === dccData.builtinMonitorName) {
+                    return i;
+                }
             }
+            return -1;
         }
+
         DccRepeater {
             model: screen.screenItems
             delegate: DccObject {
                 name: "brightness" + index
                 parentName: "display/brightnessGroup"
-                weight: 20 + index
+                weight: 200 + index * 5
                 displayName: screen.screenItems[index].name
                 pageType: DccObject.Editor
                 page: BrightnessComponent {
                     screenItem: screen.screenItems[index]
                 }
+            }
+        }
+        DccObject {
+            name: "autoBrightness"
+            parentName: "display/brightnessGroup"
+            displayName: qsTr("Auto Brightness")
+            weight: 200 + brightnessGroup.getBuiltinScreenIndex() * 5 + 1
+            visible: dccData.autoBacklightSupported && brightnessGroup.getBuiltinScreenIndex() >= 0
+            backgroundType: DccObject.Normal
+            pageType: DccObject.Editor
+            onParentItemChanged: item => { if (item) { item.rightItemTopMargin = 6; item.rightItemBottomMargin = 6 } }
+            page: Switch {
+                checked: dccData.autoBacklightEnabled
+                onClicked: dccData.autoBacklightEnabled = checked
             }
         }
     }
@@ -624,6 +639,20 @@ DccObject {
             pageType: DccObject.Editor
             page: BrightnessComponent {
                 screenItem: screen.screenItems[0]
+            }
+        }
+        DccObject {
+            name: "autoBrightness"
+            parentName: "display/screenGroup"
+            displayName: qsTr("Auto Brightness")
+            weight: 15
+            visible: dccData.autoBacklightSupported && screen.screenItems.length === 1 && screen.screenItems[0].name === dccData.builtinMonitorName
+            backgroundType: DccObject.Normal
+            pageType: DccObject.Editor
+            onParentItemChanged: item => { if (item) { item.rightItemTopMargin = 6; item.rightItemBottomMargin = 6 } }
+            page: Switch {
+                checked: dccData.autoBacklightEnabled
+                onClicked: dccData.autoBacklightEnabled = checked
             }
         }
 


### PR DESCRIPTION
1. Add DBus proxy methods to get/set auto brightness state and fetch the built-in monitor name
2. Extend DisplayModel with properties for autoBacklightSupported, autoBacklightEnabled, and builtinMonitorName
3. Implement initialization and state synchronization logic in DisplayWorker
4. Expose new properties via DisplayModule for QML binding
5. Add "Auto Brightness" switch in QML for both single and multi-monitor layouts
6. Dynamically position the switch after the built-in monitor's brightness slider

Log: Added auto brightness toggle switch in display settings

Influence:
1. Test multi-monitor setup to ensure the auto brightness switch appears correctly after the built-in monitor's slider
2. Test single built-in monitor setup to verify the switch visibility and functionality
3. Test single external monitor setup to verify the switch is hidden
4. Toggle the auto brightness switch and verify the system brightness adjusts according to ambient light
5. Test on hardware without an ambient light sensor to ensure the switch remains hidden
6. Verify DBus connection and error handling if the backend service fails to set the state

feat: 新增自动亮度调节开关

1. 新增 DBus 代理方法，用于获取/设置自动亮度状态并获取内置显示器名称
2. 在 DisplayModel 中扩展 autoBacklightSupported、autoBacklightEnabled 和 builtinMonitorName 属性
3. 在 DisplayWorker 中实现初始化和状态同步逻辑
4. 通过 DisplayModule 暴露新属性以供 QML 绑定
5. 在 QML 的单显示器和多显示器布局中添加“自动亮度”开关
6. 将该开关动态定位在内置显示器的亮度滑块之后

Log: 显示设置中新增自动亮度调节开关

Influence:
1. 测试多显示器设置，确保自动亮度开关正确显示在内置显示器的滑块之后
2. 测试单内置显示器设置，以验证开关的可见性和功能
3. 测试单外接显示器设置，以验证开关被隐藏
4. 切换自动亮度开关，验证系统亮度是否根据环境光进行调节
5. 在没有环境光传感器的硬件上测试，确保开关保持隐藏
6. 验证 DBus 连接以及后端服务设置状态失败时的错误处理

PMS: BUG-358023
Change-Id: Ide72a70f742d074d46b4f6432c61e840a364b805

## Summary by Sourcery

Add support for an auto brightness toggle in display settings, wired through DBus, the display model/worker, and exposed to QML for built‑in monitors.

New Features:
- Introduce auto brightness DBus properties and methods, including support and enabled state plus querying the built‑in monitor name.
- Expose auto brightness support/enabled flags and built‑in monitor name via DisplayModel and DisplayModule for QML bindings.
- Add an Auto Brightness switch to the single- and multi-monitor brightness UI, shown only for built‑in displays with ambient light support.

Enhancements:
- Initialize and synchronize auto brightness state in DisplayWorker, including error-handled updates via the backend service.