### PR TITLE
fix: filter nodes with empty displayName in event logger page tags

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -961,7 +961,7 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
         // Build page tags directly from current objects
         m_lastPageTags.clear();
         for (auto *obj : m_currentObjects) {
-            if (obj != m_root) {
+            if (!obj->displayName().isEmpty()) {
                 m_lastPageTags.append(obj->name());
             }
         }


### PR DESCRIPTION
修复: 事件日志页面标签过滤空 displayName 的节点

PMS: BUG-361175

## Summary by Sourcery

Bug Fixes:
- Prevent empty or unnamed nodes from being added as page tags in the event logger.