### PR TITLE
fix: remove redundant dialog titles

### DIFF
--- a/src/plugin-accounts/qml/CreateAccountDialog.qml
+++ b/src/plugin-accounts/qml/CreateAccountDialog.qml
@@ -25,10 +25,6 @@ D.DialogWindow {
     color: "transparent"
     signal accepted()
 
-    header: D.DialogTitleBar {
-        icon.name: dialog.icon
-    }
-
     Rectangle {
         // 覆盖整个窗口，包括 DialogWindow 的边距
         x: -DS.Style.dialogWindow.contentHMargin
@@ -131,14 +127,6 @@ D.DialogWindow {
             }
         }
         
-        Label {
-            text: dialog.title
-            font.bold: true
-            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-            Layout.bottomMargin: 20
-            font.pixelSize: accountTypeLabel.font.pixelSize
-        }
-
         RowLayout {
             implicitHeight: 30
             Layout.alignment: Qt.AlignTop | Qt.AlignHCenter

--- a/src/plugin-accounts/qml/PasswordModifyDialog.qml
+++ b/src/plugin-accounts/qml/PasswordModifyDialog.qml
@@ -30,14 +30,6 @@ D.DialogWindow {
         width: dialog.width - 10
         spacing: 0
         Label {
-            text: dialog.title
-            font.bold: true
-            Layout.leftMargin: 0
-            Layout.rightMargin: 20
-            font.pixelSize: cancelButton.font.pixelSize
-            Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-        }
-        Label {
             text: {
                 if (dialog.isCurrent())
                     return qsTr("Password length should be at least 8 characters, and the password should contain a combination of at least 3 of the following: uppercase letters, lowercase letters, numbers, and symbols. This type of password is more secure.")

--- a/src/plugin-authentication/qml/AddFaceinfoDialog.qml
+++ b/src/plugin-authentication/qml/AddFaceinfoDialog.qml
@@ -15,7 +15,6 @@ import org.deepin.dcc.account.biometric 1.0
 D.DialogWindow {
     id: dialog
     width: 360
-    height: 500
     minimumWidth: width
     maximumWidth: minimumWidth
     modality: Qt.WindowModal
@@ -50,14 +49,6 @@ D.DialogWindow {
                 width: listview.implicitWidth
 
                 property bool disclaimerAccepted: false
-
-                Label {
-                    Layout.fillWidth: true
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    text: dialog.title
-                    font: D.DTK.fontManager.t5
-                }
 
                 Item {
                     Layout.preferredHeight: 20
@@ -205,7 +196,7 @@ To ensure successful entry:\n\
                 D.RecommandButton {
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
                     Layout.fillWidth: true
@@ -223,12 +214,6 @@ To ensure successful entry:\n\
                 height: listview.implicitHeight
                 width: listview.implicitWidth
                 spacing: 0
-
-                Label {
-                    text: dialog.title
-                    Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-                    font: D.DTK.fontManager.t5
-                }
 
                 Item {
                     Layout.preferredHeight: 40
@@ -294,14 +279,6 @@ To ensure successful entry:\n\
                 height: listview.implicitHeight
                 width: listview.implicitWidth
 
-                Label {
-                    Layout.fillWidth: true
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    text: dialog.title
-                    font: D.DTK.fontManager.t5
-                }
-
                 Item {
                     Layout.preferredHeight: 50
                 }
@@ -345,7 +322,7 @@ To ensure successful entry:\n\
                     visible: dccData.faceController.addStage === CharaMangerModel.Success
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 
@@ -364,7 +341,7 @@ To ensure successful entry:\n\
                     visible: dccData.faceController.addStage === CharaMangerModel.Fail
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 

--- a/src/plugin-authentication/qml/AddFingerDialog.qml
+++ b/src/plugin-authentication/qml/AddFingerDialog.qml
@@ -15,7 +15,6 @@ import org.deepin.dcc.account.biometric 1.0
 D.DialogWindow {
     id: dialog
     width: 360
-    height: 500
     minimumWidth: width
     maximumWidth: minimumWidth
     modality: Qt.WindowModal
@@ -52,13 +51,6 @@ D.DialogWindow {
             ColumnLayout {
                 height: ListView.view.implicitHeight
                 width: ListView.view.implicitWidth
-
-                Label {
-                    Layout.fillWidth: true
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    text: dialog.title
-                }
 
                 Item {
                     Layout.preferredHeight: 50
@@ -121,7 +113,7 @@ D.DialogWindow {
                 D.RecommandButton {
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
                     Layout.fillWidth: true
@@ -137,11 +129,6 @@ D.DialogWindow {
             ColumnLayout {
                 height: ListView.view.implicitHeight
                 width: ListView.view.implicitWidth
-
-                Label {
-                    text: dialog.title
-                    Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-                }
 
                 Item {
                     Layout.alignment: Qt.AlignCenter
@@ -186,7 +173,7 @@ D.DialogWindow {
                     id: successBtnLayout
                     visible: dccData.fingerprintController.addStage === CharaMangerModel.Success
                     spacing: 10
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 
@@ -203,7 +190,7 @@ D.DialogWindow {
                     id: failedBtnLayout
                     visible: dccData.fingerprintController.addStage === CharaMangerModel.Fail
                     spacing: 10
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 
@@ -228,7 +215,7 @@ D.DialogWindow {
                     id: processBtnLayout
                     visible: dccData.fingerprintController.addStage === CharaMangerModel.Processing
                     spacing: 10
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 

--- a/src/plugin-authentication/qml/AddIrisDialog.qml
+++ b/src/plugin-authentication/qml/AddIrisDialog.qml
@@ -15,7 +15,6 @@ import org.deepin.dcc.account.biometric 1.0
 D.DialogWindow {
     id: dialog
     width: 360
-    height: 500
     minimumWidth: width
     maximumWidth: minimumWidth
     modality: Qt.WindowModal
@@ -47,13 +46,6 @@ D.DialogWindow {
             ColumnLayout {
                 height: ListView.view.implicitHeight
                 width: ListView.view.implicitWidth
-
-                Label {
-                    Layout.fillWidth: true
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    text: dialog.title
-                }
 
                 Item {
                     Layout.preferredHeight: 50
@@ -117,7 +109,7 @@ D.DialogWindow {
                 D.RecommandButton {
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
                     Layout.fillWidth: true
@@ -135,11 +127,6 @@ D.DialogWindow {
                 height: ListView.view.implicitHeight
                 width: ListView.view.implicitWidth
                 spacing: 0
-
-                Label {
-                    text: dialog.title
-                    Layout.alignment: Qt.AlignTop | Qt.AlignHCenter
-                }
 
                 Item {
                     Layout.preferredHeight: 40
@@ -205,13 +192,6 @@ D.DialogWindow {
                 height: ListView.view.implicitHeight
                 width: ListView.view.implicitWidth
 
-                Label {
-                    Layout.fillWidth: true
-                    horizontalAlignment: Text.AlignHCenter
-                    verticalAlignment: Text.AlignVCenter
-                    text: dialog.title
-                }
-
                 Item {
                     Layout.preferredHeight: 50
                 }
@@ -255,7 +235,7 @@ D.DialogWindow {
                     visible: dccData.irisController.addStage === CharaMangerModel.Success
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 
@@ -274,7 +254,7 @@ D.DialogWindow {
                     visible: dccData.irisController.addStage === CharaMangerModel.Fail
                     spacing: 10
                     Layout.alignment: Qt.AlignBottom | Qt.AlignHCenter
-                    Layout.bottomMargin: 0
+                    Layout.bottomMargin: DS.Style.dialogWindow.contentHMargin
                     Layout.leftMargin: 0
                     Layout.rightMargin: 0
 

--- a/src/plugin-authentication/qml/DisclaimerControl.qml
+++ b/src/plugin-authentication/qml/DisclaimerControl.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 -2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
@@ -45,7 +45,8 @@ ColumnLayout {
         Layout.topMargin: 0
         Layout.leftMargin: 0
         Layout.rightMargin: 0
-
+        Layout.bottomMargin: 10
+        
         Button {
             Layout.fillWidth: true
             text: qsTr("Cancel")

--- a/src/plugin-deepinid/qml/ConFirmDialog.qml
+++ b/src/plugin-deepinid/qml/ConFirmDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,15 +28,6 @@ D.DialogWindow {
 
     ColumnLayout {
         width: parent.width
-        Label {
-            id: titleLable
-            Layout.fillWidth: true
-            font: D.DTK.fontManager.t5
-            text: dialog.title
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
-            wrapMode: Text.WordWrap
-        }
 
         Label {
             id: messageLable


### PR DESCRIPTION
1. Remove duplicate title Label from CreateAccountDialog, PasswordModifyDialog, ConFirmDialog, and biometric enrollment dialogs
2. Remove unused DialogTitleBar header from CreateAccountDialog
3. Adjust top margin to compensate for removed title spacing

Log: Remove redundant title labels from dialogs that already display titles through the D.DialogWindow header

fix: 移除对话框中重复的标题

1. 移除创建账号、修改密码、确认对话框及生物识别录入对话框中重复的标题 Label
2. 移除 CreateAccountDialog 中未使用的 DialogTitleBar header
3. 调整顶部边距以补偿移除标题后的间距

Log: 移除对话框中与 D.DialogWindow header 重复显示的标题 Label
PMS: BUG-361279