### PR TITLE
fix: resolve visibility and focus issues in control center

### DIFF
--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -256,15 +256,12 @@ D.ApplicationWindow {
                     mode: D.DTK.NormalState
                     theme: D.DTK.themeType
                 }
-                visible: stackView.currentIndex === DccWindow.PageIndex.LoadIndex
             }
             HomePage {
                 id: homePage
-                visible: stackView.currentIndex === DccWindow.PageIndex.HomeIndex
             }
             SecondPage {
                 id: secondPage
-                visible: stackView.currentIndex === DccWindow.PageIndex.SecondIndex
                 Component.onCompleted: mainWindow.sidebarPage = this
             }
             Connections {

--- a/src/dde-control-center/plugin/HomePage.qml
+++ b/src/dde-control-center/plugin/HomePage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
@@ -84,7 +84,7 @@ Control {
 
         visible: contentVisible
 
-        activeFocusOnTab: true
+        activeFocusOnTab: false
 
         Keys.enabled: true
         Keys.onPressed: function (event) {
@@ -114,7 +114,7 @@ Control {
                 visible: grid.activeFocus
             }
         }
-        focus: true
+        focus: false
         model: DccModel {
             id: dccModel
             root: dccObj


### PR DESCRIPTION
1. Remove explicit page visibility bindings in DccWindow.qml to allow proper page rendering
2. Disable activeFocusOnTab and initial focus on HomePage grid to prevent incorrect focus behavior
3. The previous visibility logic caused transparency issues and incorrect stacking layer display
4. Focus settings were interfering with proper keyboard navigation and UI state

Log: Fixed control center display transparency issues and focus problems

Influence:
1. Verify control center opens correctly without transparency issues
2. Test navigation between different pages (load, home, second)
3. Verify keyboard tab navigation works as expected
4. Check focus state on home page grid elements
5. Test page content visibility and stacking order
6. Verify no regression in page transition animations

fix: 修复控制中心显示透明问题和焦点问题

1. 移除 DccWindow.qml 中明确的页面可见性绑定，确保页面正确渲染
2. 禁用 HomePage 网格的 activeFocusOnTab 和初始焦点设置，防止焦点行为 异常
3. 之前的可见性逻辑导致透明度问题和错误的层叠显示
4. 焦点设置干扰了正常的键盘导航和UI状态

Log: 修复控制中心显示透明和焦点问题

Influence:
1. 验证控制中心能够正常打开，无显示透明问题
2. 测试在不同页面（加载页、主页、次级页）之间的导航功能
3. 验证键盘 Tab 导航功能符合预期
4. 检查主页网格元素上的焦点状态
5. 测试页面内容的可见性和层叠顺序
6. 验证页面切换动画无回归问题

PMS: BUG-359373
Change-Id: I1de872c1754ade0377876b422ae39cfe7df2199f