### PR TITLE
fix: restore sidebar display after window minimization

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -161,7 +161,7 @@ void DccManager::loadModules(bool async, const QStringList &dirs)
 int DccManager::width() const
 {
     auto w = m_dconfig->value(WidthConfig).toInt();
-    return w >= 520 ? w : 780;
+    return w > 630 ? w : 630;
 }
 
 int DccManager::height() const


### PR DESCRIPTION
Changed the minimum width threshold from 520 to 630 pixels, ensuring the sidebar remains visible when the window is restored after being minimized. Previously, when the window width was between 520 and 630 pixels, the sidebar would be hidden upon restoration, causing a poor user experience. This adjustment guarantees that the sidebar is always displayed when the window is restored from a minimized state.

Log: Fixed sidebar not showing after window restoration from minimized state

Influence:
1. Minimize the control center window and restore it to verify sidebar visibility
2. Test with window widths at various breakpoints (below 630px and above 630px)
3. Verify sidebar display consistency across different screen resolutions
4. Test window restoration from minimized state in different desktop environments

fix: 窗口最小化关闭后还原显示侧边栏

将最小宽度阈值从520像素调整为630像素，确保窗口从最小化状态还原时侧边栏始
终可见。此前当窗口宽度在520到630像素之间时，还原后侧边栏会隐藏，影响用户
体验。此调整保证了从最小化状态还原窗口时侧边栏的正常显示。

Log: 修复从最小化状态还原窗口后侧边栏不显示的问题

Influence:
1. 最小化控制中心窗口并还原，验证侧边栏是否可见
2. 在不同宽度阈值（低于630像素和高于630像素）下测试窗口行为
3. 在不同屏幕分辨率下验证侧边栏显示一致性
4. 在不同桌面环境中测试窗口从最小化状态还原的效果

PMS: BUG-360847
Change-Id: I73c4e1d5bc6c2f3c3cae735b8225c3d1395a141e

## Summary by Sourcery

Bug Fixes:
- Fix sidebar not displaying after window restoration by updating the minimum stored window width threshold.