### PR TITLE
fix(privacy): resolve folder permission bypass for script-launched apps

### DIFF
--- a/src/plugin-privacy/operation/privacysecurityworker.cpp
+++ b/src/plugin-privacy/operation/privacysecurityworker.cpp
@@ -404,6 +404,16 @@ void PrivacySecurityWorker::processBatchPathUpdates()
             p.itemName = d.itemName;
             p.appPath = getAppPath(d.execs);
             p.dpkgQueryPath = d.desktopPath.isEmpty() ? p.appPath : d.desktopPath;
+            if (!p.dpkgQueryPath.isEmpty()) {
+                QFileInfo info(p.dpkgQueryPath);
+                if (info.isSymLink()) {
+                    QString target = info.symLinkTarget();
+                    qCInfo(DCC_PRIVACY) << "dpkg query path is a symlink for app"
+                                           << d.itemName << ", original:" << p.dpkgQueryPath
+                                           << ", resolved:" << target;
+                    p.dpkgQueryPath = target;
+                }
+            }
             processed.append(p);
 
             if (!p.dpkgQueryPath.isEmpty()) {


### PR DESCRIPTION
Fix an issue where folder permission deny policies were ineffective for applications launched via shell scripts (e.g. WPS, htbrowser).

The root cause was two-fold: dpkg-query only searched desktopPath to resolve package names, missing appPath which contained the correct path; and when package name was unresolved, getAppEntityJson registered only the shell script path in the entity's exes field, causing FileArmor to fail matching the actual ELF binary process.

- Add appPath as fallback path for dpkg-query package resolution
- Use executablePaths when available in getAppEntityJson for non-package apps

fix(privacy): 修复通过脚本启动的应用文件夹权限无法生效的问题

修复通过 shell 脚本启动的应用（如 WPS、红莲花浏览器）关闭文件夹权限后
仍能正常写入的问题。

根因有两方面：dpkg-query 仅使用 desktopPath 查询包名，遗漏了包含正确路径
的 appPath；包名解析失败时，getAppEntityJson 仅注册了 shell 脚本路径到实体 的 exes 字段，导致 FileArmor 无法匹配实际的 ELF 二进制进程。

- 增加 appPath 作为 dpkg-query 包名查询的兜底路径
- getAppEntityJson 中非包名应用优先使用 executablePaths

PMS: BUG-360273