### PR TITLE
feat: use DTK single instance and fix window activation under Wayland

### DIFF
--- a/src/dde-control-center/controlcenterdbusadaptor.cpp
+++ b/src/dde-control-center/controlcenterdbusadaptor.cpp
@@ -93,10 +93,7 @@ void ControlCenterDBusAdaptor::ShowPage(const QString &url)
 
 void ControlCenterDBusAdaptor::Toggle()
 {
-    QWindow *w = parent()->mainWindow();
-    w->setVisible(!w->isVisible());
-    if (w->isVisible())
-        w->requestActivate();
+    parent()->toggle();
 }
 
 QString ControlCenterDBusAdaptor::GetAllModule()

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -472,6 +472,18 @@ void DccManager::show()
     w->requestActivate();
 }
 
+void DccManager::toggle()
+{
+    QWindow *w = DccManager::mainWindow();
+    if (!w) {
+        return;
+    }
+
+    w->setVisible(!w->isVisible());
+    if (w->isVisible())
+        w->requestActivate();
+}
+
 void DccManager::initConfig()
 {
     if (!m_dconfig->isValid()) {

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -74,6 +74,7 @@ public Q_SLOTS:
     void cacheImage(const QString &id, const QSize &thumbnailSize = QSize());
 
     void show();
+    void toggle();
     void showHelp();
     // DBus Search
     QString search(const QString &json) const;

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -7,6 +7,7 @@
 #include <DDBusSender>
 #include <DIconTheme>
 #include <DLog>
+#include <DGuiApplicationHelper>
 
 #include <QCommandLineOption>
 #include <QCommandLineParser>
@@ -119,27 +120,27 @@ int main(int argc, char *argv[])
     parser.addOption(pluginDir);
     parser.process(*app);
 
-    QString reqPage = parser.value(pageOption);
-    const QString &reqModule = parser.value(moduleOption);
-    if (!reqModule.isEmpty()) {
-        reqPage = reqModule + "/" + reqPage;
-    }
+    auto parseReqPage = [&]() -> QString {
+         QString reqPage = parser.value(pageOption);
+         const QString &reqModule = parser.value(moduleOption);
+         if (!reqModule.isEmpty()) {
+             reqPage = reqModule + "/" + reqPage;
+         }
+         return reqPage;
+    };
+    QString reqPage = parseReqPage();
+
     const QStringList &refPluginDirs = parser.values(pluginDir);
+
+    if (!DGuiApplicationHelper::setSingleInstance("org.deepin.dde.control-center")) {
+        qDebug() << "dde-control-center is already running, pid:" << qApp->applicationPid();
+        return -1;
+    }
 
     QDBusConnection conn = QDBusConnection::sessionBus();
     if (!conn.registerService(DccDBusService)) {
         qDebug() << "dbus service already registered!"
                  << "pid is:" << qApp->applicationPid();
-        if (parser.isSet(toggleOption)) {
-            DDBusSender().service(DccDBusService).interface(DccDBusInterface).path(DccDBusPath).method("Toggle").call();
-        }
-
-        if (!reqPage.isEmpty()) {
-            DDBusSender().service(DccDBusService).interface(DccDBusInterface).path(DccDBusPath).method("ShowPage").arg(reqPage).call();
-        } else if (parser.isSet(showOption) && !parser.isSet(dbusOption)) {
-            DDBusSender().service(DccDBusService).interface(DccDBusInterface).path(DccDBusPath).method("Show").call();
-        }
-
         return -1;
     }
 
@@ -190,6 +191,23 @@ int main(int argc, char *argv[])
         qWarning() << "Failed to create window";
         return 1;
     }
+
+    // 监听 DTK 单例信号：当有新实例尝试启动时，在原进程内直接解析其参数并响应.
+    QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::newProcessInstance,
+                     [&](qint64 pid, const QStringList &arguments) {
+        qDebug() << "new instance started, pid:" << pid << "arguments:" << arguments;
+        parser.parse(arguments);
+
+        QString page = parseReqPage();
+
+        if (parser.isSet(toggleOption)) {
+            dccManager->toggle();
+        } else if (!page.isEmpty()) {
+            dccManager->showPage(page);
+        } else if (parser.isSet(showOption) && !parser.isSet(dbusOption)) {
+            dccManager->show();
+        }
+    });
 
     dccV25::ControlCenterDBusAdaptor *adaptor = new dccV25::ControlCenterDBusAdaptor(dccManager);
     dccV25::DBusControlCenterGrandSearchService *grandSearchadAptor = new dccV25::DBusControlCenterGrandSearchService(dccManager);


### PR DESCRIPTION
1. Replace the original D-Bus based singleton mechanism with DTK's
DGuiApplicationHelper::setSingleInstance to prevent duplicate instances
2. Remove old logic in the D-Bus registration failure branch that used
DDBusSender to forward commands to the running instance
3. Add toggle() method to DccManager to centralize window toggle logic
and improve code reuse
4. Connect to DGuiApplicationHelper::newProcessInstance signal to handle
command-line arguments (toggle, show page, show) in the already-running
process
5. Ensure proper window activation under Wayland by using DTK's single
instance mechanism

Log: Replaced singleton mechanism with DTK single instance for better
Wayland compatibility

Influence:
1. Test launching the control center multiple times to verify only one
instance runs
2. Test window toggle functionality via D-Bus and command line
3. Verify window activation works correctly under Wayland
4. Test showing specific pages via command line arguments
5. Test the "show" and "toggle" options when control center is already
running
6. Verify the new instance process correctly passes arguments to the
running instance

feat: 使用 DTK 单例并在 Wayland 下正确激活窗口

1. 使用 DTK 的 DGuiApplicationHelper::setSingleInstance 替换原有的基于
D-Bus 的单例机制，防止重复实例
2. 移除 D-Bus 注册失败分支中使用 DDBusSender 向运行实例转发命令的旧逻辑
3. 在 DccManager 中添加 toggle() 方法以集中管理窗口切换逻辑，提高代码复
用性
4. 连接 DGuiApplicationHelper::newProcessInstance 信号，在已运行的进程中
处理命令行参数（切换、显示页面、显示）
5. 通过使用 DTK 的单例机制，确保在 Wayland 下窗口能够正确激活

Log: 替换单例机制为 DTK 单例以提高 Wayland 兼容性

Influence:
1. 多次启动控制中心，验证只有一个实例在运行
2. 通过 D-Bus 和命令行测试窗口切换功能
3. 验证在 Wayland 下窗口激活是否正常
4. 通过命令行参数测试显示指定页面功能
5. 当控制中心已运行时测试"show"和"toggle"选项
6. 验证新实例进程能够正确将参数传递给已运行实例

PMS: BUG-345417
