### PR TITLE
feat(display): add multi-monitor concat screen support

### DIFF
--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -61,6 +61,7 @@ DisplayModulePrivate::DisplayModulePrivate(DisplayModule *parent)
     : q_ptr(parent)
     , m_primary(nullptr)
     , m_maxGlobalScale(1.0)
+    , m_screensFormRect(false)
 {
     qRegisterMetaType<QHash<Monitor *, QPair<int, int>>>("QHash<Monitor *, QPair<int, int>>");
     m_model = new DisplayModel(q_ptr);
@@ -88,9 +89,11 @@ void DisplayModulePrivate::init()
     q_ptr->connect(m_model, &DisplayModel::autoBacklightSupportedChanged, q_ptr, &DisplayModule::autoBacklightSupportedChanged);
     q_ptr->connect(m_model, &DisplayModel::autoBacklightEnabledChanged, q_ptr, &DisplayModule::autoBacklightEnabledChanged);
     q_ptr->connect(m_model, &DisplayModel::builtinMonitorNameChanged, q_ptr, &DisplayModule::builtinMonitorNameChanged);
+    q_ptr->connect(m_model, &DisplayModel::concatScreenModeChanged, q_ptr, &DisplayModule::isConcatScreenModeChanged);
     updateMonitorList();
     updatePrimary();
     updateDisplayMode();
+    updateConcatScreenMode();
 }
 
 void DisplayModulePrivate::updateVirtualScreens()
@@ -160,10 +163,14 @@ void DisplayModulePrivate::updateVirtualScreens()
         updatePrimary();
         Q_EMIT q_ptr->virtualScreensChanged();
     }
+    updateScreensFormRect();
 }
 
 void DisplayModulePrivate::updateMonitorList()
 {
+    if (m_model->isConcatScreenMode()) {
+        resetConcatScreenMode();
+    }
     bool changed = false;
     QList<Monitor *> addMonitorList = m_model->monitorList();
     for (auto it = m_screens.cbegin(); it != m_screens.cend();) {
@@ -205,6 +212,7 @@ void DisplayModulePrivate::updateMonitorList()
         updateVirtualScreens();
         updateMaxGlobalScale();
         updateDisplayMode();
+        updateConcatScreenMode();
         Q_EMIT q_ptr->screensChanged();
     }
 }
@@ -249,6 +257,7 @@ void DisplayModulePrivate::updateDisplayMode()
         m_displayMode = displayMode;
         Q_EMIT q_ptr->displayModeChanged();
     }
+    updateScreensFormRect();
 }
 
 void DisplayModulePrivate::updateMaxGlobalScale()
@@ -276,9 +285,62 @@ void DisplayModulePrivate::updateMaxGlobalScale()
     }
 }
 
+void DisplayModulePrivate::updateScreensFormRect()
+{
+    QList<DccScreen *> screens = enabledScreens();
+    bool isRect = false;
+    if (screens.size() >= 2) {
+        QList<QRectF> rects;
+        for (auto s : screens) {
+            rects << QRectF(s->x(), s->y(), s->width(), s->height());
+        }
+        QRectF bounding = rects[0];
+        qreal totalArea = rects[0].width() * rects[0].height();
+        for (int i = 1; i < rects.size(); ++i) {
+            bounding = bounding.united(rects[i]);
+            totalArea += rects[i].width() * rects[i].height();
+        }
+        isRect = qFuzzyCompare(bounding.width() * bounding.height(), totalArea);
+    }
+    if (m_screensFormRect != isRect) {
+        m_screensFormRect = isRect;
+        Q_EMIT q_ptr->screensFormRectChanged();
+    }
+}
+
+void DisplayModulePrivate::updateConcatScreenMode()
+{
+    m_worker->updateConcatScreenMode();
+}
+
+void DisplayModulePrivate::mergeToConcatScreen()
+{
+    QStringList outputs;
+    for (auto s : enabledScreens()) {
+        outputs << s->name();
+    }
+    m_worker->mergeToConcatScreen(outputs);
+}
+
+void DisplayModulePrivate::resetConcatScreenMode()
+{
+    m_worker->resetConcatScreenMode();
+}
+
 DccScreen *DisplayModulePrivate::primary() const
 {
     return m_primary;
+}
+
+QList<DccScreen *> DisplayModulePrivate::enabledScreens() const
+{
+    QList<DccScreen *> result;
+    for (auto s : m_screens) {
+        if (s->enable()) {
+            result << s;
+        }
+    }
+    return result;
 }
 
 QString DisplayModulePrivate::displayMode() const
@@ -401,6 +463,9 @@ void DisplayModule::setDisplayMode(const QString &mode)
         name = mode;
     }
     Q_D(DisplayModule);
+    if (d->m_model->isConcatScreenMode() && modeType != EXTEND_MODE) {
+        d->resetConcatScreenMode();
+    }
     d->m_worker->switchMode(modeType, name);
 }
 
@@ -582,6 +647,30 @@ QString DisplayModule::builtinMonitorName() const
 {
     Q_D(const DisplayModule);
     return d->m_model->builtinMonitorName();
+}
+
+bool DisplayModule::screensFormRect() const
+{
+    Q_D(const DisplayModule);
+    return d->m_screensFormRect;
+}
+
+bool DisplayModule::isConcatScreenMode() const
+{
+    Q_D(const DisplayModule);
+    return d->m_model->isConcatScreenMode();
+}
+
+void DisplayModule::mergeToConcatScreen()
+{
+    Q_D(DisplayModule);
+    d->mergeToConcatScreen();
+}
+
+void DisplayModule::resetConcatScreenMode()
+{
+    Q_D(DisplayModule);
+    d->resetConcatScreenMode();
 }
 
 void DisplayModule::saveChanges()

--- a/src/plugin-display/operation/displaymodule.h
+++ b/src/plugin-display/operation/displaymodule.h
@@ -30,6 +30,8 @@ class DisplayModule : public QObject
     Q_PROPERTY(bool autoBacklightSupported READ autoBacklightSupported NOTIFY autoBacklightSupportedChanged FINAL)
     Q_PROPERTY(bool autoBacklightEnabled READ autoBacklightEnabled WRITE setAutoBacklightEnabled NOTIFY autoBacklightEnabledChanged FINAL)
     Q_PROPERTY(QString builtinMonitorName READ builtinMonitorName NOTIFY builtinMonitorNameChanged FINAL)
+    Q_PROPERTY(bool screensFormRect READ screensFormRect NOTIFY screensFormRectChanged FINAL)
+    Q_PROPERTY(bool isConcatScreenMode READ isConcatScreenMode NOTIFY isConcatScreenModeChanged FINAL)
 public:
     explicit DisplayModule(QObject *parent = nullptr);
     ~DisplayModule() override;
@@ -58,6 +60,8 @@ public:
     bool autoBacklightEnabled() const;
     void setAutoBacklightEnabled(bool enabled);
     QString builtinMonitorName() const;
+    bool screensFormRect() const;
+    bool isConcatScreenMode() const;
 
 public Q_SLOTS:
     void saveChanges();
@@ -67,6 +71,8 @@ public Q_SLOTS:
     void executemultiScreenAlgo(QList<QObject *> listItems, QObject *pw, qreal scale);
     void applySettings(QList<QObject *> listItems, qreal scale);
     void applyChanged(); // 修改分辨率、方向时，要重新处理下拼接
+    Q_INVOKABLE void mergeToConcatScreen();
+    Q_INVOKABLE void resetConcatScreenMode();
 
 Q_SIGNALS:
     void virtualScreensChanged();
@@ -85,6 +91,8 @@ Q_SIGNALS:
     void autoBacklightSupportedChanged();
     void autoBacklightEnabledChanged();
     void builtinMonitorNameChanged();
+    void screensFormRectChanged();
+    void isConcatScreenModeChanged();
 
 private:
     QScopedPointer<DisplayModulePrivate> d_ptrDisplayModule;

--- a/src/plugin-display/operation/private/displaymodel.cpp
+++ b/src/plugin-display/operation/private/displaymodel.cpp
@@ -287,3 +287,12 @@ void DisplayModel::setmodeChanging(bool changing)
 {
     m_monitorModeChanging = changing;
 }
+
+void DisplayModel::setIsConcatScreenMode(bool enabled)
+{
+    if (m_isConcatScreenMode == enabled) {
+        return;
+    }
+    m_isConcatScreenMode = enabled;
+    Q_EMIT concatScreenModeChanged(m_isConcatScreenMode);
+}

--- a/src/plugin-display/operation/private/displaymodel.h
+++ b/src/plugin-display/operation/private/displaymodel.h
@@ -103,6 +103,9 @@ public:
     inline bool monitorModeChanging() const { return m_monitorModeChanging; }
     void setmodeChanging(bool changing);
 
+    inline bool isConcatScreenMode() const { return m_isConcatScreenMode; }
+    void setIsConcatScreenMode(bool enabled);
+
 Q_SIGNALS:
     void screenHeightChanged(const int h) const;
     void screenWidthChanged(const int w) const;
@@ -133,6 +136,7 @@ Q_SIGNALS:
     void sharedDevicesChanged(bool on) const;
     void filesStoragePathChanged(const QString& path) const;
     void customColorTempTimePeriodChanged(const QString& timePeriod);
+    void concatScreenModeChanged(bool enabled);
 
 private Q_SLOTS:
     void setScreenHeight(const int h);
@@ -175,6 +179,7 @@ private:
     uint m_maxBacklightBrightness {0};
     bool m_allSupportFillModes;
     bool m_monitorModeChanging; // 配置修改中,仅控制中心修改时才处理自动拼接
+    bool m_isConcatScreenMode { false };
 };
 }
 

--- a/src/plugin-display/operation/private/displaymodule_p.h
+++ b/src/plugin-display/operation/private/displaymodule_p.h
@@ -30,7 +30,12 @@ public:
     void updatePrimary();
     void updateDisplayMode();
     void updateMaxGlobalScale();
+    void updateScreensFormRect();
+    void mergeToConcatScreen();
+    void resetConcatScreenMode();
+    void updateConcatScreenMode();
     DccScreen *primary() const;
+    QList<DccScreen *> enabledScreens() const;
     QString displayMode() const;
     void setScreenPosition(const QList<ScreenData *> &screensData);
     void updateScale(DccScreen *item);
@@ -45,6 +50,7 @@ public:
     DccScreen *m_primary;
     QString m_displayMode;
     qreal m_maxGlobalScale;
+    bool m_screensFormRect;
 
     Q_DECLARE_PUBLIC(DisplayModule)
 };

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -22,6 +22,7 @@ Q_LOGGING_CATEGORY(DdcDisplayWorker, "dcc-display-worker")
 
 
 const QString DisplayInterface("org.deepin.dde.Display1");
+constexpr const char * const CONCAT_SCREEN_NAME = "DDE-CONCAT-SCREEN";
 
 Q_DECLARE_METATYPE(QList<QDBusObjectPath>)
 using namespace dccV25;
@@ -1038,4 +1039,59 @@ void DisplayWorker::setMonitorResolutionBySize(Monitor *mon, const int width, co
         });
         watcher->waitForFinished();
     }
+}
+
+void DisplayWorker::mergeToConcatScreen(const QStringList &outputs)
+{
+    if (WQt::Utils::isTreeland()) {
+        return;
+    }
+
+    if (outputs.size() < 2) {
+        return;
+    }
+        
+    QString outputsStr = outputs.join(",");
+    qCDebug(DdcDisplayWorker) << "[ConcatScreen] mergeToConcatScreen: xrandr --setmonitor" << CONCAT_SCREEN_NAME << "auto" << outputsStr;
+    QProcess p;
+    p.start("xrandr", {"--setmonitor", CONCAT_SCREEN_NAME, "auto", outputsStr});
+    p.waitForFinished(5000);
+    if (p.exitCode() != 0) {
+        qCWarning(DdcDisplayWorker) << "[ConcatScreen] mergeToConcatScreen failed:" << p.readAllStandardError();
+        return;
+    }
+    m_model->setIsConcatScreenMode(true);
+}
+
+void DisplayWorker::resetConcatScreenMode()
+{
+    if (WQt::Utils::isTreeland()) {
+        return;
+    }
+
+    QProcess p;
+    p.start("xrandr", {"--delmonitor", CONCAT_SCREEN_NAME});
+    p.waitForFinished(5000);
+    if (p.exitCode() != 0) {
+        qCWarning(DdcDisplayWorker) << "[ConcatScreen] delmonitor failed:" << p.readAllStandardError();
+        return;
+    }
+
+    m_model->setIsConcatScreenMode(false);
+}
+
+void DisplayWorker::updateConcatScreenMode()
+{
+    if (WQt::Utils::isTreeland()) {
+        return;
+    }
+
+    QProcess p;
+    p.start("xrandr", {"--listmonitors"});
+    p.waitForFinished(3000);
+    if (p.exitCode() != 0) {
+        qCWarning(DdcDisplayWorker) << "[ConcatScreen] listmonitors failed:" << p.readAllStandardError();
+    }
+    QByteArray output = p.readAllStandardOutput();
+    m_model->setIsConcatScreenMode(output.contains(CONCAT_SCREEN_NAME));
 }

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -69,6 +69,10 @@ public Q_SLOTS:
     void setCurrentFillMode(Monitor *mon, const QString fillMode);
     void setAutoBacklightEnabled(const bool value);
 
+    void mergeToConcatScreen(const QStringList &outputs);
+    void resetConcatScreenMode();
+    void updateConcatScreenMode();
+
     void backupConfig();
     void clearBackup();
     void resetBackup();

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -12,6 +12,8 @@ DccObject {
     id: root
     property var screen: dccData.virtualScreens[0]
     property var activeDialogs: []
+    property bool screensFormRect: dccData.screensFormRect
+    property bool isExtendMode: dccData.displayMode === "EXTEND"
     property var scaleModelConst: [{
             "text": qsTr("100%"),
             "value": 1.0
@@ -188,7 +190,7 @@ DccObject {
             name: "monitorsGround"
             parentName: "monitorControl"
             weight: 10
-            enabled: dccData.virtualScreens.length > 1
+            enabled: dccData.virtualScreens.length > 1 && !(root.isExtendMode && dccData.isConcatScreenMode)
             Component.onCompleted: cacheImage()
             pageType: DccObject.Item
             onParentItemChanged: item => { if (item) { item.topInset = 0; item.bottomInset = 0 } }
@@ -482,6 +484,25 @@ DccObject {
                 }
             }
         }
+        DccObject {
+            name: "mergeToConcatScreen"
+            parentName: "display/displayMultipleDisplays"
+            displayName: qsTr("Concat Screen")
+            weight: 40
+            visible: root.isExtendMode && dccData.isX11 && dccData.screens.length > 1
+            pageType: DccObject.Editor
+            page: Switch {
+                checked: dccData.isConcatScreenMode
+                enabled: root.screensFormRect || dccData.isConcatScreenMode
+                onCheckedChanged: {
+                    if (checked) {
+                        dccData.mergeToConcatScreen()
+                    } else {
+                        dccData.resetConcatScreenMode()
+                    }
+                }
+            }
+        }
     }
     DccTitleObject {
         name: "screenTitle"
@@ -665,6 +686,7 @@ DccObject {
             page: ComboBox {
                 id: resolutionComboBox
                 flat: true
+                enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 model: root.getResolutionModel(screen.resolutionList, screen.bestResolution)
                 textRole: "text"
                 valueRole: "value"
@@ -809,6 +831,7 @@ DccObject {
             pageType: DccObject.Editor
             page: ComboBox {
                 flat: true
+                enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 textRole: "text"
                 valueRole: "value"
                 model: root.getRateModel(screen.rateList, screen.bestRate)
@@ -842,6 +865,7 @@ DccObject {
             pageType: DccObject.Editor
             page: ComboBox {
                 flat: true
+                enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 textRole: "text"
                 valueRole: "value"
                 model: [{
@@ -888,6 +912,7 @@ DccObject {
             pageType: DccObject.Editor
             page: ComboBox {
                 flat: true
+                enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 textRole: "text"
                 valueRole: "value"
                 model: dccData.isX11 ? root.getScaleModel(dccData.maxGlobalScale, dccData.globalScale) : root.getScaleModel(screen.maxScale, screen.scale)
@@ -918,6 +943,7 @@ DccObject {
         onParentItemChanged: item => { if (item) item.topInset = 6 }
         page: ComboBox {
             flat: true
+            enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
             textRole: "text"
             valueRole: "value"
             model: root.getScaleModel(dccData.maxGlobalScale, dccData.globalScale)


### PR DESCRIPTION
Support merging multiple physical monitors into a single logical display area via xrandr on X11, with a Switch toggle in extend mode that activates when screens form a rectangle.

支持在 X11 下通过 xrandr 命令将多个物理显示器拼接为单一逻辑显示区域，扩展模式下屏幕排列为矩形时可一键切换。

Log: 实现 X11 环境下多屏拼接
PMS: TASK-40959
Influence: 1.扩展模式下，多屏排列称矩形时，支持跨屏拼接 2.切换显示模式或热插拔时自动退出拼接模式；3.拼接模式下禁用分辨率、刷新率、方向、缩放调整及屏幕拖动