### PR TITLE
fix: update model accels role after shortcut data changes

### DIFF
--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -629,7 +629,7 @@ void ShortcutListModel::onUpdateShortcut(ShortcutInfo *info)
     if (row >= 0)
     {
         QModelIndex modelIndex = index(row);
-        Q_EMIT dataChanged(modelIndex, modelIndex, {Qt::DisplayRole, KeySequenceRole});
+        Q_EMIT dataChanged(modelIndex, modelIndex, {Qt::DisplayRole, KeySequenceRole, AccelsRole});
     }
 }
 


### PR DESCRIPTION
## Summary
- `ShortcutListModel::onUpdateShortcut` now emits `AccelsRole` in `dataChanged`
- Fixes QML cached `model.accels` staleness after async shortcut updates (`resetAll`/re-conflict)

## Root Cause
`onUpdateShortcut` only notified `{DisplayRole, KeySequenceRole}`, missing `AccelsRole`.
After `resetAll` restores defaults, the C++ model updates `info->accels` correctly via `onKeyBindingChanged`,
but QML cached `model.accels` stayed stale (empty string from prior conflict clear).
On re-conflict, `showWarnning: model.accels.length > 0` evaluated false because the cached value was still "".

## Test
1. Edit launcher shortcut → type conflicting key → replace
2. Restore default
3. Edit launcher again → type same key
4. ✅ Conflicted shortcut now shows warnning icon

## PMS
BUG-361841

## Summary by Sourcery

Bug Fixes:
- Ensure `AccelsRole` is emitted in `dataChanged` for updated shortcuts so QML `model.accels` is refreshed and no longer becomes stale after async shortcut updates.