### PR TITLE
fix: remove duplicate title label in timeout dialog

### DIFF
--- a/src/plugin-display/qml/TimeoutDialog.qml
+++ b/src/plugin-display/qml/TimeoutDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Layouts 1.15
@@ -44,15 +44,6 @@ D.DialogWindow {
             }
         }
         width: parent.width
-        Label {
-            Layout.fillWidth: true
-            Layout.leftMargin: 50
-            Layout.rightMargin: 50
-            text: title
-            font.bold: true
-            wrapMode: Text.WordWrap
-            horizontalAlignment: Text.AlignHCenter
-        }
         Label {
             Layout.fillWidth: true
             Layout.leftMargin: 50


### PR DESCRIPTION
1. Remove the redundant title Label from TimeoutDialog.qml
2. The title text is already displayed via the dialog header, so the extra Label caused a duplicate display issue

Log: Remove duplicate title label from display timeout dialog

fix: 移除超时对话框中重复的标题标签

1. 从 TimeoutDialog.qml 中移除冗余的标题 Label
2. 标题文本已通过对话框头部显示，多余的 Label 导致标题重复展示

Log: 移除显示超时对话框中重复的标题标签
PMS: BUG-362237

## Summary by Sourcery

Bug Fixes:
- Resolve duplicate title text in the display timeout dialog by removing an extra label.