### PR TITLE
fix(display): disable primary screen switch and screen identify in concat screen mode

### DIFF
--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -342,6 +342,7 @@ DccObject {
             displayName: qsTr("Identify")
             weight: 20
             visible: dccData.virtualScreens.length > 1 || (dccData.virtualScreens.length === 1 && dccData.virtualScreens[0].screenItems.length > 1)
+            enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
             pageType: DccObject.Item
             onParentItemChanged: item => { if (item) item.topInset = 6 }
             page: Item {
@@ -465,6 +466,7 @@ DccObject {
             visible: dccData.virtualScreens.length > 1
             page: ComboBox {
                 flat: true
+                enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 textRole: "name"
                 model: dccData.virtualScreens
                 function indexOfScreen(primary) {


### PR DESCRIPTION
When in concat screen mode, all physical monitors are merged into a single logical display, making primary screen switching and monitor identification meaningless.

进入扩展模式的跨屏拼接后，禁用主屏幕切换和屏幕识别功能。

Log: “跨屏拼接”模式下，禁用屏幕识别和主屏切换
PMS: 362681
Influence: “跨屏拼接”模式下，禁用屏幕识别和主屏切换

## Summary by Sourcery

Bug Fixes:
- Prevent using screen identification and primary screen switching when in concat screen extend mode to avoid invalid operations.