### PR TITLE
chore: update changelog to 6.1.88

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-control-center (6.1.88) unstable; urgency=medium
+
+  * feat(display): add help icon with tooltip for concat screen
+  * fix(display): disable primary screen switch and screen identify in
+    concat screen mode
+  * fix: remove duplicate title label in timeout dialog
+  * fix: update model accels role after shortcut data changes
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 22 May 2026 21:30:24 +0800
+
 dde-control-center (6.1.87) unstable; urgency=medium
 
   * feat(display): add translation for "Concat Screen" in


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.88

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.88
- 目标分支: master

## Summary by Sourcery

Chores:
- Refresh debian/changelog entries to document version 6.1.88 targeting master.