### PR TITLE
fix(power): remove Wayland visibility restrictions on power settings

### DIFF
--- a/src/plugin-power/qml/BatteryPage.qml
+++ b/src/plugin-power/qml/BatteryPage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
@@ -13,7 +13,6 @@ DccObject {
         name: "screenAndSuspendTitle"
         parentName: "power/onBattery"
         displayName: qsTr("Screen and Suspend")
-        visible: dccData.platformName() !== "wayland"
         weight: 10
     }
 
@@ -22,7 +21,6 @@ DccObject {
         parentName: "power/onBattery"
         weight: 100
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
 
         DccObject {
@@ -72,7 +70,6 @@ DccObject {
         parentName: "power/onBattery"
         weight: 200
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
 
         DccObject {
@@ -122,7 +119,7 @@ DccObject {
         parentName: "power/onBattery"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment && dccData.model.canSuspend
+        visible: !dccData.model.isVirtualEnvironment && dccData.model.canSuspend
         page: DccGroupView {}
 
         DccObject {
@@ -172,7 +169,6 @@ DccObject {
         parentName: "power/onBattery"
         weight: 400
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
 
         DccObject {
@@ -265,7 +261,7 @@ DccObject {
         parentName: "power/onBattery"
         weight: 700
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland" && (dccData.model.canSuspend || dccData.model.canHibernate)
+        visible: dccData.model.canSuspend || dccData.model.canHibernate
         page: DccGroupView {}
 
         DccObject {

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -14,7 +14,6 @@ DccObject {
         parentName: "power/general"
         displayName: qsTr("Power Plans")
         weight: 10
-        visible: dccData.platformName() !== "wayland"
     }
 
     DccObject {
@@ -22,7 +21,6 @@ DccObject {
         parentName: "power/general"
         weight: 100
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
         PowerPlansListview {}
     }
@@ -32,7 +30,6 @@ DccObject {
         parentName: "power/general"
         displayName: qsTr("Power Saving Settings")
         weight: 200
-        visible: dccData.platformName() !== "wayland"
     }
 
     DccObject {
@@ -40,7 +37,6 @@ DccObject {
         parentName: "power/general"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
 
         DccObject {
@@ -83,7 +79,7 @@ DccObject {
         displayName: qsTr("Auto power saving on battery")
         weight: 400
         backgroundType: DccObject.Normal
-        visible: dccData.model.haveBettary && dccData.platformName() !== "wayland"
+        visible: dccData.model.haveBettary
         pageType: DccObject.Editor
         page: D.Switch {
             checked: dccData.model.autoPowerSaveMode
@@ -98,7 +94,6 @@ DccObject {
         parentName: "power/general"
         displayName: qsTr("Decrease screen brightness on power saver")
         weight: 450
-        visible: dccData.platformName() !== "wayland"
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
         page: ColumnLayout {

--- a/src/plugin-power/qml/PowerMain.qml
+++ b/src/plugin-power/qml/PowerMain.qml
@@ -27,7 +27,6 @@ DccObject {
         description: qsTr("Screen and suspend")
         icon: "plugged_in"
         weight: 100
-        visible: dccData.platformName() !== "wayland"
         page: DccRightView {
             spacing: 0
         }

--- a/src/plugin-power/qml/PowerPage.qml
+++ b/src/plugin-power/qml/PowerPage.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
@@ -13,7 +13,6 @@ DccObject {
         name: "screenAndSuspendTitle"
         parentName: "power/onPower"
         displayName: qsTr("Screen and Suspend")
-        visible: dccData.platformName() !== "wayland"
         weight: 10
     }
 
@@ -22,7 +21,6 @@ DccObject {
         parentName: "power/onPower"
         weight: 100
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
 
         DccObject {
@@ -73,7 +71,6 @@ DccObject {
         parentName: "power/onPower"
         weight: 200
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland"
         page: DccGroupView {}
 
         DccObject {
@@ -123,7 +120,7 @@ DccObject {
         parentName: "power/onPower"
         weight: 300
         pageType: DccObject.Item
-        visible: dccData.platformName() !== "wayland" && !dccData.model.isVirtualEnvironment && dccData.model.canSuspend
+        visible: !dccData.model.isVirtualEnvironment && dccData.model.canSuspend
         page: DccGroupView {}
 
         DccObject {
@@ -200,7 +197,6 @@ DccObject {
             displayName: qsTr("When the power button is pressed")
             weight: 2
             pageType: DccObject.Editor
-            visible: dccData.platformName() !== "wayland"
             page: CustomComboBox {
                 textRole: "text"
                 enableRole: "enable"


### PR DESCRIPTION
1. Removed `platformName() !== "wayland"` visibility guards from BatteryPage, GeneralPage, PowerMain, and PowerPage
2. Power settings (screen & suspend, power plans, power saving, power button shortcuts) now show on Wayland
3. Kept applicable non-Wayland checks (virtual environment, battery presence, suspend capability) intact

Log: Power management settings are no longer hidden on Wayland

fix(power): 移除电源管理设置页面在 Wayland 下的可见性限制

1. 移除了 BatteryPage、GeneralPage、PowerMain、PowerPage 中的 `platformName() !== "wayland"` 可见性限制
2. 电源管理设置（屏幕与休眠、电源计划、省电设置、电源按钮快捷键）现在可在 Wayland 下显示
3. 保留了其他非 Wayland 相关的可见性检查（虚拟环境、电池状态、休眠能力） Log: 电源管理设置在 Wayland 环境下不再被隐藏
PMS: BUG-346597
PMS: BUG-346589
PMS: BUG-346575

Change-Id: I93bb377d21f1b6d5580c2ddd980411e8a87f92da