### PR TITLE
fix: add null pointer checks for D-Bus proxy member variables

### DIFF
--- a/src/plugin-sound/operation/sounddbusproxy.cpp
+++ b/src/plugin-sound/operation/sounddbusproxy.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "sounddbusproxy.h"
@@ -188,7 +188,10 @@ void SoundDBusProxy::setSinkDevicePath(const QString &path)
 
 bool SoundDBusProxy::muteSink()
 {
-    return qvariant_cast<bool>(m_defaultSink->property("MuteSink"));
+    if (m_defaultSink) {
+        return qvariant_cast<bool>(m_defaultSink->property("MuteSink"));
+    }
+    return false;
 }
 
 void SoundDBusProxy::SetMuteSink(bool in0)
@@ -202,12 +205,18 @@ void SoundDBusProxy::SetMuteSink(bool in0)
 
 double SoundDBusProxy::balanceSink()
 {
-    return qvariant_cast<double>(m_defaultSink->property("BalanceSink"));
+    if (m_defaultSink) {
+        return qvariant_cast<double>(m_defaultSink->property("BalanceSink"));
+    }
+    return 0.0;
 }
 
 double SoundDBusProxy::baseVolumeSink()
 {
-     return qvariant_cast<double>(m_defaultSink->property("BaseVolumeSink"));
+    if (m_defaultSink) {
+        return qvariant_cast<double>(m_defaultSink->property("BaseVolumeSink"));
+    }
+    return 0.0;
 }
 
 void SoundDBusProxy::SetBalanceSink(double in0, bool in1)
@@ -221,7 +230,10 @@ void SoundDBusProxy::SetBalanceSink(double in0, bool in1)
 
 double SoundDBusProxy::volumeSink()
 {
-    return qvariant_cast<double>(m_defaultSink->property("VolumeSink"));
+    if (m_defaultSink) {
+        return qvariant_cast<double>(m_defaultSink->property("VolumeSink"));
+    }
+    return 0.0;
 }
 
 void SoundDBusProxy::SetVolumeSink(double in0, bool in1)
@@ -237,12 +249,18 @@ void SoundDBusProxy::SetVolumeSink(double in0, bool in1)
 
 AudioPort SoundDBusProxy::activePortSink()
 {
-    return qvariant_cast<AudioPort>(m_defaultSink->property("ActivePortSink"));
+    if (m_defaultSink) {
+        return qvariant_cast<AudioPort>(m_defaultSink->property("ActivePortSink"));
+    }
+    return AudioPort();
 }
 
 uint SoundDBusProxy::cardSink()
 {
-    return qvariant_cast<uint>(m_defaultSink->property("CardSink"));
+    if (m_defaultSink) {
+        return qvariant_cast<uint>(m_defaultSink->property("CardSink"));
+    }
+    return 0;
 }
 
 void SoundDBusProxy::setSourceDevicePath(const QString &path)
@@ -266,12 +284,18 @@ void SoundDBusProxy::SetSourceMute(bool in0)
 
 double SoundDBusProxy::volumeSource()
 {
-    return qvariant_cast<double>(m_defaultSource->property("VolumeSource"));
+    if (m_defaultSource) {
+        return qvariant_cast<double>(m_defaultSource->property("VolumeSource"));
+    }
+    return 0.0;
 }
 
 AudioPort SoundDBusProxy::activePortSource()
 {
-    return qvariant_cast<AudioPort>(m_defaultSource->property("ActivePortSource"));
+    if (m_defaultSource) {
+        return qvariant_cast<AudioPort>(m_defaultSource->property("ActivePortSource"));
+    }
+    return AudioPort();
 }
 
 void SoundDBusProxy::SetSourceVolume(double in0, bool in1)
@@ -285,13 +309,19 @@ void SoundDBusProxy::SetSourceVolume(double in0, bool in1)
 
 uint SoundDBusProxy::cardSource()
 {
-    return qvariant_cast<uint>(m_defaultSource->property("CardSource"));
+    if (m_defaultSource) {
+        return qvariant_cast<uint>(m_defaultSource->property("CardSource"));
+    }
+    return 0;
 }
 
 QDBusObjectPath SoundDBusProxy::GetMeter()
 {
-    QList<QVariant> argumentList;
-    return QDBusPendingReply<QDBusObjectPath>(m_defaultSource->asyncCallWithArgumentList(QStringLiteral("GetMeter"), argumentList));
+    if (m_defaultSource) {
+        QList<QVariant> argumentList;
+        return QDBusPendingReply<QDBusObjectPath>(m_defaultSource->asyncCallWithArgumentList(QStringLiteral("GetMeter"), argumentList));
+    }
+    return QDBusObjectPath();
 }
 
 void SoundDBusProxy::setMeterDevicePath(const QString &path)
@@ -305,7 +335,10 @@ void SoundDBusProxy::setMeterDevicePath(const QString &path)
 
 double SoundDBusProxy::volumeMeter()
 {
-    return qvariant_cast<double>(m_sourceMeter->property("VolumeMeter"));
+    if (m_sourceMeter) {
+        return qvariant_cast<double>(m_sourceMeter->property("VolumeMeter"));
+    }
+    return 0.0;
 }
 
 void SoundDBusProxy::Tick()
@@ -333,7 +366,10 @@ QList<QDBusObjectPath> SoundDBusProxy::sources()
 
 bool SoundDBusProxy::muteSource()
 {
-    return qvariant_cast<bool>(m_defaultSource->property("MuteSource"));
+    if (m_defaultSource) {
+        return qvariant_cast<bool>(m_defaultSource->property("MuteSource"));
+    }
+    return false;
 }
 
 bool SoundDBusProxy::audioMono()


### PR DESCRIPTION
1. Add null pointer checks before accessing properties on m_defaultSink, m_defaultSource, and m_sourceMeter
2. Return safe default values (false, 0.0, 0, empty AudioPort, empty QDBusObjectPath) when pointers are null
3. Prevent potential crashes caused by dereferencing null pointers when D-Bus services are unavailable or not properly initialized

Log: null pointer checks added for sound D-Bus proxy members

Influence:
1. Test sound settings panel with audio device disconnected or unavailable
2. Verify mute, volume, balance, base volume, active port, and card functions return safe defaults
3. Test source and meter related functions with null D-Bus object
4. Ensure no application crashes occur when audio D-Bus services are not ready
5. Validate audio state transitions between device plugged and unplugged scenarios

fix: 为 D-Bus 代理成员变量添加空指针检查

1. 在访问 m_defaultSink、m_defaultSource 和 m_sourceMeter 的属性之前添加 空指针检查
2. 当指针为空时返回安全默认值（false、0.0、0、空 AudioPort、空 QDBusObjectPath）
3. 防止因 D-Bus 服务不可用或未正确初始化时解引用空指针导致程序崩溃

Log: 为声音 D-Bus 代理成员添加空指针检查

Influence:
1. 在音频设备断开或不可用时测试声音设置面板
2. 验证静音、音量、平衡、基础音量、活动端口和卡片功能返回安全默认值
3. 在 D-Bus 对象为空时测试源和仪表相关函数
4. 确保音频 D-Bus 服务未就绪时应用程序不会崩溃
5. 验证设备插入和拔出场景下音频状态的正确转换

Change-Id: Idb74020cc57cbfe5cec931abb422609de16f60b8