### PR TITLE
feat(dccquickdbusinterface): add enabled property to control D-Bus connection

### DIFF
--- a/src/dde-control-center/plugin/dccquickdbusinterface.cpp
+++ b/src/dde-control-center/plugin/dccquickdbusinterface.cpp
@@ -423,6 +423,26 @@ void DccQuickDBusInterface::setSuffix(const QString &suffix)
     }
 }
 
+bool DccQuickDBusInterface::isEnabled() const
+{
+    return p_ptr->m_enabled;
+}
+
+void DccQuickDBusInterface::setEnabled(bool enabled)
+{
+    if (p_ptr->m_enabled == enabled)
+        return;
+    p_ptr->m_enabled = enabled;
+    if (p_ptr->m_completed) {
+        if (p_ptr->m_enabled) {
+            connectToDBus();
+        } else {
+            disconnectFromDBus();
+        }
+    }
+    Q_EMIT enabledChanged(p_ptr->m_enabled);
+}
+
 bool DccQuickDBusInterface::callWithCallback(const QString &method, const QList<QVariant> &args, const QJSValue member, const QJSValue errorSlot)
 {
     DccQuickDBusCallback *callback = new DccQuickDBusCallback(member, errorSlot, this);
@@ -445,7 +465,7 @@ void DccQuickDBusInterface::classBegin() { }
 
 void DccQuickDBusInterface::componentComplete()
 {
-    static const QStringList ReservedPropertyNames{ "service", "path", "inter", "connection", "suffix" };
+    static const QStringList ReservedPropertyNames{ "service", "path", "inter", "connection", "suffix", "enabled" };
     const QMetaObject *mo = this->metaObject();
     const int count = mo->propertyCount();
     for (int i = mo->propertyOffset(); i < count; ++i) {
@@ -457,12 +477,24 @@ void DccQuickDBusInterface::componentComplete()
             }
         }
     }
+
+    p_ptr->m_completed = true;
+
+    if (p_ptr->m_enabled)
+        connectToDBus();
+}
+
+void DccQuickDBusInterface::connectToDBus()
+{
+    const QMetaObject *mo = this->metaObject();
     const int mcount = mo->methodCount();
     for (int i = mo->methodOffset(); i < mcount; ++i) {
         const QMetaMethod &m = mo->method(i);
         if (m.methodType() == 2 && m.name().startsWith("on")) {
+            const QString signalName = m.name().mid(2);
             DccDBusSignalCallback *callback = new DccDBusSignalCallback(m, this);
-            p_ptr->m_connection.connect(p_ptr->m_service, p_ptr->m_path, p_ptr->m_interface, m.name().mid(2), callback, SLOT(returnMethod(QDBusMessage)));
+            p_ptr->m_connection.connect(p_ptr->m_service, p_ptr->m_path, p_ptr->m_interface, signalName, callback, SLOT(returnMethod(QDBusMessage)));
+            p_ptr->m_signalCallbacks.append({ callback, signalName });
         }
     }
     if (!p_ptr->m_mapProperties.isEmpty()) {
@@ -475,6 +507,30 @@ void DccQuickDBusInterface::componentComplete()
                                     QString(),
                                     p_ptr,
                                     SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+        p_ptr->m_propertyConnected = true;
+    }
+}
+
+void DccQuickDBusInterface::disconnectFromDBus()
+{
+    for (const auto &[callback, signalName] : std::as_const(p_ptr->m_signalCallbacks)) {
+        p_ptr->m_connection.disconnect(p_ptr->m_service,
+                                       p_ptr->m_path,
+                                       p_ptr->m_interface,
+                                       signalName,
+                                       callback,
+                                       SLOT(returnMethod(QDBusMessage)));
+    }
+    p_ptr->m_signalCallbacks.clear();
+
+    if (p_ptr->m_propertyConnected) {
+        p_ptr->m_connection.disconnect(p_ptr->m_service,
+                                       p_ptr->m_path,
+                                       PropertiesInterface,
+                                       PropertiesChanged,
+                                       p_ptr,
+                                       SLOT(onPropertiesChanged(QString, QVariantMap, QStringList)));
+        p_ptr->m_propertyConnected = false;
     }
 }
 

--- a/src/dde-control-center/plugin/dccquickdbusinterface.h
+++ b/src/dde-control-center/plugin/dccquickdbusinterface.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DCCQUICKDBUSINTERFACE_H
@@ -19,6 +19,7 @@ class DccQuickDBusInterface : public QObject, public QQmlParserStatus
     Q_PROPERTY(QString inter READ interface WRITE setInterface NOTIFY interfaceChanged)
     Q_PROPERTY(BusType connection READ connection WRITE setConnection NOTIFY connectionChanged)
     Q_PROPERTY(QString suffix READ suffix WRITE setSuffix NOTIFY suffixChanged)
+    Q_PROPERTY(bool enabled READ isEnabled WRITE setEnabled NOTIFY enabledChanged)
 public:
     explicit DccQuickDBusInterface(QObject *parent = nullptr);
     ~DccQuickDBusInterface() override;
@@ -40,6 +41,8 @@ public:
     // 属性前缀，防止属性与关键字冲突
     QString suffix() const;
     void setSuffix(const QString &suffix);
+    bool isEnabled() const;
+    void setEnabled(bool enabled);
 
 public Q_SLOTS:
     bool callWithCallback(const QString &method, const QList<QVariant> &args, const QJSValue member, const QJSValue errorSlot);
@@ -50,12 +53,17 @@ Q_SIGNALS:
     void interfaceChanged(const QString &interface);
     void connectionChanged(const BusType &connection);
     void suffixChanged(const QString &suffix);
+    void enabledChanged(bool enabled);
 
 protected:
     void connectNotify(const QMetaMethod &signal) override;
     void disconnectNotify(const QMetaMethod &signal) override;
     void classBegin() override;
     void componentComplete() override;
+
+private:
+    void connectToDBus();
+    void disconnectFromDBus();
 
 protected:
     class Private;

--- a/src/dde-control-center/plugin/dccquickdbusinterface_p.h
+++ b/src/dde-control-center/plugin/dccquickdbusinterface_p.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DCCQUICKDBUSINTERFACE_P_H
@@ -72,6 +72,10 @@ public:
     BusType m_connectionType;
     QDBusConnection m_connection;
     QVariantMap m_propertyMap; // DBus属性值
+    QList<QPair<DccDBusSignalCallback *, QString>> m_signalCallbacks;
+    bool m_propertyConnected = false;
+    bool m_completed = false;
+    bool m_enabled = true;
 
     friend class DccQuickDBusCallback;
 };


### PR DESCRIPTION
## Summary
- Add enabled Q_PROPERTY to DccQuickDBusInterface for dynamic D-Bus connection control
- Implement connectToDBus() and disconnectFromDBus() private methods
- Track signal callbacks for proper disconnection
- Add m_completed flag to handle componentComplete() ordering

## Changes
- Add enabled property with getter, setter, and notification signal
- When enabled=false, disconnects from D-Bus signals and properties
- When enabled=true, reconnects to D-Bus

## Test plan
- Verify D-Bus connections are established when enabled=true (default)
- Verify D-Bus connections are disconnected when enabled=false
- Verify reconnection works when toggling enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)