### PR TITLE
fix: correct window flags to prevent KWin animation on screen indicator

### DIFF
--- a/src/plugin-display/qml/ScreenIndicator.qml
+++ b/src/plugin-display/qml/ScreenIndicator.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 
@@ -6,7 +6,7 @@ import org.deepin.dcc 1.0
 
 Window {
     id: root
-    flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
+    flags: Qt.WindowStaysOnTopHint | Qt.Tool | Qt.X11BypassWindowManagerHint
     color: "#2ca7f8"
     x: screen.virtualX
     y: screen.virtualY
@@ -19,7 +19,7 @@ Window {
         onTriggered: root.close()
     }
     Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
+        flags: Qt.WindowStaysOnTopHint | Qt.Tool | Qt.X11BypassWindowManagerHint
         visible: root.visible
         color: root.color
         screen: root.screen
@@ -29,7 +29,7 @@ Window {
         height: 10
     }
     Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
+        flags: Qt.WindowStaysOnTopHint | Qt.Tool | Qt.X11BypassWindowManagerHint
         visible: root.visible
         color: root.color
         screen: root.screen
@@ -39,7 +39,7 @@ Window {
         height: screen.height
     }
     Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
+        flags: Qt.WindowStaysOnTopHint | Qt.Tool | Qt.X11BypassWindowManagerHint
         visible: root.visible
         color: root.color
         screen: root.screen


### PR DESCRIPTION
The previous window flags included Qt.FramelessWindowHint and Qt.SplashScreen, which caused KWin to apply unnecessary window animations to the screen indicator windows. Changed to use Qt.Tool instead, which is more appropriate for transient helper windows and prevents KWin from adding animations.

Log: Fixed incorrect window type causing unwanted KWin animations

Influence:
1. Verify screen indicator displays correctly without animation effects
2. Test screen indicator visibility on multi-monitor setups
3. Confirm window stays on top as expected
4. Verify screen indicator closes properly when timer elapses

fix: 修复窗口类型错误导致kwin给屏幕指示器窗口添加动画

之前的窗口标志包含了Qt.FramelessWindowHint和Qt.SplashScreen，导致KWin为 屏幕指示器窗口应用了不必要的动画。改为使用Qt.Tool，这个类型更适合临时辅
助窗口，可以防止KWin添加动画效果。

Log: 修复错误的窗口类型导致KWin动画问题

Influence:
1. 验证屏幕指示器正常显示且无动画效果
2. 测试多显示器设置下的屏幕指示器可见性
3. 确认窗口保持置顶功能正常
4. 验证屏幕指示器在计时结束后正常关闭

PMS: BUG-360795