### PR TITLE
feat(display): add virtual output protocol for clone mode

### DIFF
--- a/src/plugin-display/CMakeLists.txt
+++ b/src/plugin-display/CMakeLists.txt
@@ -1,21 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
-###########################################
-function(ws_generate_local type input_file output_name)
-    pkg_get_variable(WAYLAND_SCANNER wayland-scanner wayland_scanner)
-    message(${input_file})
-    execute_process(COMMAND ${WAYLAND_SCANNER}
-        ${type}-header
-        ${input_file}
-        ${CMAKE_CURRENT_BINARY_DIR}/${output_name}.h
-    )
 
-    execute_process(COMMAND ${WAYLAND_SCANNER}
-        public-code
-        ${input_file}
-        ${CMAKE_CURRENT_BINARY_DIR}/${output_name}.c
-    )
-endfunction()
-
+find_package(${QT_NS} REQUIRED COMPONENTS WaylandClient)
 find_package(PkgConfig REQUIRED)
 find_package(TreelandProtocols REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
@@ -27,14 +12,6 @@ execute_process(
     OUTPUT_STRIP_TRAILING_WHITESPACE
 )
 
-ws_generate_local(client
-    ${WLR_PROTOCOLS_XML_DIR}/unstable/wlr-output-management-unstable-v1.xml
-    wlr-output-management-unstable-v1-client-protocol)
-
-ws_generate_local(client
-    ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
-    treeland-output-management-client-protocol)
-
 file(GLOB_RECURSE LIBWAYQT_SRCS
     "wayland/libwayqt/*.cpp"
     "wayland/libwayqt/*.h"
@@ -43,8 +20,14 @@ file(GLOB_RECURSE LIBWAYQT_SRCS
 add_library(libwayqt6
     OBJECT
     ${LIBWAYQT_SRCS}
-    wlr-output-management-unstable-v1-client-protocol.c
-    treeland-output-management-client-protocol.c
+)
+
+qt_generate_wayland_protocol_client_sources(libwayqt6
+    FILES
+        ${WLR_PROTOCOLS_XML_DIR}/unstable/wlr-output-management-unstable-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-virtual-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-wallpaper-manager-unstable-v1.xml
 )
 
 # fix arm64 build failed relocation R_AARCH64_ADR_PREL_PG_HI21 against symbol
@@ -62,6 +45,7 @@ target_link_libraries(libwayqt6
     ${QT_NS}::Core
     ${QT_NS}::Gui
     ${QT_NS}::GuiPrivate
+    ${QT_NS}::WaylandClient
     PkgConfig::WaylandClient
 )
 ###########################################

--- a/src/plugin-display/operation/dccscreen.cpp
+++ b/src/plugin-display/operation/dccscreen.cpp
@@ -140,11 +140,6 @@ void DccScreenPrivate::setMonitors(QList<Monitor *> monitors)
 
 Monitor *DccScreenPrivate::monitor()
 {
-    for (auto mon : m_monitors) {
-        if (mon->isPrimary()) {
-            return mon;
-        }
-    }
     return m_monitors.first();
 }
 
@@ -180,7 +175,9 @@ void DccScreenPrivate::setMode(QSize resolution, double rate)
 void DccScreenPrivate::setRotate(uint rotate)
 {
     m_worker->backupConfig();
-    m_worker->setMonitorRotate(monitor(), rotate);
+    for (auto monitor : m_monitors) {
+        m_worker->setMonitorRotate(monitor, rotate);
+    }
     m_worker->applyChanges();
 }
 

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -25,38 +25,6 @@
 namespace dccV25 {
 static const QString DEFAULT_TIME_FORMAT = "hh:mm";
 
-class Rect : public QRect
-{
-public:
-    using QRect::QRect;
-
-    bool operator<(const Rect &r) const
-    {
-        if (x() < r.x()) {
-            return true;
-        }
-        if (x() > r.x()) {
-            return false;
-        }
-        if (y() < r.y()) {
-            return true;
-        }
-        if (y() > r.y()) {
-            return false;
-        }
-        if (width() < r.width()) {
-            return true;
-        }
-        if (width() > r.width()) {
-            return false;
-        }
-        if (height() < r.height()) {
-            return true;
-        }
-        return false;
-    }
-};
-
 DisplayModulePrivate::DisplayModulePrivate(DisplayModule *parent)
     : q_ptr(parent)
     , m_primary(nullptr)
@@ -82,6 +50,9 @@ void DisplayModulePrivate::init()
         updateVirtualScreens();
         updateDisplayMode();
     });
+    q_ptr->connect(m_model, &DisplayModel::virtualOutputChanged, q_ptr, [this]() {
+        updateVirtualScreens();
+    });
     q_ptr->connect(m_model, &DisplayModel::colorTemperatureEnabledChanged, q_ptr, &DisplayModule::colorTemperatureEnabledChanged);
     q_ptr->connect(m_model, &DisplayModel::colorTemperatureChanged, q_ptr, &DisplayModule::colorTemperatureChanged);
     q_ptr->connect(m_model, &DisplayModel::customColorTempTimePeriodChanged, q_ptr, &DisplayModule::customColorTempTimePeriodChanged);
@@ -99,38 +70,78 @@ void DisplayModulePrivate::init()
 void DisplayModulePrivate::updateVirtualScreens()
 {
     bool changed = false;
-    QMap<Rect, QList<Monitor *>> addScreenMap;
-    for (auto srcScreen : m_screens) {
-        if (!srcScreen->enable()) {
-            continue;
+    const auto virtualOutputs = m_model->virtualOutput();
+    QMap<QString, QList<Monitor *>> addScreenMap;
+
+    if (!virtualOutputs.isEmpty()) {
+        QMap<QString, Monitor *> nameToMonitor;
+        for (auto srcScreen : m_screens) {
+            if (!srcScreen->enable())
+                continue;
+            DccScreenPrivate *screenPrivate = DccScreenPrivate::Private(srcScreen);
+            for (auto *mon : screenPrivate->monitors())
+                nameToMonitor.insert(mon->name(), mon);
         }
-        DccScreenPrivate *screenPrivate = DccScreenPrivate::Private(srcScreen);
-        Rect rect(QPoint(srcScreen->x(), srcScreen->y()), srcScreen->currentResolution());
-        if (addScreenMap.contains(rect)) {
-            addScreenMap[rect].append(screenPrivate->monitors());
-        } else {
-            addScreenMap.insert(rect, screenPrivate->monitors());
+
+        QSet<Monitor *> grouped;
+        for (auto it = virtualOutputs.constBegin(); it != virtualOutputs.constEnd(); ++it) {
+            QList<Monitor *> groupMonitors;
+            const auto &outputNames = it.value();
+            for (const auto &monName : outputNames) {
+                if (nameToMonitor.contains(monName)) {
+                    groupMonitors << nameToMonitor.value(monName);
+                    grouped.insert(nameToMonitor.value(monName));
+                }
+            }
+            if (!groupMonitors.isEmpty())
+                addScreenMap.insert(it.key(), groupMonitors);
+        }
+
+        for (auto srcScreen : m_screens) {
+            if (!srcScreen->enable())
+                continue;
+            DccScreenPrivate *screenPrivate = DccScreenPrivate::Private(srcScreen);
+            for (auto *mon : screenPrivate->monitors()) {
+                if (!grouped.contains(mon)) {
+                    addScreenMap.insert(mon->name(), { mon });
+                }
+            }
+        }
+    } else {
+        for (auto srcScreen : m_screens) {
+            if (!srcScreen->enable())
+                continue;
+            DccScreenPrivate *screenPrivate = DccScreenPrivate::Private(srcScreen);
+            QRect rect(QPoint(srcScreen->x(), srcScreen->y()), srcScreen->currentResolution());
+            QString key = QStringLiteral("%1,%2,%3,%4").arg(rect.x()).arg(rect.y()).arg(rect.width()).arg(rect.height());
+            if (addScreenMap.contains(key)) {
+                addScreenMap[key].append(screenPrivate->monitors());
+            } else {
+                addScreenMap.insert(key, screenPrivate->monitors());
+            }
         }
     }
     for (auto it = m_virtualScreens.cbegin(); it != m_virtualScreens.cend();) {
         DccScreenPrivate *screenPrivate = DccScreenPrivate::Private(*it);
-        Rect rect(QPoint((*it)->x(), (*it)->y()), (*it)->currentResolution());
-        bool isSame = addScreenMap.contains(rect);
-        if (isSame) {
-            auto monitors = addScreenMap[rect];
-            auto screenMonitors = screenPrivate->monitors();
-            isSame = monitors.size() == screenMonitors.size();
-            if (isSame) {
-                for (auto monitor : monitors) {
-                    if (!screenMonitors.contains(monitor)) {
-                        isSame = false;
-                        break;
-                    }
+        auto screenMonitors = screenPrivate->monitors();
+        QString matchedKey;
+        for (auto mapIt = addScreenMap.constBegin(); mapIt != addScreenMap.constEnd(); ++mapIt) {
+            if (mapIt.value().size() != screenMonitors.size())
+                continue;
+            bool isSame = true;
+            for (auto monitor : mapIt.value()) {
+                if (!screenMonitors.contains(monitor)) {
+                    isSame = false;
+                    break;
                 }
             }
+            if (isSame) {
+                matchedKey = mapIt.key();
+                break;
+            }
         }
-        if (isSame) {
-            addScreenMap.remove(rect);
+        if (!matchedKey.isEmpty()) {
+            addScreenMap.remove(matchedKey);
             it++;
         } else {
             changed = true;

--- a/src/plugin-display/operation/private/displaymodel.cpp
+++ b/src/plugin-display/operation/private/displaymodel.cpp
@@ -296,3 +296,12 @@ void DisplayModel::setIsConcatScreenMode(bool enabled)
     m_isConcatScreenMode = enabled;
     Q_EMIT concatScreenModeChanged(m_isConcatScreenMode);
 }
+
+void DisplayModel::setVirtualOutput(const QMap<QString, QStringList> &virtualOutput)
+{
+    if (m_virtualOutput == virtualOutput)
+        return;
+
+    m_virtualOutput = virtualOutput;
+    Q_EMIT virtualOutputChanged(m_virtualOutput);
+}

--- a/src/plugin-display/operation/private/displaymodel.h
+++ b/src/plugin-display/operation/private/displaymodel.h
@@ -100,6 +100,9 @@ public:
     inline bool allSupportFillModes() const { return m_allSupportFillModes; }
     void checkAllSupportFillModes();
 
+    inline QMap<QString, QStringList> virtualOutput() const { return m_virtualOutput; }
+    void setVirtualOutput(const QMap<QString, QStringList> &virtualOutput);
+
     inline bool monitorModeChanging() const { return m_monitorModeChanging; }
     void setmodeChanging(bool changing);
 
@@ -137,6 +140,7 @@ Q_SIGNALS:
     void filesStoragePathChanged(const QString& path) const;
     void customColorTempTimePeriodChanged(const QString& timePeriod);
     void concatScreenModeChanged(bool enabled);
+    void virtualOutputChanged(const QMap<QString, QStringList> &virtualOutput);
 
 private Q_SLOTS:
     void setScreenHeight(const int h);
@@ -180,6 +184,7 @@ private:
     bool m_allSupportFillModes;
     bool m_monitorModeChanging; // 配置修改中,仅控制中心修改时才处理自动拼接
     bool m_isConcatScreenMode { false };
+    QMap<QString, QStringList> m_virtualOutput; // 虚拟输出组
 };
 }
 

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -1,28 +1,28 @@
-//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
-//SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include "displayworker.h"
+
 #include "displaymodel.h"
 
+#include <Output.h>
+#include <OutputManager.h>
+#include <Registry.h>
+#include <TreeLandOutputManager.h>
+#include <WallpaperManager.h>
+#include <WayQtUtils.h>
 #include <dconfig.h>
 
-#include <QDebug>
 #include <QDateTime>
+#include <QDebug>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLoggingCategory>
 
-#include <Registry.h>
-#include <WayQtUtils.h>
-#include <OutputManager.h>
-#include <Output.h>
-#include <TreeLandOutputManager.h>
-
 Q_LOGGING_CATEGORY(DdcDisplayWorker, "dcc-display-worker")
 
-
 const QString DisplayInterface("org.deepin.dde.Display1");
-constexpr const char * const CONCAT_SCREEN_NAME = "DDE-CONCAT-SCREEN";
+constexpr const char *const CONCAT_SCREEN_NAME = "DDE-CONCAT-SCREEN";
 
 Q_DECLARE_METATYPE(QList<QDBusObjectPath>)
 using namespace dccV25;
@@ -34,6 +34,7 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
     , m_updateScale(false)
     , m_timer(new QTimer(this))
     , m_dconfig(DTK_CORE_NAMESPACE::DConfig::create("org.deepin.dde.control-center", QStringLiteral("org.deepin.dde.control-center.display"), QString(), this))
+    , m_reg(nullptr)
 {
     // NOTE: what will it be used?
     Q_UNUSED(isSync)
@@ -41,9 +42,7 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
     m_timer->setInterval(200);
 
     if (WQt::Utils::isTreeland()) {
-        m_reg = new WQt::Registry(WQt::Wayland::display(), this);
-        connect(m_reg, &WQt::Registry::interfaceRegistered, this, &DisplayWorker::onInterfaceRegistered);
-        m_reg->setup();
+        QMetaObject::invokeMethod(this, "initTreeland", Qt::QueuedConnection);
     } else {
         connect(m_displayInter, &DisplayDBusProxy::WallpaperURlsChanged, this, &DisplayWorker::updateWallpaper);
         connect(m_displayInter, &DisplayDBusProxy::WorkspaceSwitched, this, &DisplayWorker::updateWallpaper);
@@ -62,7 +61,7 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
         connect(m_displayInter, &DisplayDBusProxy::CustomColorTempTimePeriodChanged, model, &DisplayModel::setCustomColorTempTimePeriod);
         connect(m_displayInter, static_cast<void (DisplayDBusProxy::*)(const QString &) const>(&DisplayDBusProxy::PrimaryChanged), model, &DisplayModel::setPrimary);
 
-        //display redSfit/autoLight
+        // display redSfit/autoLight
         connect(m_displayInter, &DisplayDBusProxy::HasAmbientLightSensorChanged, m_model, &DisplayModel::autoLightAdjustVaildChanged);
         connect(m_timer, &QTimer::timeout, this, [this] {
             m_displayInter->ApplyChanges().waitForFinished();
@@ -75,6 +74,14 @@ DisplayWorker::~DisplayWorker()
 {
     qDeleteAll(m_monitors.keys());
     qDeleteAll(m_monitors.values());
+}
+
+void DisplayWorker::initTreeland()
+{
+    // treeland协议需要在主线程中初始化
+    m_reg = new WQt::Registry(WQt::Wayland::display(), this);
+    connect(m_reg, &WQt::Registry::interfaceRegistered, this, &DisplayWorker::onInterfaceRegistered);
+    m_reg->setup();
 }
 
 void DisplayWorker::active()
@@ -139,45 +146,69 @@ void DisplayWorker::saveChanges()
 void DisplayWorker::switchMode(const int mode, const QString &name)
 {
     if (WQt::Utils::isTreeland()) {
-        auto *opCfg = m_reg->outputManager()->createConfiguration();
-        m_model->setDisplayMode(mode);
-        int posX = 0;
+        auto *voMgr = m_reg->virtualOutputManager();
 
-        for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
-            switch (mode) {
-            case MERGE_MODE: {
-                auto *cfgHead = opCfg->enableHead(it.value());
-                cfgHead->setPosition({0, 0});
-                break;
-            }
-            case EXTEND_MODE: {
-                auto *cfgHead = opCfg->enableHead(it.value());
-                cfgHead->setPosition({posX, 0});
-                posX += it.key()->w();
-                break;
-            }
-            case SINGLE_MODE: {
-                if (it.key()->name() == name) {
-                    auto *cfgHead = opCfg->enableHead(it.value());
-                    WQt::OutputMode *preferMode = nullptr;
-                    for (auto *mode: it.value()->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
-                        preferMode = mode;
-                        if (mode->isPreferred())
-                            break;
-                    }
-                    cfgHead->setMode(preferMode);
-                    cfgHead->setPosition({0, 0});
-                } else {
-                    opCfg->disableHead(it.value());
-                }
-                break;
-            }
-            default:
-                break;
+        // 销毁所有已有的虚拟输出
+        if (voMgr) {
+            for (const auto &name : voMgr->virtualOutputs().keys()) {
+                voMgr->destroyVirtualOutput(name);
             }
         }
 
-        opCfg->apply();
+        if (mode == MERGE_MODE) {
+            if (voMgr) {
+                QStringList outputNames;
+                for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
+                    if (it.key()->name() == m_model->primary()) {
+                        outputNames.prepend(it.key()->name());
+                    } else {
+                        outputNames.append(it.key()->name());
+                    }
+                }
+                if (outputNames.size() >= 2) {
+                    voMgr->createVirtualOutput("ddeScreenGroup", outputNames);
+                    QMap<QString, QStringList> voMap;
+                    voMap.insert("ddeScreenGroup", outputNames);
+                    m_model->setVirtualOutput(voMap);
+                }
+            }
+            m_model->setDisplayMode(mode);
+        } else {
+            auto *opCfg = m_reg->outputManager()->createConfiguration();
+            m_model->setDisplayMode(mode);
+            int posX = 0;
+
+            for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
+                switch (mode) {
+                case EXTEND_MODE: {
+                    auto *cfgHead = opCfg->enableHead(it.value());
+                    cfgHead->setPosition({ posX, 0 });
+                    posX += it.key()->w();
+                    break;
+                }
+                case SINGLE_MODE: {
+                    if (it.key()->name() == name) {
+                        auto *cfgHead = opCfg->enableHead(it.value());
+                        WQt::OutputMode *preferMode = nullptr;
+                        for (auto *mode : it.value()->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
+                            preferMode = mode;
+                            if (mode->isPreferred())
+                                break;
+                        }
+                        cfgHead->setMode(preferMode);
+                        cfgHead->setPosition({ 0, 0 });
+                    } else {
+                        opCfg->disableHead(it.value());
+                    }
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+
+            opCfg->apply();
+        }
     } else {
         m_displayInter->SwitchMode(static_cast<uchar>(mode), name).waitForFinished();
     }
@@ -238,7 +269,69 @@ void DisplayWorker::updateMonitorWallpaper(Monitor *mon)
     mon->setWallpaper(m_displayInter->GetCurrentWorkspaceBackgroundForMonitor(mon->name()));
 }
 
-void DisplayWorker::onBrightnessChanged(const treeland_output_color_control_v1 *colorControl, double brightness)
+void DisplayWorker::updateWallpaperFromWayland()
+{
+    auto *wpMgr = m_reg->wallpaperManager();
+    if (!wpMgr || !wpMgr->isActive())
+        return;
+
+    for (auto *output : m_reg->waylandOutputs()) {
+        auto *wp = wpMgr->getWallpaper(output->get());
+        if (!wp)
+            continue;
+        connect(wp, &WQt::Wallpaper::changed, this, [this, output](const QString &fileSource, uint32_t sourceType, uint32_t role) {
+            Q_UNUSED(sourceType);
+            Q_UNUSED(role);
+            for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
+                if (it.key()->name() == output->name()) {
+                    it.key()->setWallpaper(fileSource);
+                    break;
+                }
+            }
+        });
+    }
+}
+
+void DisplayWorker::onOutputWallpaperReady(WQt::Output *output)
+{
+    auto *wpMgr = m_reg->wallpaperManager();
+    if (!wpMgr || !wpMgr->isActive())
+        return;
+
+    auto *wp = wpMgr->getWallpaper(output->get());
+    if (wp) {
+        connect(wp, &WQt::Wallpaper::changed, this, [this, output, wp]() {
+            onWallpaperChanged(output, wp->fileSource(), wp->sourceType(), 0);
+        });
+    }
+}
+
+void DisplayWorker::onWallpaperChanged(WQt::Output *output, const QString &fileSource, uint32_t sourceType, uint32_t role)
+{
+    Q_UNUSED(sourceType);
+    Q_UNUSED(role);
+    for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
+        if (it.key()->name() == output->name()) {
+            it.key()->setWallpaper(fileSource);
+            break;
+        }
+    }
+}
+
+void DisplayWorker::updateVirtualOutputs()
+{
+    auto *voMgr = m_reg->virtualOutputManager();
+    if (!voMgr)
+        return;
+
+    QMap<QString, QStringList> virtualOutputMap;
+    for (auto it = voMgr->virtualOutputs().cbegin(); it != voMgr->virtualOutputs().cend(); ++it) {
+        virtualOutputMap.insert(it.key(), it.value()->outputs());
+    }
+    m_model->setVirtualOutput(virtualOutputMap);
+}
+
+void DisplayWorker::onBrightnessChanged(WQt::ColorControl *colorControl, double brightness)
 {
     brightness = qBound(0.0, brightness / 100.0, 1.0);
     for (auto it(m_control_monitors.cbegin()); it != m_control_monitors.cend(); ++it) {
@@ -275,9 +368,7 @@ void DisplayWorker::onGetScreenScalesFinished(QDBusPendingCallWatcher *w)
 
     for (auto &m : m_model->monitorList()) {
         if (rmap.find(m->name()) != rmap.end()) {
-            m->setScale(rmap.value(m->name()) < 1.0
-                            ? m_model->uiScale()
-                            : rmap.value(m->name()));
+            m->setScale(rmap.value(m->name()) < 1.0 ? m_model->uiScale() : rmap.value(m->name()));
         }
     }
 
@@ -290,12 +381,45 @@ void DisplayWorker::onInterfaceRegistered(WQt::Registry::Interface interface)
     case WQt::Registry::OutputManagerInterface: {
         auto *opMgr = m_reg->outputManager();
         if (!opMgr) {
-            qCFatal(DdcDisplayWorker) << "Unable to start the output manager";
+            qCCritical(DdcDisplayWorker) << "Unable to start the output manager";
+        } else {
+            connect(opMgr, &WQt::OutputManager::done, this, &DisplayWorker::onWlOutputManagerDone);
         }
-        connect(opMgr, &WQt::OutputManager::done, this, &DisplayWorker::onWlOutputManagerDone);
     } break;
     case WQt::Registry::TreeLandOutputManagerInterface: {
-        connect(m_reg->treeLandOutputManager(), &WQt::TreeLandOutputManager::brightnessChanged, this, &DisplayWorker::onBrightnessChanged);
+        updateControl();
+    } break;
+    case WQt::Registry::VirtualOutputManagerInterface: {
+        auto *virtOpMgr = m_reg->virtualOutputManager();
+        if (!virtOpMgr) {
+            qCCritical(DdcDisplayWorker) << "Unable to start the virtual output manager";
+        } else {
+            virtOpMgr->getVirtualOutputList();
+            connect(virtOpMgr, &WQt::VirtualOutputManager::virtualOutputList, this, [this, virtOpMgr](const QStringList &names) {
+                if (names.isEmpty()) {
+                    m_model->setDisplayMode(EXTEND_MODE);
+                } else {
+                    m_model->setDisplayMode(MERGE_MODE);
+                }
+                for (const auto &name : names) {
+                    auto *vo = virtOpMgr->virtualOutputs().value(name);
+                    if (vo) {
+                        connect(vo, &WQt::VirtualOutput::outputsChanged, this, [this]() {
+                            updateVirtualOutputs();
+                        });
+                    }
+                }
+                updateVirtualOutputs();
+            });
+        }
+    } break;
+    case WQt::Registry::WallpaperManagerInterface: {
+        auto *wpMgr = m_reg->wallpaperManager();
+        if (!wpMgr) {
+            qCCritical(DdcDisplayWorker) << "Unable to start the wallpaper manager";
+        } else {
+            updateWallpaperFromWayland();
+        }
     } break;
     default:
         break;
@@ -308,10 +432,12 @@ void DisplayWorker::onWlOutputManagerDone()
 
     m_model->setDisplayMode(EXTEND_MODE); // TODO: use dconfig
     auto *treelandOpMgr = m_reg->treeLandOutputManager();
-    m_model->setPrimary(treelandOpMgr->mPrimaryOutput);
-    connect(treelandOpMgr, &WQt::TreeLandOutputManager::primaryOutputChanged, this, [this](){
-        m_model->setPrimary(m_reg->treeLandOutputManager()->mPrimaryOutput);
-    });
+    if (treelandOpMgr) {
+        m_model->setPrimary(treelandOpMgr->mPrimaryOutput);
+        connect(treelandOpMgr, &WQt::TreeLandOutputManager::primaryOutputChanged, this, [this]() {
+            m_model->setPrimary(m_reg->treeLandOutputManager()->mPrimaryOutput);
+        });
+    }
 
     m_model->setResolutionRefreshEnable(true);
     m_model->setBrightnessEnable(false); // TODO: support gamma effects
@@ -319,7 +445,8 @@ void DisplayWorker::onWlOutputManagerDone()
 
 #ifndef DCC_DISABLE_ROTATE
 
-constexpr static int wlRotate2dcc(int wlRotate) {
+constexpr static int wlRotate2dcc(int wlRotate)
+{
     switch (wlRotate) {
     case WL_OUTPUT_TRANSFORM_NORMAL:
         return 1;
@@ -335,7 +462,8 @@ constexpr static int wlRotate2dcc(int wlRotate) {
     }
 }
 
-constexpr static int dccRotate2wl(int dccRotate) {
+constexpr static int dccRotate2wl(int dccRotate)
+{
     switch (dccRotate) {
     case 1:
         return WL_OUTPUT_TRANSFORM_NORMAL;
@@ -383,7 +511,9 @@ void DisplayWorker::setMonitorRotate(Monitor *mon, const quint16 rotate)
 void DisplayWorker::setPrimary(const QString &name)
 {
     if (WQt::Utils::isTreeland()) {
-        m_reg->treeLandOutputManager()->setPrimaryOutput(name.toStdString().c_str());;
+        auto *treelandOpMgr = m_reg->treeLandOutputManager();
+        if (treelandOpMgr)
+            treelandOpMgr->setPrimaryOutput(name.toStdString().c_str());
     } else {
         m_displayInter->SetPrimary(name);
     }
@@ -399,7 +529,7 @@ void DisplayWorker::setMonitorEnable(Monitor *monitor, const bool enable)
                 if (enable) {
                     auto *cfgHead = opCfg->enableHead(it.value());
                     WQt::OutputMode *preferMode = nullptr;
-                    for (auto *mode: it.value()->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
+                    for (auto *mode : it.value()->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
                         preferMode = mode;
                         if (mode->isPreferred())
                             break;
@@ -460,7 +590,7 @@ void DisplayWorker::setCustomColorTempTimePeriod(const QString &timePeriod)
     m_displayInter->SetCustomColorTempTimePeriod(timePeriod);
 }
 
-void DisplayWorker::setCurrentFillMode(Monitor *mon,const QString fillMode)
+void DisplayWorker::setCurrentFillMode(Monitor *mon, const QString fillMode)
 {
     if (WQt::Utils::isTreeland()) {
         // TODO: support treeland
@@ -483,15 +613,15 @@ void DisplayWorker::clearBackup()
 
 void DisplayWorker::resetBackup()
 {
-    //TODO: can't use in treeland
+    // TODO: can't use in treeland
     if (!m_displayConfig.isEmpty()) {
 
         QJsonDocument doc = QJsonDocument::fromJson(m_displayConfig.toLatin1());
         QJsonObject jsonObj = doc.object();
 
         QDateTime time = QDateTime::currentDateTime();
-        int offset = time.offsetFromUtc()/60;
-        bool negative = offset <0;
+        int offset = time.offsetFromUtc() / 60;
+        bool negative = offset < 0;
         if (negative)
             offset = -offset;
 
@@ -519,10 +649,8 @@ void DisplayWorker::setMonitorResolution(Monitor *mon, const int mode)
             }
             auto *cfgHead = opCfg->enableHead(it.value());
             if (it.key() == mon) {
-                for (auto *mode: it.value()->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
-                    if (mode->size().width() == res.value().width()
-                        && mode->size().height() == res.value().height()
-                        && qFuzzyCompare(mode->refreshRate()*0.001, res.value().rate())) {
+                for (auto *mode : it.value()->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
+                    if (mode->size().width() == res.value().width() && mode->size().height() == res.value().height() && qFuzzyCompare(mode->refreshRate() * 0.001, res.value().rate())) {
                         cfgHead->setMode(mode);
                         break;
                     }
@@ -548,7 +676,7 @@ void DisplayWorker::setMonitorBrightness(Monitor *mon, const double brightness)
 #else
         for (auto it(m_control_monitors.cbegin()); it != m_control_monitors.cend(); ++it) {
             if (it.key() == mon) {
-                m_reg->treeLandOutputManager()->setBrightness(it.value(), brightness * 100.0);
+                it.value()->setBrightness(brightness * 100.0);
                 break;
             }
         }
@@ -657,7 +785,6 @@ void DisplayWorker::setIndividualScaling(Monitor *m, const double scaling)
     }
 }
 
-
 void DisplayWorker::monitorAdded(const QString &path)
 {
     MonitorDBusProxy *inter = new MonitorDBusProxy(path, this);
@@ -695,7 +822,6 @@ void DisplayWorker::monitorAdded(const QString &path)
     connect(inter, &MonitorDBusProxy::CurrentRotateModeChanged, mon, &Monitor::setCurrentRotateMode);
     connect(inter, &MonitorDBusProxy::AvailableFillModesChanged, mon, &Monitor::setAvailableFillModes);
     connect(inter, &MonitorDBusProxy::CurrentFillModeChanged, mon, &Monitor::setCurrentFillMode);
-    connect(m_displayInter, static_cast<void (DisplayDBusProxy::*)(const QString &) const>(&DisplayDBusProxy::PrimaryChanged), mon, &Monitor::setPrimary);
     connect(this, &DisplayWorker::requestUpdateModeList, this, [=] {
         mon->setModeList(inter->modes());
     });
@@ -728,7 +854,6 @@ void DisplayWorker::monitorAdded(const QString &path)
         }
     }
     mon->setRotateList(inter->rotations());
-    mon->setPrimary(m_displayInter->primary());
     mon->setMmWidth(inter->mmWidth());
     mon->setMmHeight(inter->mmHeight());
 
@@ -760,9 +885,14 @@ void DisplayWorker::monitorRemoved(const QString &path)
     monitor->deleteLater();
 }
 
-static inline Resolution createResolutionFromMode(WQt::OutputMode *mode) {
+static inline Resolution createResolutionFromMode(WQt::OutputMode *mode)
+{
     static int idcount = 0;
     Resolution res;
+    if (!mode) {
+        res.m_id = 0;
+        return res;
+    }
     res.m_id = ++idcount;
     res.m_width = mode->size().width();
     res.m_height = mode->size().height();
@@ -791,7 +921,7 @@ void DisplayWorker::wlMonitorAdded(WQt::OutputHead *head)
         }
         case WQt::OutputHead::Modes: {
             ResolutionList resolutionList;
-            for (auto *mode: head->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
+            for (auto *mode : head->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
                 Resolution res = createResolutionFromMode(mode);
                 resolutionList << res;
                 if (mode->isPreferred()) {
@@ -847,11 +977,11 @@ void DisplayWorker::wlMonitorAdded(WQt::OutputHead *head)
     mon->setX(head->property(WQt::OutputHead::Position).toPoint().x());
     mon->setY(head->property(WQt::OutputHead::Position).toPoint().y());
 
-    mon->setRotateList({1, 2, 4, 8});
+    mon->setRotateList({ 1, 2, 4, 8 });
     mon->setRotate(wlRotate2dcc(head->property(WQt::OutputHead::Transform).toInt()));
 
     ResolutionList resolutionList;
-    for (auto *mode: head->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
+    for (auto *mode : head->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
         Resolution res = createResolutionFromMode(mode);
         resolutionList << res;
         if (mode->isPreferred()) {
@@ -859,11 +989,12 @@ void DisplayWorker::wlMonitorAdded(WQt::OutputHead *head)
         }
     }
     mon->setModeList(resolutionList);
-
     Resolution currentRes = createResolutionFromMode(head->property(WQt::OutputHead::CurrentMode).value<WQt::OutputMode *>());
-    mon->setCurrentMode(currentRes);
-    mon->setW(currentRes.width());
-    mon->setH(currentRes.height());
+    if (currentRes.id() != 0) { // 0 is invalid
+        mon->setCurrentMode(currentRes);
+        mon->setW(currentRes.width());
+        mon->setH(currentRes.height());
+    }
 
     if (m_model->isRefreshRateEnable() == false) {
         for (auto resolutionModel : mon->modeList()) {
@@ -872,15 +1003,14 @@ void DisplayWorker::wlMonitorAdded(WQt::OutputHead *head)
             }
         }
     }
-    mon->setPrimary(m_reg->treeLandOutputManager()->mPrimaryOutput);
 
     auto physicalSize = head->property(WQt::OutputHead::PhysicalSize).toSize();
     mon->setMmWidth(physicalSize.width());
     mon->setMmHeight(physicalSize.height());
 
-
     m_model->monitorAdded(mon);
     m_wl_monitors.insert(mon, head);
+    updateControl();
 
 #if GAMMA_SUPPORT
     auto *gammaMgr = m_reg->gammaControlManager();
@@ -894,8 +1024,8 @@ void DisplayWorker::wlMonitorAdded(WQt::OutputHead *head)
     effectsConfig->temperature = 6500;
     effectsConfig->latitude = 0; // How to get
     effectsConfig->longitude = 0;
-    effectsConfig->sunrise = QTime( 6, 30, 0 );
-    effectsConfig->sunset = QTime( 18, 30, 0 );
+    effectsConfig->sunrise = QTime(6, 30, 0);
+    effectsConfig->sunset = QTime(18, 30, 0);
     effectsConfig->whitepoint = { 0, 0, 0 };
 
     // gammaEffect->setConfiguration(config);
@@ -919,14 +1049,14 @@ void DisplayWorker::wlMonitorRemoved(WQt::OutputHead *head)
     m_model->monitorRemoved(monitor);
 
 #if GAMMA_SUPPORT
-    //delete m_wl_gammaConfig[monitor];
-    //delete m_wl_gammaEffects[monitor];
+    // delete m_wl_gammaConfig[monitor];
+    // delete m_wl_gammaEffects[monitor];
 #endif
     head->deleteLater();
 
     m_wl_monitors.remove(monitor);
     if (m_control_monitors.contains(monitor)) {
-        m_reg->treeLandOutputManager()->destroyColorControl(m_control_monitors.value(monitor));
+        delete m_control_monitors.value(monitor);
         m_control_monitors.remove(monitor);
     }
 
@@ -936,6 +1066,9 @@ void DisplayWorker::wlMonitorRemoved(WQt::OutputHead *head)
 void DisplayWorker::wlOutputAdded(WQt::Output *output)
 {
     connect(output, &WQt::Output::done, this, &DisplayWorker::updateControl);
+    connect(output, &WQt::Output::done, this, [this, output]() {
+        onOutputWallpaperReady(output);
+    });
 }
 
 void DisplayWorker::wlOutputRemoved(WQt::Output *output)
@@ -946,12 +1079,21 @@ void DisplayWorker::wlOutputRemoved(WQt::Output *output)
 
 void DisplayWorker::updateControl()
 {
+    auto *treelandOpMgr = m_reg->treeLandOutputManager();
+    if (!treelandOpMgr) {
+        return;
+    }
     for (auto output : m_reg->waylandOutputs()) {
         if (output->isReady()) {
             for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
                 if (it.key()->name() == output->name()) {
                     if (!m_control_monitors.contains(it.key())) {
-                        auto control = m_reg->treeLandOutputManager()->getColorControl(output->get());
+                        auto control = treelandOpMgr->getColorControl(output->get());
+                        if (control) {
+                            connect(control, &WQt::ColorControl::brightnessChanged, this, [this, control](double brightness) {
+                                onBrightnessChanged(control, brightness);
+                            });
+                        }
                         m_control_monitors.insert(it.key(), control);
                     }
                     break;
@@ -1022,7 +1164,7 @@ void DisplayWorker::setMonitorResolutionBySize(Monitor *mon, const int width, co
             }
             auto *cfgHead = opCfg->enableHead(it.value());
             if (it.key() == mon)
-                cfgHead->setCustomMode({width, height}, mon->currentMode().rate());
+                cfgHead->setCustomMode({ width, height }, mon->currentMode().rate());
         }
         opCfg->apply();
     } else {
@@ -1050,11 +1192,11 @@ void DisplayWorker::mergeToConcatScreen(const QStringList &outputs)
     if (outputs.size() < 2) {
         return;
     }
-        
+
     QString outputsStr = outputs.join(",");
     qCDebug(DdcDisplayWorker) << "[ConcatScreen] mergeToConcatScreen: xrandr --setmonitor" << CONCAT_SCREEN_NAME << "auto" << outputsStr;
     QProcess p;
-    p.start("xrandr", {"--setmonitor", CONCAT_SCREEN_NAME, "auto", outputsStr});
+    p.start("xrandr", { "--setmonitor", CONCAT_SCREEN_NAME, "auto", outputsStr });
     p.waitForFinished(5000);
     if (p.exitCode() != 0) {
         qCWarning(DdcDisplayWorker) << "[ConcatScreen] mergeToConcatScreen failed:" << p.readAllStandardError();
@@ -1070,7 +1212,7 @@ void DisplayWorker::resetConcatScreenMode()
     }
 
     QProcess p;
-    p.start("xrandr", {"--delmonitor", CONCAT_SCREEN_NAME});
+    p.start("xrandr", { "--delmonitor", CONCAT_SCREEN_NAME });
     p.waitForFinished(5000);
     if (p.exitCode() != 0) {
         qCWarning(DdcDisplayWorker) << "[ConcatScreen] delmonitor failed:" << p.readAllStandardError();
@@ -1087,7 +1229,7 @@ void DisplayWorker::updateConcatScreenMode()
     }
 
     QProcess p;
-    p.start("xrandr", {"--listmonitors"});
+    p.start("xrandr", { "--listmonitors" });
     p.waitForFinished(3000);
     if (p.exitCode() != 0) {
         qCWarning(DdcDisplayWorker) << "[ConcatScreen] listmonitors failed:" << p.readAllStandardError();

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -5,6 +5,7 @@
 #define DISPLAYWORKER_H
 
 #include "Registry.h"
+#include "VirtualOutputManager.h"
 #include "displaydbusproxy.h"
 #include "monitor.h"
 
@@ -29,8 +30,8 @@ namespace WQt {
     class Output;
     class Registry;
     class OutputHead;
+    class ColorControl;
 }
-struct treeland_output_color_control_v1;
 
 namespace dccV25 {
 class DisplayModel;
@@ -89,8 +90,13 @@ private Q_SLOTS:
     void onWlMonitorListChanged();
     void updateWallpaper();
     void updateMonitorWallpaper(Monitor *mon);
+    void updateWallpaperFromWayland();
+    void onOutputWallpaperReady(WQt::Output *output);
+    void onWallpaperChanged(WQt::Output *output, const QString &fileSource, uint32_t sourceType, uint32_t role);
+    void updateVirtualOutputs();
 
-    void onBrightnessChanged(const treeland_output_color_control_v1 *colorControl, double brightness);
+    void onBrightnessChanged(WQt::ColorControl *colorControl, double brightness);
+    void initTreeland();
 
 private:
     void monitorAdded(const QString &path);
@@ -117,7 +123,7 @@ private:
     // for wlroots-based compositors
     WQt::Registry *m_reg { nullptr };
     QMap<Monitor *, WQt::OutputHead *> m_wl_monitors;
-    QMap<Monitor *, treeland_output_color_control_v1 *> m_control_monitors;
+    QMap<Monitor *, WQt::ColorControl *> m_control_monitors;
 #if GAMMA_SUPPORT
     QMap<Monitor *, DFL::GammaEffects *> *m_wl_gammaEffects;
     QMap<Monitor *, DFL::GammaEffectsConfig *> *m_wl_gammaConfig;

--- a/src/plugin-display/operation/private/monitor.cpp
+++ b/src/plugin-display/operation/private/monitor.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "monitor.h"
@@ -87,11 +87,6 @@ void Monitor::setScale(const double scale)
     m_scale = scale;
 
     Q_EMIT scaleChanged(m_scale);
-}
-
-void Monitor::setPrimary(const QString &primaryName)
-{
-    m_primary = primaryName;
 }
 
 void Monitor::setRotate(const quint16 rotate)

--- a/src/plugin-display/operation/private/monitor.h
+++ b/src/plugin-display/operation/private/monitor.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef MONITOR_H
@@ -38,7 +38,6 @@ public:
     inline int mmWidth() const { return m_mmWidth; }
     inline int mmHeight() const { return m_mmHeight; }
     inline double scale() const { return m_scale; }
-    inline bool isPrimary() const { return m_primary == m_name; }
     inline quint16 rotate() const { return m_rotate; }
     inline double brightness() const { return m_brightness; }
     inline const QRect rect() const { return QRect(m_x, m_y, m_w, m_h); }
@@ -104,7 +103,6 @@ private Q_SLOTS:
     void setMmWidth(const uint mmWidth);
     void setMmHeight(const uint mmHeight);
     void setScale(const double scale);
-    void setPrimary(const QString &primaryName);
     void setRotate(const quint16 rotate);
     void setBrightness(const double brightness);
     void setName(const QString &name);
@@ -137,7 +135,6 @@ private:
     QString m_manufacturer;
     QString m_model;
     QString m_path;
-    QString m_primary;
     Resolution m_currentMode;
     QList<quint16> m_rotateList;
     QList<Resolution> m_modeList;

--- a/src/plugin-display/operation/private/types/resolution.cpp
+++ b/src/plugin-display/operation/private/types/resolution.cpp
@@ -1,6 +1,6 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
-//SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-3.0-or-later
 #include "resolution.h"
 
 #include <QDebug>
@@ -13,16 +13,16 @@ void registerResolutionMetaType()
 
 QDebug operator<<(QDebug debug, const Resolution &resolution)
 {
-    debug << QString("Resolution(%1, %2, %3, %4)").arg(resolution.m_id)
-                                                    .arg(resolution.m_width)
-                                                    .arg(resolution.m_height)
-                                                    .arg(resolution.m_rate);
+    debug << QString("Resolution(%1, %2, %3, %4)").arg(resolution.m_id).arg(resolution.m_width).arg(resolution.m_height).arg(resolution.m_rate);
 
     return debug;
 }
 
 Resolution::Resolution()
-    : m_rate(0.0)
+    : m_id(0)
+    , m_width(0)
+    , m_height(0)
+    , m_rate(0.0)
 {
 }
 

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -413,7 +413,7 @@ DccObject {
             parentName: "display/displayMultipleDisplays"
             displayName: qsTr("Mode")
             weight: 10
-            visible: dccData.screens.length > 1 && dccData.isX11
+            visible: dccData.screens.length > 1
             pageType: DccObject.Editor
             page: D.ComboBox {
                 ListModel {
@@ -904,7 +904,6 @@ DccObject {
             parentName: "display/screenGroup"
             displayName: qsTr("Rotation") // 方向
             weight: 50
-            visible: dccData.isX11
             pageType: DccObject.Editor
             page: ComboBox {
                 flat: true

--- a/src/plugin-display/wayland/libwayqt/Output.cpp
+++ b/src/plugin-display/wayland/libwayqt/Output.cpp
@@ -2,20 +2,25 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+#include "Output.h"
+
+#include "WayQtLogging.h"
 #include "wayland-client-protocol.h"
 
-#include "Output.h"
 #include <wayland-client.h>
 
 #include <QCoreApplication>
 #include <QDebug>
 #include <QImage>
+#include <QLoggingCategory>
 #include <QObject>
 #include <QThread>
 
-WQt::Output::Output(wl_output *op)
+WQt::Output::Output(wl_output *op, QObject *parent)
+    : QObject(parent)
 {
     mObj = op;
+    qCDebug(DccWayQt) << "Output created" << op;
 
     wl_output_add_listener(mObj, &mListener, this);
 }
@@ -85,16 +90,7 @@ wl_output *WQt::Output::get()
     return mObj;
 }
 
-void WQt::Output::handleGeometryEvent(void *data,
-                                      struct wl_output *,
-                                      int32_t x,
-                                      int32_t y,
-                                      int32_t w,
-                                      int32_t h,
-                                      int32_t e,
-                                      const char *f,
-                                      const char *g,
-                                      int32_t t)
+void WQt::Output::handleGeometryEvent(void *data, struct wl_output *, int32_t x, int32_t y, int32_t w, int32_t h, int32_t e, const char *f, const char *g, int32_t t)
 {
     Output *output = reinterpret_cast<WQt::Output *>(data);
 
@@ -106,12 +102,7 @@ void WQt::Output::handleGeometryEvent(void *data,
     output->mTransform = t;
 }
 
-void WQt::Output::handleModeEvent(void *data,
-                                  struct wl_output *,
-                                  uint32_t current,
-                                  int32_t xres,
-                                  int32_t yres,
-                                  int32_t refresh)
+void WQt::Output::handleModeEvent(void *data, struct wl_output *, uint32_t current, int32_t xres, int32_t yres, int32_t refresh)
 {
     Output *output = reinterpret_cast<WQt::Output *>(data);
 
@@ -125,6 +116,7 @@ void WQt::Output::handleDone(void *data, struct wl_output *)
     Output *output = reinterpret_cast<WQt::Output *>(data);
 
     output->mDone = true;
+    qCDebug(DccWayQt) << "Output done:" << output->mName;
     Q_EMIT output->done();
 }
 
@@ -150,6 +142,5 @@ void WQt::Output::handleDescriptionEvent(void *data, struct wl_output *, const c
 }
 
 const wl_output_listener WQt::Output::mListener = {
-    handleGeometryEvent, handleModeEvent, handleDone,
-    handleScale,         handleNameEvent, handleDescriptionEvent,
+    handleGeometryEvent, handleModeEvent, handleDone, handleScale, handleNameEvent, handleDescriptionEvent,
 };

--- a/src/plugin-display/wayland/libwayqt/Output.h
+++ b/src/plugin-display/wayland/libwayqt/Output.h
@@ -50,7 +50,7 @@ public:
         bool current = false;
     } OutputMode;
 
-    Output(wl_output *);
+    Output(wl_output *, QObject *parent = nullptr);
     ~Output();
 
     QString name();
@@ -73,16 +73,7 @@ Q_SIGNALS:
     void done();
 
 private:
-    static void handleGeometryEvent(void *,
-                                    struct wl_output *,
-                                    int32_t,
-                                    int32_t,
-                                    int32_t,
-                                    int32_t,
-                                    int32_t,
-                                    const char *,
-                                    const char *,
-                                    int32_t);
+    static void handleGeometryEvent(void *, struct wl_output *, int32_t, int32_t, int32_t, int32_t, int32_t, const char *, const char *, int32_t);
     static void handleModeEvent(void *, struct wl_output *, uint32_t, int32_t, int32_t, int32_t);
     static void handleDone(void *, struct wl_output *);
     static void handleScale(void *, struct wl_output *, int32_t);

--- a/src/plugin-display/wayland/libwayqt/OutputManager.cpp
+++ b/src/plugin-display/wayland/libwayqt/OutputManager.cpp
@@ -4,13 +4,14 @@
 
 #include "OutputManager.h"
 
-#include "wlr-output-management-unstable-v1-client-protocol.h"
+#include "WayQtLogging.h"
 
 #include <wayland-client.h>
 
 #include <QCoreApplication>
 #include <QDebug>
 #include <QImage>
+#include <QLoggingCategory>
 #include <QObject>
 #include <QThread>
 #include <QVariant>
@@ -21,16 +22,13 @@
  * Obtain a pointer to this object from Wayland Registry
  */
 
-WQt::OutputManager::OutputManager(zwlr_output_manager_v1 *opMgr)
+WQt::OutputManager::OutputManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::OutputManager>(2)
 {
-    mObj = opMgr;
-    zwlr_output_manager_v1_add_listener(mObj, &mListener, this);
+    setParent(parent);
 }
 
-WQt::OutputManager::~OutputManager()
-{
-    zwlr_output_manager_v1_destroy(mObj);
-}
+WQt::OutputManager::~OutputManager() { }
 
 QList<WQt::OutputHead *> WQt::OutputManager::heads()
 {
@@ -39,57 +37,47 @@ QList<WQt::OutputHead *> WQt::OutputManager::heads()
 
 WQt::OutputConfiguration *WQt::OutputManager::createConfiguration()
 {
-    return new WQt::OutputConfiguration(zwlr_output_manager_v1_create_configuration(mObj, mSerial));
+    qCDebug(DccWayQt) << "OutputManager::createConfiguration serial:" << mSerial;
+    return new WQt::OutputConfiguration(QtWayland::zwlr_output_manager_v1::create_configuration(mSerial), this);
 }
 
 void WQt::OutputManager::stop()
 {
-    zwlr_output_manager_v1_stop(mObj);
+    qCDebug(DccWayQt) << "OutputManager::stop";
+    QtWayland::zwlr_output_manager_v1::stop();
 }
 
-zwlr_output_manager_v1 *WQt::OutputManager::get()
+::zwlr_output_manager_v1 *WQt::OutputManager::get()
 {
-    return mObj;
+    return object();
 }
 
-void WQt::OutputManager::handleHead(void *data, zwlr_output_manager_v1 *, zwlr_output_head_v1 *head)
+void WQt::OutputManager::zwlr_output_manager_v1_head(zwlr_output_head_v1 *id)
 {
-    WQt::OutputManager *mgr = reinterpret_cast<WQt::OutputManager *>(data);
+    WQt::OutputHead *opHead = new WQt::OutputHead(id, this);
 
-    WQt::OutputHead *opHead = new WQt::OutputHead(head);
-
-    mgr->mHeads << opHead;
-
+    mHeads << opHead;
+    qCInfo(DccWayQt) << "OutputHead added:" << opHead << "total:" << mHeads.count();
     connect(opHead, &WQt::OutputHead::finished, [=]() {
-        mgr->mHeads.removeAll(opHead);
+        mHeads.removeAll(opHead);
     });
 
-    emit mgr->headAttached(opHead);
+    Q_EMIT headAttached(opHead);
 }
 
-void WQt::OutputManager::handleDone(void *data, zwlr_output_manager_v1 *, uint32_t serial)
+void WQt::OutputManager::zwlr_output_manager_v1_done(uint32_t serial)
 {
-    WQt::OutputManager *mgr = reinterpret_cast<WQt::OutputManager *>(data);
+    mSerial = serial;
+    mIsDone = true;
+    qCDebug(DccWayQt) << "OutputManager::done serial:" << serial;
 
-    mgr->mSerial = serial;
-    mgr->mIsDone = true;
-
-    emit mgr->done();
+    Q_EMIT done();
 }
 
-void WQt::OutputManager::handleFinished(void *data, zwlr_output_manager_v1 *)
+void WQt::OutputManager::zwlr_output_manager_v1_finished()
 {
-    WQt::OutputManager *mgr = reinterpret_cast<WQt::OutputManager *>(data);
-
-    zwlr_output_manager_v1_destroy(mgr->mObj);
-    mgr->mObj = nullptr;
+    qCDebug(DccWayQt) << "OutputManager::finished";
 }
-
-const struct zwlr_output_manager_v1_listener WQt::OutputManager::mListener = {
-    handleHead,
-    handleDone,
-    handleFinished,
-};
 
 /**
  * Output Head
@@ -97,12 +85,16 @@ const struct zwlr_output_manager_v1_listener WQt::OutputManager::mListener = {
  * or via OutputManager::heads() function;
  */
 
-WQt::OutputHead::OutputHead() { }
-
-WQt::OutputHead::OutputHead(zwlr_output_head_v1 *head)
+WQt::OutputHead::OutputHead(QObject *parent)
+    : QObject(parent)
 {
-    mObj = head;
-    zwlr_output_head_v1_add_listener(mObj, &mListener, this);
+}
+
+WQt::OutputHead::OutputHead(zwlr_output_head_v1 *head, QObject *parent)
+    : QObject(parent)
+    , mObj(head)
+{
+    setupListeners();
 }
 
 WQt::OutputHead::OutputHead(const WQt::OutputHead &otherHead)
@@ -117,7 +109,8 @@ WQt::OutputHead::OutputHead(const WQt::OutputHead &otherHead)
 
 WQt::OutputHead::~OutputHead()
 {
-    zwlr_output_head_v1_destroy(mObj);
+    if (mObj)
+        zwlr_output_head_v1_destroy(mObj);
 }
 
 QVariant WQt::OutputHead::property(WQt::OutputHead::Property prop)
@@ -140,144 +133,126 @@ zwlr_output_head_v1 *WQt::OutputHead::get()
     return mObj;
 }
 
+void WQt::OutputHead::setupListeners()
+{
+    static const zwlr_output_head_v1_listener listener = {
+        &WQt::OutputHead::handleName,      &WQt::OutputHead::handleDescription, &WQt::OutputHead::handlePhysicalSize, &WQt::OutputHead::handleMode, &WQt::OutputHead::handleEnabled, &WQt::OutputHead::handleCurrentMode,  &WQt::OutputHead::handlePosition,
+        &WQt::OutputHead::handleTransform, &WQt::OutputHead::handleScale,       &WQt::OutputHead::handleFinished,     &WQt::OutputHead::handleMake, &WQt::OutputHead::handleModel,   &WQt::OutputHead::handleSerialNumber, &WQt::OutputHead::handleAdaptiveSync,
+    };
+    zwlr_output_head_v1_add_listener(mObj, &listener, this);
+}
+
 void WQt::OutputHead::handleName(void *data, zwlr_output_head_v1 *, const char *name)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
-    opHead->mPropsMap[WQt::OutputHead::Name] = name;
-
-    emit opHead->changed(WQt::OutputHead::Name);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    opHead->mPropsMap[WQt::OutputHead::Name] = QString::fromUtf8(name);
+    Q_EMIT opHead->changed(WQt::OutputHead::Name);
 }
 
 void WQt::OutputHead::handleDescription(void *data, zwlr_output_head_v1 *, const char *descr)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
-    opHead->mPropsMap[WQt::OutputHead::Description] = descr;
-
-    emit opHead->changed(WQt::OutputHead::Description);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    opHead->mPropsMap[WQt::OutputHead::Description] = QString::fromUtf8(descr);
+    Q_EMIT opHead->changed(WQt::OutputHead::Description);
 }
 
-void WQt::OutputHead::handlePhysicalSize(void *data,
-                                         zwlr_output_head_v1 *,
-                                         int32_t width,
-                                         int32_t height)
+void WQt::OutputHead::handlePhysicalSize(void *data, zwlr_output_head_v1 *, int32_t width, int32_t height)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
     opHead->mPropsMap[WQt::OutputHead::PhysicalSize] = QSize(width, height);
-
-    emit opHead->changed(WQt::OutputHead::PhysicalSize);
+    Q_EMIT opHead->changed(WQt::OutputHead::PhysicalSize);
 }
 
 void WQt::OutputHead::handleMode(void *data, zwlr_output_head_v1 *, zwlr_output_mode_v1 *mode)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
 
     if (opHead->mPropsMap.contains(WQt::OutputHead::Modes)) {
-        opHead->mPropsMap[WQt::OutputHead::Modes] =
-                QVariant::fromValue<QList<WQt::OutputMode *>>(QList<WQt::OutputMode *>());
+        opHead->mPropsMap[WQt::OutputHead::Modes] = QVariant::fromValue<QList<WQt::OutputMode *>>(QList<WQt::OutputMode *>());
     }
 
-    WQt::OutputMode *opMode = new WQt::OutputMode(mode);
+    WQt::OutputMode *opMode = new WQt::OutputMode(mode, opHead);
 
     connect(opMode, &WQt::OutputMode::finished, [=]() {
         opHead->mModes.removeAll(opMode);
     });
     opHead->mModes << opMode;
 
-    emit opHead->changed(WQt::OutputHead::Modes);
+    Q_EMIT opHead->changed(WQt::OutputHead::Modes);
 }
 
 void WQt::OutputHead::handleEnabled(void *data, zwlr_output_head_v1 *, int32_t yes)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
     opHead->mPropsMap[WQt::OutputHead::Enabled] = (bool)yes;
-
-    emit opHead->changed(WQt::OutputHead::Enabled);
+    Q_EMIT opHead->changed(WQt::OutputHead::Enabled);
 }
 
-void WQt::OutputHead::handleCurrentMode(void *data,
-                                        zwlr_output_head_v1 *,
-                                        zwlr_output_mode_v1 *curMode)
+void WQt::OutputHead::handleCurrentMode(void *data, zwlr_output_head_v1 *, zwlr_output_mode_v1 *curMode)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
 
     for (auto *mode : opHead->property(WQt::OutputHead::Modes).value<QList<WQt::OutputMode *>>()) {
         if (mode->get() == curMode)
             opHead->mCurrentMode = mode;
     }
 
-    emit opHead->changed(WQt::OutputHead::CurrentMode);
+    Q_EMIT opHead->changed(WQt::OutputHead::CurrentMode);
 }
 
 void WQt::OutputHead::handlePosition(void *data, zwlr_output_head_v1 *, int32_t x, int32_t y)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
     opHead->mPropsMap[WQt::OutputHead::Position] = QPoint(x, y);
-
-    emit opHead->changed(WQt::OutputHead::Position);
+    Q_EMIT opHead->changed(WQt::OutputHead::Position);
 }
 
 void WQt::OutputHead::handleTransform(void *data, zwlr_output_head_v1 *, int32_t transform)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
     opHead->mPropsMap[WQt::OutputHead::Transform] = transform;
-
-    emit opHead->changed(WQt::OutputHead::Transform);
+    Q_EMIT opHead->changed(WQt::OutputHead::Transform);
 }
 
 void WQt::OutputHead::handleScale(void *data, zwlr_output_head_v1 *, wl_fixed_t scale)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
     opHead->mPropsMap[WQt::OutputHead::Scale] = wl_fixed_to_double(scale);
-
-    emit opHead->changed(WQt::OutputHead::Scale);
+    Q_EMIT opHead->changed(WQt::OutputHead::Scale);
 }
 
 void WQt::OutputHead::handleFinished(void *data, zwlr_output_head_v1 *)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
-    emit opHead->finished();
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    Q_EMIT opHead->finished();
 }
 
 void WQt::OutputHead::handleMake(void *data, zwlr_output_head_v1 *, const char *make)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
-    opHead->mPropsMap[WQt::OutputHead::Make] = make;
-
-    emit opHead->changed(WQt::OutputHead::Make);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    opHead->mPropsMap[WQt::OutputHead::Make] = QString::fromUtf8(make);
+    Q_EMIT opHead->changed(WQt::OutputHead::Make);
 }
 
 void WQt::OutputHead::handleModel(void *data, zwlr_output_head_v1 *, const char *model)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
-    opHead->mPropsMap[WQt::OutputHead::Model] = model;
-
-    emit opHead->changed(WQt::OutputHead::Model);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    opHead->mPropsMap[WQt::OutputHead::Model] = QString::fromUtf8(model);
+    Q_EMIT opHead->changed(WQt::OutputHead::Model);
 }
 
 void WQt::OutputHead::handleSerialNumber(void *data, zwlr_output_head_v1 *, const char *serialNo)
 {
-    WQt::OutputHead *opHead = reinterpret_cast<WQt::OutputHead *>(data);
-
-    opHead->mPropsMap[WQt::OutputHead::SerialNumber] = serialNo;
-
-    emit opHead->changed(WQt::OutputHead::SerialNumber);
+    auto *opHead = reinterpret_cast<WQt::OutputHead *>(data);
+    opHead->mPropsMap[WQt::OutputHead::SerialNumber] = QString::fromUtf8(serialNo);
+    Q_EMIT opHead->changed(WQt::OutputHead::SerialNumber);
 }
 
-const struct zwlr_output_head_v1_listener WQt::OutputHead::mListener = {
-    handleName,        handleDescription, handlePhysicalSize, handleMode,  handleEnabled,
-    handleCurrentMode, handlePosition,    handleTransform,    handleScale, handleFinished,
-    handleMake,        handleModel,       handleSerialNumber,
-};
+void WQt::OutputHead::handleAdaptiveSync(void *data, zwlr_output_head_v1 *, uint32_t state)
+{
+    Q_UNUSED(data)
+    Q_UNUSED(state)
+}
 
 /**
  * Output Mode
@@ -286,12 +261,16 @@ const struct zwlr_output_head_v1_listener WQt::OutputHead::mListener = {
  * or from OutputHead::property( CurrentMode )
  */
 
-WQt::OutputMode::OutputMode() { }
-
-WQt::OutputMode::OutputMode(zwlr_output_mode_v1 *mode)
+WQt::OutputMode::OutputMode(QObject *parent)
+    : QObject(parent)
 {
-    mObj = mode;
-    zwlr_output_mode_v1_add_listener(mObj, &mListener, this);
+}
+
+WQt::OutputMode::OutputMode(zwlr_output_mode_v1 *mode, QObject *parent)
+    : QObject(parent)
+    , mObj(mode)
+{
+    setupListeners();
 }
 
 WQt::OutputMode::OutputMode(const WQt::OutputMode &otherMode)
@@ -306,7 +285,8 @@ WQt::OutputMode::OutputMode(const WQt::OutputMode &otherMode)
 
 WQt::OutputMode::~OutputMode()
 {
-    zwlr_output_mode_v1_destroy(mObj);
+    if (mObj)
+        zwlr_output_mode_v1_destroy(mObj);
 }
 
 QSize WQt::OutputMode::size()
@@ -329,46 +309,43 @@ zwlr_output_mode_v1 *WQt::OutputMode::get()
     return mObj;
 }
 
+void WQt::OutputMode::setupListeners()
+{
+    static const zwlr_output_mode_v1_listener listener = {
+        &WQt::OutputMode::handleSize,
+        &WQt::OutputMode::handleRefreshRate,
+        &WQt::OutputMode::handlePreferred,
+        &WQt::OutputMode::handleFinished,
+    };
+    zwlr_output_mode_v1_add_listener(mObj, &listener, this);
+}
+
 void WQt::OutputMode::handleSize(void *data, zwlr_output_mode_v1 *, int32_t width, int32_t height)
 {
-    WQt::OutputMode *opMode = reinterpret_cast<WQt::OutputMode *>(data);
-
+    auto *opMode = reinterpret_cast<WQt::OutputMode *>(data);
     opMode->mSize = QSize(width, height);
-
-    emit opMode->sizeChanged(opMode->mSize);
+    Q_EMIT opMode->sizeChanged(opMode->mSize);
 }
 
 void WQt::OutputMode::handleRefreshRate(void *data, zwlr_output_mode_v1 *, int32_t refreshRate)
 {
-    WQt::OutputMode *opMode = reinterpret_cast<WQt::OutputMode *>(data);
-
+    auto *opMode = reinterpret_cast<WQt::OutputMode *>(data);
     opMode->mRefreshRate = refreshRate;
-
-    emit opMode->refreshRateChanged(refreshRate);
+    Q_EMIT opMode->refreshRateChanged(refreshRate);
 }
 
 void WQt::OutputMode::handlePreferred(void *data, zwlr_output_mode_v1 *)
 {
-    WQt::OutputMode *opMode = reinterpret_cast<WQt::OutputMode *>(data);
-
+    auto *opMode = reinterpret_cast<WQt::OutputMode *>(data);
     opMode->mIsPreferred = true;
-
-    emit opMode->setAsPreferred();
+    Q_EMIT opMode->setAsPreferred();
 }
 
 void WQt::OutputMode::handleFinished(void *data, zwlr_output_mode_v1 *)
 {
-    WQt::OutputMode *opMode = reinterpret_cast<WQt::OutputMode *>(data);
-
-    emit opMode->finished();
+    auto *opMode = reinterpret_cast<WQt::OutputMode *>(data);
+    Q_EMIT opMode->finished();
 }
-
-const struct zwlr_output_mode_v1_listener WQt::OutputMode::mListener = {
-    handleSize,
-    handleRefreshRate,
-    handlePreferred,
-    handleFinished,
-};
 
 /**
  * Output Configuration
@@ -376,70 +353,58 @@ const struct zwlr_output_mode_v1_listener WQt::OutputMode::mListener = {
  * Obtained from OutputManager::createConfiguration()
  */
 
-WQt::OutputConfiguration::OutputConfiguration(zwlr_output_configuration_v1 *config)
+WQt::OutputConfiguration::OutputConfiguration(struct ::zwlr_output_configuration_v1 *config, QObject *parent)
+    : QObject(parent)
+    , QtWayland::zwlr_output_configuration_v1(config)
 {
-    mObj = config;
-    zwlr_output_configuration_v1_add_listener(mObj, &mListener, this);
 }
 
 WQt::OutputConfiguration::~OutputConfiguration()
 {
-    zwlr_output_configuration_v1_destroy(mObj);
+    QtWayland::zwlr_output_configuration_v1::destroy();
 }
 
 WQt::OutputConfigurationHead *WQt::OutputConfiguration::enableHead(WQt::OutputHead *head)
 {
-    return new WQt::OutputConfigurationHead(
-            zwlr_output_configuration_v1_enable_head(mObj, head->get()));
+    qCDebug(DccWayQt) << "OutputConfiguration::enableHead";
+    return new WQt::OutputConfigurationHead(QtWayland::zwlr_output_configuration_v1::enable_head(head->get()), this);
 }
 
 void WQt::OutputConfiguration::disableHead(WQt::OutputHead *head)
 {
-    zwlr_output_configuration_v1_disable_head(mObj, head->get());
+    qCDebug(DccWayQt) << "OutputConfiguration::disableHead";
+    QtWayland::zwlr_output_configuration_v1::disable_head(head->get());
 }
 
 void WQt::OutputConfiguration::apply()
 {
-    zwlr_output_configuration_v1_apply(mObj);
+    qCDebug(DccWayQt) << "OutputConfiguration::apply";
+    QtWayland::zwlr_output_configuration_v1::apply();
 }
 
 void WQt::OutputConfiguration::test()
 {
-    zwlr_output_configuration_v1_test(mObj);
+    qCDebug(DccWayQt) << "OutputConfiguration::test";
+    QtWayland::zwlr_output_configuration_v1::test();
 }
 
-void WQt::OutputConfiguration::handleSucceeded(void *data, zwlr_output_configuration_v1 *)
+void WQt::OutputConfiguration::zwlr_output_configuration_v1_succeeded()
 {
-    WQt::OutputConfiguration *config = reinterpret_cast<WQt::OutputConfiguration *>(data);
-
-    emit config->succeeded();
-
-    zwlr_output_configuration_v1_destroy(config->mObj);
+    qCDebug(DccWayQt) << "OutputConfiguration::succeeded";
+    Q_EMIT succeeded();
 }
 
-void WQt::OutputConfiguration::handleFailed(void *data, zwlr_output_configuration_v1 *)
+void WQt::OutputConfiguration::zwlr_output_configuration_v1_failed()
 {
-    WQt::OutputConfiguration *config = reinterpret_cast<WQt::OutputConfiguration *>(data);
-
-    emit config->failed();
-
-    zwlr_output_configuration_v1_destroy(config->mObj);
+    qCWarning(DccWayQt) << "OutputConfiguration::failed";
+    Q_EMIT failed();
 }
 
-void WQt::OutputConfiguration::handleCanceled(void *data, zwlr_output_configuration_v1 *)
+void WQt::OutputConfiguration::zwlr_output_configuration_v1_cancelled()
 {
-    WQt::OutputConfiguration *config = reinterpret_cast<WQt::OutputConfiguration *>(data);
-
-    emit config->canceled();
-
-    zwlr_output_configuration_v1_destroy(config->mObj); // need?
+    qCDebug(DccWayQt) << "OutputConfiguration::cancelled";
+    Q_EMIT canceled();
 }
-
-const struct zwlr_output_configuration_v1_listener WQt::OutputConfiguration::mListener = {
-    handleSucceeded,
-    handleFailed,
-    handleCanceled,
-};
 
 /**
  * Output Configuration Head
@@ -447,37 +412,44 @@ const struct zwlr_output_configuration_v1_listener WQt::OutputConfiguration::mLi
  * Obtained from OutputConfiguration::enableHead()
  */
 
-WQt::OutputConfigurationHead::OutputConfigurationHead(zwlr_output_configuration_head_v1 *configHead)
+WQt::OutputConfigurationHead::OutputConfigurationHead(zwlr_output_configuration_head_v1 *configHead, QObject *parent)
+    : QObject(parent)
+    , mObj(configHead)
 {
-    mObj = configHead;
 }
 
 WQt::OutputConfigurationHead::~OutputConfigurationHead()
 {
-    zwlr_output_configuration_head_v1_destroy(mObj);
+    if (mObj)
+        zwlr_output_configuration_head_v1_destroy(mObj);
 }
 
 void WQt::OutputConfigurationHead::setMode(WQt::OutputMode *mode)
 {
+    qCDebug(DccWayQt) << "OutputConfigurationHead::setMode" << mode->size() << mode->refreshRate();
     zwlr_output_configuration_head_v1_set_mode(mObj, mode->get());
 }
 
 void WQt::OutputConfigurationHead::setCustomMode(QSize size, int32_t refresh)
 {
+    qCDebug(DccWayQt) << "OutputConfigurationHead::setCustomMode" << size << refresh;
     zwlr_output_configuration_head_v1_set_custom_mode(mObj, size.width(), size.height(), refresh);
 }
 
 void WQt::OutputConfigurationHead::setPosition(QPoint pos)
 {
+    qCDebug(DccWayQt) << "OutputConfigurationHead::setPosition" << pos;
     zwlr_output_configuration_head_v1_set_position(mObj, pos.x(), pos.y());
 }
 
 void WQt::OutputConfigurationHead::setTransform(int32_t transform)
 {
+    qCDebug(DccWayQt) << "OutputConfigurationHead::setTransform" << transform;
     zwlr_output_configuration_head_v1_set_transform(mObj, transform);
 }
 
 void WQt::OutputConfigurationHead::setScale(qreal scale)
 {
+    qCDebug(DccWayQt) << "OutputConfigurationHead::setScale" << scale;
     zwlr_output_configuration_head_v1_set_scale(mObj, wl_fixed_from_double(scale));
 }

--- a/src/plugin-display/wayland/libwayqt/OutputManager.h
+++ b/src/plugin-display/wayland/libwayqt/OutputManager.h
@@ -4,26 +4,13 @@
 
 #pragma once
 
-#include <wayland-client-protocol.h>
+#include "qwayland-wlr-output-management-unstable-v1.h"
 
 #include <QMap>
 #include <QObject>
 #include <QRect>
 #include <QString>
-
-struct wl_buffer;
-struct wl_output;
-
-struct zwlr_output_manager_v1;
-struct zwlr_output_head_v1;
-struct zwlr_output_mode_v1;
-struct zwlr_output_configuration_v1;
-struct zwlr_output_configuration_head_v1;
-
-struct zwlr_output_manager_v1_listener;
-struct zwlr_output_head_v1_listener;
-struct zwlr_output_mode_v1_listener;
-struct zwlr_output_configuration_v1_listener;
+#include <QtWaylandClient/QWaylandClientExtension>
 
 namespace WQt {
 class OutputManager;
@@ -33,34 +20,29 @@ class OutputConfiguration;
 class OutputConfigurationHead;
 } // namespace WQt
 
-class WQt::OutputManager : public QObject
+class WQt::OutputManager : public QWaylandClientExtensionTemplate<WQt::OutputManager>, public QtWayland::zwlr_output_manager_v1
 {
-    Q_OBJECT;
+    Q_OBJECT
+    Q_PROPERTY(bool active READ isActive NOTIFY activeChanged)
 
 public:
-    OutputManager(zwlr_output_manager_v1 *);
-    ~OutputManager();
+    OutputManager(QObject *parent = nullptr);
+    ~OutputManager() override;
 
-    /** Create a configuration object */
     WQt::OutputConfiguration *createConfiguration();
-
     QList<WQt::OutputHead *> heads();
 
-    /** Stop monitoring the outupts */
     void stop();
 
-    zwlr_output_manager_v1 *get();
+    ::zwlr_output_manager_v1 *get();
+
+protected:
+    void zwlr_output_manager_v1_head(zwlr_output_head_v1 *id) override;
+    void zwlr_output_manager_v1_done(uint32_t serial) override;
+    void zwlr_output_manager_v1_finished() override;
 
 private:
-    static void handleHead(void *, zwlr_output_manager_v1 *, zwlr_output_head_v1 *);
-    static void handleDone(void *, zwlr_output_manager_v1 *, uint32_t);
-    static void handleFinished(void *, zwlr_output_manager_v1 *);
-
-    zwlr_output_manager_v1 *mObj;
-    uint32_t mSerial;
-
-    static const zwlr_output_manager_v1_listener mListener;
-
+    uint32_t mSerial = 0;
     QList<WQt::OutputHead *> mHeads;
     bool mIsDone = false;
 
@@ -89,17 +71,22 @@ public:
         SerialNumber,
     };
 
-    OutputHead();
-    OutputHead(zwlr_output_head_v1 *);
+    OutputHead(QObject *parent = nullptr);
+    OutputHead(zwlr_output_head_v1 *obj, QObject *parent = nullptr);
     OutputHead(const WQt::OutputHead &);
     ~OutputHead();
 
-    /** Get the suitable property of this head */
     QVariant property(WQt::OutputHead::Property);
-
     zwlr_output_head_v1 *get();
 
 private:
+    zwlr_output_head_v1 *mObj = nullptr;
+    QMap<int, QVariant> mPropsMap;
+    QList<WQt::OutputMode *> mModes;
+    WQt::OutputMode *mCurrentMode = nullptr;
+
+    void setupListeners();
+
     static void handleName(void *, zwlr_output_head_v1 *, const char *);
     static void handleDescription(void *, zwlr_output_head_v1 *, const char *);
     static void handlePhysicalSize(void *, zwlr_output_head_v1 *, int32_t, int32_t);
@@ -113,19 +100,10 @@ private:
     static void handleMake(void *, zwlr_output_head_v1 *, const char *);
     static void handleModel(void *, zwlr_output_head_v1 *, const char *);
     static void handleSerialNumber(void *, zwlr_output_head_v1 *, const char *);
-
-    static const zwlr_output_head_v1_listener mListener;
-
-    zwlr_output_head_v1 *mObj;
-
-    /** Properties map */
-    QMap<int, QVariant> mPropsMap;
-    QList<WQt::OutputMode *> mModes;
-    WQt::OutputMode *mCurrentMode;
+    static void handleAdaptiveSync(void *, zwlr_output_head_v1 *, uint32_t);
 
 Q_SIGNALS:
     void changed(WQt::OutputHead::Property);
-
     void finished();
 };
 
@@ -134,8 +112,8 @@ class WQt::OutputMode : public QObject
     Q_OBJECT;
 
 public:
-    OutputMode();
-    OutputMode(zwlr_output_mode_v1 *);
+    OutputMode(QObject *parent = nullptr);
+    OutputMode(zwlr_output_mode_v1 *obj, QObject *parent = nullptr);
     OutputMode(const WQt::OutputMode &);
     ~OutputMode();
 
@@ -146,33 +124,26 @@ public:
     zwlr_output_mode_v1 *get();
 
 private:
+    zwlr_output_mode_v1 *mObj = nullptr;
+    QSize mSize{ 0, 0 };
+    int32_t mRefreshRate{ 0 };
+    bool mIsPreferred{ false };
+
+    void setupListeners();
+
     static void handleSize(void *, zwlr_output_mode_v1 *, int32_t, int32_t);
     static void handleRefreshRate(void *, zwlr_output_mode_v1 *, int32_t);
     static void handlePreferred(void *, zwlr_output_mode_v1 *);
     static void handleFinished(void *, zwlr_output_mode_v1 *);
 
-    static const zwlr_output_mode_v1_listener mListener;
-
-    zwlr_output_mode_v1 *mObj{ nullptr };
-
-    /** Resolution */
-    QSize mSize{ 0, 0 };
-
-    /** Refresh rate */
-    int32_t mRefreshRate{ 0 };
-
-    /** By default this is false */
-    bool mIsPreferred{ false };
-
 Q_SIGNALS:
     void sizeChanged(QSize);
     void refreshRateChanged(int32_t);
     void setAsPreferred();
-
     void finished();
 };
 
-class WQt::OutputConfiguration : public QObject
+class WQt::OutputConfiguration : public QObject, public QtWayland::zwlr_output_configuration_v1
 {
     Q_OBJECT;
 
@@ -183,29 +154,18 @@ public:
         AlreadyUsed = 3,
     };
 
-    OutputConfiguration(zwlr_output_configuration_v1 *);
-    ~OutputConfiguration();
+    OutputConfiguration(struct ::zwlr_output_configuration_v1 *obj, QObject *parent = nullptr);
+    ~OutputConfiguration() override;
 
-    /** Get the outupt configuration head object for the enabled output head */
     WQt::OutputConfigurationHead *enableHead(WQt::OutputHead *);
-
-    /** Disabled the given head */
     void disableHead(WQt::OutputHead *);
-
-    /** This object is destroyed after calling this function */
     void apply();
-
-    /** This object is destroyed after calling this function */
     void test();
 
-private:
-    static void handleSucceeded(void *, zwlr_output_configuration_v1 *);
-    static void handleFailed(void *, zwlr_output_configuration_v1 *);
-    static void handleCanceled(void *, zwlr_output_configuration_v1 *);
-
-    static const zwlr_output_configuration_v1_listener mListener;
-
-    zwlr_output_configuration_v1 *mObj;
+protected:
+    void zwlr_output_configuration_v1_succeeded() override;
+    void zwlr_output_configuration_v1_failed() override;
+    void zwlr_output_configuration_v1_cancelled() override;
 
 Q_SIGNALS:
     void succeeded();
@@ -226,7 +186,7 @@ public:
         InvalidScale = 5,
     };
 
-    OutputConfigurationHead(zwlr_output_configuration_head_v1 *);
+    OutputConfigurationHead(zwlr_output_configuration_head_v1 *obj, QObject *parent = nullptr);
     ~OutputConfigurationHead();
 
     void setMode(WQt::OutputMode *);
@@ -236,7 +196,7 @@ public:
     void setScale(qreal);
 
 private:
-    zwlr_output_configuration_head_v1 *mObj;
+    zwlr_output_configuration_head_v1 *mObj = nullptr;
 };
 
 Q_DECLARE_METATYPE(WQt::OutputHead);

--- a/src/plugin-display/wayland/libwayqt/Registry.cpp
+++ b/src/plugin-display/wayland/libwayqt/Registry.cpp
@@ -2,18 +2,23 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-#include "treeland-output-management-client-protocol.h"
 #include "wayland-client-protocol.h"
-#include "wlr-output-management-unstable-v1-client-protocol.h"
 
 #include "Output.h"
 #include "OutputManager.h"
 #include "Registry.h"
 #include "TreeLandOutputManager.h"
+#include "VirtualOutputManager.h"
+#include "WallpaperManager.h"
 
 #include <QCoreApplication>
 #include <QDebug>
+#include <QLoggingCategory>
 #include <QThread>
+
+#include "WayQtLogging.h"
+
+Q_LOGGING_CATEGORY(DccWayQt, "dcc-wayqt")
 
 /* Convenience functions */
 void WQt::Registry::globalAnnounce(
@@ -25,11 +30,7 @@ void WQt::Registry::globalAnnounce(
 
 void WQt::Registry::globalRemove(void *data, struct wl_registry *, uint32_t name)
 {
-    // who cares :D
-    // but we will call WQt::Registry::handleRemove just for the heck of it
-
     auto r = reinterpret_cast<WQt::Registry *>(data);
-
     r->handleRemove(name);
 }
 
@@ -47,14 +48,14 @@ WQt::Registry::Registry(wl_display *wlDisplay, QObject *parent)
     if (wl_proxy_get_listener((wl_proxy *)mObj) != &mRegListener) {
         wl_registry_add_listener(mObj, &mRegListener, this);
     }
-
+    qCDebug(DccWayQt) << "Registry created" << mWlDisplay << mObj;
     wl_display_roundtrip(mWlDisplay);
 }
 
 WQt::Registry::~Registry()
 {
     wl_registry_destroy(mObj);
-
+    qCDebug(DccWayQt) << "Registry destroyed";
     wl_seat_destroy(mWlSeat);
     wl_shm_destroy(mWlShm);
 
@@ -62,13 +63,10 @@ WQt::Registry::~Registry()
         delete op;
     }
 
-    if (mOutputMgr != nullptr) {
-        delete mOutputMgr;
-    }
-
-    if (mTreeLandOutputMgr != nullptr) {
-        delete mTreeLandOutputMgr;
-    }
+    delete mOutputMgr;
+    delete mTreeLandOutputMgr;
+    delete mVirtualOutputMgr;
+    delete mWallpaperMgr;
 }
 
 void WQt::Registry::setup()
@@ -77,15 +75,15 @@ void WQt::Registry::setup()
         mIsSetup = true;
 
         for (WQt::Registry::ErrorType et : pendingErrors) {
-            emit errorOccured(et);
+            Q_EMIT errorOccured(et);
         }
 
         for (WQt::Registry::Interface iface : pendingInterfaces) {
-            emit interfaceRegistered(iface);
+            Q_EMIT interfaceRegistered(iface);
         }
 
         for (WQt::Output *op : pendingOutputs) {
-            emit outputAdded(op);
+            Q_EMIT outputAdded(op);
         }
     }
 }
@@ -130,11 +128,18 @@ WQt::TreeLandOutputManager *WQt::Registry::treeLandOutputManager()
     return mTreeLandOutputMgr;
 }
 
+WQt::VirtualOutputManager *WQt::Registry::virtualOutputManager()
+{
+    return mVirtualOutputMgr;
+}
+
+WQt::WallpaperManager *WQt::Registry::wallpaperManager()
+{
+    return mWallpaperMgr;
+}
+
 void WQt::Registry::handleAnnounce(uint32_t name, const char *interface, uint32_t version)
 {
-    /**
-     * We really don't care about wl_seat version right now.
-     */
     if (strcmp(interface, wl_seat_interface.name) == 0) {
         mWlSeat = (wl_seat *)wl_registry_bind(mObj, name, &wl_seat_interface, version);
 
@@ -143,9 +148,6 @@ void WQt::Registry::handleAnnounce(uint32_t name, const char *interface, uint32_
         }
     }
 
-    /**
-     * We really don't care about wl_shm version right now.
-     */
     if (strcmp(interface, wl_shm_interface.name) == 0) {
         mWlShm = (wl_shm *)wl_registry_bind(mObj, name, &wl_shm_interface, version);
 
@@ -159,59 +161,80 @@ void WQt::Registry::handleAnnounce(uint32_t name, const char *interface, uint32_
         }
     }
 
-    /**
-     * We really don't care about wl_output version right now.
-     */
     if (strcmp(interface, wl_output_interface.name) == 0) {
         wl_output *op = (wl_output *)wl_registry_bind(mObj, name, &wl_output_interface, version);
-
+        qCInfo(DccWayQt) << "wl_output added:" << op << "name:" << name << "version:" << version << "total:" << mOutputs.size();
         if (op) {
-            auto outputObj = new WQt::Output(op);
+            auto outputObj = new WQt::Output(op, this);
             mOutputs[name] = outputObj;
             emitOutput(outputObj, true);
         }
     }
 
-    /**
-     * We've implemented version 2.
-     * And wlroots 0.15.0 has version 2 available.
-     */
     else if (strcmp(interface, zwlr_output_manager_v1_interface.name) == 0) {
-        mWlrOutputMgr = (zwlr_output_manager_v1 *)
-                wl_registry_bind(mObj, name, &zwlr_output_manager_v1_interface, 2);
-
-        if (!mWlrOutputMgr) {
-            emitError(WQt::Registry::EmptyOutputManager);
-        }
-
-        else {
-            mOutputMgr = new WQt::OutputManager(mWlrOutputMgr);
-
-            mRegisteredInterfaces << OutputManagerInterface;
-            emitInterface(OutputManagerInterface, true);
+        qCDebug(DccWayQt) << "zwlr_output_manager_v1 announced:" << name << version << "thread:" << QThread::currentThread();
+        if (!mOutputMgr) {
+            mOutputMgr = new WQt::OutputManager(this);
+            qCDebug(DccWayQt) << "OutputManager created, active:" << mOutputMgr->isActive() << "thread:" << QThread::currentThread();
+            connect(mOutputMgr, &WQt::OutputManager::activeChanged, this, [this]() {
+                if (!mOutputMgr->isActive()) {
+                    emitError(WQt::Registry::EmptyOutputManager);
+                } else {
+                    mRegisteredInterfaces << OutputManagerInterface;
+                    emitInterface(OutputManagerInterface, true);
+                }
+            });
         }
     }
 
     else if (strcmp(interface, treeland_output_manager_v1_interface.name) == 0) {
-        m_treeland_output_mgr = (treeland_output_manager_v1 *)
-                wl_registry_bind(mObj, name, &treeland_output_manager_v1_interface, 2);
-        if (!m_treeland_output_mgr) {
-            emitError(WQt::Registry::EmptyTreeLandOuputManager);
-        } else {
-            mTreeLandOutputMgr = new WQt::TreeLandOutputManager(m_treeland_output_mgr);
+        if (!mTreeLandOutputMgr) {
+            mTreeLandOutputMgr = new WQt::TreeLandOutputManager(this);
 
-            mRegisteredInterfaces << TreeLandOutputManagerInterface;
-            emitInterface(TreeLandOutputManagerInterface, true);
+            connect(mTreeLandOutputMgr, &WQt::TreeLandOutputManager::activeChanged, this, [this]() {
+                if (!mTreeLandOutputMgr->isActive()) {
+                    emitError(WQt::Registry::EmptyTreeLandOuputManager);
+                } else {
+                    mRegisteredInterfaces << TreeLandOutputManagerInterface;
+                    emitInterface(TreeLandOutputManagerInterface, true);
+                }
+            });
+        }
+    }
+
+    else if (strcmp(interface, treeland_virtual_output_manager_v1_interface.name) == 0) {
+        if (!mVirtualOutputMgr) {
+            mVirtualOutputMgr = new WQt::VirtualOutputManager(this);
+
+            connect(mVirtualOutputMgr, &WQt::VirtualOutputManager::activeChanged, this, [this]() {
+                if (!mVirtualOutputMgr->isActive()) {
+                    emitError(WQt::Registry::EmptyVirtualOutputManager);
+                } else {
+                    mRegisteredInterfaces << VirtualOutputManagerInterface;
+                    emitInterface(VirtualOutputManagerInterface, true);
+                }
+            });
+        }
+    }
+
+    else if (strcmp(interface, treeland_wallpaper_manager_v1_interface.name) == 0) {
+        if (!mWallpaperMgr) {
+            mWallpaperMgr = new WQt::WallpaperManager(this);
+
+            connect(mWallpaperMgr, &WQt::WallpaperManager::activeChanged, this, [this]() {
+                if (!mWallpaperMgr->isActive()) {
+                    emitError(WQt::Registry::EmptyWallpaperManager);
+                } else {
+                    mRegisteredInterfaces << WallpaperManagerInterface;
+                    emitInterface(WallpaperManagerInterface, true);
+                }
+            });
         }
     }
 }
 
 void WQt::Registry::handleRemove(uint32_t name)
 {
-    /**
-     * While we do not care about most of the handleRemove,
-     * we need to worry about the wl_output * objects.
-     */
     if (mOutputs.keys().contains(name)) {
         WQt::Output *output = mOutputs.take(name);
         emitOutput(output, false);
@@ -220,8 +243,9 @@ void WQt::Registry::handleRemove(uint32_t name)
 
 void WQt::Registry::emitError(ErrorType et)
 {
+    qCWarning(DccWayQt) << "Registry error:" << et;
     if (mIsSetup) {
-        emit errorOccured(et);
+        Q_EMIT errorOccured(et);
     }
 
     else {
@@ -233,11 +257,11 @@ void WQt::Registry::emitOutput(WQt::Output *op, bool added)
 {
     if (mIsSetup) {
         if (added) {
-            emit outputAdded(op);
+            Q_EMIT outputAdded(op);
         }
 
         else {
-            emit outputRemoved(op);
+            Q_EMIT outputRemoved(op);
         }
     }
 
@@ -256,11 +280,11 @@ void WQt::Registry::emitInterface(WQt::Registry::Interface iface, bool added)
 {
     if (mIsSetup) {
         if (added) {
-            emit interfaceRegistered(iface);
+            Q_EMIT interfaceRegistered(iface);
         }
 
         else {
-            emit interfaceDeregistered(iface);
+            Q_EMIT interfaceDeregistered(iface);
         }
     }
 

--- a/src/plugin-display/wayland/libwayqt/Registry.h
+++ b/src/plugin-display/wayland/libwayqt/Registry.h
@@ -12,14 +12,8 @@ struct wl_display;
 struct wl_seat;
 struct wl_shm;
 struct wl_output;
-// struct wl_compositor;
 
 struct wl_registry_listener;
-
-struct xdg_wm_base;
-struct zwlr_output_manager_v1;
-struct zwlr_gamma_control_manager_v1;
-struct treeland_output_manager_v1;
 
 namespace WQt {
 class Registry;
@@ -28,6 +22,8 @@ class XdgShell;
 class Output;
 class OutputManager;
 class TreeLandOutputManager;
+class VirtualOutputManager;
+class WallpaperManager;
 } // namespace WQt
 
 class WQt::Registry : public QObject
@@ -36,26 +32,30 @@ class WQt::Registry : public QObject
 
 public:
     enum ErrorType {
-        EmptyShm,
+        EmptyShm, //
         EmptyIdle,
         EmptySeat,
         EmptyXdgWmBase,
         EmptyCompositor,
         EmptyOutputManager,
-        EmptyTreeLandOuputManager
+        EmptyTreeLandOuputManager,
+        EmptyVirtualOutputManager,
+        EmptyWallpaperManager
     };
 
     Q_ENUM(ErrorType);
 
     enum Interface {
-        ShmInterface,
+        ShmInterface, //
         IdleInterface,
         SeatInterface,
         WlrIdleInterface,
         XdgWmBaseInterface,
         CompositorInterface,
         OutputManagerInterface,
-        TreeLandOutputManagerInterface
+        TreeLandOutputManagerInterface,
+        VirtualOutputManagerInterface,
+        WallpaperManagerInterface
     };
 
     Q_ENUM(Interface);
@@ -76,62 +76,39 @@ public:
     /** List the already registered interfaces */
     QList<uint32_t> registeredInterfaces();
 
-    /* Ready to use Wayland Classes */
-
     /**
-     * XdgShell - Xdg Shell protocol implementation
-     */
-    WQt::XdgShell *xdgShell();
-
-    /**
-     * OutputManager - Output Management protocol implementation
+     * OutputManager - auto-bound via QWaylandClientExtensionTemplate
      */
     WQt::OutputManager *outputManager();
 
     /**
-     * TreeLandOutputManager - Primary Output Manager
+     * TreeLandOutputManager - auto-bound via QWaylandClientExtensionTemplate
      */
     WQt::TreeLandOutputManager *treeLandOutputManager();
 
+    /**
+     * VirtualOutputManager - auto-bound via QWaylandClientExtensionTemplate
+     */
+    WQt::VirtualOutputManager *virtualOutputManager();
+
+    WQt::WallpaperManager *wallpaperManager();
+
 private:
-    /** Raw C pointer to this class */
     wl_registry *mObj = nullptr;
-
-    /** wl_display object */
     wl_display *mWlDisplay = nullptr;
-
-    /** wl_seat object */
     wl_seat *mWlSeat = nullptr;
-
-    /** wl_shm object */
     wl_shm *mWlShm = nullptr;
 
-    /** Connected outputs */
     QHash<uint32_t, WQt::Output *> mOutputs;
-
-    /** List of registered interfaces */
     QList<uint32_t> mRegisteredInterfaces;
 
-    /**
-     * Output Manager Objects
-     */
-    zwlr_output_manager_v1 *mWlrOutputMgr = nullptr;
     WQt::OutputManager *mOutputMgr = nullptr;
-
-    /**
-     * Gamma Control Objects
-     */
-    zwlr_gamma_control_manager_v1 *mWlrGammaCtrl = nullptr;
-
-    treeland_output_manager_v1 *m_treeland_output_mgr = nullptr;
     WQt::TreeLandOutputManager *mTreeLandOutputMgr = nullptr;
+    WQt::VirtualOutputManager *mVirtualOutputMgr = nullptr;
+    WQt::WallpaperManager *mWallpaperMgr = nullptr;
 
     static const wl_registry_listener mRegListener;
-    static void globalAnnounce(void *data,
-                               wl_registry *registry,
-                               uint32_t name,
-                               const char *interface,
-                               uint32_t version);
+    static void globalAnnounce(void *data, wl_registry *registry, uint32_t name, const char *interface, uint32_t version);
     static void globalRemove(void *data, wl_registry *registry, uint32_t name);
 
     void handleAnnounce(uint32_t name, const char *interface, uint32_t version);
@@ -141,25 +118,13 @@ private:
     QList<WQt::Output *> pendingOutputs;
     QList<WQt::Registry::Interface> pendingInterfaces;
 
-    /** Flag to ensure setup() is called only once. */
     bool mIsSetup = false;
 
-    /** emit errorOccured or store it in pending */
     void emitError(ErrorType);
-
-    /**
-     * emit output added/removed or store in pending.
-     * bool indicates the state: true => added, false => removed.
-     */
     void emitOutput(WQt::Output *, bool);
-
-    /**
-     * emit iInterface registered/deregistered, or store in pending.
-     * bool indicates the state: true => registered, false => deregistered.
-     */
     void emitInterface(WQt::Registry::Interface, bool);
 
-signals:
+Q_SIGNALS:
     void errorOccured(ErrorType et);
 
     void outputAdded(WQt::Output *);

--- a/src/plugin-display/wayland/libwayqt/TreeLandOutputManager.cpp
+++ b/src/plugin-display/wayland/libwayqt/TreeLandOutputManager.cpp
@@ -1,86 +1,89 @@
-// SPDX-FileCopyrightText: 2018 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "TreeLandOutputManager.h"
 
-#include "treeland-output-management-client-protocol.h"
+#include "WayQtLogging.h"
 
 #include <wayland-client.h>
 
-#include <QCoreApplication>
 #include <QDebug>
-#include <QObject>
-#include <QThread>
+#include <QLoggingCategory>
 
-WQt::TreeLandOutputManager::TreeLandOutputManager(treeland_output_manager_v1 *opMgr)
+// ── WQt::ColorControl ──────────────────────────────────────────────
+
+WQt::ColorControl::ColorControl(::treeland_output_color_control_v1 *obj, QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::ColorControl>(1)
+    , QtWayland::treeland_output_color_control_v1(obj)
 {
-    mObj = opMgr;
-    treeland_output_manager_v1_add_listener(mObj, &mListener, this);
+    setParent(parent);
+}
+
+WQt::ColorControl::~ColorControl()
+{
+    QtWayland::treeland_output_color_control_v1::destroy();
+}
+
+void WQt::ColorControl::setBrightness(double brightness)
+{
+    qCDebug(DccWayQt) << "ColorControl::setBrightness" << brightness;
+    QtWayland::treeland_output_color_control_v1::set_brightness(wl_fixed_from_double(brightness));
+    commit();
+}
+
+void WQt::ColorControl::setColorTemperature(uint32_t temperature)
+{
+    qCDebug(DccWayQt) << "ColorControl::setColorTemperature" << temperature;
+    QtWayland::treeland_output_color_control_v1::set_color_temperature(temperature);
+    commit();
+}
+
+void WQt::ColorControl::treeland_output_color_control_v1_result(uint32_t success)
+{
+    Q_EMIT result(success);
+}
+
+void WQt::ColorControl::treeland_output_color_control_v1_color_temperature(uint32_t temperature)
+{
+    Q_EMIT colorTemperatureChanged(temperature);
+}
+
+void WQt::ColorControl::treeland_output_color_control_v1_brightness(int32_t brightness)
+{
+    Q_EMIT brightnessChanged(wl_fixed_to_double(brightness));
+}
+
+// ── WQt::TreeLandOutputManager ─────────────────────────────────────
+
+WQt::TreeLandOutputManager::TreeLandOutputManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::TreeLandOutputManager>(2)
+{
+    setParent(parent);
 }
 
 WQt::TreeLandOutputManager::~TreeLandOutputManager()
 {
-    treeland_output_manager_v1_destroy(mObj);
+    QtWayland::treeland_output_manager_v1::destroy();
 }
 
 void WQt::TreeLandOutputManager::setPrimaryOutput(const char *name)
 {
-    treeland_output_manager_v1_set_primary_output(mObj, name);
+    qCDebug(DccWayQt) << "TreeLandOutputManager::setPrimaryOutput" << name;
+    QtWayland::treeland_output_manager_v1::set_primary_output(name);
 }
 
-treeland_output_color_control_v1 *WQt::TreeLandOutputManager::getColorControl(struct wl_output *output)
+WQt::ColorControl *WQt::TreeLandOutputManager::getColorControl(struct wl_output *output)
 {
-    auto colorControl = treeland_output_manager_v1_get_color_control(mObj, output);
-    if (colorControl) {
-        treeland_output_color_control_v1_add_listener(colorControl, &mColorControlListener, this);
-    }
-    return colorControl;
+    auto *colorControl = get_color_control(output);
+    if (!colorControl)
+        return nullptr;
+    return new WQt::ColorControl(colorControl, this);
 }
 
-void WQt::TreeLandOutputManager::setBrightness(treeland_output_color_control_v1 *control, const double brightness)
+void WQt::TreeLandOutputManager::treeland_output_manager_v1_primary_output(const QString &output_name)
 {
-    if (control) {
-        treeland_output_color_control_v1_set_brightness(control, wl_fixed_from_double(brightness));
-        treeland_output_color_control_v1_commit(control);
-    }
+    qCDebug(DccWayQt) << "TreeLandOutputManager::primary output changed" << output_name;
+    mPrimaryOutput = output_name;
+    Q_EMIT primaryOutputChanged(output_name);
 }
-
-void WQt::TreeLandOutputManager::destroyColorControl(treeland_output_color_control_v1 *treeland_output_color_control_v1)
-{
-    treeland_output_color_control_v1_destroy(treeland_output_color_control_v1);
-}
-
-void WQt::TreeLandOutputManager::handlePrimaryOutput(void *data, struct treeland_output_manager_v1 *treeland_output_manager_v1, const char *output_name)
-{
-    Q_UNUSED(treeland_output_manager_v1)
-    WQt::TreeLandOutputManager *manager = reinterpret_cast<WQt::TreeLandOutputManager *>(data);
-    manager->mPrimaryOutput = QString::fromLocal8Bit(output_name);
-    emit manager->primaryOutputChanged(output_name);
-}
-
-void WQt::TreeLandOutputManager::handleResult(void *data, treeland_output_color_control_v1 *treeland_output_color_control_v1, uint32_t success)
-{
-    // TODO: handleResult
-}
-
-void WQt::TreeLandOutputManager::handleColorTemperature(void *data, treeland_output_color_control_v1 *treeland_output_color_control_v1, uint32_t temperature)
-{
-    WQt::TreeLandOutputManager *manager = reinterpret_cast<WQt::TreeLandOutputManager *>(data);
-    emit manager->colorTemperatureChanged(treeland_output_color_control_v1, temperature);
-}
-
-void WQt::TreeLandOutputManager::handleBrightness(void *data, struct treeland_output_color_control_v1 *treeland_output_color_control_v1, wl_fixed_t brightness)
-{
-    WQt::TreeLandOutputManager *manager = reinterpret_cast<WQt::TreeLandOutputManager *>(data);
-    double brightnessValue = wl_fixed_to_double(brightness);
-    emit manager->brightnessChanged(treeland_output_color_control_v1, brightnessValue);
-}
-
-const treeland_output_manager_v1_listener WQt::TreeLandOutputManager::mListener = { handlePrimaryOutput };
-
-const treeland_output_color_control_v1_listener WQt::TreeLandOutputManager::mColorControlListener = {
-    handleResult,  // result
-    handleColorTemperature,  // color_temperature
-    handleBrightness
-};

--- a/src/plugin-display/wayland/libwayqt/TreeLandOutputManager.h
+++ b/src/plugin-display/wayland/libwayqt/TreeLandOutputManager.h
@@ -1,64 +1,64 @@
-// SPDX-FileCopyrightText: 2018 - 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
 
-#include <wayland-client-protocol.h>
+#include "qwayland-treeland-output-manager-v1.h"
 
 #include <QMap>
 #include <QObject>
 #include <QRect>
 #include <QString>
+#include <QtWaylandClient/QWaylandClientExtension>
 
 struct wl_buffer;
 struct wl_output;
-struct treeland_output_manager_v1;
-struct treeland_output_manager_v1_listener;
-struct treeland_output_color_control_v1;
-struct treeland_output_color_control_v1_listener;
 
 namespace WQt {
 class TreeLandOutputManager;
-}
+class ColorControl;
+} // namespace WQt
 
-class WQt::TreeLandOutputManager : public QObject
+class WQt::ColorControl : public QWaylandClientExtensionTemplate<WQt::ColorControl>, public QtWayland::treeland_output_color_control_v1
 {
-    Q_OBJECT;
+    Q_OBJECT
 
 public:
-    TreeLandOutputManager(treeland_output_manager_v1 *);
-    ~TreeLandOutputManager();
+    ColorControl(::treeland_output_color_control_v1 *obj, QObject *parent = nullptr);
+    ~ColorControl() override;
 
-    /** Set the primary output */
+    void setBrightness(double brightness);
+    void setColorTemperature(uint32_t temperature);
+
+protected:
+    void treeland_output_color_control_v1_result(uint32_t success) override;
+    void treeland_output_color_control_v1_color_temperature(uint32_t temperature) override;
+    void treeland_output_color_control_v1_brightness(int32_t brightness) override;
+
+Q_SIGNALS:
+    void result(uint32_t success);
+    void colorTemperatureChanged(uint32_t temperature);
+    void brightnessChanged(double brightness);
+};
+
+class WQt::TreeLandOutputManager : public QWaylandClientExtensionTemplate<WQt::TreeLandOutputManager>, public QtWayland::treeland_output_manager_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(bool active READ isActive NOTIFY activeChanged)
+
+public:
+    TreeLandOutputManager(QObject *parent = nullptr);
+    ~TreeLandOutputManager() override;
+
     void setPrimaryOutput(const char *);
+    WQt::ColorControl *getColorControl(struct wl_output *output);
 
     QString mPrimaryOutput;
 
-    treeland_output_color_control_v1 * getColorControl(struct wl_output *output);
-    void setBrightness(treeland_output_color_control_v1 * treeland_output_color_control_v1,const double brightness);
-    void destroyColorControl(treeland_output_color_control_v1 *treeland_output_color_control_v1);
-private:
-    static void handlePrimaryOutput(void *data,
-                                    struct treeland_output_manager_v1 *treeland_output_manager_v1,
-                                    const char *output_name);
-    static void handleResult(void *data,
-                             struct treeland_output_color_control_v1 *treeland_output_color_control_v1,
-                             uint32_t success);
-    static void handleColorTemperature(void *data,
-                                       struct treeland_output_color_control_v1 *treeland_output_color_control_v1,
-                                       uint32_t temperature);
-    static void handleBrightness(void *data,
-                                 struct treeland_output_color_control_v1 *treeland_output_color_control_v1,
-                                 wl_fixed_t brightness);
-
-    static const treeland_output_manager_v1_listener mListener;
-    static const treeland_output_color_control_v1_listener mColorControlListener;
-
-    treeland_output_manager_v1 *mObj;
+protected:
+    void treeland_output_manager_v1_primary_output(const QString &output_name) override;
 
 Q_SIGNALS:
-    void primaryOutputChanged(const char *);
-    void brightnessChanged(const treeland_output_color_control_v1 *,double brightness);
-    void colorTemperatureChanged(const treeland_output_color_control_v1 *,uint temperature);
+    void primaryOutputChanged(const QString &);
 };

--- a/src/plugin-display/wayland/libwayqt/VirtualOutputManager.cpp
+++ b/src/plugin-display/wayland/libwayqt/VirtualOutputManager.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "VirtualOutputManager.h"
+
+#include "WayQtLogging.h"
+
+#include <wayland-client.h>
+
+#include <QDebug>
+#include <QLoggingCategory>
+
+static QStringList parseStringArray(struct wl_array *array)
+{
+    QStringList result;
+    if (!array || array->size == 0)
+        return result;
+
+    const char *data = static_cast<const char *>(array->data);
+    const char *end = data + array->size;
+
+    while (data < end) {
+        const char *nul = static_cast<const char *>(memchr(data, '\0', end - data));
+        if (!nul) {
+            nul = end;
+        }
+        if (nul > data) {
+            result.append(QString::fromUtf8(data, nul - data));
+        }
+        data = nul + 1;
+    }
+
+    return result;
+}
+
+// ── WQt::VirtualOutput ──────────────────────────────────────────────
+
+WQt::VirtualOutput::VirtualOutput(::treeland_virtual_output_v1 *obj, QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::VirtualOutput>(1)
+    , QtWayland::treeland_virtual_output_v1(obj)
+{
+    setParent(parent);
+    qCDebug(DccWayQt) << "VirtualOutput created";
+}
+
+WQt::VirtualOutput::~VirtualOutput()
+{
+    qCDebug(DccWayQt) << "VirtualOutput destroyed:" << mName;
+}
+
+QString WQt::VirtualOutput::name() const
+{
+    return mName;
+}
+
+QStringList WQt::VirtualOutput::outputs() const
+{
+    return mOutputs;
+}
+
+void WQt::VirtualOutput::treeland_virtual_output_v1_outputs(const QString &name, wl_array *outputs)
+{
+    mName = name;
+    mOutputs = parseStringArray(outputs);
+    qCInfo(DccWayQt) << "VirtualOutput outputs:" << mName << mOutputs;
+    Q_EMIT outputsChanged(mName, mOutputs);
+}
+
+void WQt::VirtualOutput::treeland_virtual_output_v1_error(uint32_t code, const QString &message)
+{
+    qCWarning(DccWayQt) << "VirtualOutput error:" << mName << "code:" << code << message;
+    Q_EMIT error(mName, code, message);
+}
+
+// ── WQt::VirtualOutputManager ───────────────────────────────────────
+
+WQt::VirtualOutput *WQt::VirtualOutputManager::registerVirtualOutput(const QString &name, ::treeland_virtual_output_v1 *obj)
+{
+    if (!obj) {
+        return nullptr;
+    }
+
+    auto *vo = new WQt::VirtualOutput(obj, this);
+    connect(vo, &WQt::VirtualOutput::outputsChanged, this, &WQt::VirtualOutputManager::virtualOutputOutputsChanged);
+    connect(vo, &WQt::VirtualOutput::error, this, &WQt::VirtualOutputManager::virtualOutputError);
+    connect(vo, &QObject::destroyed, this, [this, name]() {
+        mVirtualOutputs.remove(name);
+        Q_EMIT virtualOutputList(mVirtualOutputs.keys());
+    });
+    mVirtualOutputs.insert(name, vo);
+    qCDebug(DccWayQt) << "registerVirtualOutput:" << name << vo;
+    Q_EMIT virtualOutputList(mVirtualOutputs.keys());
+    return vo;
+}
+
+WQt::VirtualOutputManager::VirtualOutputManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::VirtualOutputManager>(1)
+{
+    setParent(parent);
+}
+
+WQt::VirtualOutputManager::~VirtualOutputManager()
+{
+    for (auto *vo : mVirtualOutputs) {
+        disconnect(vo, &QObject::destroyed, this, nullptr);
+    }
+    qDeleteAll(mVirtualOutputs);
+}
+
+WQt::VirtualOutput *WQt::VirtualOutputManager::createVirtualOutput(const QString &name, const QStringList &outputs)
+{
+    QByteArray screenArray;
+    for (const QString &str : outputs) {
+        screenArray.append(str.toUtf8());
+        screenArray.append('\0');
+    }
+    screenArray.append('\0');
+    auto *obj = QtWayland::treeland_virtual_output_manager_v1::create_virtual_output(name, screenArray);
+    return registerVirtualOutput(name, obj);
+}
+
+void WQt::VirtualOutputManager::getVirtualOutputList()
+{
+    QtWayland::treeland_virtual_output_manager_v1::get_virtual_output_list();
+}
+
+WQt::VirtualOutput *WQt::VirtualOutputManager::getOrCreateVirtualOutput(const QString &name)
+{
+    if (mVirtualOutputs.contains(name))
+        return mVirtualOutputs.value(name);
+
+    auto *obj = QtWayland::treeland_virtual_output_manager_v1::get_virtual_output(name);
+    return registerVirtualOutput(name, obj);
+}
+
+WQt::VirtualOutput *WQt::VirtualOutputManager::takeVirtualOutput(const QString &name)
+{
+    return mVirtualOutputs.take(name);
+}
+
+void WQt::VirtualOutputManager::destroyVirtualOutput(const QString &name)
+{
+    auto *vo = mVirtualOutputs.take(name);
+    qCDebug(DccWayQt) << "destroyVirtualOutput:" << name << "remaining:" << mVirtualOutputs.keys();
+    if (vo) {
+        vo->QtWayland::treeland_virtual_output_v1::destroy();
+        vo->deleteLater();
+    }
+    Q_EMIT virtualOutputList(mVirtualOutputs.keys());
+}
+
+QMap<QString, WQt::VirtualOutput *> WQt::VirtualOutputManager::virtualOutputs() const
+{
+    return mVirtualOutputs;
+}
+
+void WQt::VirtualOutputManager::treeland_virtual_output_manager_v1_virtual_output_list(wl_array *names)
+{
+    QStringList nameList = parseStringArray(names);
+
+    for (const auto &name : nameList) {
+        getOrCreateVirtualOutput(name);
+    }
+
+    Q_EMIT virtualOutputList(nameList);
+}

--- a/src/plugin-display/wayland/libwayqt/VirtualOutputManager.h
+++ b/src/plugin-display/wayland/libwayqt/VirtualOutputManager.h
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "qwayland-treeland-virtual-output-manager-v1.h"
+
+#include <QMap>
+#include <QObject>
+#include <QString>
+#include <QStringList>
+#include <QtWaylandClient/QWaylandClientExtension>
+
+namespace WQt {
+class VirtualOutput;
+class VirtualOutputManager;
+} // namespace WQt
+
+class WQt::VirtualOutput : public QWaylandClientExtensionTemplate<WQt::VirtualOutput>, public QtWayland::treeland_virtual_output_v1
+{
+    Q_OBJECT
+
+    friend class VirtualOutputManager;
+
+private:
+    VirtualOutput(::treeland_virtual_output_v1 *obj, QObject *parent = nullptr);
+
+public:
+    ~VirtualOutput() override;
+
+    QString name() const;
+    QStringList outputs() const;
+
+protected:
+    void treeland_virtual_output_v1_outputs(const QString &name, wl_array *outputs) override;
+    void treeland_virtual_output_v1_error(uint32_t code, const QString &message) override;
+
+    QString mName;
+    QStringList mOutputs;
+
+Q_SIGNALS:
+    void outputsChanged(const QString &name, const QStringList &outputs);
+    void error(const QString &name, uint32_t code, const QString &message);
+};
+
+class WQt::VirtualOutputManager : public QWaylandClientExtensionTemplate<WQt::VirtualOutputManager>, public QtWayland::treeland_virtual_output_manager_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(bool active READ isActive NOTIFY activeChanged)
+
+public:
+    VirtualOutputManager(QObject *parent = nullptr);
+    ~VirtualOutputManager() override;
+
+    WQt::VirtualOutput *createVirtualOutput(const QString &name, const QStringList &outputs);
+    void getVirtualOutputList();
+    WQt::VirtualOutput *takeVirtualOutput(const QString &name);
+    void destroyVirtualOutput(const QString &name);
+    QMap<QString, WQt::VirtualOutput *> virtualOutputs() const;
+
+protected:
+    void treeland_virtual_output_manager_v1_virtual_output_list(wl_array *names) override;
+
+private:
+    WQt::VirtualOutput *getOrCreateVirtualOutput(const QString &name);
+    WQt::VirtualOutput *registerVirtualOutput(const QString &name, ::treeland_virtual_output_v1 *obj);
+
+    QMap<QString, WQt::VirtualOutput *> mVirtualOutputs;
+
+Q_SIGNALS:
+    void virtualOutputList(const QStringList &names);
+    void virtualOutputOutputsChanged(const QString &name, const QStringList &outputs);
+    void virtualOutputError(const QString &name, uint32_t code, const QString &message);
+};

--- a/src/plugin-display/wayland/libwayqt/WallpaperManager.cpp
+++ b/src/plugin-display/wayland/libwayqt/WallpaperManager.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "WallpaperManager.h"
+
+#include "WayQtLogging.h"
+
+#include <QDebug>
+#include <QLoggingCategory>
+
+// ── WQt::Wallpaper ───────────────────────────────────────────────────
+
+WQt::Wallpaper::Wallpaper(struct ::treeland_wallpaper_v1 *object, wl_output *output, QObject *parent)
+    : QObject(parent)
+    , QtWayland::treeland_wallpaper_v1(object)
+    , mOutput(output)
+{
+}
+
+WQt::Wallpaper::~Wallpaper()
+{
+    if (isInitialized())
+        QtWayland::treeland_wallpaper_v1::destroy();
+}
+
+bool WQt::Wallpaper::isValid() const
+{
+    return isInitialized();
+}
+
+wl_output *WQt::Wallpaper::output() const
+{
+    return mOutput;
+}
+
+QString WQt::Wallpaper::fileSource() const
+{
+    return mFileSource;
+}
+
+uint32_t WQt::Wallpaper::sourceType() const
+{
+    return mSourceType;
+}
+
+void WQt::Wallpaper::treeland_wallpaper_v1_changed(uint32_t role, uint32_t sourceType, const QString &fileSource)
+{
+    qCInfo(DccWayQt) << "Wallpaper changed:" << mOutput << "role:" << role << "sourceType:" << sourceType << fileSource;
+    mSourceType = sourceType;
+    mFileSource = fileSource;
+    Q_EMIT changed(mFileSource, mSourceType, role);
+}
+
+void WQt::Wallpaper::treeland_wallpaper_v1_failed(const QString &source, uint32_t error)
+{
+    qCWarning(DccWayQt) << "Wallpaper failed:" << source << "error:" << error;
+    Q_EMIT failed(source, error);
+}
+
+// ── WQt::WallpaperManager ────────────────────────────────────────────
+
+WQt::WallpaperManager::WallpaperManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::WallpaperManager>(1)
+{
+    setParent(parent);
+}
+
+WQt::WallpaperManager::~WallpaperManager()
+{
+    for (auto *wp : mWallpapers) {
+        disconnect(wp, &QObject::destroyed, this, nullptr);
+    }
+    qDeleteAll(mWallpapers);
+}
+
+WQt::Wallpaper *WQt::WallpaperManager::getWallpaper(wl_output *output)
+{
+    void *key = reinterpret_cast<void *>(output);
+    if (mWallpapers.contains(key)) {
+        return mWallpapers.value(key);
+    }
+
+    auto *obj = QtWayland::treeland_wallpaper_manager_v1::get_treeland_wallpaper(output, nullptr);
+    if (!obj) {
+        return nullptr;
+    }
+
+    auto *wallpaper = new WQt::Wallpaper(obj, output, this);
+    connect(wallpaper, &QObject::destroyed, this, [this, key]() {
+        mWallpapers.remove(key);
+    });
+    mWallpapers.insert(key, wallpaper);
+    return wallpaper;
+}

--- a/src/plugin-display/wayland/libwayqt/WallpaperManager.h
+++ b/src/plugin-display/wayland/libwayqt/WallpaperManager.h
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include "qwayland-treeland-wallpaper-manager-unstable-v1.h"
+
+#include <wayland-client.h>
+
+#include <QMap>
+#include <QObject>
+#include <QtWaylandClient/QWaylandClientExtension>
+
+namespace WQt {
+class Wallpaper;
+class WallpaperManager;
+} // namespace WQt
+
+class WQt::Wallpaper : public QObject, public QtWayland::treeland_wallpaper_v1
+{
+    Q_OBJECT
+
+    friend class WallpaperManager;
+
+private:
+    explicit Wallpaper(struct ::treeland_wallpaper_v1 *object, wl_output *output, QObject *parent = nullptr);
+
+public:
+    ~Wallpaper() override;
+
+    bool isValid() const;
+
+    wl_output *output() const;
+    QString fileSource() const;
+    uint32_t sourceType() const;
+
+protected:
+    void treeland_wallpaper_v1_changed(uint32_t role, uint32_t sourceType, const QString &fileSource) override;
+    void treeland_wallpaper_v1_failed(const QString &source, uint32_t error) override;
+
+private:
+    wl_output *mOutput = nullptr;
+    QString mFileSource;
+    uint32_t mSourceType = 0;
+
+Q_SIGNALS:
+    void changed(const QString &fileSource, uint32_t sourceType, uint32_t role);
+    void failed(const QString &source, uint32_t error);
+};
+
+class WQt::WallpaperManager : public QWaylandClientExtensionTemplate<WQt::WallpaperManager>, public QtWayland::treeland_wallpaper_manager_v1
+{
+    Q_OBJECT
+
+public:
+    explicit WallpaperManager(QObject *parent = nullptr);
+    ~WallpaperManager() override;
+
+    WQt::Wallpaper *getWallpaper(wl_output *output);
+
+private:
+    QMap<void *, WQt::Wallpaper *> mWallpapers;
+};

--- a/src/plugin-display/wayland/libwayqt/WayQtLogging.h
+++ b/src/plugin-display/wayland/libwayqt/WayQtLogging.h
@@ -1,0 +1,11 @@
+//SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+//SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef WAYQT_LOGGING_H
+#define WAYQT_LOGGING_H
+
+#include <QLoggingCategory>
+
+Q_DECLARE_LOGGING_CATEGORY(DccWayQt)
+
+#endif // WAYQT_LOGGING_H

--- a/src/plugin-display/wayland/libwayqt/WayQtUtils.cpp
+++ b/src/plugin-display/wayland/libwayqt/WayQtUtils.cpp
@@ -19,8 +19,7 @@ wl_display *WQt::Wayland::display()
         return nullptr;
     }
 
-    struct wl_display *display =
-            reinterpret_cast<wl_display *>(native->nativeResourceForIntegration("display"));
+    struct wl_display *display = reinterpret_cast<wl_display *>(native->nativeResourceForIntegration("display"));
 
     return display;
 }
@@ -33,8 +32,7 @@ wl_compositor *WQt::Wayland::compositor()
         return nullptr;
     }
 
-    struct wl_compositor *display =
-            reinterpret_cast<wl_compositor *>(native->nativeResourceForIntegration("compositor"));
+    struct wl_compositor *display = reinterpret_cast<wl_compositor *>(native->nativeResourceForIntegration("compositor"));
 
     return display;
 }
@@ -47,8 +45,7 @@ wl_seat *WQt::Wayland::seat()
         return nullptr;
     }
 
-    struct wl_seat *display =
-            reinterpret_cast<wl_seat *>(native->nativeResourceForIntegration("wl_seat"));
+    struct wl_seat *display = reinterpret_cast<wl_seat *>(native->nativeResourceForIntegration("wl_seat"));
 
     return display;
 }
@@ -61,8 +58,7 @@ wl_pointer *WQt::Wayland::pointer()
         return nullptr;
     }
 
-    struct wl_pointer *display =
-            reinterpret_cast<wl_pointer *>(native->nativeResourceForIntegration("wl_pointer"));
+    struct wl_pointer *display = reinterpret_cast<wl_pointer *>(native->nativeResourceForIntegration("wl_pointer"));
 
     return display;
 }
@@ -75,8 +71,7 @@ wl_keyboard *WQt::Wayland::keyboard()
         return nullptr;
     }
 
-    struct wl_keyboard *display =
-            reinterpret_cast<wl_keyboard *>(native->nativeResourceForIntegration("wl_keyboard"));
+    struct wl_keyboard *display = reinterpret_cast<wl_keyboard *>(native->nativeResourceForIntegration("wl_keyboard"));
 
     return display;
 }
@@ -89,8 +84,7 @@ wl_touch *WQt::Wayland::touch()
         return nullptr;
     }
 
-    struct wl_touch *display =
-            reinterpret_cast<wl_touch *>(native->nativeResourceForIntegration("wl_touch"));
+    struct wl_touch *display = reinterpret_cast<wl_touch *>(native->nativeResourceForIntegration("wl_touch"));
 
     return display;
 }
@@ -113,8 +107,7 @@ wl_output *WQt::Utils::wlOutputFromQScreen(QScreen *screen)
         return nullptr;
     }
 
-    struct wl_output *output =
-            reinterpret_cast<wl_output *>(native->nativeResourceForScreen("output", screen));
+    struct wl_output *output = reinterpret_cast<wl_output *>(native->nativeResourceForScreen("output", screen));
 
     return output;
 }
@@ -128,8 +121,7 @@ wl_surface *WQt::Utils::wlSurfaceFromQWindow(QWindow *window)
         return nullptr;
     }
 
-    struct wl_surface *surface =
-            reinterpret_cast<wl_surface *>(native->nativeResourceForWindow("surface", window));
+    struct wl_surface *surface = reinterpret_cast<wl_surface *>(native->nativeResourceForWindow("surface", window));
 
     return surface;
 }


### PR DESCRIPTION
1. Add VirtualOutputManager/WallpaperManager Wayland protocol wrappers in libwayqt using Qt Wayland Client Extension pattern
2. Migrate existing libwayqt wrappers (OutputManager, Output, Registry, TreeLandOutputManager) from raw C bindings to QWaylandClientExtension
3. Integrate virtual output protocol into DisplayWorker::switchMode() to enable true clone mode on Treeland via createVirtualOutput()
4. Update updateVirtualScreens() to group monitors by virtual output when clone mode is active, fallback to rect-based grouping otherwise
5. Migrate build system from custom ws_generate_local() to qt_generate_wayland_protocol_client_sources()

Log: Users can now use clone/copy display mode on Treeland compositor

Influence:
1. Verify clone mode activates when selecting "Copy" display mode with multiple monitors on Treeland
2. Verify switching from clone mode to extend/single mode properly destroys the virtual output and restores normal display

PMS: BUG-351881

feat(display): 添加虚拟输出协议支持复制模式

1. 新增 VirtualOutputManager/WallpaperManager Wayland 协议封装， 采用 Qt Wayland Client Extension 模式
2. 将现有 libwayqt 封装（OutputManager、Output、Registry、 TreeLandOutputManager）从原始 C 绑定迁移到 QWaylandClientExtension
3. 在 DisplayWorker::switchMode() 中集成虚拟输出协议， 通过 createVirtualOutput() 在 TreeLand 上启用真正的复制模式
4. 更新 updateVirtualScreens()，在复制模式激活时按虚拟输出 分组显示器，否则回退到基于坐标的分组
5. 构建系统从自定义 ws_generate_local() 迁移到 qt_generate_wayland_protocol_client_sources()

Log: 用户现在可以在 TreeLand 合成器上使用复制显示模式

Influence:
1. 在 TreeLand 上连接多显示器时，验证选择"复制"模式能正确 激活克隆模式
2. 验证从复制模式切换到扩展/仅主屏模式时能正确销毁虚拟输出 并恢复正常显示

PMS: BUG-351881