### PR TITLE
fix: prevent hang when canceling plugin loading

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -200,7 +200,9 @@ void DccPluginManager::cancelLoad()
     if (m_threadPool) {
         qCWarning(dccLog()) << "delete threadPool";
         m_threadPool->clear();
-        m_threadPool->waitForDone();
+        if (!m_threadPool->waitForDone(3000)) {
+            qCWarning(dccLog()) << "thread pool waitForDone timeout, some tasks may still be running";
+        }
         delete m_threadPool;
         qCWarning(dccLog()) << "delete threadPool finish";
         m_threadPool = nullptr;


### PR DESCRIPTION
Add timeout to thread pool waitForDone call in cancelLoad method to
prevent
application from hanging indefinitely when thread pool shutdown takes
too long.
When the timeout expires after 3 seconds, a warning is logged instead of
blocking indefinitely, allowing the application to continue the deletion
process.

Log: Added timeout protection for thread pool shutdown

Influence:
1. Test canceling plugin loading during normal operation
2. Test canceling plugin loading when tasks are long-running
3. Verify warning message appears when timeout occurs
4. Verify application does not hang during cancel operation

fix: 修复取消插件加载时的线程池挂起问题

在cancelLoad方法中为线程池的waitForDone调用增加超时机制，防止线程池关闭
耗时过长
导致应用程序无限期挂起。当超时时间（3秒）到期后，会记录警告信息而不是无
限阻塞，
使应用程序能够继续执行线程池的删除操作。

Log: 新增线程池关闭超时保护

Influence:
1. 测试正常操作下取消插件加载
2. 测试任务正在运行时取消插件加载
3. 验证超时发生时警告信息是否正确输出
4. 验证取消操作时应用程序不会挂起

## Summary by Sourcery

Add a timeout to plugin thread pool shutdown to avoid hangs when cancelling plugin loading.

Bug Fixes:
- Prevent application hangs when cancelling plugin loading by bounding thread pool wait time with a timeout.

Enhancements:
- Log a warning when thread pool shutdown exceeds the timeout, indicating that some tasks may still be running.