### PR TITLE
refactor(personalization): move theme models from interface to model

### DIFF
--- a/src/plugin-personalization/operation/model/thememodel.cpp
+++ b/src/plugin-personalization/operation/model/thememodel.cpp
@@ -1,7 +1,120 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "thememodel.h"
+
+#include <QIcon>
+
+ThemeViewModel::ThemeViewModel(QObject *parent)
+    : QAbstractItemModel(parent)
+    , m_themeModel(nullptr)
+{
+
+}
+
+void ThemeViewModel::setThemeModel(ThemeModel *model)
+{
+    m_themeModel = model;
+    connect(m_themeModel, &ThemeModel::defaultChanged, this, &ThemeViewModel::updateData);
+    connect(m_themeModel, &ThemeModel::picAdded, this, &ThemeViewModel::updateData);
+    connect(m_themeModel, &ThemeModel::itemAdded, this, &ThemeViewModel::updateData);
+    connect(m_themeModel, &ThemeModel::itemRemoved, this, &ThemeViewModel::updateData);
+    updateData();
+}
+
+QModelIndex ThemeViewModel::index(int row, int column, const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    if (row < 0 || row >= m_keys.size())
+        return QModelIndex();
+    return createIndex(row, column);
+}
+
+QModelIndex ThemeViewModel::parent(const QModelIndex &index) const
+{
+    Q_UNUSED(index);
+    return QModelIndex();
+}
+
+int ThemeViewModel::rowCount(const QModelIndex &parent) const
+{
+    if (!parent.isValid())
+        return m_keys.size();
+
+    return 0;
+}
+
+int ThemeViewModel::columnCount(const QModelIndex &parent) const
+{
+    Q_UNUSED(parent);
+    return 1;
+}
+
+QVariant ThemeViewModel::data(const QModelIndex &index, int role) const
+{
+    if (m_keys.isEmpty() || !index.isValid())
+        return QVariant();
+
+    int row = index.row();
+    if (row < 0 || row >= m_keys.size())
+        return QVariant();
+
+    switch (role) {
+    case ThemeViewModel::NameRole:
+        return m_themeModel->getList().value(m_keys.at(row))["Name"].toString();
+    case Qt::ToolTipRole:
+        return m_themeModel->getList().value(m_keys.at(row))["Comment"].toString();
+    case Qt::DecorationRole:
+        return QIcon(m_themeModel->getPicList().value(m_keys.at(row)));
+    case Qt::CheckStateRole: {
+        QString id = m_themeModel->getDefault();
+        if (id.endsWith(".light")) {
+            id.chop(6);
+        } else if (id.endsWith(".dark")) {
+            id.chop(5);
+        }
+        return m_keys.at(row) == id ? Qt::Checked : Qt::Unchecked;
+    }
+    case ThemeViewModel::IdRole:
+        return m_keys.at(row);
+    case ThemeViewModel::PicRole: {
+        QString pic = m_themeModel->getPicList().value(m_keys.at(row));
+        return pic.startsWith("/") ? QUrl::fromLocalFile(pic).toString() : pic;
+    }
+    default:
+        break;
+    }
+    return QVariant();
+}
+
+void ThemeViewModel::updateData()
+{
+    QStringList keys = m_themeModel->keys();
+    if (keys.contains("custom")) {
+        keys.removeAll("custom");
+    }
+    // 按字母排序（不区分大小写）
+    std::sort(keys.begin(), keys.end(), [this](const QString &a, const QString &b) {
+        return m_themeModel->getList().value(a)["Name"].toString().toLower() < m_themeModel->getList().value(b)["Name"].toString().toLower();
+    });
+    // custom主题始终放在最前面
+    if (m_themeModel->keys().contains("custom")) {
+        keys.push_front("custom");
+    }
+    beginResetModel();
+    m_keys = keys;
+    endResetModel();
+}
+
+QHash<int, QByteArray> ThemeViewModel::roleNames() const
+{
+    QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
+    roles[IdRole] = "id";
+    roles[NameRole] = "name";
+    roles[PicRole] = "pic";
+    roles[Qt::CheckStateRole] = "checked";
+    return roles;
+}
 
 ThemeModel::ThemeModel(QObject *parent)
     : QObject(parent)

--- a/src/plugin-personalization/operation/model/thememodel.h
+++ b/src/plugin-personalization/operation/model/thememodel.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef THEMEMODEL_H
@@ -8,6 +8,41 @@
 #include <QMap>
 #include <QJsonObject>
 #include <QDebug>
+#include <QAbstractItemModel>
+
+class ThemeModel;
+class ThemeViewModel : public QAbstractItemModel
+{
+public:
+    enum UserDataRole {
+        IdRole = Qt::UserRole + 0x101,
+        NameRole,
+        PicRole
+    };
+    explicit ThemeViewModel(QObject *parent = nullptr);
+    ~ThemeViewModel() { }
+
+    void setThemeModel(ThemeModel *model);
+    // Basic functionality:
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &index) const override;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+
+protected:
+    QHash<int, QByteArray> roleNames() const override;
+
+private:
+    void updateData();
+
+private:
+    ThemeModel *m_themeModel;
+    QStringList m_keys;
+};
+
 
 class ThemeModel : public QObject
 {

--- a/src/plugin-personalization/operation/personalizationinterface.cpp
+++ b/src/plugin-personalization/operation/personalizationinterface.cpp
@@ -25,121 +25,10 @@
 #define PICKER_SERVICE "com.deepin.Picker"
 #define PICKER_PATH "/com/deepin/Picker"
 
-ThemeVieweModel::ThemeVieweModel(QObject *parent)
-    : QAbstractItemModel(parent)
-    , m_themeModel(nullptr)
-{
-
-}
-
-void ThemeVieweModel::setThemeModel(ThemeModel *model)
-{
-    m_themeModel = model;
-    connect(m_themeModel, &ThemeModel::defaultChanged, this, &ThemeVieweModel::updateData);
-    connect(m_themeModel, &ThemeModel::picAdded, this, &ThemeVieweModel::updateData);
-    connect(m_themeModel, &ThemeModel::itemAdded, this, &ThemeVieweModel::updateData);
-    connect(m_themeModel, &ThemeModel::itemRemoved, this, &ThemeVieweModel::updateData);
-    updateData();
-}
-
-QModelIndex ThemeVieweModel::index(int row, int column, const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    if (row < 0 || row >= m_keys.size())
-        return QModelIndex();
-    return createIndex(row, column);
-}
-
-QModelIndex ThemeVieweModel::parent(const QModelIndex &index) const
-{
-    Q_UNUSED(index);
-    return QModelIndex();
-}
-
-int ThemeVieweModel::rowCount(const QModelIndex &parent) const
-{
-    if (!parent.isValid())
-        return m_keys.size();
-
-    return 0;
-}
-
-int ThemeVieweModel::columnCount(const QModelIndex &parent) const
-{
-    Q_UNUSED(parent);
-    return 1;
-}
-
-QVariant ThemeVieweModel::data(const QModelIndex &index, int role) const
-{
-    if (m_keys.isEmpty() || !index.isValid())
-        return QVariant();
-
-    int row = index.row();
-    switch (role) {
-    case ThemeVieweModel::NameRole:
-        return m_themeModel->getList().value(m_keys.at(row))["Name"].toString();
-    case Qt::ToolTipRole:
-        return m_themeModel->getList().value(m_keys.at(row))["Comment"].toString();
-    case Qt::DecorationRole:
-        return QIcon(m_themeModel->getPicList().value(m_keys.at(row)));
-    case Qt::CheckStateRole: {
-        QString id = m_themeModel->getDefault();
-        if (id.endsWith(".light")) {
-            id.chop(6);
-        } else if (id.endsWith(".dark")) {
-            id.chop(5);
-        }
-        return m_keys.at(row) == id ? Qt::Checked : Qt::Unchecked;
-    }
-    case ThemeVieweModel::IdRole:
-        return m_keys.at(row);
-    case ThemeVieweModel::PicRole: {
-        QString pic = m_themeModel->getPicList().value(m_keys.at(row));
-        return pic.startsWith("/") ? QUrl::fromLocalFile(pic).toString() : pic;
-    }
-    default:
-        break;
-    }
-    return QVariant();
-}
-
-void ThemeVieweModel::updateData()
-{
-    QStringList keys = m_themeModel->keys();
-    if (keys.contains("custom")) {
-        keys.removeAll("custom");
-    }
-    // 按字母排序（不区分大小写）
-    std::sort(keys.begin(), keys.end(), [this](const QString &a, const QString &b) {
-        return m_themeModel->getList().value(a)["Name"].toString().toLower() < m_themeModel->getList().value(b)["Name"].toString().toLower();
-    });
-    // custom主题始终放在最前面
-    if (m_themeModel->keys().contains("custom")) {
-        keys.push_front("custom");
-    }
-    beginResetModel();
-    m_keys = keys;
-    endResetModel();
-}
-
-QHash<int, QByteArray> ThemeVieweModel::roleNames() const
-{
-    QHash<int, QByteArray> roles = QAbstractItemModel::roleNames();
-    roles[IdRole] = "id";
-    roles[NameRole] = "name";
-    roles[PicRole] = "pic";
-    roles[Qt::CheckStateRole] = "checked";
-    return roles;
-}
-
 PersonalizationInterface::PersonalizationInterface(QObject *parent) 
 : QObject(parent)
 , m_model(new PersonalizationModel(this))
 , m_imageHelper(new ImageHelper(this))
-, m_globalThemeViewModel(new ThemeVieweModel(this))
-, m_iconThemeViewModel(new ThemeVieweModel(this))
-, m_cursorThemeViewModel(new ThemeVieweModel(this))
 , m_pickerId(QUuid::createUuid().toString())
 , m_pickerAvailable(false)
 {
@@ -153,16 +42,10 @@ PersonalizationInterface::PersonalizationInterface(QObject *parent)
     qmlRegisterUncreatableMetaObject(WallpaperEnums::staticMetaObject, "org.deepin.dcc.personalization", 1, 0, "WallpaperEnums", "WallpaperEnums namespace");
     qmlRegisterType<PersonalizationExport>("org.deepin.dcc.personalization", 1, 0, "PersonalizationExport");
 
-    m_globalThemeViewModel->setThemeModel(m_model->getGlobalThemeModel());
-    m_iconThemeViewModel->setThemeModel(m_model->getIconModel());
-    m_cursorThemeViewModel->setThemeModel(m_model->getMouseModel());
-
     // after do
     m_work->active(); // refresh data
     m_work->refreshTheme();
     m_work->refreshFont();
-
-    initAppearanceSwitchModel();
 
     m_pickerAvailable = checkPickerService();
     if (m_pickerAvailable) {
@@ -172,37 +55,6 @@ PersonalizationInterface::PersonalizationInterface(QObject *parent)
     } else {
         qDebug() << "Picker service is not available, will use Qt's built-in color picker";
     }
-}
-
-void PersonalizationInterface::initAppearanceSwitchModel()
-{
-    ThemeModel *globalTheme = m_model->getGlobalThemeModel();
-
-    auto updateDefault = [this]() {
-        ThemeModel *globalTheme = m_model->getGlobalThemeModel();
-        QString mode;
-        QString themeId = getGlobalThemeId(globalTheme->getDefault(), mode);
-        m_appearanceSwitchModel.clear();
-        m_appearanceSwitchModel.append(QVariantMap{{"text", tr("Light")}, {"value", ".light"}});
-        const QJsonObject &json = globalTheme->getList().value(themeId);
-        if (json.isEmpty())
-            return;
-        if (json["hasDark"].toBool()) {
-            m_appearanceSwitchModel.append(QVariantMap{{"text", tr("Auto")}, {"value", ""}});
-            m_appearanceSwitchModel.append(QVariantMap{{"text", tr("Dark")}, {"value", ".dark"}});
-        }
-        Q_EMIT appearanceSwitchModelChanged(m_appearanceSwitchModel);
-        if (mode != m_currentAppearance) {
-            m_currentAppearance = mode;
-            Q_EMIT currentAppearanceChanged(m_currentAppearance);
-        }
-    };
-
-    updateDefault();
-
-    connect(globalTheme, &ThemeModel::defaultChanged, updateDefault);
-    connect(globalTheme, &ThemeModel::itemAdded, updateDefault);
-    connect(globalTheme, &ThemeModel::itemRemoved, updateDefault);
 }
 
 QString PersonalizationInterface::platformName()

--- a/src/plugin-personalization/operation/personalizationinterface.h
+++ b/src/plugin-personalization/operation/personalizationinterface.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -11,70 +11,29 @@
 #include "personalizationmodel.h"
 #include "imagehelper.h"
 
-class ThemeVieweModel : public QAbstractItemModel
-{
-public:
-    enum UserDataRole {
-        IdRole = Qt::UserRole + 0x101,
-        NameRole,
-        PicRole
-    };
-    explicit ThemeVieweModel(QObject *parent = nullptr);
-    ~ThemeVieweModel() { }
-
-    void setThemeModel(ThemeModel *model);
-    // Basic functionality:
-    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
-    QModelIndex parent(const QModelIndex &index) const override;
-
-    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
-    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
-
-    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
-
-protected:
-    QHash<int, QByteArray> roleNames() const override;
-
-private:
-    void updateData();
-
-private:
-    ThemeModel *m_themeModel;
-    QStringList m_keys;
-};
-
 class PersonalizationInterface : public QObject
 {
     Q_OBJECT
-    Q_PROPERTY(ThemeVieweModel *globalThemeModel MEMBER m_globalThemeViewModel CONSTANT)
-    Q_PROPERTY(ThemeVieweModel *iconThemeViewModel MEMBER m_iconThemeViewModel CONSTANT)
-    Q_PROPERTY(ThemeVieweModel *cursorThemeViewModel MEMBER m_cursorThemeViewModel CONSTANT)
     Q_PROPERTY(PersonalizationModel *model MEMBER m_model CONSTANT)
     Q_PROPERTY(PersonalizationWorker *worker MEMBER m_work CONSTANT)
     Q_PROPERTY(ImageHelper *imageHelper MEMBER m_imageHelper CONSTANT)
-    Q_PROPERTY(QVariantList appearanceSwitchModel MEMBER m_appearanceSwitchModel NOTIFY appearanceSwitchModelChanged)
-    Q_PROPERTY(QString currentAppearance MEMBER m_currentAppearance NOTIFY currentAppearanceChanged)
     Q_PROPERTY(bool pickerAvailable READ isPickerAvailable CONSTANT)
 
 public:
     explicit PersonalizationInterface(QObject *parent = nullptr);
 
-    QString getCurrentAppearance() const { return m_currentAppearance; };
     bool isPickerAvailable() const { return m_pickerAvailable; }
     Q_INVOKABLE QString platformName();
     Q_INVOKABLE void handleCmdParam(PersonalizationExport::ModuleType type, const QString &cmdParam);
     Q_INVOKABLE void startPicker();
 
 private:
-    void initAppearanceSwitchModel();
     bool checkPickerService();
 
 private Q_SLOTS:
     void onPickerColorPicked(const QString &uuid, const QString &colorName);
 
 signals:
-    void currentAppearanceChanged(const QString &appearance);
-    void appearanceSwitchModelChanged(const QVariantList &model);
     void colorPicked(const QString &color);
     void pickerError(const QString &error);
 
@@ -82,12 +41,6 @@ private:
     PersonalizationModel *m_model;
     PersonalizationWorker *m_work;
     ImageHelper *m_imageHelper;
-    ThemeVieweModel *m_globalThemeViewModel;
-    ThemeVieweModel *m_iconThemeViewModel;
-    ThemeVieweModel *m_cursorThemeViewModel;
-
-    QVariantList m_appearanceSwitchModel;
-    QString m_currentAppearance;
     QString m_pickerId;
     bool m_pickerAvailable;
 };

--- a/src/plugin-personalization/operation/personalizationmodel.cpp
+++ b/src/plugin-personalization/operation/personalizationmodel.cpp
@@ -44,6 +44,14 @@ PersonalizationModel::PersonalizationModel(QObject *parent)
     m_wantToSetWallpaperProgress = 0.0;
     m_wantToSetWallpaperStatus = WallpaperInstallStatus::Download_Installed;
     m_wantToSetWallpaper = false;
+
+    m_globalThemeViewModel = new ThemeViewModel(this);
+    m_iconThemeViewModel = new ThemeViewModel(this);
+    m_cursorThemeViewModel = new ThemeViewModel(this);
+
+    m_globalThemeViewModel->setThemeModel(m_globalThemeModel);
+    m_iconThemeViewModel->setThemeModel(m_iconModel);
+    m_cursorThemeViewModel->setThemeModel(m_mouseModel);
 }
 
 PersonalizationModel::~PersonalizationModel()
@@ -278,4 +286,19 @@ void PersonalizationModel::setWantToSetWallpaper(bool value)
 
     m_wantToSetWallpaper = value;
     Q_EMIT wantToSetWallpaperChanged();
+}
+
+void PersonalizationModel::setCurrentAppearance(const QString &appearance)
+{
+    if (m_currentAppearance == appearance)
+        return;
+
+    m_currentAppearance = appearance;
+    Q_EMIT currentAppearanceChanged(appearance);
+}
+
+void PersonalizationModel::setAppearanceSwitchModel(const QVariantList &model)
+{
+    m_appearanceSwitchModel = model;
+    Q_EMIT appearanceSwitchModelChanged(model);
 }

--- a/src/plugin-personalization/operation/personalizationmodel.h
+++ b/src/plugin-personalization/operation/personalizationmodel.h
@@ -6,6 +6,7 @@
 
 #include <QObject>
 #include "model/wallpapermodel.h"
+#include "model/thememodel.h"
 
 using namespace WallpaperEnums;
 
@@ -48,6 +49,13 @@ class PersonalizationModel : public QObject
 
     Q_PROPERTY(ThemeModel *iconModel MEMBER m_iconModel CONSTANT)
     Q_PROPERTY(ThemeModel *cursorModel MEMBER m_mouseModel CONSTANT)
+
+    Q_PROPERTY(ThemeViewModel *globalThemeViewModel MEMBER m_globalThemeViewModel CONSTANT)
+    Q_PROPERTY(ThemeViewModel *iconThemeViewModel MEMBER m_iconThemeViewModel CONSTANT)
+    Q_PROPERTY(ThemeViewModel *cursorThemeViewModel MEMBER m_cursorThemeViewModel CONSTANT)
+
+    Q_PROPERTY(QVariantList appearanceSwitchModel MEMBER m_appearanceSwitchModel NOTIFY appearanceSwitchModelChanged)
+    Q_PROPERTY(QString currentAppearance MEMBER m_currentAppearance NOTIFY currentAppearanceChanged)
 
     Q_PROPERTY(WallpaperSortModel *customWallpaperModel MEMBER m_customWallpaperSortModel CONSTANT)
     Q_PROPERTY(WallpaperSortModel *sysWallpaperModel MEMBER m_sysWallpaperSortModel CONSTANT)
@@ -158,6 +166,11 @@ public:
     inline bool wantToSetWallpaper() const { return m_wantToSetWallpaper; }
     void setWantToSetWallpaper(bool value);
 
+    QString getCurrentAppearance() const { return m_currentAppearance; };
+    void setCurrentAppearance(const QString &appearance);
+
+    void setAppearanceSwitchModel(const QVariantList &model);
+
 Q_SIGNALS:
     void wmChanged(const bool is3d);
     void opacityChanged(double opacity);
@@ -186,6 +199,9 @@ Q_SIGNALS:
     void miniEffectChanged(bool value);
     void supportEffectsChanged(const QStringList &value);
     void wantToSetWallpaperChanged();
+    void currentAppearanceChanged(const QString &appearance);
+    void appearanceSwitchModelChanged(const QVariantList &model);
+
 private:
     ThemeModel *m_windowModel;
     ThemeModel *m_iconModel;
@@ -237,5 +253,10 @@ private:
     WallpaperInstallStatus m_wantToSetWallpaperStatus;
     QString m_wantToSetWallpaperThumbnail;
     bool m_wantToSetWallpaper;
+    ThemeViewModel *m_globalThemeViewModel;
+    ThemeViewModel *m_iconThemeViewModel;
+    ThemeViewModel *m_cursorThemeViewModel;
+    QVariantList m_appearanceSwitchModel;
+    QString m_currentAppearance;
 };
 #endif // PERSONALIZATIONMODEL_H

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -171,6 +171,8 @@ void PersonalizationWorker::active()
     m_model->setScrollBarPolicyConfig(scrollbarConfig);
     QString compactDisplayConfig = m_personalizationConfig->value(COMPACT_MODE_DISPLAY_KEY).toString();
     m_model->setCompactDisplayConfig(compactDisplayConfig);
+
+    initAppearanceSwitchModel();
 }
 
 void PersonalizationWorker::deactive()
@@ -746,14 +748,47 @@ void PersonalizationWorker::setWallpaperForMonitor(const QString &, const QStrin
 
 }
 
-void PersonalizationWorker::setBackgroundForMonitor(const QString &, const QString &, bool, PersonalizationExport::WallpaperSetType type)
+void PersonalizationWorker::setBackgroundForMonitor(const QString &, const QString &, bool, PersonalizationExport::WallpaperSetType)
 {
 
 }
 
-void PersonalizationWorker::setLockBackForMonitor(const QString &, const QString &, bool, PersonalizationExport::WallpaperSetType type)
+void PersonalizationWorker::setLockBackForMonitor(const QString &, const QString &, bool, PersonalizationExport::WallpaperSetType)
 {
 
+}
+
+void PersonalizationWorker::initAppearanceSwitchModel()
+{
+    ThemeModel *globalTheme = m_model->getGlobalThemeModel();
+
+    auto updateDefault = [this]() {
+        ThemeModel *globalTheme = m_model->getGlobalThemeModel();
+        if (!globalTheme) {
+            return;
+        }
+
+        QString mode;
+        QString themeId = getGlobalThemeId(globalTheme->getDefault(), mode);
+        QVariantList appearanceSwitchModel;
+        appearanceSwitchModel.clear();
+        appearanceSwitchModel.append(QVariantMap{{"text", tr("Light")}, {"value", ".light"}});
+        const QJsonObject &json = globalTheme->getList().value(themeId);
+        if (json.isEmpty())
+            return;
+        if (json["hasDark"].toBool()) {
+            appearanceSwitchModel.append(QVariantMap{{"text", tr("Auto")}, {"value", ""}});
+            appearanceSwitchModel.append(QVariantMap{{"text", tr("Dark")}, {"value", ".dark"}});
+        }
+        m_model->setAppearanceSwitchModel(appearanceSwitchModel);
+        m_model->setCurrentAppearance(mode);
+    };
+
+    updateDefault();
+
+    connect(globalTheme, &ThemeModel::defaultChanged, updateDefault);
+    connect(globalTheme, &ThemeModel::itemAdded, updateDefault);
+    connect(globalTheme, &ThemeModel::itemRemoved, updateDefault);
 }
 
 PersonalizationWatcher::PersonalizationWatcher(PersonalizationWorker *work)

--- a/src/plugin-personalization/operation/personalizationworker.h
+++ b/src/plugin-personalization/operation/personalizationworker.h
@@ -109,6 +109,7 @@ private:
     void refreshActiveColor(const QString &color);
     void onPersonalizationConfigChanged(const QString &key);
     void onDTKConfigChanged(const QString &key);
+    void initAppearanceSwitchModel();
 
     template<typename T>
     T toSliderValue(std::vector<T> list, T value);

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -256,6 +256,12 @@ void TreeLandWorker::onWallpaperUrlsChanged()
     }
 }
 
+void TreeLandWorker::onWindowThemeTypeChanged(uint32_t type)
+{
+    qCDebug(DdcPersonnalizationTreelandWorker) << "Window theme type changed:" << type;
+    m_appearanceTheme = static_cast<PersonalizationAppearanceContext::theme_type>(type);
+}
+
 void TreeLandWorker::init()
 {
     if (m_appearanceContext.isNull()) { 
@@ -267,6 +273,8 @@ void TreeLandWorker::init()
     if (m_fontContext.isNull()) {
         m_fontContext.reset(new PersonalizationFontContext(m_personalizationManager->get_font_context(), this->m_model));
     }
+
+    connect(m_appearanceContext.get(), &PersonalizationAppearanceContext::windowThemeTypeChanged, this, &TreeLandWorker::onWindowThemeTypeChanged);
 }
 
 void TreeLandWorker::initWallpaperContext()
@@ -297,7 +305,7 @@ WallpaperContext *TreeLandWorker::getOrCreateWallpaperContext(const QString &mon
                     m_wallpaperContexts.insert(monitorName, ctx);
                     
                     connect(ctx, &WallpaperContext::wallpaperChanged, this, 
-                        [this, monitorName](WallpaperContext::wallpaper_role role, WallpaperContext::wallpaper_source_type type, const QString &fileSource) {
+                        [this, monitorName](WallpaperContext::wallpaper_role role, WallpaperContext::wallpaper_source_type, const QString &fileSource) {
                             qCDebug(DdcPersonnalizationTreelandWorker) << "Wallpaper changed for" << monitorName << "role:" << role << "source:" << fileSource;
                             
                             if (role == WallpaperContext::wallpaper_role_desktop) {
@@ -617,9 +625,25 @@ void PersonalizationAppearanceContext::treeland_personalization_appearance_conte
     // m_model->setOpacity(opacity / 100.0);
 }
 
-void PersonalizationAppearanceContext::treeland_personalization_appearance_context_v1_window_theme_type(uint32_t)
+void PersonalizationAppearanceContext::treeland_personalization_appearance_context_v1_window_theme_type(uint32_t themeType)
 {
-    // Using the value of the appearance module, this is an invalid value
+    Q_EMIT windowThemeTypeChanged(themeType);
+
+    switch (themeType) {
+    case PersonalizationAppearanceContext::theme_type::theme_type_light:
+        m_model->setCurrentAppearance(".light");
+        break;
+    case PersonalizationAppearanceContext::theme_type::theme_type_dark:
+        m_model->setCurrentAppearance(".dark");
+        break;
+    case PersonalizationAppearanceContext::theme_type::theme_type_auto:
+        m_model->setCurrentAppearance("");
+        break;
+    default:
+        qCWarning(DdcPersonnalizationTreelandWorker) << "Current theme type: unknown";
+        m_model->setCurrentAppearance("");
+        break;
+    }
 }
 
 void PersonalizationAppearanceContext::treeland_personalization_appearance_context_v1_window_titlebar_height(uint32_t height)

--- a/src/plugin-personalization/operation/treelandworker.h
+++ b/src/plugin-personalization/operation/treelandworker.h
@@ -93,6 +93,7 @@ public:
 
 public slots:
     void onWallpaperUrlsChanged() override;
+    void onWindowThemeTypeChanged(uint32_t type);
 
 signals:
     void wallpaperChanged();
@@ -166,6 +167,9 @@ protected:
     void treeland_personalization_appearance_context_v1_window_opacity(uint32_t opacity) override;
     void treeland_personalization_appearance_context_v1_window_theme_type(uint32_t type) override;
     void treeland_personalization_appearance_context_v1_window_titlebar_height(uint32_t height) override;
+signals:
+    void windowThemeTypeChanged(uint32_t type);
+
 private:
     PersonalizationModel *m_model;
 };

--- a/src/plugin-personalization/qml/ColorAndIcons.qml
+++ b/src/plugin-personalization/qml/ColorAndIcons.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick 2.15
@@ -159,7 +159,7 @@ DccObject {
                 weight: 1
                 pageType: DccObject.Item
                 page: IconThemeGridView {
-                    model: dccData.iconThemeViewModel
+                    model: dccData.model.iconThemeViewModel
                     onRequsetSetTheme: (id)=> {
                                            dccData.worker.setIconTheme(id)
                                        }
@@ -190,7 +190,7 @@ DccObject {
                 weight: 1
                 pageType: DccObject.Item
                 page: IconThemeGridView {
-                    model: dccData.cursorThemeViewModel
+                    model: dccData.model.cursorThemeViewModel
                     onRequsetSetTheme: (id)=> {
                                            dccData.worker.setCursorTheme(id)
                                        }

--- a/src/plugin-personalization/qml/PersonalizationMain.qml
+++ b/src/plugin-personalization/qml/PersonalizationMain.qml
@@ -105,10 +105,10 @@ DccObject {
             page: D.ComboBox {
                 flat: true
                 textRole: "text"
-                model: dccData.appearanceSwitchModel
+                model: dccData.model.appearanceSwitchModel
                 currentIndex: {
                     for (var i = 0; i < model.length; ++i) {
-                        if (model[i].value === dccData.currentAppearance) {
+                        if (model[i].value === dccData.model.currentAppearance) {
                             return i;
                         }
                     }
@@ -117,7 +117,7 @@ DccObject {
 
                 enabled: model.length > 1
                 onCurrentIndexChanged: {
-                    if (dccData.currentAppearance !== model[currentIndex].value) {
+                    if (dccData.model.currentAppearance !== model[currentIndex].value) {
                         dccData.worker.setAppearanceTheme(model[currentIndex].value)
                     }
                 }

--- a/src/plugin-personalization/qml/ThemeSelectView.qml
+++ b/src/plugin-personalization/qml/ThemeSelectView.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
@@ -25,7 +25,7 @@ FocusScope {
 
     property int focusedThemeIndex: 0
     // 记录上次的模型数量，用于判断是否真正需要重置焦点
-    property int lastModelCount: dccData.globalThemeModel ? dccData.globalThemeModel.rowCount() : 0
+    property int lastModelCount: dccData.model.globalThemeViewModel ? dccData.model.globalThemeViewModel.rowCount() : 0
     property bool hadLostFocus: false
 
     onActiveFocusChanged: {
@@ -51,7 +51,7 @@ FocusScope {
 
     Keys.onRightPressed: {
         // +1 for "More Wallpapers"
-        var totalCount = dccData.globalThemeModel.rowCount() + 1
+        var totalCount = dccData.model.globalThemeViewModel.rowCount() + 1
         if (focusedThemeIndex < totalCount - 1) {
             focusedThemeIndex++
             var pageIndex = Math.floor(focusedThemeIndex / (listview.gridMaxColumns * listview.gridMaxRows))
@@ -68,7 +68,7 @@ FocusScope {
     }
 
     Keys.onDownPressed: {
-        var totalCount = dccData.globalThemeModel.rowCount() + 1
+        var totalCount = dccData.model.globalThemeViewModel.rowCount() + 1
         if (focusedThemeIndex + listview.gridMaxColumns < totalCount) {
             focusedThemeIndex += listview.gridMaxColumns
         }
@@ -78,13 +78,13 @@ FocusScope {
     Keys.onEnterPressed: activateCurrentItem()
     Keys.onSpacePressed: activateCurrentItem()
 
-    // IdRole value from ThemeVieweModel::UserDataRole (Qt::UserRole + 0x101 = 0x201)
+    // IdRole value from ThemeViewModel::UserDataRole (Qt::UserRole + 0x101 = 0x201)
     readonly property int themeIdRole: 0x201
 
     function activateCurrentItem() {
-        var totalThemes = dccData.globalThemeModel.rowCount()
+        var totalThemes = dccData.model.globalThemeViewModel.rowCount()
         if (focusedThemeIndex < totalThemes) {
-            var themeId = dccData.globalThemeModel.data(dccData.globalThemeModel.index(focusedThemeIndex, 0), themeIdRole)
+            var themeId = dccData.model.globalThemeViewModel.data(dccData.model.globalThemeViewModel.index(focusedThemeIndex, 0), themeIdRole)
             listview.selectTheme = themeId
             dccData.worker.setGlobalTheme(themeId)
         } else {
@@ -119,7 +119,7 @@ FocusScope {
             property int gridMaxRows: 2
 
             property string selectTheme: ""
-            model: Math.ceil((dccData.globalThemeModel.rowCount()  + 1) / (2 * gridMaxColumns))
+            model: Math.ceil((dccData.model.globalThemeViewModel.rowCount()  + 1) / (2 * gridMaxColumns))
             spacing: 0
             clip: true
             orientation: ListView.Horizontal
@@ -132,9 +132,9 @@ FocusScope {
             highlightMoveVelocity: -1
 
             Connections {
-                target: dccData.globalThemeModel
+                target: dccData.model.globalThemeViewModel
                 function onModelReset() {
-                    var newCount = dccData.globalThemeModel.rowCount()
+                    var newCount = dccData.model.globalThemeViewModel.rowCount()
                     // 只有当模型数量真正发生变化时才重置焦点
                     if (newCount !== root.lastModelCount) {
                         listview.selectTheme = ""
@@ -149,7 +149,7 @@ FocusScope {
                 height: listview.height
                 D.SortFilterModel {
                     id: sortedModel
-                    model: dccData.globalThemeModel
+                    model: dccData.model.globalThemeViewModel
                     property int pageIndex: index
                     property int maxCount: listview.gridMaxColumns * listview.gridMaxRows
                     lessThan: function(left, right) {
@@ -244,7 +244,7 @@ FocusScope {
                         Layout.fillWidth: true
                         visible: index === listview.model - 1
                         color: "transparent"
-                        property int itemGlobalIndex: dccData.globalThemeModel.rowCount()
+                        property int itemGlobalIndex: dccData.model.globalThemeViewModel.rowCount()
                         property bool isFocused: root.activeFocus && root.focusedThemeIndex === itemGlobalIndex
 
                         ColumnLayout {


### PR DESCRIPTION
1. Move ThemeVieweModel class from PersonalizationInterface to ThemeModel
2. Move globalThemeViewModel, iconThemeViewModel, cursorThemeViewModel to PersonalizationModel
3. Move appearanceSwitchModel and currentAppearance from PersonalizationInterface to PersonalizationModel
4. Move initAppearanceSwitchModel() from PersonalizationInterface to PersonalizationWorker
5. Update QML bindings to use dccData.model.xxx instead of dccData.xxx
6. Handle TreeLand window theme type changes to update current appearance

Log: refactor personalization module, move theme view models and appearance state from interface to model layer

refactor(personalization): 将主题模型从接口层移至模型层

1. 将 ThemeVieweModel 类从 PersonalizationInterface 移至 ThemeModel
2. 将 globalThemeViewModel、iconThemeViewModel、cursorThemeViewModel 移至 PersonalizationModel
3. 将 appearanceSwitchModel 和 currentAppearance 从 PersonalizationInterface 移至 PersonalizationModel
4. 将 initAppearanceSwitchModel() 从 PersonalizationInterface 移至 PersonalizationWorker
5. 更新 QML 绑定路径，使用 dccData.model.xxx 替代 dccData.xxx
6. 处理 TreeLand 窗口主题类型变化以更新当前外观状态

Log: 重构个性化模块，将主题视图模型和外观状态从接口层移至模型层
PMS: BUG-346357