### PR TITLE
fix(personalization): hide automatic wallpaper option in Treeland env…

### DIFF
--- a/src/plugin-personalization/operation/personalizationdbusproxy.cpp
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.cpp
@@ -52,13 +52,13 @@ PersonalizationDBusProxy::PersonalizationDBusProxy(QObject *parent)
 {
     m_AppearanceInter = new DDBusInterface(AppearanceService, AppearancePath, AppearanceInterface, QDBusConnection::sessionBus(), this);
     m_DaemonInter = new DDBusInterface(DaemonService, DaemonPath, DaemonInterface, QDBusConnection::systemBus(), this);
-    m_wallpaperSlideshowInter = new DDBusInterface(WallpaperSlideshowService, WallpaperSlideshowPath, WallpaperSlideshowInterface, QDBusConnection::sessionBus(), this);
     m_powerInter = new DDBusInterface(PowerService, PowerPath, PowerInterface, QDBusConnection::sessionBus(), this);
     m_lastoreManagerInter = new DDBusInterface(LastoreManagerService, LastoreManagerPath, LastoreManagerInterface, QDBusConnection::systemBus(), this);
     if (!DGuiApplicationHelper::testAttribute(DGuiApplicationHelper::IsWaylandPlatform)) {
         m_WMInter = new DDBusInterface(WMService, WMPath, WMInterface, QDBusConnection::sessionBus(), this);
         m_EffectsInter = new DDBusInterface(EffectsService, EffectsPath, EffectsInterface, QDBusConnection::sessionBus(), this);
         m_screenSaverInter = new DDBusInterface(ScreenSaverServive, ScreenSaverPath, ScreenSaverInterface, QDBusConnection::sessionBus(), this);
+        m_wallpaperSlideshowInter = new DDBusInterface(WallpaperSlideshowService, WallpaperSlideshowPath, WallpaperSlideshowInterface, QDBusConnection::sessionBus(), this);
     }
 
     connect(m_AppearanceInter, SIGNAL(Changed(const QString &, const QString &)), this, SIGNAL(Changed(const QString &, const QString &)));

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -328,6 +328,10 @@ void PersonalizationWorker::onBatteryScreenSaverTimeoutChanged(int value)
 
 void PersonalizationWorker::onWallpaperSlideShowChanged()
 {
+    if (Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform)) {
+        return;
+    }
+
     QVariantMap wallpaperSlideShowMap;
     QStringList screenNameList;
     for (const auto screen : qApp->screens()) {
@@ -565,6 +569,11 @@ void PersonalizationWorker::setScreenSaver(const QString &value)
 
 void PersonalizationWorker::setWallpaperSlideShow(const QString &monitorName, const QString &sliderShow)
 {
+    if (Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform)) {
+        qCWarning(DdcPersonalWorker) << "Wallpaper slideshow is not supported in Treeland currently.";
+        return;
+    }
+
     m_personalizationDBusProxy->setWallpaperSlideShow(monitorName, sliderShow);
 }
 

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -166,6 +166,7 @@ DccObject {
                 name: "automaticWallpaper"
                 parentName: "personalization/wallpaper/wallpaperStatusGroup/wallpaperSetGroup"
                 displayName: qsTr("Automatic wallpaper change")
+                visible: !DccApp.isTreeland()
                 weight: 200
                 pageType: DccObject.Editor
                 page: CustomComboBox {


### PR DESCRIPTION
…ironment

1. Added visible property to hide automatic wallpaper change option when running Treeland
2. Automatic wallpaper change is not supported in Treeland environment

Log: Hide automatic wallpaper change option in Treeland

fix(personalization): 隐藏 Treeland 环境下的自动换壁纸选项

1. 添加 visible 属性，在 Treeland 环境下隐藏自动换壁纸选项
2. Treeland 环境暂不支持自动更换壁纸

Log: 在 Treeland 环境下隐藏自动换壁纸选项

## Summary by Sourcery

Bug Fixes:
- Prevent users in Treeland environments from seeing and selecting the unsupported automatic wallpaper change option.