### PR TITLE
fix: ensure control center displays when showing specific page

### DIFF
--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -204,6 +204,7 @@ int main(int argc, char *argv[])
             dccManager->toggle();
         } else if (!page.isEmpty()) {
             dccManager->showPage(page);
+            dccManager->show();
         } else if (parser.isSet(showOption) && !parser.isSet(dbusOption)) {
             dccManager->show();
         }


### PR DESCRIPTION
When navigating to a specific page via command line argument, the
control center was being prepared in the background without making it
visible. Adding the show() call ensures the window is properly displayed
after loading the target page.

Log: Fixed control center not showing when opening specific page

Influence:
1. Test opening control center with specific page argument, verify
window appears
2. Test opening without arguments, ensure normal behavior unchanged
3. Verify regression: toggle and show options still work correctly
4. Test with invalid page argument, verify error handling

fix: 确保打开指定页面时控制中心正常显示

通过命令行参数导航到特定页面时，控制中心仅在后台准备就绪而未显示窗口。添
加 show() 调用确保加载目标页面后窗口正确显示。

Log: 修复了打开指定页面时控制中心不显示的问题

Influence:
1. 测试使用指定页面参数打开控制中心，验证窗口是否显示
2. 测试不传参数打开，确保原有功能正常
3. 回归测试：切换和显示选项是否正常工作
4. 测试无效页面参数，验证错误处理

PMS: BUG-295555

## Summary by Sourcery

Bug Fixes:
- Fix control center not becoming visible when opened with a specific page argument while still loading the requested page in the background.