### PR TITLE
fix(wallpaper): replace visibility/scale with opacity animation for d…

### DIFF
--- a/src/plugin-personalization/qml/WallpaperSelectView.qml
+++ b/src/plugin-personalization/qml/WallpaperSelectView.qml
@@ -401,13 +401,21 @@ ColumnLayout {
                         anchors.rightMargin: - width / 2 + root.imageMargin + 2
                         hoverEnabled: true
                         z: 999
+                        // replace visible with opacity for animation
+                        opacity: ((control.hovered || hovered) && model.deleteAble && !model.selected) ? 1 : 0
+                        visible: opacity > 0
+                        Behavior on opacity {
+                            NumberAnimation {
+                                duration: 300
+                                easing.type: Easing.OutExpo
+                            }
+                        }
                         contentItem: D.ActionButton {
                             icon.name: "close"
                             implicitWidth: 20
                             implicitHeight: 20
                             icon.width: 14
                             icon.height: 14
-                            visible: (control.hovered || parent.hovered) && model.deleteAble && !model.selected
                             background: D.BoxPanel {
                                 radius: width / 2
                                 enableBoxShadow: true
@@ -440,13 +448,6 @@ ColumnLayout {
                             }
                             onClicked: {
                                 root.wallpaperDeleteClicked(model.url)
-                            }
-                            scale: visible ? 1 : 0
-                            Behavior on scale {
-                                NumberAnimation {
-                                    duration: 300
-                                    easing.type: Easing.OutExpo
-                                }
                             }
                         }
                     }


### PR DESCRIPTION
…elete button

1. Replaced visible property with opacity on the delete button loader for smoother show/hide transitions
2. Removed scale-based animation on the ActionButton in favor of opacity fade on the parent container
3. Added NumberAnimation with Easing.OutExpo for a 300ms opacity transition

Log: Use opacity fade instead of visibility/scale for wallpaper delete button animation

fix(wallpaper): 用透明度动画替换删除按钮的可见性/缩放动画

1. 将删除按钮加载器的 visible 属性替换为 opacity，实现更平滑的显示/隐藏过渡
2. 移除 ActionButton 上的 scale 缩放动画，改为在父容器上使用 opacity 淡入淡出
3. 添加 300ms 的 NumberAnimation 透明度过渡动画，使用 Easing.OutExpo 缓动曲线

Log: 壁纸删除按钮动画改用透明度淡入淡出替代可见性/缩放动画
PMS: BUG-363375

## Summary by Sourcery

Use opacity-based animation for the wallpaper delete button to improve its show/hide transition.

Bug Fixes:
- Resolve jerky or abrupt wallpaper delete button appearance by replacing visibility and scale changes with a smooth opacity transition.

Enhancements:
- Switch the delete button loader and container to a 300ms eased opacity fade instead of visibility/scale-based animation for a smoother UX.