### PR TITLE
fix(treeland-worker): bind wallpaper context lifecycle to screen and …

### DIFF
--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -519,6 +519,15 @@ void TreeLandWorker::active()
             }
         });
     }
+
+    connect(qApp, &QGuiApplication::screenRemoved, this, [this](QScreen *screen) {
+        const QString &name = screen->name();
+        qCDebug(DdcPersonnalizationTreelandWorker) << "Screen removed, cleaning up wallpaper contexts for:" << name;
+        delete m_wallpaperContexts.take(name);
+        delete m_wallpapers.take(name);
+        delete m_lockWallpapers.take(name);
+    });
+
     PersonalizationWorker::active();
 }
 
@@ -750,7 +759,19 @@ void WallpaperContext::treeland_wallpaper_v1_changed(uint32_t role, uint32_t sou
 
 void WallpaperContext::treeland_wallpaper_v1_failed(const QString &file_source, uint32_t error)
 {
-    qCWarning(DdcPersonnalizationTreelandWorker) << "wallpaper failed:" << file_source << "error:" << error;
+    const char *errorDesc = "unknown error";
+    switch (error) {
+    case error_already_used:
+        errorDesc = "source already configured";
+        break;
+    case error_invalid_source:
+        errorDesc = "source is invalid, unsupported, or could not be processed";
+        break;
+    case error_permission_denied:
+        errorDesc = "permission denied, check file permissions";
+        break;
+    }
+    qCWarning(DdcPersonnalizationTreelandWorker) << "wallpaper failed:" << file_source << "-" << errorDesc;
     Q_EMIT wallpaperFailed(file_source, error);
 }
 


### PR DESCRIPTION
…improve error logging

1. Clean up wallpaper contexts and metadata when a screen is removed, ensuring treeland_wallpaper_v1 is destroyed before wl_output per protocol requirement
2. Replace raw numeric error code with human-readable description in treeland_wallpaper_v1_failed log output

Log: Clean up wallpaper contexts on screen removal and improve error logging

fix(treeland-worker): 绑定壁纸上下文生命周期到屏幕并优化错误日志

1. 屏幕移除时清理对应的壁纸上下文和元数据，确保 treeland_wallpaper_v1 在 wl_output 之前销毁，满足协议要求
2. 将 treeland_wallpaper_v1_failed 中的裸数字错误码替换为可读的错误描述

Log: 屏幕移除时清理壁纸上下文，优化错误日志输出

## Summary by Sourcery

Bind wallpaper context lifecycle to screen removal and improve wallpaper failure logging.

Bug Fixes:
- Clean up wallpaper contexts and associated metadata when a screen is removed to prevent stale state and respect protocol destruction order between treeland_wallpaper_v1 and wl_output.

Enhancements:
- Log human-readable error descriptions instead of raw numeric codes when wallpaper initialization fails.