### PR TITLE
refactor(personalization): use libffmpegthumbnailer for video thumbnails

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,6 +37,7 @@ Build-Depends:
  libssl-dev,
  libdde-shell-dev(>= 1.99.20),
  libdpkg-dev,
+ libffmpegthumbnailer-dev,
  dde-api-dev (>> 6.0.39)
 Standards-Version: 4.5.0
 Homepage: https://github.com/linuxdeepin/dde-control-center
@@ -53,7 +54,6 @@ Depends:
  libdtk6declarative(>> 6.7.40),
  netselect,
  dde-daemon (>> 6.1.88),
- ffmpeg,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock
 Replaces: dde-control-center-dock

--- a/src/plugin-personalization/CMakeLists.txt
+++ b/src/plugin-personalization/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.18)
 set(LIB_NAME personalization)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FFMPEGTHUMBNAILER REQUIRED IMPORTED_TARGET libffmpegthumbnailer)
+
 find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
   find_package(Qt6 COMPONENTS WaylandClientPrivate REQUIRED)
@@ -41,6 +44,7 @@ set(Personalization_Libraries
     ${QT_NS}::DBus
     ${QT_NS}::Qml
     ${QT_NS}::WaylandClientPrivate
+    PkgConfig::FFMPEGTHUMBNAILER
 )
 
 target_include_directories(${LIB_NAME} PUBLIC

--- a/src/plugin-personalization/operation/wallpaperprovider.cpp
+++ b/src/plugin-personalization/operation/wallpaperprovider.cpp
@@ -14,7 +14,7 @@
 #include <QUrl>
 #include <QDir>
 #include <QHash>
-#include <QProcess>
+#include <libffmpegthumbnailer/videothumbnailer.h>
 #include <QCryptographicHash>
 #include <QStandardPaths>
 #include <QPointer>
@@ -554,17 +554,25 @@ void InterfaceWorker::generateVideoThumbnail(const QString &videoPath, const QSt
         if (!guard->m_running.load(std::memory_order_acquire))
             return;
 
-        QProcess ffmpeg;
-        ffmpeg.setProgram("/usr/bin/ffmpeg");
-        ffmpeg.setArguments({"-i", videoPath, "-ss", "00:00:01", "-vframes", "1",
-                             "-vf", "scale=480:-1", "-update", "1", "-y", cachePath});
-        ffmpeg.start();
-        ffmpeg.waitForFinished(5000);
+        ffmpegthumbnailer::VideoThumbnailer thumbnailer(480, false, true, 8, false);
+        thumbnailer.setThumbnailSize(480, -1);
+        thumbnailer.setSeekTime("00:00:01");
+
+        try {
+            thumbnailer.generateThumbnail(videoPath.toStdString(), Png, cachePath.toStdString());
+        } catch (const std::exception &e) {
+            if (!guard)
+                return;
+            qCWarning(DdcPersonalizationWallpaperWorker)
+                << "Failed to generate video thumbnail:" << e.what()
+                << "video:" << videoPath;
+            return;
+        }
 
         if (!guard)
             return;
 
-        if (ffmpeg.exitCode() == 0 && QFile::exists(cachePath)) {
+        if (QFile::exists(cachePath)) {
             Q_EMIT guard->videoThumbnailReady(id, cachePath);
         }
     });


### PR DESCRIPTION
1. Replace QProcess-based ffmpeg call with libffmpegthumbnailer C API
2. Add libffmpegthumbnailer-dev as build dependency, drop ffmpeg runtime dependency
3. Integrate libffmpegthumbnailer via pkg-config in CMakeLists.txt
4. Maintain same thumbnail settings: 480px width, 1s seek time, PNG output

Log: Replace external ffmpeg process with libffmpegthumbnailer library for generating video thumbnails

refactor(personalization): 使用 libffmpegthumbnailer 库生成视频缩略图

1. 使用 libffmpegthumbnailer C API 替代基于 QProcess 的 ffmpeg 调用
2. 添加 libffmpegthumbnailer-dev 编译依赖，移除 ffmpeg 运行时依赖
3. 在 CMakeLists.txt 中通过 pkg-config 集成 libffmpegthumbnailer
4. 保持相同的缩略图参数：480px 宽度、1 秒定位、PNG 输出格式

Log: 使用 libffmpegthumbnailer 库替代外部 ffmpeg 进程生成视频缩略图

## Summary by Sourcery

Refactor video thumbnail generation in the personalization plugin to use the libffmpegthumbnailer library instead of spawning an external ffmpeg process, and wire the new dependency into the CMake build.

Enhancements:
- Replace QProcess-based ffmpeg invocation with libffmpegthumbnailer C API for video thumbnail generation while preserving existing thumbnail parameters.
- Integrate libffmpegthumbnailer via pkg-config and link it into the personalization plugin build.