### PR TITLE
feat: add Treeland Wayland input device support for keyboard and mouse settings

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends:
  qt6-wayland-private-dev,
  qt6-wayland-dev-tools,
  wlr-protocols,
- treeland-protocols(>=0.4.1),
+ treeland-protocols(>>0.5.7),
  systemd,
  libdareader-dev,
  libdeepin-pw-check-dev,

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -954,9 +954,10 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     setAnimationMode(animationMode);
 
     // 更新当前对象
+    const bool currentObjectsUpdated = (m_currentObjects != modules);
+    const bool triggeredObjectsUpdated = (m_triggeredObjects != triggeredObjs);
     m_currentObjects = modules;
     m_triggeredObjects = triggeredObjs;
-    Q_EMIT triggeredObjectsChanged(m_triggeredObjects);
     if (auto *lastObj = m_currentObjects.last(); lastObj != m_activeObject) {
         m_activeObject = lastObj;
         Q_EMIT activeObjectChanged(m_activeObject);
@@ -985,6 +986,11 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     if (auto *parentItem = triggeredObj->parentItem(); !(triggeredObj->pageType() & DccObject::Menu) && parentItem) {
         Q_EMIT activeItemChanged(parentItem, indicatorShown);
     }
+
+    if (currentObjectsUpdated)
+        Q_EMIT currentObjectsChanged(m_currentObjects);
+    if (triggeredObjectsUpdated)
+        Q_EMIT triggeredObjectsChanged(m_triggeredObjects);
 }
 
 QSet<QString> findAddItems(QSet<QString> *oldSet, QSet<QString> *newSet)

--- a/src/plugin-keyboard/CMakeLists.txt
+++ b/src/plugin-keyboard/CMakeLists.txt
@@ -5,6 +5,9 @@ if (BUILD_PLUGIN)
         "operation/*.cpp"
         "operation/qrc/keyboard.qrc"
     )
+    if (NOT Enable_TreelandSupport)
+        list(FILTER keyboard_SRCS EXCLUDE REGEX ".*/operation/keyboardwaylandproxy\\.(h|cpp)$")
+    endif()
     file(GLOB_RECURSE keyboard_qml_SRCS
         "qml/*.qml"
     )

--- a/src/plugin-keyboard/operation/ikeyboarddeviceproxy.h
+++ b/src/plugin-keyboard/operation/ikeyboarddeviceproxy.h
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QtGlobal>
+
+namespace DCC_NAMESPACE {
+
+class IKeyboardDeviceProxy
+{
+public:
+    virtual ~IKeyboardDeviceProxy() = default;
+
+    virtual void active() = 0;
+
+    virtual uint repeatDelay() const = 0;
+    virtual uint repeatInterval() const = 0;
+    virtual int numLockState() const = 0;
+
+    virtual void setRepeatDelay(uint value) = 0;
+    virtual void setRepeatInterval(uint value) = 0;
+    virtual void setNumLockState(int value) = 0;
+};
+
+} // namespace DCC_NAMESPACE
+

--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -403,6 +403,13 @@ bool KeyboardController::isShortcutNameExists(const QString &name, const QString
     return isCustomShortcutNameExists(name, excludeId);
 }
 
+void KeyboardController::refreshKeyboard()
+{
+    if (m_worker) {
+        m_worker->refreshKeyboard();
+    }
+}
+
 }
 
 #include "keyboardcontroller.moc"

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -74,6 +74,9 @@ public Q_SLOTS:
     
     // 检查自定义快捷键名称是否已存在（排除指定ID）
     bool isCustomShortcutNameExists(const QString &name, const QString &excludeId = QString());
+
+    /** 刷新键盘 settings） */
+    Q_INVOKABLE void refreshKeyboard();
     
     // 检查系统快捷键名称是否已存在
     bool isSystemShortcutNameExists(const QString &name);

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -119,7 +119,7 @@ void KeyboardDBusProxy::setLayoutScope(int value)
 }
 
 
-uint KeyboardDBusProxy::repeatDelay()
+uint KeyboardDBusProxy::repeatDelay() const
 {
     return qvariant_cast<uint>(m_dBusKeyboardInter->property("RepeatDelay"));
 }
@@ -141,7 +141,7 @@ void KeyboardDBusProxy::setRepeatEnabled(bool value)
 }
 
 
-uint KeyboardDBusProxy::repeatInterval()
+uint KeyboardDBusProxy::repeatInterval() const
 {
     return qvariant_cast<uint>(m_dBusKeyboardInter->property("RepeatInterval"));
 }
@@ -180,9 +180,14 @@ QStringList KeyboardDBusProxy::locales()
 }
 
 //Keybinding
-int KeyboardDBusProxy::numLockState()
+int KeyboardDBusProxy::numLockState() const
 {
     return qvariant_cast<int>(m_dBusKeybingdingInter->property("NumLockState"));
+}
+
+void KeyboardDBusProxy::setNumLockState(int value)
+{
+    SetNumLockState(value != 0);
 }
 
 uint KeyboardDBusProxy::shortcutSwitchLayout()

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -1,9 +1,11 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
 #ifndef KEYBOARDDBUSPROXY_H
 #define KEYBOARDDBUSPROXY_H
+
+#include "ikeyboarddeviceproxy.h"
 
 #include <DDBusInterface>
 
@@ -65,11 +67,12 @@ namespace dccV25 {
 class DCCDBusInterface;
 }
 
-class KeyboardDBusProxy : public QObject
+class KeyboardDBusProxy : public QObject, public DCC_NAMESPACE::IKeyboardDeviceProxy
 {
     Q_OBJECT
 public:
     explicit KeyboardDBusProxy(QObject *parent = nullptr);
+    void active() override {}
 
     //Keyboard
     Q_PROPERTY(bool CapslockToggle READ capslockToggle WRITE setCapslockToggle NOTIFY CapslockToggleChanged)
@@ -89,7 +92,7 @@ public:
     void setLayoutScope(int value);
 
     Q_PROPERTY(uint RepeatDelay READ repeatDelay WRITE setRepeatDelay NOTIFY RepeatDelayChanged)
-    uint repeatDelay();
+    uint repeatDelay() const override;
     void setRepeatDelay(uint value);
 
     Q_PROPERTY(bool RepeatEnabled READ repeatEnabled WRITE setRepeatEnabled NOTIFY RepeatEnabledChanged)
@@ -97,7 +100,7 @@ public:
     void setRepeatEnabled(bool value);
 
     Q_PROPERTY(uint RepeatInterval READ repeatInterval WRITE setRepeatInterval NOTIFY RepeatIntervalChanged)
-    uint repeatInterval();
+    uint repeatInterval() const override;
     void setRepeatInterval(uint value);
 
     Q_PROPERTY(QStringList UserLayoutList READ userLayoutList NOTIFY UserLayoutListChanged)
@@ -118,7 +121,8 @@ public:
 
     //Keybinding
     Q_PROPERTY(int NumLockState READ numLockState NOTIFY NumLockStateChanged)
-    int numLockState();
+    int numLockState() const override;
+    void setNumLockState(int value) override;
 
     Q_PROPERTY(uint ShortcutSwitchLayout READ shortcutSwitchLayout WRITE setShortcutSwitchLayout NOTIFY ShortcutSwitchLayoutChanged)
     uint shortcutSwitchLayout();

--- a/src/plugin-keyboard/operation/keyboardmodel.h
+++ b/src/plugin-keyboard/operation/keyboardmodel.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/src/plugin-keyboard/operation/keyboardwaylandproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboardwaylandproxy.cpp
@@ -1,0 +1,169 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "keyboardwaylandproxy.h"
+
+#include "treelandinputmanager.h"
+
+#include <QLoggingCategory>
+
+using namespace DCC_NAMESPACE;
+
+Q_LOGGING_CATEGORY(lcKeyboardWaylandProxy, "dde.dcc.keyboard.wayland")
+
+KeyboardWaylandProxy::KeyboardWaylandProxy(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void KeyboardWaylandProxy::active()
+{
+    qCDebug(lcKeyboardWaylandProxy) << "KeyboardWaylandProxy::active()";
+    m_inputManager = new TreelandInputManager(this);
+
+    connect(m_inputManager, &TreelandInputManager::keyboardAvailableChanged, this,
+            [this](bool avail) {
+                qCDebug(lcKeyboardWaylandProxy) << "keyboardAvailableChanged:" << avail;
+                if (avail) {
+                    connectKeyboardSettings(m_inputManager->keyboardSettings());
+                } else {
+                    disconnectKeyboardSettings();
+                }
+                Q_EMIT KeyboardAvailableChanged(avail);
+            });
+
+    if (m_inputManager->keyboardAvailable()) {
+        qCDebug(lcKeyboardWaylandProxy) << "Keyboard already available, connecting immediately";
+        connectKeyboardSettings(m_inputManager->keyboardSettings());
+    } else {
+        qCDebug(lcKeyboardWaylandProxy) << "Keyboard not yet available, waiting for signal";
+    }
+    Q_EMIT KeyboardAvailableChanged(m_inputManager->keyboardAvailable());
+}
+
+void KeyboardWaylandProxy::connectKeyboardSettings(TreelandKeyboardSettings *kbd)
+{
+    if (!kbd || m_keyboardSettings == kbd)
+        return;
+    m_keyboardSettings = kbd;
+    qCDebug(lcKeyboardWaylandProxy) << "Connecting to TreelandKeyboardSettings";
+
+    connect(kbd, &TreelandKeyboardSettings::repeatChanged, this,
+            [this](int rate, int delay) {
+                qCDebug(lcKeyboardWaylandProxy) << "repeatChanged: rate=" << rate << "Hz delay=" << delay << "ms";
+                Q_EMIT RepeatDelayChanged(static_cast<uint>(delay));
+                Q_EMIT RepeatIntervalChanged(rateToInterval(rate));
+            });
+
+    connect(kbd, &TreelandKeyboardSettings::numLockChanged, this,
+            [this](bool on) {
+                qCDebug(lcKeyboardWaylandProxy) << "numLockChanged:" << on;
+                Q_EMIT NumLockStateChanged(on ? 1 : 0);
+            });
+
+    // 发射当前已缓存的初始状态，使 Worker 立即更新 Model
+    qCDebug(lcKeyboardWaylandProxy) << "Emitting initial state: rate=" << kbd->repeatRate()
+                                    << "delay=" << kbd->repeatDelay()
+                                    << "numLock=" << kbd->numLock();
+    Q_EMIT RepeatDelayChanged(static_cast<uint>(kbd->repeatDelay()));
+    Q_EMIT RepeatIntervalChanged(rateToInterval(kbd->repeatRate()));
+    Q_EMIT NumLockStateChanged(kbd->numLock() ? 1 : 0);
+}
+
+void KeyboardWaylandProxy::disconnectKeyboardSettings()
+{
+    if (!m_keyboardSettings)
+        return;
+
+    disconnect(m_keyboardSettings, nullptr, this, nullptr);
+    m_keyboardSettings = nullptr;
+}
+
+bool KeyboardWaylandProxy::keyboardAvailable() const
+{
+    return m_inputManager && m_inputManager->keyboardAvailable();
+}
+
+// ---------------------------------------------------------------------------
+// Getters
+// ---------------------------------------------------------------------------
+
+uint KeyboardWaylandProxy::repeatDelay() const
+{
+    if (m_keyboardSettings)
+        return static_cast<uint>(m_keyboardSettings->repeatDelay());
+    return 480; // 默认回退到合法档位
+}
+
+uint KeyboardWaylandProxy::repeatInterval() const
+{
+    if (m_keyboardSettings)
+        return rateToInterval(m_keyboardSettings->repeatRate());
+    return 50; // 默认回退到合法档位
+}
+
+int KeyboardWaylandProxy::numLockState() const
+{
+    if (m_keyboardSettings)
+        return m_keyboardSettings->numLock() ? 1 : 0;
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+void KeyboardWaylandProxy::setRepeatDelay(uint value)
+{
+    qCDebug(lcKeyboardWaylandProxy) << "setRepeatDelay:" << value << "ms";
+    if (m_keyboardSettings)
+        m_keyboardSettings->setRepeatDelay(static_cast<int>(value));
+}
+
+void KeyboardWaylandProxy::setRepeatInterval(uint value)
+{
+    qCDebug(lcKeyboardWaylandProxy) << "setRepeatInterval:" << value
+                                    << "-> protocol rate=" << intervalToRate(value);
+    if (m_keyboardSettings)
+        m_keyboardSettings->setRepeatRate(intervalToRate(value));
+}
+
+void KeyboardWaylandProxy::setNumLockState(int value)
+{
+    qCDebug(lcKeyboardWaylandProxy) << "setNumLockState:" << value;
+    if (m_keyboardSettings)
+        m_keyboardSettings->setNumLock(value != 0);
+}
+
+void KeyboardWaylandProxy::refreshKeyboard()
+{
+    qCDebug(lcKeyboardWaylandProxy) << "refreshKeyboard: requesting keyboard settings refresh";
+
+    disconnectKeyboardSettings();
+
+    // 执行刷新
+    m_inputManager->refreshKeyboard();
+
+    // 重新连接
+    if (m_inputManager->keyboardAvailable()) {
+        connectKeyboardSettings(m_inputManager->keyboardSettings());
+    }
+    Q_EMIT KeyboardAvailableChanged(m_inputManager->keyboardAvailable());
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+uint KeyboardWaylandProxy::rateToInterval(int rate)
+{
+    if (rate <= 0)
+        return 50;
+    return 1000 / static_cast<uint>(rate);
+}
+
+int KeyboardWaylandProxy::intervalToRate(uint intervalValue)
+{
+    if (intervalValue == 0)
+        return 50;
+    return static_cast<int>(1000 / intervalValue);
+}

--- a/src/plugin-keyboard/operation/keyboardwaylandproxy.h
+++ b/src/plugin-keyboard/operation/keyboardwaylandproxy.h
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include "ikeyboarddeviceproxy.h"
+#include "treelandinputmanager.h"
+
+#include <QObject>
+
+namespace DCC_NAMESPACE {
+
+class TreelandInputManager;
+class TreelandKeyboardSettings;
+
+/**
+ * @brief 封装 treeland 输入管理协议的键盘代理类，对外提供与 KeyboardDBusProxy 相同的信号/槽接口，
+ *        使 KeyboardWorker 无需感知底层协议细节。
+ *
+ * 在 treeland 会话下替代 KeyboardDBusProxy 承担键盘重复参数和 NumLock
+ * 状态的上报与写入操作。
+ * 所有数值均与 DBus 接口保持相同单位，转换逻辑在本类内部完成。
+ *
+ * 同时实现 IKeyboardDeviceProxy 接口，以便 KeyboardWorker 通过多态调用。
+ */
+class KeyboardWaylandProxy : public QObject, public IKeyboardDeviceProxy
+{
+    Q_OBJECT
+public:
+    explicit KeyboardWaylandProxy(QObject *parent = nullptr);
+
+    /** 初始化并连接 TreelandInputManager 信号，发射当前初始状态 */
+    void active() override;
+    bool keyboardAvailable() const;
+
+    // ---- 同步读取当前缓存值（与 KeyboardDBusProxy 接口保持兼容）----
+    /** 重复延迟，单位毫秒 */
+    uint repeatDelay()    const override;
+    /** 重复速率兼容值，沿用 DBus/旧 daemon 的离散值（100/80/65/50/35/25/20） */
+    uint repeatInterval() const override;
+    /** NumLock 状态（0=off, 1=on） */
+    int  numLockState()   const override;
+
+Q_SIGNALS:
+    // ---- 状态变化信号（与 KeyboardDBusProxy 保持相同接口）----
+    /** 重复延迟变化，单位毫秒 */
+    void RepeatDelayChanged(uint value);
+    /** 重复速率兼容值变化，沿用 DBus/旧 daemon 的离散值 */
+    void RepeatIntervalChanged(uint value);
+    /** NumLock 状态变化（0=off, 1=on） */
+    void NumLockStateChanged(int value);
+    /** 键盘能力可用性变化 */
+    void KeyboardAvailableChanged(bool value);
+
+public Q_SLOTS:
+    // ---- 写入槽（与 KeyboardDBusProxy 保持相同接口，同时实现 IKeyboardDeviceProxy）----
+    /** @param value 重复延迟，单位毫秒 */
+    void setRepeatDelay(uint value)    override;
+    /** @param value 重复速率兼容值，Wayland 下直接按旧 daemon 兼容值传给协议 */
+    void setRepeatInterval(uint value) override;
+    /** @param value NumLock 状态（0=off, 1=on） */
+    void setNumLockState(int value)    override;
+
+    /** 刷新键盘 settings 对象（重新从 compositor 获取状态） */
+    void refreshKeyboard();
+
+private:
+    void connectKeyboardSettings(TreelandKeyboardSettings *kbd);
+    void disconnectKeyboardSettings();
+
+    // treeland rate <-> DBus RepeatInterval 兼容值
+    // Interval(ms) = 1000 / Rate(Hz)
+    static uint  rateToInterval(int rate);
+    static int   intervalToRate(uint intervalValue);
+
+    TreelandInputManager *m_inputManager = nullptr;
+    TreelandKeyboardSettings *m_keyboardSettings = nullptr;
+};
+
+} // namespace DCC_NAMESPACE
+

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -2,13 +2,14 @@
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
-
 #include "keyboardwork.h"
 
 #include "dcclocale.h"
+#include <DGuiApplicationHelper>
 
 #include <QTimer>
 #include <QDebug>
+#include <QLoggingCategory>
 #include <QLocale>
 #include <QCollator>
 #include <QCoreApplication>
@@ -25,6 +26,8 @@ using namespace DTK_NAMESPACE::Core;
 using namespace dccV25;
 bool caseInsensitiveLessThan(const MetaData &s1, const MetaData &s2);
 
+Q_LOGGING_CATEGORY(lcKeyboardWorker, "dde.dcc.keyboard.worker")
+
 const QMap<QString, QString> &ModelKeycode = {{"minus", "-"}, {"equal", "="}, {"backslash", "\\"}, {"question", "?/"}, {"exclam", "1"}, {"numbersign", "3"},
     {"semicolon", ";"}, {"apostrophe", "'"}, {"less", ",<"}, {"period", ">."}, {"slash", "?/"}, {"parenleft", "9"}, {"bracketleft", "["},
     {"parenright", "0"}, {"bracketright", "]"}, {"quotedbl", "'"}, {"space", " "}, {"dollar", "$"}, {"plus", "+"}, {"asterisk", "*"},
@@ -38,25 +41,52 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
     , m_model(model)
     , m_keyboardDBusProxy(new KeyboardDBusProxy(this))
     , m_translatorLanguage(nullptr)
-    , m_inputDevCfg(DConfig::create("org.deepin.dde.daemon", "org.deepin.dde.daemon.inputdevices", QString(), this))
+    , m_inputDevCfg(nullptr)
+    , m_isTreelandSession(Dtk::Gui::DGuiApplicationHelper::testAttribute(
+               Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform))
 {
+    qCDebug(lcKeyboardWorker) << "KeyboardWorker: session type =" << (m_isTreelandSession ? "Treeland/Wayland" : "X11/DBus");
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_isTreelandSession) {
+        m_waylandProxy = new DCC_NAMESPACE::KeyboardWaylandProxy(this);
+        qCDebug(lcKeyboardWorker) << "KeyboardWorker: KeyboardWaylandProxy created for treeland session";
+        // treeland 下由 waylandProxy 上报键盘重复参数、NumLock 和 keyboardAvailable 状态
+        connect(m_waylandProxy, &DCC_NAMESPACE::KeyboardWaylandProxy::RepeatDelayChanged,
+                this, &KeyboardWorker::setModelRepeatDelay);
+        connect(m_waylandProxy, &DCC_NAMESPACE::KeyboardWaylandProxy::RepeatIntervalChanged,
+                this, &KeyboardWorker::setModelRepeatInterval);
+        connect(m_waylandProxy, &DCC_NAMESPACE::KeyboardWaylandProxy::NumLockStateChanged,
+                m_model, &KeyboardModel::setNumLock);
+        connect(m_waylandProxy, &DCC_NAMESPACE::KeyboardWaylandProxy::KeyboardAvailableChanged,
+                m_model, &KeyboardModel::setKeyboardEnabled);
+        m_deviceProxy = m_waylandProxy;
+    } else
+#endif
+    {
+        m_inputDevCfg = DConfig::create("org.deepin.dde.daemon", "org.deepin.dde.daemon.inputdevices", QString(), this);
+        connect(m_keyboardDBusProxy, &KeyboardDBusProxy::NumLockStateChanged, m_model, &KeyboardModel::setNumLock);
+        connect(m_keyboardDBusProxy, &KeyboardDBusProxy::RepeatDelayChanged, this, &KeyboardWorker::setModelRepeatDelay);
+        connect(m_keyboardDBusProxy, &KeyboardDBusProxy::RepeatIntervalChanged, this, &KeyboardWorker::setModelRepeatInterval);
+        m_deviceProxy = m_keyboardDBusProxy;
+    }
+
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Added, this, &KeyboardWorker::onAdded);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Deleted, this, &KeyboardWorker::removed);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::UserLayoutListChanged, this, &KeyboardWorker::onUserLayout);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::CurrentLayoutChanged, this, &KeyboardWorker::onCurrentLayout);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::CapslockToggleChanged, m_model, &KeyboardModel::setCapsLock);
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::NumLockStateChanged, m_model, &KeyboardModel::setNumLock);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::langSelectorServiceStartFinished, this, [=] {
         QTimer::singleShot(100, this, &KeyboardWorker::onLangSelectorServiceFinished);
     });
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::RepeatDelayChanged, this, &KeyboardWorker::setModelRepeatDelay);
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::RepeatIntervalChanged, this, &KeyboardWorker::setModelRepeatInterval);
 
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Changed, this, &KeyboardWorker::onShortcutChanged);
 
     m_model->setLangChangedState(m_keyboardDBusProxy->localeState());
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::LocaleStateChanged, m_model, &KeyboardModel::setLangChangedState);
+
+    if (!m_isTreelandSession)
+        initKeyboardEnabledSync();
 }
 
 void KeyboardWorker::resetAll() {
@@ -111,6 +141,9 @@ void KeyboardWorker::refreshLang()
 
 void KeyboardWorker::windowSwitch()
 {
+    if (m_isTreelandSession) {
+        return;
+    }
     QDBusInterface licenseInfo("com.deepin.wm",
                                "/com/deepin/wm",
                                "com.deepin.wm",
@@ -126,10 +159,14 @@ void KeyboardWorker::windowSwitch()
 
 void KeyboardWorker::active()
 {
+    qCDebug(lcKeyboardWorker) << "KeyboardWorker::active()";
     m_keyboardDBusProxy->blockSignals(false);
 
-    setModelRepeatDelay(m_keyboardDBusProxy->repeatDelay());
-    setModelRepeatInterval(m_keyboardDBusProxy->repeatInterval());
+    m_deviceProxy->active();
+    setModelRepeatDelay(m_deviceProxy->repeatDelay());
+    setModelRepeatInterval(m_deviceProxy->repeatInterval());
+    qCDebug(lcKeyboardWorker) << "initial repeatDelay=" << m_deviceProxy->repeatDelay()
+                              << "repeatInterval=" << m_deviceProxy->repeatInterval();
 
     m_metaDatas.clear();
     m_letters.clear();
@@ -138,27 +175,36 @@ void KeyboardWorker::active()
     Q_EMIT onLettersChanged(m_letters);
 
     m_model->setCapsLock(m_keyboardDBusProxy->capslockToggle());
-    m_model->setNumLock(m_keyboardDBusProxy->numLockState());
+    m_model->setNumLock(m_deviceProxy->numLockState());
 
     onRefreshKBLayout();
     refreshLang();
     windowSwitch();
     refreshShortcut();
-    if (m_inputDevCfg->isValid()) {
-        QMetaObject::invokeMethod(m_model, "setKeyboardEnabled", Qt::DirectConnection, Q_ARG(bool, m_inputDevCfg->value("keyboardEnabled", true).toBool()));
-        connect(m_inputDevCfg, &DConfig::valueChanged, this, [=](QString key) {
-            if (key == "keyboardEnabled") {
-                QMetaObject::invokeMethod(m_model, "setKeyboardEnabled", Qt::DirectConnection, Q_ARG(bool, m_inputDevCfg->value(key).toBool()));
-            }
-        });
-    } else {
-        qWarning() << QString("DConfig is invalide, name:[%1], subpath[%2].").arg(m_inputDevCfg->name(), m_inputDevCfg->subpath());
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_waylandProxy) {
+        m_model->setKeyboardEnabled(m_waylandProxy->keyboardAvailable());
+    } else
+#endif
+    {
+        syncKeyboardEnabled();
     }
 }
 
 void KeyboardWorker::deactive()
 {
     m_keyboardDBusProxy->blockSignals(true);
+}
+
+void KeyboardWorker::refreshKeyboard()
+{
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_waylandProxy) {
+        qCDebug(lcKeyboardWorker) << "KeyboardWorker::refreshKeyboard() via wayland proxy";
+        m_waylandProxy->refreshKeyboard();
+        return;
+    }
+#endif
 }
 
 bool KeyboardWorker::keyOccupy(const QStringList &list)
@@ -304,12 +350,16 @@ void KeyboardWorker::delShortcut(ShortcutInfo* info)
 
 void KeyboardWorker::setRepeatDelay(uint value)
 {
-    m_keyboardDBusProxy->setRepeatDelay(converToDBusDelay(value));
+    qCDebug(lcKeyboardWorker) << "setRepeatDelay: slider=" << value
+                              << "-> dbus=" << converToDBusDelay(value);
+    m_deviceProxy->setRepeatDelay(converToDBusDelay(value));
 }
 
 void KeyboardWorker::setRepeatInterval(uint value)
 {
-    m_keyboardDBusProxy->setRepeatInterval(static_cast<uint>(converToDBusInterval(value)));
+    qCDebug(lcKeyboardWorker) << "setRepeatInterval: slider=" << value
+                              << "-> dbus=" << converToDBusInterval(value);
+    m_deviceProxy->setRepeatInterval(static_cast<uint>(converToDBusInterval(value)));
 }
 
 void KeyboardWorker::setModelRepeatDelay(uint value)
@@ -324,19 +374,67 @@ void KeyboardWorker::setModelRepeatInterval(uint value)
 
 void KeyboardWorker::setNumLock(bool value)
 {
-    m_keyboardDBusProxy->SetNumLockState(value);
+    qCDebug(lcKeyboardWorker) << "setNumLock:" << value;
+    m_deviceProxy->setNumLockState(value ? 1 : 0);
 }
 
 void KeyboardWorker::setCapsLock(bool value)
 {
+    qCDebug(lcKeyboardWorker) << "setCapsLock:" << value;
     m_keyboardDBusProxy->setCapslockToggle(value);
 }
 
 void KeyboardWorker::setKeyboardEnabled(bool value)
 {
-    if (m_inputDevCfg->isValid()) {
-        m_inputDevCfg->setValue("keyboardEnabled", value);
+    if (!m_inputDevCfg) {
+        if (m_isTreelandSession) {
+            m_model->setKeyboardEnabled(value);
+            return;
+        }
+        qWarning() << "DConfig is null.";
+        return;
     }
+    if (!m_inputDevCfg->isValid()) {
+        qWarning() << QString("DConfig is invalide, name:[%1], subpath[%2].").arg(m_inputDevCfg->name(), m_inputDevCfg->subpath());
+        return;
+    }
+
+    // 先同步 model，保证 Wayland 下界面状态立即更新；后续仍由 DConfig 变更信号做一致性回写。
+    m_model->setKeyboardEnabled(value);
+    m_inputDevCfg->setValue("keyboardEnabled", value);
+    syncKeyboardEnabled();
+}
+
+void KeyboardWorker::initKeyboardEnabledSync()
+{
+    if (!m_inputDevCfg) {
+        qWarning() << "DConfig is null.";
+        return;
+    }
+    if (!m_inputDevCfg->isValid()) {
+        qWarning() << QString("DConfig is invalide, name:[%1], subpath[%2].").arg(m_inputDevCfg->name(), m_inputDevCfg->subpath());
+        return;
+    }
+
+    connect(m_inputDevCfg, &DConfig::valueChanged, this, [this](const QString &key) {
+        if (key == "keyboardEnabled")
+            syncKeyboardEnabled();
+    });
+}
+
+void KeyboardWorker::syncKeyboardEnabled()
+{
+    if (!m_inputDevCfg) {
+        qWarning() << "DConfig is null.";
+        return;
+    }
+    if (!m_inputDevCfg->isValid()) {
+        qWarning() << QString("DConfig is invalide, name:[%1], subpath[%2].").arg(m_inputDevCfg->name(), m_inputDevCfg->subpath());
+        return;
+    }
+
+    QMetaObject::invokeMethod(m_model, "setKeyboardEnabled", Qt::DirectConnection,
+                              Q_ARG(bool, m_inputDevCfg->value("keyboardEnabled", true).toBool()));
 }
 
 void KeyboardWorker::addUserLayout(const QString &value)

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,11 @@
 #include "shortcutmodel.h"
 #include "keyboardmodel.h"
 #include "keyboarddbusproxy.h"
+#include "ikeyboarddeviceproxy.h"
+
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+#include "keyboardwaylandproxy.h"
+#endif
 
 #include <DConfig>
 
@@ -58,6 +63,8 @@ public:
     void setCapsLock(bool value);
     void setKeyboardEnabled(bool value);
     Q_INVOKABLE void active();
+
+    void refreshKeyboard();
     void deactive();
     bool keyOccupy(const QStringList &list);
     void onRefreshKBLayout();
@@ -107,6 +114,8 @@ public Q_SLOTS:
 
 private:
     static QString makeShortcutKey(const QString &id, int type);
+    void initKeyboardEnabledSync();
+    void syncKeyboardEnabled();
     uint converToDBusDelay(uint value);
     uint converToModelDelay(uint value);
     int converToDBusInterval(int value);
@@ -126,6 +135,11 @@ private:
     bool m_isResetting = false; // Flag to prevent duplicate reset calls
     QMap<QString, qint64> m_shortcutQueryTime; // 记录每个快捷键最后一次 Query 的时间戳
     QSet<QString> m_replacingShortcuts; // 记录正在替换的快捷键，用于屏蔽中间状态的UI更新
+    bool m_isTreelandSession = false;
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    DCC_NAMESPACE::KeyboardWaylandProxy *m_waylandProxy = nullptr;
+#endif
+    DCC_NAMESPACE::IKeyboardDeviceProxy *m_deviceProxy = nullptr; ///< 当前会话的键盘设备代理（构造时注入）
 };
 }
 #endif // KEYBOARDWORK_H

--- a/src/plugin-keyboard/qml/Keyboard.qml
+++ b/src/plugin-keyboard/qml/Keyboard.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import org.deepin.dcc 1.0
 
@@ -10,7 +10,6 @@ DccObject {
     description: qsTr("General Settings, input method, shortcuts")
     icon: "device_keyboard"
     weight: 40
-    visible: false
     DccDBusInterface {
         property var numLockState
         service: "org.deepin.dde.Keybinding1"
@@ -18,5 +17,6 @@ DccObject {
         inter: "org.deepin.dde.Keybinding1"
         connection: DccDBusInterface.SessionBus
         onNumLockStateChanged: keyboard.visible = true
+        enabled: !DccApp.isTreeland()
     }
 }

--- a/src/plugin-keyboard/qml/KeyboardMain.qml
+++ b/src/plugin-keyboard/qml/KeyboardMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.3
@@ -6,6 +6,17 @@ import QtQuick.Controls 2.3
 import org.deepin.dcc 1.0
 
 DccObject {
+    Connections {
+        target: DccApp
+        function onCurrentObjectsChanged(objects) {
+            for (var i = 0; i < objects.length; i++) {
+                if (objects[i].name === "keyboard") {
+                    dccData.refreshKeyboard()
+                    break
+                }
+            }
+        }
+    }
     DccObject {
         name: "KeyboardCommon"
         parentName: "keyboard"

--- a/src/plugin-mouse/CMakeLists.txt
+++ b/src/plugin-mouse/CMakeLists.txt
@@ -7,13 +7,16 @@ if (BUILD_PLUGIN)
     endif()
 
     if (Enable_TreelandSupport)
-    find_package(TreelandProtocols REQUIRED)
+        find_package(TreelandProtocols REQUIRED)
     endif()
 
     file(GLOB_RECURSE mouse_SRCS
         "operation/*.cpp"
         "operation/qrc/mouse.qrc"
     )
+    if (NOT Enable_TreelandSupport)
+        list(FILTER mouse_SRCS EXCLUDE REGEX ".*/operation/mousewaylandproxy\\.cpp$")
+    endif()
     file(GLOB_RECURSE mouse_qml_SRCS
         "qml/*.qml"
     )
@@ -39,6 +42,7 @@ if (BUILD_PLUGIN)
         ${QT_NS}::DBus
         ${QT_NS}::Qml
         ${QT_NS}::WaylandClientPrivate
+        dcc-shared-utils
         # PkgConfig::QGSettings
     )
     target_include_directories(${Mouse_Name} PUBLIC

--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -4,6 +4,8 @@
 #include "mousedbusproxy.h"
 #include "gesturedata.h"
 
+#include <DGuiApplicationHelper>
+
 #include <QJsonArray>
 #include <QDBusArgument>
 #include <QDBusConnection>
@@ -49,59 +51,66 @@ MouseDBusProxy::MouseDBusProxy(QObject *parent)
     , m_dbusDevices(nullptr)
     , m_dbusGesture(nullptr)
     , m_appearance(nullptr)
+    , m_isTreelandSession(DTK_GUI_NAMESPACE::DGuiApplicationHelper::testAttribute(
+               DTK_GUI_NAMESPACE::DGuiApplicationHelper::IsWaylandPlatform))
 {
     init();
 }
 
 void MouseDBusProxy::active()
 {
-    // initial mouse settingss
-    bool exist = m_dbusMouseProperties->call("Get", MouseInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    bool leftHanded = m_dbusMouseProperties->call("Get", MouseInterface, "LeftHanded").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    bool naturalScroll = m_dbusMouseProperties->call("Get", MouseInterface, "NaturalScroll").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    int doubleClick = m_dbusMouseProperties->call("Get", MouseInterface, "DoubleClick").arguments().at(0).value<QDBusVariant>().variant().toInt();
-    bool disableTpad = m_dbusMouseProperties->call("Get", MouseInterface, "DisableTpad").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    bool adaptiveAccelProfile = m_dbusMouseProperties->call("Get", MouseInterface, "AdaptiveAccelProfile").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    double motionAcceleration = m_dbusMouseProperties->call("Get", MouseInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
+    if (!m_isTreelandSession) {
+        // initial mouse settingss
+        bool exist = m_dbusMouseProperties->call("Get", MouseInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        bool leftHanded = m_dbusMouseProperties->call("Get", MouseInterface, "LeftHanded").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        bool naturalScroll = m_dbusMouseProperties->call("Get", MouseInterface, "NaturalScroll").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        int doubleClick = m_dbusMouseProperties->call("Get", MouseInterface, "DoubleClick").arguments().at(0).value<QDBusVariant>().variant().toInt();
+        bool disableTpad = m_dbusMouseProperties->call("Get", MouseInterface, "DisableTpad").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        bool adaptiveAccelProfile = m_dbusMouseProperties->call("Get", MouseInterface, "AdaptiveAccelProfile").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        double motionAcceleration = m_dbusMouseProperties->call("Get", MouseInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
 
-    Q_EMIT mouseExistChanged(exist);
-    Q_EMIT leftHandStateChanged(leftHanded);
-    Q_EMIT mouseNaturalScrollStateChanged(naturalScroll);
-    Q_EMIT douClickChanged(doubleClick);
-    Q_EMIT disTouchPadChanged(disableTpad);
-    Q_EMIT accelProfileChanged(adaptiveAccelProfile);
-    Q_EMIT mouseMotionAccelerationChanged(motionAcceleration);
+        Q_EMIT mouseExistChanged(exist);
+        Q_EMIT leftHandStateChanged(leftHanded);
+        Q_EMIT mouseNaturalScrollStateChanged(naturalScroll);
+        Q_EMIT douClickChanged(doubleClick);
+        Q_EMIT disTouchPadChanged(disableTpad);
+        Q_EMIT accelProfileChanged(adaptiveAccelProfile);
+        Q_EMIT mouseMotionAccelerationChanged(motionAcceleration);
 
-    // initial touchpad settings
-    motionAcceleration = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
-    bool tapClick = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "TapClick").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    exist = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    bool touchpadEnabled = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "TPadEnable").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    naturalScroll = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "NaturalScroll").arguments().at(0).value<QDBusVariant>().variant().toBool();
-    bool disableIfTyping = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "DisableIfTyping").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        // initial touchpad settings
+        motionAcceleration = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
+        bool tapClick = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "TapClick").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        exist = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        bool touchpadEnabled = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "TPadEnable").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        naturalScroll = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "NaturalScroll").arguments().at(0).value<QDBusVariant>().variant().toBool();
+        bool disableIfTyping = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "DisableIfTyping").arguments().at(0).value<QDBusVariant>().variant().toBool();
+
+        Q_EMIT touchpadMotionAccelerationChanged(motionAcceleration);
+        Q_EMIT tpadEnabledChanged(touchpadEnabled);
+        Q_EMIT tapClickChanged(tapClick);
+        Q_EMIT tpadExistChanged(exist);
+        Q_EMIT touchNaturalScrollStateChanged(naturalScroll);
+        Q_EMIT disTypingChanged(disableIfTyping);
+
+        // initial device properties
+        uint wheelSpeed  = m_dbusDevicesProperties->call("Get", InputDevicesInterface, "WheelSpeed").arguments().at(0).value<QDBusVariant>().variant().toUInt();
+        Q_EMIT scrollSpeedChanged(wheelSpeed);
+    }
+
+    // common settings (X11/treeland 都会使用)
     bool palmDetect = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "PalmDetect").arguments().at(0).value<QDBusVariant>().variant().toInt();
     int palmMinWidth = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "PalmMinWidth").arguments().at(0).value<QDBusVariant>().variant().toInt();
     bool palmMinZ = m_dbusTouchPadProperties->call("Get", TouchpadInterface, "PalmMinZ").arguments().at(0).value<QDBusVariant>().variant().toBool();
 
-    Q_EMIT touchpadMotionAccelerationChanged(motionAcceleration);
-    Q_EMIT tpadEnabledChanged(touchpadEnabled);
-    Q_EMIT tapClickChanged(tapClick);
-    Q_EMIT tpadExistChanged(exist);
-    Q_EMIT touchNaturalScrollStateChanged(naturalScroll);
-    Q_EMIT disTypingChanged(disableIfTyping);
     Q_EMIT palmDetectChanged(palmDetect);
     Q_EMIT palmMinWidthChanged(palmMinWidth);
     Q_EMIT palmMinzChanged(palmMinZ);
 
-    motionAcceleration = m_dbusTrackPointProperties->call("Get", TrackpointInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
-    exist = m_dbusTouchPadProperties->call("Get", TrackpointInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
+    double motionAcceleration = m_dbusTrackPointProperties->call("Get", TrackpointInterface, "MotionAcceleration").arguments().at(0).value<QDBusVariant>().variant().toDouble();
+    bool exist = m_dbusTouchPadProperties->call("Get", TrackpointInterface, "Exist").arguments().at(0).value<QDBusVariant>().variant().toBool();
 
     Q_EMIT trackPointMotionAccelerationChanged(motionAcceleration);
     Q_EMIT redPointExistChanged(exist);
-
-    // initial device properties
-    uint wheelSpeed  = m_dbusDevicesProperties->call("Get", InputDevicesInterface, "WheelSpeed").arguments().at(0).value<QDBusVariant>().variant().toUInt();
-    Q_EMIT scrollSpeedChanged(wheelSpeed);
 
     // initial lid is present
     bool lidIsPresent = getLidIsPresent();
@@ -122,14 +131,15 @@ void MouseDBusProxy::deactive()
 void MouseDBusProxy::init()
 {
     // 监控dbus上的属性改变信号
-    QDBusConnection::sessionBus().connect(Service,
-                                          MousePath,
-                                          PropertiesInterface,
-                                          "PropertiesChanged",
-                                          "sa{sv}as",
-                                          this,
-                                          SLOT(onMousePathPropertiesChanged(QDBusMessage)));
-
+    if (!m_isTreelandSession) {
+        QDBusConnection::sessionBus().connect(Service,
+                                              MousePath,
+                                              PropertiesInterface,
+                                              "PropertiesChanged",
+                                              "sa{sv}as",
+                                              this,
+                                              SLOT(onMousePathPropertiesChanged(QDBusMessage)));
+    }
     QDBusConnection::sessionBus().connect(Service,
                                           TouchpadPath,
                                           PropertiesInterface,
@@ -146,13 +156,6 @@ void MouseDBusProxy::init()
                                           this,
                                           SLOT(onTrackpointPathPropertiesChanged(QDBusMessage)));
 
-    QDBusConnection::sessionBus().connect(Service,
-                                          InputDevicesPath,
-                                          PropertiesInterface,
-                                          "PropertiesChanged",
-                                          "sa{sv}as",
-                                          this,
-                                          SLOT(onInputDevicesPathPropertiesChanged(QDBusMessage)));
     QDBusConnection::sessionBus().connect(GestureService,
                                           GesturePath,
                                           PropertiesInterface,
@@ -168,6 +171,15 @@ void MouseDBusProxy::init()
                                           "sa{sv}as",
                                           this,
                                           SLOT(onAppearancePropertiesChanged(QDBusMessage)));
+    if (!m_isTreelandSession) {
+        QDBusConnection::sessionBus().connect(Service,
+                                              InputDevicesPath,
+                                              PropertiesInterface,
+                                              "PropertiesChanged",
+                                              "sa{sv}as",
+                                              this,
+                                              SLOT(onInputDevicesPathPropertiesChanged(QDBusMessage)));
+    }
 
     // 初始化dbus接口
     m_dbusMouseProperties = new QDBusInterface(Service,
@@ -406,26 +418,39 @@ void MouseDBusProxy::onTouchpadPathPropertiesChanged(QDBusMessage msg)
         QVariantMap changedProps = qdbus_cast<QVariantMap>(arguments.at(1).value<QDBusArgument>());
         QStringList keys = changedProps.keys();
         for (int i = 0; i < keys.size(); i++) {
-            if (keys.at(i) == "Exist") {
-                Q_EMIT tpadExistChanged(changedProps.value(keys.at(i)).toBool());
-            } else if(keys.at(i) == "TPadEnable") {
-                Q_EMIT tpadEnabledChanged(changedProps.value(keys.at(i)).toBool());
-            } else if(keys.at(i) == "NaturalScroll") {
-                Q_EMIT touchNaturalScrollStateChanged(changedProps.value(keys.at(i)).toBool());
-            } else if(keys.at(i) == "DisableIfTyping") {
-                Q_EMIT disTypingChanged(changedProps.value(keys.at(i)).toBool());
-            } else if(keys.at(i) == "DoubleClick") {
-                Q_EMIT douClickChanged(changedProps.value(keys.at(i)).toInt());
-            } else if(keys.at(i) == "MotionAcceleration") {
-                Q_EMIT touchpadMotionAccelerationChanged(changedProps.value(keys.at(i)).toDouble());
-            } else if(keys.at(i) == "TapClick") {
-                Q_EMIT tapClickChanged(changedProps.value(keys.at(i)).toBool());
-            } else if(keys.at(i) == "PalmDetect") {
-                Q_EMIT palmDetectChanged(changedProps.value(keys.at(i)).toBool());
-            } else if(keys.at(i) == "PalmMinWidth") {
-                Q_EMIT palmMinWidthChanged(changedProps.value(keys.at(i)).toInt());
-            } else if(keys.at(i) == "PalmMinZ") {
-                Q_EMIT palmMinzChanged(changedProps.value(keys.at(i)).toInt());
+            const QString &key = keys.at(i);
+
+            if (m_isTreelandSession) {
+                if (key == "PalmDetect") {
+                    Q_EMIT palmDetectChanged(changedProps.value(key).toBool());
+                } else if (key == "PalmMinWidth") {
+                    Q_EMIT palmMinWidthChanged(changedProps.value(key).toInt());
+                } else if (key == "PalmMinZ") {
+                    Q_EMIT palmMinzChanged(changedProps.value(key).toInt());
+                }
+                continue;
+            }
+
+            if (key == "PalmDetect") {
+                Q_EMIT palmDetectChanged(changedProps.value(key).toBool());
+            } else if (key == "PalmMinWidth") {
+                Q_EMIT palmMinWidthChanged(changedProps.value(key).toInt());
+            } else if (key == "PalmMinZ") {
+                Q_EMIT palmMinzChanged(changedProps.value(key).toInt());
+            } else if (key == "Exist") {
+                Q_EMIT tpadExistChanged(changedProps.value(key).toBool());
+            } else if (key == "TPadEnable") {
+                Q_EMIT tpadEnabledChanged(changedProps.value(key).toBool());
+            } else if (key == "NaturalScroll") {
+                Q_EMIT touchNaturalScrollStateChanged(changedProps.value(key).toBool());
+            } else if (key == "DisableIfTyping") {
+                Q_EMIT disTypingChanged(changedProps.value(key).toBool());
+            } else if (key == "DoubleClick") {
+                Q_EMIT douClickChanged(changedProps.value(key).toInt());
+            } else if (key == "MotionAcceleration") {
+                Q_EMIT touchpadMotionAccelerationChanged(changedProps.value(key).toDouble());
+            } else if (key == "TapClick") {
+                Q_EMIT tapClickChanged(changedProps.value(key).toBool());
             }
         }
     }

--- a/src/plugin-mouse/operation/mousedbusproxy.h
+++ b/src/plugin-mouse/operation/mousedbusproxy.h
@@ -106,6 +106,7 @@ private:
     QDBusInterface *m_dbusDevices;
     QDBusInterface *m_dbusGesture;
     QDBusInterface *m_appearance;
+    bool m_isTreelandSession = false;
 };
 }
 

--- a/src/plugin-mouse/operation/mousemodel.cpp
+++ b/src/plugin-mouse/operation/mousemodel.cpp
@@ -57,7 +57,8 @@ void MouseModel::setLeftHandState(const bool state)
 
     m_leftHandState = state;
 
-    QMetaObject::invokeMethod(m_worker,"onLeftHandStateChanged", Qt::QueuedConnection, Q_ARG(bool, m_leftHandState));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onLeftHandStateChanged", Qt::QueuedConnection, Q_ARG(bool, m_leftHandState));
     Q_EMIT leftHandStateChanged(state);
 }
 
@@ -68,7 +69,8 @@ void MouseModel::setDisIfTyping(const bool state)
 
     m_disIfTyping = state;
 
-    QMetaObject::invokeMethod(m_worker,"onDisTypingChanged", Qt::QueuedConnection, Q_ARG(bool, m_disIfTyping));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onDisTypingChanged", Qt::QueuedConnection, Q_ARG(bool, m_disIfTyping));
     Q_EMIT disIfTypingStateChanged(state);
 }
 
@@ -109,7 +111,8 @@ void MouseModel::setDoubleSpeed(int doubleSpeed)
 
     m_doubleSpeed = doubleSpeed;
 
-    QMetaObject::invokeMethod(m_worker,"onDouClickChanged", Qt::QueuedConnection, Q_ARG(int, m_doubleSpeed));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onDouClickChanged", Qt::QueuedConnection, Q_ARG(int, m_doubleSpeed));
     Q_EMIT doubleSpeedChanged(doubleSpeed);
 }
 
@@ -120,7 +123,8 @@ void MouseModel::setMouseNaturalScroll(bool mouseNaturalScroll)
 
     m_mouseNaturalScroll = mouseNaturalScroll;
 
-    QMetaObject::invokeMethod(m_worker,"onMouseNaturalScrollStateChanged", Qt::QueuedConnection, Q_ARG(bool, m_mouseNaturalScroll));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onMouseNaturalScrollStateChanged", Qt::QueuedConnection, Q_ARG(bool, m_mouseNaturalScroll));
     Q_EMIT mouseNaturalScrollChanged(mouseNaturalScroll);
 }
 
@@ -131,7 +135,8 @@ void MouseModel::setTpadNaturalScroll(bool tpadNaturalScroll)
 
     m_tpadNaturalScroll = tpadNaturalScroll;
 
-    QMetaObject::invokeMethod(m_worker,"onTouchNaturalScrollStateChanged", Qt::QueuedConnection, Q_ARG(bool, m_tpadNaturalScroll));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onTouchNaturalScrollStateChanged", Qt::QueuedConnection, Q_ARG(bool, m_tpadNaturalScroll));
     Q_EMIT tpadNaturalScrollChanged(tpadNaturalScroll);
 }
 
@@ -142,7 +147,8 @@ void MouseModel::setMouseMoveSpeed(int mouseMoveSpeed)
 
     m_mouseMoveSpeed = mouseMoveSpeed;
 
-    QMetaObject::invokeMethod(m_worker,"onMouseMotionAccelerationChanged", Qt::QueuedConnection, Q_ARG(int, m_mouseMoveSpeed));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onMouseMotionAccelerationChanged", Qt::QueuedConnection, Q_ARG(int, m_mouseMoveSpeed));
     Q_EMIT mouseMoveSpeedChanged(mouseMoveSpeed);
 }
 
@@ -153,7 +159,8 @@ void MouseModel::setTpadMoveSpeed(int tpadMoveSpeed)
 
     m_tpadMoveSpeed = tpadMoveSpeed;
 
-    QMetaObject::invokeMethod(m_worker,"onTouchpadMotionAccelerationChanged", Qt::QueuedConnection, Q_ARG(int, m_tpadMoveSpeed));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onTouchpadMotionAccelerationChanged", Qt::QueuedConnection, Q_ARG(int, m_tpadMoveSpeed));
     Q_EMIT tpadMoveSpeedChanged(tpadMoveSpeed);
 }
 
@@ -164,7 +171,8 @@ void MouseModel::setAccelProfile(bool useAdaptiveProfile)
 
     m_accelProfile = useAdaptiveProfile;
 
-    QMetaObject::invokeMethod(m_worker,"onAccelProfileChanged", Qt::QueuedConnection, Q_ARG(bool, m_accelProfile));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onAccelProfileChanged", Qt::QueuedConnection, Q_ARG(bool, m_accelProfile));
     Q_EMIT accelProfileChanged(useAdaptiveProfile);
 }
 
@@ -175,7 +183,8 @@ void MouseModel::setDisTpad(bool disTpad)
 
     m_disTpad = disTpad;
 
-    QMetaObject::invokeMethod(m_worker,"onDisTouchPadChanged", Qt::QueuedConnection, Q_ARG(bool, m_disTpad));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onDisTouchPadChanged", Qt::QueuedConnection, Q_ARG(bool, m_disTpad));
     Q_EMIT disTpadChanged(disTpad);
 }
 
@@ -226,7 +235,8 @@ void MouseModel::setTapClick(bool tapClick)
 
     m_tapClick = tapClick;
 
-    QMetaObject::invokeMethod(m_worker,"onTapClick", Qt::QueuedConnection, Q_ARG(bool, m_tapClick));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onTapClick", Qt::QueuedConnection, Q_ARG(bool, m_tapClick));
     Q_EMIT tapClickChanged(tapClick);
 }
 
@@ -237,7 +247,8 @@ void MouseModel::setTapEnabled(bool tabEnabled)
 
     m_touchpadEnabled = tabEnabled;
 
-    QMetaObject::invokeMethod(m_worker,"onTouchpadEnabledChanged", Qt::QueuedConnection, Q_ARG(bool, m_touchpadEnabled));
+    if (!m_syncingFromBackend)
+        QMetaObject::invokeMethod(m_worker,"onTouchpadEnabledChanged", Qt::QueuedConnection, Q_ARG(bool, m_touchpadEnabled));
     Q_EMIT tapEnabledChanged(tabEnabled);
 }
 
@@ -248,10 +259,12 @@ void MouseModel::setScrollSpeed(int speed)
 
     m_scrollSpeed = speed;
 
-    QMetaObject::invokeMethod(m_worker,
-                              "onScrollSpeedChanged",
-                              Qt::QueuedConnection,
-                              Q_ARG(int, m_scrollSpeed));
+    if (!m_syncingFromBackend) {
+        QMetaObject::invokeMethod(m_worker,
+                                  "onScrollSpeedChanged",
+                                  Qt::QueuedConnection,
+                                  Q_ARG(int, m_scrollSpeed));
+    }
     Q_EMIT scrollSpeedChanged(speed);
 }
 
@@ -262,10 +275,12 @@ void MouseModel::setCursorSize(int cursorSize)
 
     m_cursorSize = cursorSize;
 
-    QMetaObject::invokeMethod(m_worker,
-                              "onCursorSizeChanged",
-                              Qt::QueuedConnection,
-                              Q_ARG(int, m_cursorSize));
+    if (!m_syncingFromBackend) {
+        QMetaObject::invokeMethod(m_worker,
+                                  "onCursorSizeChanged",
+                                  Qt::QueuedConnection,
+                                  Q_ARG(int, m_cursorSize));
+    }
     Q_EMIT cursorSizeChanged(cursorSize);
 }
 
@@ -439,6 +454,13 @@ void MouseModel::setLidIsPresent(bool lidIsPresent)
 
     m_lidIsPresent = lidIsPresent;
     Q_EMIT lidIsPresentChanged(lidIsPresent);
+}
+
+void MouseModel::refreshMouse()
+{
+    if (m_worker) {
+        m_worker->refreshMouse();
+    }
 }
 
 DCC_FACTORY_CLASS(MouseModel)

--- a/src/plugin-mouse/operation/mousemodel.h
+++ b/src/plugin-mouse/operation/mousemodel.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef MOUSEMODEL_H
@@ -117,6 +117,8 @@ public:
     Q_INVOKABLE void setGestures(int fingerNum, int index, QString actionName);
     Q_INVOKABLE void updateFigerGestureAni(int fingerNum, int index, QString acitonDec);
 
+    Q_INVOKABLE void refreshMouse();
+
     QString getGestureFingerAniPath() const;
     void setGestureFingerAniPath(const QString &newGestureFingerAniPath);
 
@@ -163,6 +165,7 @@ Q_SIGNALS:
     void themeTypeChanged();
 
 private:
+    bool m_syncingFromBackend = false;
     bool m_leftHandState;
     bool m_disIfTyping;
     bool m_tpadExist;

--- a/src/plugin-mouse/operation/mousewaylandproxy.cpp
+++ b/src/plugin-mouse/operation/mousewaylandproxy.cpp
@@ -1,0 +1,394 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "mousewaylandproxy.h"
+
+#include "treelandinputmanager.h"
+
+#include <dguiapplicationhelper.h>
+#include <QLoggingCategory>
+
+using namespace DCC_NAMESPACE;
+
+Q_LOGGING_CATEGORY(lcMouseWaylandProxy, "dde.dcc.mouse.wayland")
+
+MouseWaylandProxy::MouseWaylandProxy(QObject *parent)
+    : QObject(parent)
+{
+}
+
+void MouseWaylandProxy::active()
+{
+    qCDebug(lcMouseWaylandProxy) << "MouseWaylandProxy::active()";
+    m_inputManager = new TreelandInputManager(this);
+
+    connect(m_inputManager, &TreelandInputManager::mouseAvailableChanged, this,
+            [this](bool avail) {
+                qCDebug(lcMouseWaylandProxy) << "mouseAvailableChanged:" << avail;
+                Q_EMIT mouseExistChanged(avail);
+                if (avail) {
+                    connectMouseSettings(m_inputManager->mouseSettings());
+                } else {
+                    disconnectMouseSettings();
+                }
+            });
+
+    connect(m_inputManager, &TreelandInputManager::touchpadAvailableChanged, this,
+            [this](bool avail) {
+                qCDebug(lcMouseWaylandProxy) << "touchpadAvailableChanged:" << avail;
+                Q_EMIT tpadExistChanged(avail);
+                if (avail) {
+                    connectTouchpadSettings(m_inputManager->touchpadSettings());
+                } else {
+                    disconnectTouchpadSettings();
+                }
+            });
+
+    // 立即发送已有状态
+    if (m_inputManager->mouseAvailable()) {
+        qCDebug(lcMouseWaylandProxy) << "Mouse already available, connecting immediately";
+        Q_EMIT mouseExistChanged(true);
+        connectMouseSettings(m_inputManager->mouseSettings());
+    }
+    if (m_inputManager->touchpadAvailable()) {
+        qCDebug(lcMouseWaylandProxy) << "Touchpad already available, connecting immediately";
+        Q_EMIT tpadExistChanged(true);
+        connectTouchpadSettings(m_inputManager->touchpadSettings());
+    }
+}
+
+void MouseWaylandProxy::connectMouseSettings(TreelandMouseSettings *mouse)
+{
+    if (!mouse || m_connectedMouseSettings == mouse)
+        return;
+    disconnectMouseSettings();
+    m_connectedMouseSettings = mouse;
+    qCDebug(lcMouseWaylandProxy) << "Connecting to TreelandMouseSettings";
+
+    connect(mouse, &TreelandMouseSettings::leftHandedChanged,
+            this, &MouseWaylandProxy::emitSharedLeftHanded);
+    connect(mouse, &TreelandMouseSettings::naturalScrollChanged,
+            this, &MouseWaylandProxy::emitMouseNaturalScroll);
+    connect(mouse, &TreelandMouseSettings::speedChanged,
+            this, &MouseWaylandProxy::emitMouseSpeed);
+    connect(mouse, &TreelandMouseSettings::scrollFactorChanged,
+            this, &MouseWaylandProxy::emitSharedScrollFactor);
+    connect(mouse, &TreelandMouseSettings::accelerationProfileChanged,
+            this, [this](uint32_t profile) { Q_EMIT accelProfileChanged(profileToState(profile)); });
+
+    emitSharedLeftHanded(mouse->leftHanded());
+    emitMouseNaturalScroll(mouse->naturalScroll());
+    emitMouseSpeed(mouse->speed());
+    emitSharedScrollFactor(mouse->scrollFactor());
+    Q_EMIT accelProfileChanged(profileToState(mouse->accelerationProfile()));
+}
+
+void MouseWaylandProxy::connectTouchpadSettings(TreelandTouchpadSettings *tpad)
+{
+    if (!tpad || m_connectedTouchpadSettings == tpad)
+        return;
+    disconnectTouchpadSettings();
+    m_connectedTouchpadSettings = tpad;
+    qCDebug(lcMouseWaylandProxy) << "Connecting to TreelandTouchpadSettings";
+
+    connect(tpad, &TreelandTouchpadSettings::leftHandedChanged,
+            this, [this](bool value) {
+                if (shouldUseTouchpadSharedState())
+                    emitSharedLeftHanded(value);
+            });
+    connect(tpad, &TreelandTouchpadSettings::naturalScrollChanged,
+            this, &MouseWaylandProxy::emitTouchpadNaturalScroll);
+    connect(tpad, &TreelandTouchpadSettings::speedChanged,
+            this, &MouseWaylandProxy::emitTouchpadSpeed);
+    connect(tpad, &TreelandTouchpadSettings::scrollFactorChanged,
+            this, [this](double value) {
+                if (shouldUseTouchpadSharedState())
+                    emitSharedScrollFactor(value);
+            });
+    connect(tpad, &TreelandTouchpadSettings::sendEventsModeChanged,
+            this, &MouseWaylandProxy::emitTouchpadMode);
+    connect(tpad, &TreelandTouchpadSettings::disableWhileTypingChanged,
+            this, [this](bool v) { Q_EMIT disTypingChanged(v); });
+    connect(tpad, &TreelandTouchpadSettings::tapToClickChanged,
+            this, [this](bool v) { Q_EMIT tapClickChanged(v); });
+
+    if (shouldUseTouchpadSharedState()) {
+        emitSharedLeftHanded(tpad->leftHanded());
+        emitSharedScrollFactor(tpad->scrollFactor());
+    }
+    emitTouchpadNaturalScroll(tpad->naturalScroll());
+    emitTouchpadSpeed(tpad->speed());
+    emitTouchpadMode(tpad->sendEventsMode());
+    Q_EMIT disTypingChanged(tpad->disableWhileTyping());
+    Q_EMIT tapClickChanged(tpad->tapToClick());
+}
+
+void MouseWaylandProxy::disconnectMouseSettings()
+{
+    if (!m_connectedMouseSettings)
+        return;
+    qCDebug(lcMouseWaylandProxy) << "Disconnecting from TreelandMouseSettings";
+    disconnect(m_connectedMouseSettings, nullptr, this, nullptr);
+    m_connectedMouseSettings = nullptr;
+}
+
+void MouseWaylandProxy::disconnectTouchpadSettings()
+{
+    if (!m_connectedTouchpadSettings)
+        return;
+    qCDebug(lcMouseWaylandProxy) << "Disconnecting from TreelandTouchpadSettings";
+    disconnect(m_connectedTouchpadSettings, nullptr, this, nullptr);
+    m_connectedTouchpadSettings = nullptr;
+}
+
+bool MouseWaylandProxy::shouldUseTouchpadSharedState() const
+{
+    return m_connectedMouseSettings == nullptr;
+}
+
+void MouseWaylandProxy::emitSharedLeftHanded(bool value)
+{
+    if (m_leftHandedInitialized && m_leftHanded == value)
+        return;
+    m_leftHandedInitialized = true;
+    m_leftHanded = value;
+    Q_EMIT leftHandStateChanged(value);
+}
+
+void MouseWaylandProxy::emitMouseNaturalScroll(bool value)
+{
+    if (m_mouseNaturalScrollInitialized && m_mouseNaturalScroll == value)
+        return;
+    m_mouseNaturalScrollInitialized = true;
+    m_mouseNaturalScroll = value;
+    Q_EMIT mouseNaturalScrollStateChanged(value);
+}
+
+void MouseWaylandProxy::emitTouchpadNaturalScroll(bool value)
+{
+    if (m_touchpadNaturalScrollInitialized && m_touchpadNaturalScroll == value)
+        return;
+    m_touchpadNaturalScrollInitialized = true;
+    m_touchpadNaturalScroll = value;
+    Q_EMIT touchNaturalScrollStateChanged(value);
+}
+
+void MouseWaylandProxy::emitMouseSpeed(double value)
+{
+    const double libinputValue = fromInputMotionAccelration(value);
+    if (m_mouseSpeedInitialized
+        && (qFuzzyCompare(m_mouseSpeed, libinputValue) || qFuzzyIsNull(m_mouseSpeed - libinputValue))) {
+        return;
+    }
+    m_mouseSpeedInitialized = true;
+    m_mouseSpeed = libinputValue;
+    Q_EMIT mouseMotionAccelerationChanged(m_mouseSpeed);
+}
+
+void MouseWaylandProxy::emitTouchpadSpeed(double value)
+{
+    const double libinputValue = fromInputMotionAccelration(value);
+    if (m_touchpadSpeedInitialized
+        && (qFuzzyCompare(m_touchpadSpeed, libinputValue) || qFuzzyIsNull(m_touchpadSpeed - libinputValue))) {
+        return;
+    }
+    m_touchpadSpeedInitialized = true;
+    m_touchpadSpeed = libinputValue;
+
+    Q_EMIT touchpadMotionAccelerationChanged(m_touchpadSpeed);
+}
+
+void MouseWaylandProxy::emitSharedScrollFactor(double factor)
+{
+    if (m_scrollFactorInitialized && qFuzzyCompare(m_scrollFactor, factor))
+        return;
+    m_scrollFactorInitialized = true;
+    m_scrollFactor = factor;
+    Q_EMIT scrollSpeedChanged(scrollFactorToSpeed(factor));
+}
+
+void MouseWaylandProxy::emitTouchpadMode(uint32_t mode)
+{
+    const bool touchpadEnabled = isTouchpadEnabledInModel(mode);
+    const bool disableWhenMouseExist = isDisableTouchpadWhenMouseExistEnabled(mode);
+
+    if (!m_disTouchPadInitialized || m_disTouchPad != disableWhenMouseExist) {
+        m_disTouchPadInitialized = true;
+        m_disTouchPad = disableWhenMouseExist;
+        Q_EMIT disTouchPadChanged(disableWhenMouseExist);
+    }
+    Q_EMIT tpadEnabledChanged(touchpadEnabled);
+}
+
+uint32_t MouseWaylandProxy::touchpadSendEventsMode(bool touchpadEnabled,
+                                                   bool disableWhenMouseExist) const
+{
+    if (!touchpadEnabled)
+        return TreelandTouchpadSettings::send_events_mode_disabled;
+
+    return disableWhenMouseExist
+            ? TreelandTouchpadSettings::send_events_mode_disabled_on_external_mouse
+            : TreelandTouchpadSettings::send_events_mode_enabled;
+}
+
+// ---------------------------------------------------------------------------
+// Setters
+// ---------------------------------------------------------------------------
+
+void MouseWaylandProxy::setLeftHandState(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setLeftHandState:" << state;
+    if (auto *mouse = m_inputManager->mouseSettings())
+        mouse->setLeftHanded(state);
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setLeftHanded(state);
+}
+
+void MouseWaylandProxy::setMouseNaturalScrollState(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setMouseNaturalScrollState:" << state;
+    if (auto *mouse = m_inputManager->mouseSettings())
+        mouse->setNaturalScroll(state);
+}
+
+void MouseWaylandProxy::setTouchNaturalScrollState(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setTouchNaturalScrollState:" << state;
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setNaturalScroll(state);
+}
+
+void MouseWaylandProxy::setDisTyping(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setDisTyping:" << state;
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setDisableWhileTyping(state);
+}
+
+void MouseWaylandProxy::setTapClick(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setTapClick:" << state;
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setTapToClick(state);
+}
+
+void MouseWaylandProxy::setMouseMotionAcceleration(double value)
+{
+    qCDebug(lcMouseWaylandProxy) << "setMouseMotionAcceleration: libinput=" << value
+                                 << "-> treeland=" << toInputMotionAccelration(value);
+    const double speed = toInputMotionAccelration(value);
+    if (auto *mouse = m_inputManager->mouseSettings())
+        mouse->setSpeed(speed);
+}
+
+void MouseWaylandProxy::setAccelProfile(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setAccelProfile: adaptive=" << state;
+    if (auto *mouse = m_inputManager->mouseSettings())
+        mouse->setAccelerationProfile(stateToProfile(state));
+}
+
+void MouseWaylandProxy::setTouchpadMotionAcceleration(double value)
+{
+    qCDebug(lcMouseWaylandProxy) << "setTouchpadMotionAcceleration: libinput=" << value
+                                 << "-> treeland=" << toInputMotionAccelration(value);
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setSpeed(toInputMotionAccelration(value));
+}
+
+void MouseWaylandProxy::setScrollSpeed(uint speed)
+{
+    qCDebug(lcMouseWaylandProxy) << "setScrollSpeed:" << speed
+                                 << "-> scrollFactor=" << speedToScrollFactor(speed);
+    // X11 侧 WheelSpeed 是全局输入设备属性，Wayland 侧需同时同步到 mouse/touchpad。
+    const double factor = speedToScrollFactor(speed);
+    if (auto *mouse = m_inputManager->mouseSettings())
+        mouse->setScrollFactor(factor);
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setScrollFactor(factor);
+}
+
+void MouseWaylandProxy::setTouchpadEnabled(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setTouchpadEnabled:" << state;
+    if (auto *tpad = m_inputManager->touchpadSettings())
+        tpad->setSendEventsMode(touchpadSendEventsMode(state, m_disTouchPad));
+}
+
+void MouseWaylandProxy::setDisableTouchPadWhenMouseExist(bool state)
+{
+    qCDebug(lcMouseWaylandProxy) << "setDisableTouchPadWhenMouseExist:" << state;
+    m_disTouchPadInitialized = true;
+    m_disTouchPad = state;
+    if (auto *tpad = m_inputManager->touchpadSettings()) {
+        const uint32_t currentMode = tpad->sendEventsMode();
+        const bool touchpadEnabled = isTouchpadEnabledInModel(currentMode);
+        tpad->setSendEventsMode(touchpadSendEventsMode(touchpadEnabled, state));
+    }
+}
+
+void MouseWaylandProxy::refreshMouse()
+{
+    qCDebug(lcMouseWaylandProxy) << "refreshMouse: requesting mouse settings refresh";
+
+    disconnectMouseSettings();
+    disconnectTouchpadSettings();
+
+    m_inputManager->refreshMouse();
+
+    if (m_inputManager->mouseAvailable()) {
+        connectMouseSettings(m_inputManager->mouseSettings());
+    }
+    if (m_inputManager->touchpadAvailable()) {
+        connectTouchpadSettings(m_inputManager->touchpadSettings());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion helpers
+// ---------------------------------------------------------------------------
+
+double MouseWaylandProxy::toInputMotionAccelration(double libinput)
+{
+    auto accel = 1 - libinput / 1.5;
+    accel = qBound(-1.0, accel, 1.0);
+    return accel;
+}
+
+double MouseWaylandProxy::fromInputMotionAccelration(double speed)
+{
+    return qBound(0.0, (1 - speed) * 1.5, 3.0);
+}
+
+uint MouseWaylandProxy::scrollFactorToSpeed(double factor)
+{
+    return static_cast<uint>(qBound(1.0, static_cast<double>(qRound(factor)), 10.0));
+}
+
+double MouseWaylandProxy::speedToScrollFactor(uint speed)
+{
+    return static_cast<double>(qBound(1u, speed, 10u));
+}
+
+bool MouseWaylandProxy::profileToState(uint32_t profile)
+{
+    return profile
+            == static_cast<uint32_t>(TreelandMouseSettings::AccelerationProfile::Adaptive);
+}
+
+uint32_t MouseWaylandProxy::stateToProfile(bool state)
+{
+    return state
+            ? static_cast<uint32_t>(TreelandMouseSettings::AccelerationProfile::Adaptive)
+            : static_cast<uint32_t>(TreelandMouseSettings::AccelerationProfile::Flat);
+}
+
+bool MouseWaylandProxy::isTouchpadEnabledInModel(uint32_t mode) const
+{
+    return mode != TreelandTouchpadSettings::send_events_mode_disabled;
+}
+
+bool MouseWaylandProxy::isDisableTouchpadWhenMouseExistEnabled(uint32_t mode) const
+{
+    return mode == TreelandTouchpadSettings::send_events_mode_disabled_on_external_mouse;
+}

--- a/src/plugin-mouse/operation/mousewaylandproxy.h
+++ b/src/plugin-mouse/operation/mousewaylandproxy.h
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include <QObject>
+
+namespace DCC_NAMESPACE {
+
+class TreelandMouseSettings;
+class TreelandTouchpadSettings;
+class TreelandInputManager;
+
+/**
+ * @brief 封装 treeland 输入管理协议的代理类，对外提供与 MouseDBusProxy 相同的信号/槽接口，
+ *        使 MouseWorker 无需感知底层协议细节。
+ *
+ * 在 treeland 会话下替代 MouseDBusProxy 承担状态上报和写入操作。
+ * 所有数值均与 DBus 接口保持相同单位，转换逻辑在本类内部完成。
+ */
+class MouseWaylandProxy : public QObject
+{
+    Q_OBJECT
+public:
+    explicit MouseWaylandProxy(QObject *parent = nullptr);
+
+    /** 初始化并连接 TreelandInputManager 信号 */
+    void active();
+
+Q_SIGNALS:
+    // ---- 状态变化信号（与 MouseDBusProxy 保持相同接口）----
+    void mouseExistChanged(bool exist);
+    void tpadExistChanged(bool exist);
+    void tpadEnabledChanged(bool enabled);
+    void disTouchPadChanged(bool state);
+    void leftHandStateChanged(bool state);
+    void mouseNaturalScrollStateChanged(bool state);
+    void touchNaturalScrollStateChanged(bool state);
+    void disTypingChanged(bool state);
+    void tapClickChanged(bool state);
+    /** libinput 加速度值（与 MouseDBusProxy::mouseMotionAccelerationChanged 相同单位） */
+    void mouseMotionAccelerationChanged(double value);
+    /** false=平坦, true=自适应（与 MouseDBusProxy::accelProfileChanged 相同语义） */
+    void accelProfileChanged(bool state);
+    /** libinput 加速度值（与 MouseDBusProxy::touchpadMotionAccelerationChanged 相同单位） */
+    void touchpadMotionAccelerationChanged(double value);
+    /** 滚动速度 1~10（与 MouseDBusProxy::scrollSpeedChanged / 旧 daemon WheelSpeed 相同单位） */
+    void scrollSpeedChanged(uint speed);
+
+public Q_SLOTS:
+    // ---- 写入槽（与 MouseDBusProxy 保持相同接口）----
+    void setLeftHandState(bool state);
+    void setMouseNaturalScrollState(bool state);
+    void setTouchNaturalScrollState(bool state);
+    void setDisTyping(bool state);
+    void setTapClick(bool state);
+    /** @param value libinput 加速度值 */
+    void setMouseMotionAcceleration(double value);
+    void setAccelProfile(bool state);
+    /** @param value libinput 加速度值 */
+    void setTouchpadMotionAcceleration(double value);
+    void setScrollSpeed(uint speed);
+    void setTouchpadEnabled(bool state);
+    /** 使用 treeland send_events_mode 的 disabled_on_external_mouse 模式 */
+    void setDisableTouchPadWhenMouseExist(bool state);
+
+    void refreshMouse();
+
+private:
+    void connectMouseSettings(TreelandMouseSettings *mouse);
+    void connectTouchpadSettings(TreelandTouchpadSettings *tpad);
+    void disconnectMouseSettings();
+    void disconnectTouchpadSettings();
+    bool shouldUseTouchpadSharedState() const;
+    bool isTouchpadEnabledInModel(uint32_t mode) const;
+    bool isDisableTouchpadWhenMouseExistEnabled(uint32_t mode) const;
+    void emitSharedLeftHanded(bool value);
+    void emitSharedScrollFactor(double factor);
+    void emitMouseNaturalScroll(bool value);
+    void emitTouchpadNaturalScroll(bool value);
+    void emitMouseSpeed(double value);
+    void emitTouchpadSpeed(double value);
+    void emitTouchpadMode(uint32_t mode);
+    uint32_t touchpadSendEventsMode(bool touchpadEnabled, bool disableWhenMouseExist) const;
+
+    // libinput 值（DBus 单位）<-> treeland speed [-1, 1]
+    static double toInputMotionAccelration(double libinput);
+    static double fromInputMotionAccelration(double speed);
+
+    // 滚动速度（uint, 1..10）<-> treeland scroll factor（double，保持旧 daemon 1:1 兼容）
+    static uint   scrollFactorToSpeed(double factor);
+    static double speedToScrollFactor(uint speed);
+
+    // 加速度模式：bool（DBus）<-> uint32（treeland）
+    static bool     profileToState(uint32_t profile);
+    static uint32_t stateToProfile(bool state);
+
+    TreelandInputManager *m_inputManager = nullptr;
+    TreelandMouseSettings *m_connectedMouseSettings = nullptr;
+    TreelandTouchpadSettings *m_connectedTouchpadSettings = nullptr;
+    bool m_leftHandedInitialized = false;
+    bool m_leftHanded = false;
+    bool m_mouseNaturalScrollInitialized = false;
+    bool m_mouseNaturalScroll = false;
+    bool m_touchpadNaturalScrollInitialized = false;
+    bool m_touchpadNaturalScroll = false;
+    bool m_mouseSpeedInitialized = false;
+    double m_mouseSpeed = 0.0;
+    bool m_touchpadSpeedInitialized = false;
+    double m_touchpadSpeed = 0.0;
+    bool m_scrollFactorInitialized = false;
+    double m_scrollFactor = 1.0;
+    bool m_disTouchPadInitialized = false;
+    bool m_disTouchPad = false;
+};
+
+} // namespace DCC_NAMESPACE
+

--- a/src/plugin-mouse/operation/mouseworker.cpp
+++ b/src/plugin-mouse/operation/mouseworker.cpp
@@ -4,18 +4,46 @@
 #include "mouseworker.h"
 
 #include "mousedbusproxy.h"
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+#include "mousewaylandproxy.h"
+#endif
+
+#include <array>
+#include <cmath>
+#include <QLoggingCategory>
 
 using namespace DCC_NAMESPACE;
 const QString Service = "org.deepin.dde.InputDevices1";
 
+Q_LOGGING_CATEGORY(lcMouseWorker, "dde.dcc.mouse.worker")
+
+namespace {
+constexpr std::array<double, 7> kMotionAccelerationLevels { 3.2, 2.3, 1.6, 1.0, 0.6, 0.3, 0.2 };
+}
+
 MouseWorker::MouseWorker(MouseModel *model, QObject *parent)
     : QObject(parent)
     , m_model(model)
+    , m_isTreelandSession(Dtk::Gui::DGuiApplicationHelper::testAttribute(
+               Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform))
     , m_mouseProxy(new MouseDBusProxy(this))
     , m_treelandWorker(new TreeLandWorker(this))
 {
+    qCDebug(lcMouseWorker) << "MouseWorker: session type =" << (m_isTreelandSession ? "Treeland/Wayland" : "X11/DBus");
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_isTreelandSession) {
+        m_waylandProxy = new MouseWaylandProxy(this);
+        qCDebug(lcMouseWorker) << "MouseWorker: MouseWaylandProxy created for treeland session";
+    }
+#endif
     bindProxySignals();
     bindRequestSignals();
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_isTreelandSession) {
+        qCDebug(lcMouseWorker) << "MouseWorker: activating Wayland proxy";
+        m_waylandProxy->active();
+    }
+#endif
     QMetaObject::invokeMethod(m_mouseProxy, "active", Qt::QueuedConnection);
 #ifdef Enable_Treeland
     m_treelandWorker->active();
@@ -34,27 +62,71 @@ void MouseWorker::init()
 {
 }
 
+void MouseWorker::refreshMouse()
+{
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_waylandProxy) {
+        qCDebug(lcMouseWorker) << "MouseWorker::refreshMouse()";
+        m_waylandProxy->refreshMouse();
+    }
+#endif
+}
+
 void MouseWorker::bindProxySignals()
 {
-    connect(m_mouseProxy, &MouseDBusProxy::mouseExistChanged, this, &MouseWorker::setMouseExist);
-    connect(m_mouseProxy, &MouseDBusProxy::tpadExistChanged, this, &MouseWorker::setTpadExist);
-    connect(m_mouseProxy, &MouseDBusProxy::tpadEnabledChanged, this, &MouseWorker::setTpadEnabled);
-    connect(m_mouseProxy, &MouseDBusProxy::leftHandStateChanged, this, &MouseWorker::setLeftHandState);
-    connect(m_mouseProxy, &MouseDBusProxy::mouseNaturalScrollStateChanged, this, &MouseWorker::setMouseNaturalScrollState);
-    connect(m_mouseProxy, &MouseDBusProxy::touchNaturalScrollStateChanged, this, &MouseWorker::setTouchNaturalScrollState);
-    connect(m_mouseProxy, &MouseDBusProxy::disTypingChanged, this, &MouseWorker::setDisTyping);
-    connect(m_mouseProxy, &MouseDBusProxy::disTouchPadChanged, this, &MouseWorker::setDisTouchPad);
-    connect(m_mouseProxy, &MouseDBusProxy::tapClickChanged, this, &MouseWorker::setTapClick);
-    connect(m_mouseProxy, &MouseDBusProxy::douClickChanged, this, &MouseWorker::setDouClick);
-    connect(m_mouseProxy, &MouseDBusProxy::mouseMotionAccelerationChanged, this, &MouseWorker::setMouseMotionAcceleration);
-    connect(m_mouseProxy, &MouseDBusProxy::accelProfileChanged, this, &MouseWorker::setAccelProfile);
-    connect(m_mouseProxy, &MouseDBusProxy::touchpadMotionAccelerationChanged, this, &MouseWorker::setTouchpadMotionAcceleration);
+    // 设备存在状态：treeland 下由 waylandProxy 上报，DBus 侧跳过
+    if (!m_isTreelandSession) {
+        connect(m_mouseProxy, &MouseDBusProxy::mouseExistChanged, this, &MouseWorker::setMouseExist);
+        connect(m_mouseProxy, &MouseDBusProxy::tpadExistChanged, this, &MouseWorker::setTpadExist);
+        connect(m_mouseProxy, &MouseDBusProxy::tpadEnabledChanged, this, &MouseWorker::setTpadEnabled);
+        connect(m_mouseProxy, &MouseDBusProxy::leftHandStateChanged, this, &MouseWorker::setLeftHandState);
+        connect(m_mouseProxy, &MouseDBusProxy::mouseNaturalScrollStateChanged, this, &MouseWorker::setMouseNaturalScrollState);
+        connect(m_mouseProxy, &MouseDBusProxy::touchNaturalScrollStateChanged, this, &MouseWorker::setTouchNaturalScrollState);
+        connect(m_mouseProxy, &MouseDBusProxy::disTypingChanged, this, &MouseWorker::setDisTyping);
+        connect(m_mouseProxy, &MouseDBusProxy::tapClickChanged, this, &MouseWorker::setTapClick);
+        connect(m_mouseProxy, &MouseDBusProxy::douClickChanged, this, &MouseWorker::setDouClick);
+        connect(m_mouseProxy, &MouseDBusProxy::mouseMotionAccelerationChanged, this, &MouseWorker::setMouseMotionAcceleration);
+        connect(m_mouseProxy, &MouseDBusProxy::accelProfileChanged, this, &MouseWorker::setAccelProfile);
+        connect(m_mouseProxy, &MouseDBusProxy::touchpadMotionAccelerationChanged, this, &MouseWorker::setTouchpadMotionAcceleration);
+        connect(m_mouseProxy, &MouseDBusProxy::scrollSpeedChanged, this, &MouseWorker::setScrollSpeed);
+    }
+    #ifdef ENABLE_TREELAND_INPUT_MANAGER
+        if (m_waylandProxy) {
+        connect(m_waylandProxy, &MouseWaylandProxy::mouseExistChanged,
+            this, &MouseWorker::setMouseExist);
+        connect(m_waylandProxy, &MouseWaylandProxy::tpadExistChanged,
+            this, &MouseWorker::setTpadExist);
+        connect(m_waylandProxy, &MouseWaylandProxy::tpadEnabledChanged,
+            this, &MouseWorker::setTpadEnabled);
+        connect(m_waylandProxy, &MouseWaylandProxy::disTouchPadChanged,
+            this, &MouseWorker::setDisTouchPad);
+        connect(m_waylandProxy, &MouseWaylandProxy::leftHandStateChanged,
+            this, &MouseWorker::setLeftHandState);
+        connect(m_waylandProxy, &MouseWaylandProxy::mouseNaturalScrollStateChanged,
+            this, &MouseWorker::setMouseNaturalScrollState);
+        connect(m_waylandProxy, &MouseWaylandProxy::touchNaturalScrollStateChanged,
+            this, &MouseWorker::setTouchNaturalScrollState);
+        connect(m_waylandProxy, &MouseWaylandProxy::disTypingChanged,
+            this, &MouseWorker::setDisTyping);
+        connect(m_waylandProxy, &MouseWaylandProxy::tapClickChanged,
+            this, &MouseWorker::setTapClick);
+        connect(m_waylandProxy, &MouseWaylandProxy::mouseMotionAccelerationChanged,
+            this, &MouseWorker::setMouseMotionAcceleration);
+        connect(m_waylandProxy, &MouseWaylandProxy::accelProfileChanged,
+            this, &MouseWorker::setAccelProfile);
+        connect(m_waylandProxy, &MouseWaylandProxy::touchpadMotionAccelerationChanged,
+            this, &MouseWorker::setTouchpadMotionAcceleration);
+        connect(m_waylandProxy, &MouseWaylandProxy::scrollSpeedChanged,
+            this, &MouseWorker::setScrollSpeed);
+        }
+    #endif
+    if (!m_isTreelandSession)
+        connect(m_mouseProxy, &MouseDBusProxy::disTouchPadChanged, this, &MouseWorker::setDisTouchPad);
     connect(m_mouseProxy, &MouseDBusProxy::redPointExistChanged, this, &MouseWorker::setRedPointExist);
     connect(m_mouseProxy, &MouseDBusProxy::trackPointMotionAccelerationChanged, this, &MouseWorker::setTrackPointMotionAcceleration);
     connect(m_mouseProxy, &MouseDBusProxy::palmDetectChanged, this, &MouseWorker::setPalmDetect);
     connect(m_mouseProxy, &MouseDBusProxy::palmMinWidthChanged, this, &MouseWorker::setPalmMinWidth);
     connect(m_mouseProxy, &MouseDBusProxy::palmMinzChanged, this, &MouseWorker::setPalmMinz);
-    connect(m_mouseProxy, &MouseDBusProxy::scrollSpeedChanged, this, &MouseWorker::setScrollSpeed);
     connect(m_mouseProxy, &MouseDBusProxy::gestureDataChanged, this, [this](const GestureData &data) {
         setGestureData(data);
         initFingerGestures();
@@ -69,21 +141,50 @@ void MouseWorker::bindRequestSignals()
     connect(this, &MouseWorker::requestSetPalmDetect, m_mouseProxy, &MouseDBusProxy::setPalmDetect);
     connect(this, &MouseWorker::requestSetPalmMinWidth, m_mouseProxy, &MouseDBusProxy::setPalmMinWidth);
     connect(this, &MouseWorker::requestSetPalmMinz, m_mouseProxy, &MouseDBusProxy::setPalmMinz);
-    connect(this, &MouseWorker::requestSetDouClick, m_mouseProxy, &MouseDBusProxy::setDouClick);
-    connect(this, &MouseWorker::requestSetScrollSpeed, m_mouseProxy, &MouseDBusProxy::setScrollSpeed);
-    connect(this, &MouseWorker::requestSetLeftHandState, m_mouseProxy, &MouseDBusProxy::setLeftHandState);
-    connect(this, &MouseWorker::requestSetMouseNaturalScrollState, m_mouseProxy, &MouseDBusProxy::setMouseNaturalScrollState);
-    connect(this, &MouseWorker::requestSetTouchNaturalScrollState, m_mouseProxy, &MouseDBusProxy::setTouchNaturalScrollState);
-    connect(this, &MouseWorker::requestSetDisTyping, m_mouseProxy, &MouseDBusProxy::setDisTyping);
-    connect(this, &MouseWorker::requestSetDisTouchPad, m_mouseProxy, &MouseDBusProxy::setDisableTouchPadWhenMouseExist);
-    connect(this, &MouseWorker::requestSetTapClick, m_mouseProxy, &MouseDBusProxy::setTapClick);
-    connect(this, &MouseWorker::requestSetMouseMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setMouseMotionAcceleration);
-    connect(this, &MouseWorker::requestSetAccelProfile, m_mouseProxy, &MouseDBusProxy::setAccelProfile);
-    connect(this, &MouseWorker::requestSetTouchpadMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setTouchpadMotionAcceleration);
     connect(this, &MouseWorker::requestSetTrackPointMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setTrackPointMotionAcceleration);
-    connect(this, &MouseWorker::requestSetTouchpadEnabled, m_mouseProxy, &MouseDBusProxy::setTouchpadEnabled);
     connect(this, &MouseWorker::requestSetGesture, m_mouseProxy, &MouseDBusProxy::setGesture);
     connect(this, &MouseWorker::requestSetCursorSize, m_mouseProxy, &MouseDBusProxy::setCursorSize);
+    // treeland 下由 MouseWaylandProxy 处理的写请求，X11 下走 DBus
+    if (!m_isTreelandSession) {
+        connect(this, &MouseWorker::requestSetDouClick, m_mouseProxy, &MouseDBusProxy::setDouClick);
+        connect(this, &MouseWorker::requestSetScrollSpeed, m_mouseProxy, &MouseDBusProxy::setScrollSpeed);
+        connect(this, &MouseWorker::requestSetLeftHandState, m_mouseProxy, &MouseDBusProxy::setLeftHandState);
+        connect(this, &MouseWorker::requestSetMouseNaturalScrollState, m_mouseProxy, &MouseDBusProxy::setMouseNaturalScrollState);
+        connect(this, &MouseWorker::requestSetTouchNaturalScrollState, m_mouseProxy, &MouseDBusProxy::setTouchNaturalScrollState);
+        connect(this, &MouseWorker::requestSetDisTyping, m_mouseProxy, &MouseDBusProxy::setDisTyping);
+        connect(this, &MouseWorker::requestSetDisTouchPad, m_mouseProxy, &MouseDBusProxy::setDisableTouchPadWhenMouseExist);
+        connect(this, &MouseWorker::requestSetTapClick, m_mouseProxy, &MouseDBusProxy::setTapClick);
+        connect(this, &MouseWorker::requestSetMouseMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setMouseMotionAcceleration);
+        connect(this, &MouseWorker::requestSetAccelProfile, m_mouseProxy, &MouseDBusProxy::setAccelProfile);
+        connect(this, &MouseWorker::requestSetTouchpadMotionAcceleration, m_mouseProxy, &MouseDBusProxy::setTouchpadMotionAcceleration);
+        connect(this, &MouseWorker::requestSetTouchpadEnabled, m_mouseProxy, &MouseDBusProxy::setTouchpadEnabled);
+    }
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    if (m_waylandProxy) {
+        connect(this, &MouseWorker::requestSetLeftHandState,
+                m_waylandProxy, &MouseWaylandProxy::setLeftHandState);
+        connect(this, &MouseWorker::requestSetMouseNaturalScrollState,
+                m_waylandProxy, &MouseWaylandProxy::setMouseNaturalScrollState);
+        connect(this, &MouseWorker::requestSetTouchNaturalScrollState,
+                m_waylandProxy, &MouseWaylandProxy::setTouchNaturalScrollState);
+        connect(this, &MouseWorker::requestSetDisTyping,
+                m_waylandProxy, &MouseWaylandProxy::setDisTyping);
+        connect(this, &MouseWorker::requestSetDisTouchPad,
+                m_waylandProxy, &MouseWaylandProxy::setDisableTouchPadWhenMouseExist);
+        connect(this, &MouseWorker::requestSetTapClick,
+                m_waylandProxy, &MouseWaylandProxy::setTapClick);
+        connect(this, &MouseWorker::requestSetMouseMotionAcceleration,
+                m_waylandProxy, &MouseWaylandProxy::setMouseMotionAcceleration);
+        connect(this, &MouseWorker::requestSetAccelProfile,
+                m_waylandProxy, &MouseWaylandProxy::setAccelProfile);
+        connect(this, &MouseWorker::requestSetTouchpadMotionAcceleration,
+                m_waylandProxy, &MouseWaylandProxy::setTouchpadMotionAcceleration);
+        connect(this, &MouseWorker::requestSetScrollSpeed,
+                m_waylandProxy, &MouseWaylandProxy::setScrollSpeed);
+        connect(this, &MouseWorker::requestSetTouchpadEnabled,
+                m_waylandProxy, &MouseWaylandProxy::setTouchpadEnabled);
+    }
+#endif
 }
 
 void MouseWorker::initFingerGestures()
@@ -103,7 +204,9 @@ void MouseWorker::setTpadExist(bool exist)
 
 void MouseWorker::setTpadEnabled(bool enabled)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setTapEnabled(enabled);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setRedPointExist(bool exist)
@@ -113,52 +216,72 @@ void MouseWorker::setRedPointExist(bool exist)
 
 void MouseWorker::setLeftHandState(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setLeftHandState(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setMouseNaturalScrollState(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setMouseNaturalScroll(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setTouchNaturalScrollState(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setTpadNaturalScroll(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setDisTyping(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setDisIfTyping(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setDisTouchPad(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setDisTpad(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setTapClick(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setTapClick(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setDouClick(const int &value)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setDoubleSpeed(converToDoubleModel(value));
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setMouseMotionAcceleration(const double &value)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setMouseMoveSpeed(converToModelMotionAcceleration(value));
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setAccelProfile(const bool state)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setAccelProfile(state);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setTouchpadMotionAcceleration(const double &value)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setTpadMoveSpeed(converToModelMotionAcceleration(value));
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setTrackPointMotionAcceleration(const double &value)
@@ -183,7 +306,9 @@ void MouseWorker::setPalmMinz(int palmMinz)
 
 void MouseWorker::setScrollSpeed(uint speed)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setScrollSpeed(speed);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setGestureData(const GestureData &data)
@@ -193,7 +318,9 @@ void MouseWorker::setGestureData(const GestureData &data)
 
 void MouseWorker::setCursorSize(const int cursorSize)
 {
+    m_model->m_syncingFromBackend = true;
     m_model->setCursorSize(cursorSize);
+    m_model->m_syncingFromBackend = false;
 }
 
 void MouseWorker::setAvailableCursorSizes(QList<int> sizes)
@@ -309,43 +436,24 @@ int MouseWorker::converToDoubleModel(int value)
 //conver slider value to real value
 double MouseWorker::converToMotionAcceleration(int value)
 {
-    switch (value) {
-    case 0:
-        return 3.2;
-    case 1:
-        return 2.3;
-    case 2:
-        return 1.6;
-    case 3:
+    if (value < 0 || value >= static_cast<int>(kMotionAccelerationLevels.size()))
         return 1.0;
-    case 4:
-        return 0.6;
-    case 5:
-        return 0.3;
-    case 6:
-        return 0.2;
-    default:
-        return 1.0;
-    }
+
+    return kMotionAccelerationLevels[static_cast<size_t>(value)];
 }
 //conver real value to slider value
 int MouseWorker::converToModelMotionAcceleration(double value)
 {
-    if (value <= 0.2) {
-        return 6;
-    } else if (value <= 0.3) {
-        return 5;
-    } else if (value <= 0.6) {
-        return 4;
-    } else if (value <= 1.0) {
-        return 3;
-    } else if (value <= 1.6) {
-        return 2;
-    } else if (value <= 2.3) {
-        return 1;
-    } else if (value <= 3.2) {
-        return 0;
-    } else {
-        return 3;
+    int nearestIndex = 3;
+    double nearestDistance = std::abs(value - kMotionAccelerationLevels[nearestIndex]);
+
+    for (size_t i = 0; i < kMotionAccelerationLevels.size(); ++i) {
+        const double distance = std::abs(value - kMotionAccelerationLevels[i]);
+        if (distance < nearestDistance) {
+            nearestDistance = distance;
+            nearestIndex = static_cast<int>(i);
+        }
     }
+
+    return nearestIndex;
 }

--- a/src/plugin-mouse/operation/mouseworker.h
+++ b/src/plugin-mouse/operation/mouseworker.h
@@ -9,6 +9,10 @@
 
 #include <QObject>
 
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+#include "mousewaylandproxy.h"
+#endif
+
 using namespace DCC_MOUSE;
 namespace DCC_NAMESPACE {
 class MouseDBusProxy;
@@ -22,6 +26,9 @@ public:
     void init();
 
     void initFingerGestures();
+
+    /** 刷新鼠标/触摸板 */
+    void refreshMouse();
 
 public Q_SLOTS:
     void setMouseExist(bool exist);
@@ -97,8 +104,12 @@ private:
 
 private:
     MouseModel *m_model;
+    bool m_isTreelandSession = false;
     MouseDBusProxy *m_mouseProxy;
     TreeLandWorker *m_treelandWorker;
+#ifdef ENABLE_TREELAND_INPUT_MANAGER
+    MouseWaylandProxy *m_waylandProxy = nullptr;
+#endif
 };
 }
 

--- a/src/plugin-mouse/qml/Mouse.qml
+++ b/src/plugin-mouse/qml/Mouse.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 import org.deepin.dcc 1.0
@@ -15,6 +15,4 @@ DccObject {
     page: DccRightView {
         spacing: -4
     }
-
-    visible: !DccApp.isTreeland()
 }

--- a/src/plugin-mouse/qml/MouseMain.qml
+++ b/src/plugin-mouse/qml/MouseMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Window 2.15
@@ -8,6 +8,17 @@ import org.deepin.dcc 1.0
 import org.deepin.dtk 1.0 as D
 
 DccObject {
+    Connections {
+        target: DccApp
+        function onCurrentObjectsChanged(objects) {
+            for (var i = 0; i < objects.length; i++) {
+                if (objects[i].name === "MouseAndTouchpad") {
+                    dccData.refreshMouse()
+                    break
+                }
+            }
+        }
+    }
     DccObject {
         name: "MouseAndTouchpadCommon"
         parentName: "MouseAndTouchpad"

--- a/src/shared-utils/CMakeLists.txt
+++ b/src/shared-utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+# SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -24,3 +24,39 @@ target_link_libraries(dcc-shared-utils PRIVATE
     ICU::uc
     ${QT_NS}::Core
 )
+
+# Treeland input manager (wraps treeland_input_manager_v1 Wayland protocol)
+if (Enable_TreelandSupport)
+    find_package(TreelandProtocols REQUIRED)
+    find_package(${QT_NS} REQUIRED COMPONENTS WaylandClient)
+    if(${QT_NS}_VERSION VERSION_GREATER_EQUAL 6.10)
+        find_package(${QT_NS} COMPONENTS WaylandClientPrivate REQUIRED)
+    endif()
+
+    qt6_generate_wayland_protocol_client_sources(dcc-shared-utils
+        FILES
+            ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-input-manager-unstable-v1.xml
+    )
+
+    target_include_directories(dcc-shared-utils PUBLIC
+        ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    target_sources(dcc-shared-utils PRIVATE
+        treelandinputmanager.h
+        treelandinputmanager.cpp
+    )
+
+    if(${QT_NS}_VERSION VERSION_GREATER_EQUAL 6.10)
+        target_link_libraries(dcc-shared-utils PUBLIC
+            ${QT_NS}::WaylandClient
+            ${QT_NS}::WaylandClientPrivate
+        )
+    else()
+        target_link_libraries(dcc-shared-utils PUBLIC
+            ${QT_NS}::WaylandClient
+        )
+    endif()
+
+    target_compile_definitions(dcc-shared-utils PUBLIC ENABLE_TREELAND_INPUT_MANAGER)
+endif()

--- a/src/shared-utils/treelandinputmanager.cpp
+++ b/src/shared-utils/treelandinputmanager.cpp
@@ -1,0 +1,982 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "treelandinputmanager.h"
+
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <wayland-client.h>
+
+// Note: qwayland-treeland-input-manager-unstable-v1.h is already included
+// transitively via treelandinputmanager.h.
+
+namespace DCC_NAMESPACE {
+
+Q_LOGGING_CATEGORY(lcTreelandInput, "dde.dcc.treeland.input")
+
+namespace {
+
+// device_type bitfield values from the protocol enum
+constexpr uint32_t kMouseBit    = TREELAND_INPUT_MANAGER_V1_DEVICE_TYPE_MOUSE;
+constexpr uint32_t kTouchpadBit = TREELAND_INPUT_MANAGER_V1_DEVICE_TYPE_TOUCHPAD;
+constexpr uint32_t kKeyboardBit = TREELAND_INPUT_MANAGER_V1_DEVICE_TYPE_KEYBOARD;
+
+template<typename T>
+bool updateValue(T &current, const T &next)
+{
+    if (current == next)
+        return false;
+    current = next;
+    return true;
+}
+
+} // namespace
+
+class TreelandInputManagerPrivate
+{
+public:
+    explicit TreelandInputManagerPrivate(TreelandInputManager *qq)
+        : q(qq)
+    {
+    }
+
+    ~TreelandInputManagerPrivate()
+    {
+        shutdown();
+    }
+
+    void initialize();
+    void flush() const;
+    void shutdown();
+
+    void onCapabilityAvailable(uint32_t type, wl_seat *capSeat);
+    void onCapabilityUnavailable(uint32_t type, wl_seat *capSeat);
+
+    void ensureMouseSettings();
+    void releaseMouseSettings();
+    void ensureTouchpadSettings();
+    void releaseTouchpadSettings();
+    void ensureKeyboardSettings();
+    void releaseKeyboardSettings();
+    void refreshMouse();
+    void refreshKeyboard();
+
+public:
+    TreelandInputManager *q = nullptr;
+    wl_display *display = nullptr;
+    wl_seat *seat = nullptr;
+
+    bool initialized = false;
+    bool shutDown = false;
+    bool mouseAvail = false;
+    bool touchpadAvail = false;
+    bool keyboardAvail = false;
+
+    TreelandMouseSettings *mouseSettings = nullptr;
+    TreelandTouchpadSettings *touchpadSettings = nullptr;
+    TreelandKeyboardSettings *keyboardSettings = nullptr;
+};
+
+// ---------------------------------------------------------------------------
+// Private implementation
+// ---------------------------------------------------------------------------
+
+void TreelandInputManagerPrivate::initialize()
+{
+    if (initialized)
+        return;
+
+    initialized = true;
+
+    auto *waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+    if (!waylandApp) {
+        qCWarning(lcTreelandInput) << "No Wayland application interface available, treeland input manager disabled";
+        return;
+    }
+
+    display = waylandApp->display();
+    if (!display) {
+        qCWarning(lcTreelandInput) << "Failed to get Wayland display";
+        return;
+    }
+}
+
+void TreelandInputManagerPrivate::flush() const
+{
+    if (display)
+        wl_display_flush(display);
+}
+
+void TreelandInputManagerPrivate::shutdown()
+{
+    if (shutDown)
+        return;
+    shutDown = true;
+
+    releaseMouseSettings();
+    releaseTouchpadSettings();
+    releaseKeyboardSettings();
+
+    if (q->QtWayland::treeland_input_manager_v1::isInitialized())
+        q->QtWayland::treeland_input_manager_v1::destroy();
+    seat = nullptr;
+    display = nullptr;
+}
+
+void TreelandInputManagerPrivate::onCapabilityAvailable(uint32_t type, wl_seat *capSeat)
+{
+    // Accept the first seat that reports capabilities; ignore others.
+    if (!seat)
+        seat = capSeat;
+    else if (capSeat != seat)
+        return;
+
+    qCDebug(lcTreelandInput) << "Capability available: type=" << type
+                             << "mouse=" << bool(type & kMouseBit)
+                             << "touchpad=" << bool(type & kTouchpadBit)
+                             << "keyboard=" << bool(type & kKeyboardBit);
+
+    if (type & kMouseBit) {
+        if (updateValue(mouseAvail, true)) {
+            qCDebug(lcTreelandInput) << "Mouse capability acquired, creating mouse settings";
+            ensureMouseSettings();
+            Q_EMIT q->mouseAvailableChanged(true);
+        }
+    }
+
+    if (type & kTouchpadBit) {
+        if (updateValue(touchpadAvail, true)) {
+            qCDebug(lcTreelandInput) << "Touchpad capability acquired, creating touchpad settings";
+            ensureTouchpadSettings();
+            Q_EMIT q->touchpadAvailableChanged(true);
+        }
+    }
+
+    if (type & kKeyboardBit) {
+        if (updateValue(keyboardAvail, true)) {
+            qCDebug(lcTreelandInput) << "Keyboard capability acquired, creating keyboard settings";
+            ensureKeyboardSettings();
+            Q_EMIT q->keyboardAvailableChanged(true);
+        }
+    }
+}
+
+void TreelandInputManagerPrivate::onCapabilityUnavailable(uint32_t type, wl_seat *capSeat)
+{
+    if (capSeat != seat)
+        return;
+
+    qCDebug(lcTreelandInput) << "Capability unavailable: type=" << type
+                             << "mouse=" << bool(type & kMouseBit)
+                             << "touchpad=" << bool(type & kTouchpadBit)
+                             << "keyboard=" << bool(type & kKeyboardBit);
+
+    if (type & kMouseBit) {
+        if (updateValue(mouseAvail, false)) {
+            qCDebug(lcTreelandInput) << "Mouse capability lost, releasing mouse settings";
+            releaseMouseSettings();
+            Q_EMIT q->mouseAvailableChanged(false);
+        }
+    }
+
+    if (type & kTouchpadBit) {
+        if (updateValue(touchpadAvail, false)) {
+            qCDebug(lcTreelandInput) << "Touchpad capability lost, releasing touchpad settings";
+            releaseTouchpadSettings();
+            Q_EMIT q->touchpadAvailableChanged(false);
+        }
+    }
+
+    if (type & kKeyboardBit) {
+        if (updateValue(keyboardAvail, false)) {
+            qCDebug(lcTreelandInput) << "Keyboard capability lost, releasing keyboard settings";
+            releaseKeyboardSettings();
+            Q_EMIT q->keyboardAvailableChanged(false);
+        }
+    }
+
+    // If no capabilities remain on this seat, release it so a new one can be accepted.
+    if (!mouseAvail && !touchpadAvail && !keyboardAvail) {
+        qCDebug(lcTreelandInput) << "All capabilities lost, releasing seat";
+        seat = nullptr;
+    }
+}
+
+void TreelandInputManagerPrivate::ensureMouseSettings()
+{
+    if (!q->isActive() || !seat || mouseSettings)
+        return;
+
+    qCDebug(lcTreelandInput) << "Creating mouse-specific settings";
+    auto *handle = q->get_mouse_settings(seat);
+    if (!handle) {
+        qCWarning(lcTreelandInput) << "Failed to get mouse settings handle from compositor";
+        return;
+    }
+
+    mouseSettings = new TreelandMouseSettings(this, q);
+    mouseSettings->QtWayland::treeland_mouse_settings_v1::init(handle);
+    mouseSettings->initPointerConfiguration();
+
+    qCDebug(lcTreelandInput) << "Mouse-specific settings created";
+}
+
+void TreelandInputManagerPrivate::releaseMouseSettings()
+{
+    if (!mouseSettings)
+        return;
+    mouseSettings->releaseHandle();
+    delete mouseSettings;
+    mouseSettings = nullptr;
+}
+
+void TreelandInputManagerPrivate::ensureTouchpadSettings()
+{
+    if (!q->isActive() || !seat || touchpadSettings)
+        return;
+
+    qCDebug(lcTreelandInput) << "Creating touchpad-specific settings";
+    auto *handle = q->get_touchpad_settings(seat);
+    if (!handle) {
+        qCWarning(lcTreelandInput) << "Failed to get touchpad settings handle from compositor";
+        return;
+    }
+
+    touchpadSettings = new TreelandTouchpadSettings(this, q);
+    touchpadSettings->QtWayland::treeland_touchpad_settings_v1::init(handle);
+    touchpadSettings->initPointerConfiguration();
+
+    qCDebug(lcTreelandInput) << "Touchpad-specific settings created";
+}
+
+void TreelandInputManagerPrivate::releaseTouchpadSettings()
+{
+    if (!touchpadSettings)
+        return;
+    touchpadSettings->releaseHandle();
+    delete touchpadSettings;
+    touchpadSettings = nullptr;
+}
+
+void TreelandInputManagerPrivate::ensureKeyboardSettings()
+{
+    if (!q->isActive() || !seat || keyboardSettings)
+        return;
+
+    qCDebug(lcTreelandInput) << "Creating keyboard settings";
+    auto *handle = q->get_keyboard_settings(seat);
+    if (!handle) {
+        qCWarning(lcTreelandInput) << "Failed to get keyboard settings handle from compositor";
+        return;
+    }
+
+    keyboardSettings = new TreelandKeyboardSettings(this, q);
+    // init() registers the listener table on the underlying Wayland object.
+    keyboardSettings->init(handle);
+    qCDebug(lcTreelandInput) << "Keyboard settings created";
+}
+
+void TreelandInputManagerPrivate::releaseKeyboardSettings()
+{
+    if (!keyboardSettings)
+        return;
+    keyboardSettings->releaseHandle();
+    delete keyboardSettings;
+    keyboardSettings = nullptr;
+}
+
+void TreelandInputManagerPrivate::refreshMouse()
+{
+    qCDebug(lcTreelandInput) << "Refreshing mouse/touchpad settings";
+
+    releaseMouseSettings();
+    releaseTouchpadSettings();
+
+    if (mouseAvail) {
+        ensureMouseSettings();
+    }
+    if (touchpadAvail) {
+        ensureTouchpadSettings();
+    }
+
+    qCDebug(lcTreelandInput) << "Mouse refresh complete:"
+                             << "mouse=" << (mouseSettings != nullptr)
+                             << "touchpad=" << (touchpadSettings != nullptr);
+}
+
+void TreelandInputManagerPrivate::refreshKeyboard()
+{
+    qCDebug(lcTreelandInput) << "Refreshing keyboard settings";
+
+    // Release keyboard settings only
+    releaseKeyboardSettings();
+
+    // Re-create based on current capability state
+    if (keyboardAvail) {
+        ensureKeyboardSettings();
+    }
+
+    qCDebug(lcTreelandInput) << "Keyboard refresh complete:"
+                             << "keyboard=" << (keyboardSettings != nullptr);
+}
+
+// ===========================================================================
+// TreelandMouseSettings
+// ===========================================================================
+
+TreelandMouseSettings::TreelandMouseSettings(TreelandInputManagerPrivate *priv, QObject *parent)
+    : QObject(parent)
+    , m_priv(priv)
+{
+}
+
+TreelandMouseSettings::~TreelandMouseSettings()
+{
+    releaseHandle();
+}
+
+uint32_t TreelandMouseSettings::accelerationProfile() const { return m_accelerationProfile; }
+uint32_t TreelandMouseSettings::sendEventsMode() const { return m_sendEventsMode; }
+double TreelandMouseSettings::scrollFactor() const { return m_scrollFactor; }
+bool TreelandMouseSettings::leftHanded() const { return m_leftHanded; }
+double TreelandMouseSettings::speed() const { return m_speed; }
+bool TreelandMouseSettings::naturalScroll() const { return m_naturalScroll; }
+
+void TreelandMouseSettings::initPointerConfiguration(uint32_t serial)
+{
+    if (!QtWayland::treeland_mouse_settings_v1::isInitialized()
+        || QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) {
+        return;
+    }
+
+    qCDebug(lcTreelandInput) << "MouseSettings: requesting pointer_device_configuration, serial=" << serial;
+    auto *rawCfg = get_pointer_configuration(serial);
+    if (!rawCfg) {
+        qCWarning(lcTreelandInput) << "MouseSettings: failed to get pointer_device_configuration from compositor";
+        return;
+    }
+
+    QtWayland::treeland_pointer_device_configuration_v1::init(rawCfg);
+    qCDebug(lcTreelandInput) << "MouseSettings: pointer_device_configuration initialized";
+}
+
+void TreelandMouseSettings::setAccelerationProfile(uint32_t profile)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_ACCELERATION_PROFILE)) {
+        qCDebug(lcTreelandInput) << "MouseSettings::setAccelerationProfile ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "MouseSettings::setAccelerationProfile:" << profile;
+    set_acceleration_profile(profile);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandMouseSettings::setSendEventsMode(uint32_t mode)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_SEND_EVENTS_MODE)) {
+        qCDebug(lcTreelandInput) << "MouseSettings::setSendEventsMode ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "MouseSettings::setSendEventsMode:" << mode;
+    set_send_events_mode(mode);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandMouseSettings::setScrollFactor(double factor)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_SCROLL_FACTOR)) {
+        qCDebug(lcTreelandInput) << "MouseSettings::setScrollFactor ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "MouseSettings::setScrollFactor:" << factor;
+    set_scroll_factor(wl_fixed_from_double(factor));
+    apply();
+    m_priv->flush();
+}
+
+void TreelandMouseSettings::setLeftHanded(bool leftHanded)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_HANDED_MODE)) {
+        qCDebug(lcTreelandInput) << "MouseSettings::setLeftHanded ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "MouseSettings::setLeftHanded:" << leftHanded;
+    set_handed_mode(leftHanded ? handed_mode_left : handed_mode_right);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandMouseSettings::setSpeed(double speed)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_ACCEL_SPEED)) {
+        qCDebug(lcTreelandInput) << "MouseSettings::setSpeed ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "MouseSettings::setSpeed:" << speed;
+    set_accel_speed(wl_fixed_from_double(speed));
+    apply();
+    m_priv->flush();
+}
+
+void TreelandMouseSettings::setNaturalScroll(bool enabled)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_NATURAL_SCROLL)) {
+        qCDebug(lcTreelandInput) << "MouseSettings::setNaturalScroll ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "MouseSettings::setNaturalScroll:" << enabled;
+    set_natural_scroll(enabled ? TREELAND_INPUT_MANAGER_V1_STATE_ENABLED
+                               : TREELAND_INPUT_MANAGER_V1_STATE_DISABLED);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandMouseSettings::releaseHandle()
+{
+    if (QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        QtWayland::treeland_pointer_device_configuration_v1::destroy();
+    if (QtWayland::treeland_mouse_settings_v1::isInitialized())
+        QtWayland::treeland_mouse_settings_v1::destroy();
+}
+
+// ---------------------------------------------------------------------------
+// TreelandMouseSettings — Qt Wayland virtual overrides
+// ---------------------------------------------------------------------------
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_feature(uint32_t feature)
+{
+    m_features = feature;
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_scroll_factor(wl_fixed_t factor)
+{
+    double v = wl_fixed_to_double(factor);
+    if (m_scrollFactor == v)
+        return;
+    m_scrollFactor = v;
+    Q_EMIT scrollFactorChanged(m_scrollFactor);
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_handed_mode(uint32_t mode)
+{
+    bool lh = (mode == handed_mode_left);
+    if (m_leftHanded == lh)
+        return;
+    m_leftHanded = lh;
+    Q_EMIT leftHandedChanged(m_leftHanded);
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_accel_speed(wl_fixed_t accel_speed)
+{
+    double v = wl_fixed_to_double(accel_speed);
+    if (m_speed == v)
+        return;
+    m_speed = v;
+    Q_EMIT speedChanged(m_speed);
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_acceleration_profile(uint32_t profile)
+{
+    if (m_accelerationProfile == profile)
+        return;
+    m_accelerationProfile = profile;
+    Q_EMIT accelerationProfileChanged(m_accelerationProfile);
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_send_events_mode(uint32_t mode)
+{
+    if (m_sendEventsMode == mode)
+        return;
+    m_sendEventsMode = mode;
+    Q_EMIT sendEventsModeChanged(m_sendEventsMode);
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_natural_scroll(uint32_t state)
+{
+    bool enabled = (state == TREELAND_INPUT_MANAGER_V1_STATE_ENABLED);
+    if (m_naturalScroll == enabled)
+        return;
+    m_naturalScroll = enabled;
+    Q_EMIT naturalScrollChanged(m_naturalScroll);
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_disable_while_typing(uint32_t state)
+{
+    qCWarning(lcTreelandInput) << "MouseSettings: unexpected disable_while_typing event from compositor, state="
+                               << state;
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_tap_to_click(uint32_t state)
+{
+    qCWarning(lcTreelandInput) << "MouseSettings: unexpected tap_to_click event from compositor, state="
+                               << state;
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_failed()
+{
+    qCWarning(lcTreelandInput) << "MouseSettings: compositor failed to apply pending configuration";
+    Q_EMIT failed();
+}
+
+void TreelandMouseSettings::treeland_pointer_device_configuration_v1_done(uint32_t serial)
+{
+    qCDebug(lcTreelandInput) << "MouseSettings: state batch done, serial=" << serial;
+    m_lastSerial = serial;
+    Q_EMIT done();
+}
+
+// ===========================================================================
+// TreelandTouchpadSettings
+// ===========================================================================
+
+TreelandTouchpadSettings::TreelandTouchpadSettings(TreelandInputManagerPrivate *priv, QObject *parent)
+    : QObject(parent)
+    , m_priv(priv)
+{
+}
+
+TreelandTouchpadSettings::~TreelandTouchpadSettings()
+{
+    releaseHandle();
+}
+
+bool TreelandTouchpadSettings::isEnabled() const { return m_enabled; }
+uint32_t TreelandTouchpadSettings::sendEventsMode() const { return m_sendEventsMode; }
+bool TreelandTouchpadSettings::disableWhileTyping() const { return m_disableWhileTyping; }
+bool TreelandTouchpadSettings::tapToClick() const { return m_tapToClick; }
+uint32_t TreelandTouchpadSettings::features() const { return m_features; }
+double TreelandTouchpadSettings::scrollFactor() const { return m_scrollFactor; }
+bool TreelandTouchpadSettings::leftHanded() const { return m_leftHanded; }
+double TreelandTouchpadSettings::speed() const { return m_speed; }
+bool TreelandTouchpadSettings::naturalScroll() const { return m_naturalScroll; }
+
+void TreelandTouchpadSettings::initPointerConfiguration(uint32_t serial)
+{
+    if (!QtWayland::treeland_touchpad_settings_v1::isInitialized()
+        || QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) {
+        return;
+    }
+
+    qCDebug(lcTreelandInput) << "TouchpadSettings: requesting pointer_device_configuration, serial=" << serial;
+    auto *rawCfg = get_pointer_configuration(serial);
+    if (!rawCfg) {
+        qCWarning(lcTreelandInput) << "TouchpadSettings: failed to get pointer_device_configuration from compositor";
+        return;
+    }
+
+    QtWayland::treeland_pointer_device_configuration_v1::init(rawCfg);
+    qCDebug(lcTreelandInput) << "TouchpadSettings: pointer_device_configuration initialized";
+}
+
+void TreelandTouchpadSettings::setEnabled(bool enabled)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        return;
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setEnabled:" << enabled;
+    setSendEventsMode(enabled ? send_events_mode_enabled : send_events_mode_disabled);
+}
+
+void TreelandTouchpadSettings::setSendEventsMode(uint32_t mode)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_SEND_EVENTS_MODE)) {
+        qCDebug(lcTreelandInput) << "TouchpadSettings::setSendEventsMode ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setSendEventsMode:" << mode;
+    set_send_events_mode(mode);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::setDisableWhileTyping(bool enabled)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        return;
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setDisableWhileTyping:" << enabled;
+    set_disable_while_typing(enabled ? TREELAND_INPUT_MANAGER_V1_STATE_ENABLED
+                                     : TREELAND_INPUT_MANAGER_V1_STATE_DISABLED);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::setTapToClick(bool enabled)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        return;
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setTapToClick:" << enabled;
+    set_tap_to_click(enabled ? TREELAND_INPUT_MANAGER_V1_STATE_ENABLED
+                             : TREELAND_INPUT_MANAGER_V1_STATE_DISABLED);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::setScrollFactor(double factor)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_SCROLL_FACTOR)) {
+        qCDebug(lcTreelandInput) << "TouchpadSettings::setScrollFactor ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setScrollFactor:" << factor;
+    set_scroll_factor(wl_fixed_from_double(factor));
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::setLeftHanded(bool leftHanded)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_HANDED_MODE)) {
+        qCDebug(lcTreelandInput) << "TouchpadSettings::setLeftHanded ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setLeftHanded:" << leftHanded;
+    set_handed_mode(leftHanded ? handed_mode_left : handed_mode_right);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::setSpeed(double speed)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_ACCEL_SPEED)) {
+        qCDebug(lcTreelandInput) << "TouchpadSettings::setSpeed ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setSpeed:" << speed;
+    set_accel_speed(wl_fixed_from_double(speed));
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::setNaturalScroll(bool enabled)
+{
+    if (!QtWayland::treeland_pointer_device_configuration_v1::isInitialized()) return;
+    if (!(m_features & TREELAND_POINTER_DEVICE_CONFIGURATION_V1_FEATURE_NATURAL_SCROLL)) {
+        qCDebug(lcTreelandInput) << "TouchpadSettings::setNaturalScroll ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "TouchpadSettings::setNaturalScroll:" << enabled;
+    set_natural_scroll(enabled ? TREELAND_INPUT_MANAGER_V1_STATE_ENABLED
+                               : TREELAND_INPUT_MANAGER_V1_STATE_DISABLED);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandTouchpadSettings::releaseHandle()
+{
+    if (QtWayland::treeland_pointer_device_configuration_v1::isInitialized())
+        QtWayland::treeland_pointer_device_configuration_v1::destroy();
+    if (QtWayland::treeland_touchpad_settings_v1::isInitialized())
+        QtWayland::treeland_touchpad_settings_v1::destroy();
+}
+
+// ---------------------------------------------------------------------------
+// TreelandTouchpadSettings — Qt Wayland virtual overrides
+// ---------------------------------------------------------------------------
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_feature(uint32_t feature)
+{
+    if (m_features == feature)
+        return;
+    m_features = feature;
+    Q_EMIT featuresChanged(m_features);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_scroll_factor(wl_fixed_t factor)
+{
+    double v = wl_fixed_to_double(factor);
+    if (m_scrollFactor == v)
+        return;
+    m_scrollFactor = v;
+    Q_EMIT scrollFactorChanged(m_scrollFactor);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_handed_mode(uint32_t mode)
+{
+    bool lh = (mode == handed_mode_left);
+    if (m_leftHanded == lh)
+        return;
+    m_leftHanded = lh;
+    Q_EMIT leftHandedChanged(m_leftHanded);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_accel_speed(wl_fixed_t accel_speed)
+{
+    double v = wl_fixed_to_double(accel_speed);
+    if (m_speed == v)
+        return;
+    m_speed = v;
+    Q_EMIT speedChanged(m_speed);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_acceleration_profile(uint32_t /*profile*/)
+{
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_send_events_mode(uint32_t mode)
+{
+    const bool enabled = (mode != send_events_mode_disabled);
+    const bool modeChanged = (m_sendEventsMode != mode);
+    const bool enabledChanged = (m_enabled != enabled);
+
+    m_sendEventsMode = mode;
+    m_enabled = enabled;
+
+    if (modeChanged)
+        Q_EMIT sendEventsModeChanged(m_sendEventsMode);
+    if (enabledChanged)
+        Q_EMIT this->enabledChanged(m_enabled);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_natural_scroll(uint32_t state)
+{
+    bool enabled = (state == TREELAND_INPUT_MANAGER_V1_STATE_ENABLED);
+    if (m_naturalScroll == enabled)
+        return;
+    m_naturalScroll = enabled;
+    Q_EMIT naturalScrollChanged(m_naturalScroll);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_disable_while_typing(uint32_t state)
+{
+    bool enabled = (state == TREELAND_INPUT_MANAGER_V1_STATE_ENABLED);
+    if (m_disableWhileTyping == enabled)
+        return;
+    m_disableWhileTyping = enabled;
+    Q_EMIT disableWhileTypingChanged(m_disableWhileTyping);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_tap_to_click(uint32_t state)
+{
+    bool enabled = (state == TREELAND_INPUT_MANAGER_V1_STATE_ENABLED);
+    if (m_tapToClick == enabled)
+        return;
+    m_tapToClick = enabled;
+    Q_EMIT tapToClickChanged(m_tapToClick);
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_failed()
+{
+    qCWarning(lcTreelandInput) << "TouchpadSettings: compositor failed to apply pending configuration";
+    Q_EMIT failed();
+}
+
+void TreelandTouchpadSettings::treeland_pointer_device_configuration_v1_done(uint32_t serial)
+{
+    qCDebug(lcTreelandInput) << "TouchpadSettings: state batch done, serial=" << serial;
+    m_lastSerial = serial;
+    Q_EMIT done();
+}
+
+// ===========================================================================
+// TreelandKeyboardSettings
+// ===========================================================================
+
+TreelandKeyboardSettings::TreelandKeyboardSettings(TreelandInputManagerPrivate *priv, QObject *parent)
+    : QObject(parent)
+    , m_priv(priv)
+{
+}
+
+TreelandKeyboardSettings::~TreelandKeyboardSettings()
+{
+    releaseHandle();
+}
+
+int TreelandKeyboardSettings::repeatRate() const { return m_repeatRate; }
+int TreelandKeyboardSettings::repeatDelay() const { return m_repeatDelay; }
+bool TreelandKeyboardSettings::numLock() const { return m_numLock; }
+
+void TreelandKeyboardSettings::setRepeatRate(int rate)
+{
+    if (!isInitialized())
+        return;
+    qCDebug(lcTreelandInput) << "KeyboardSettings::setRepeatRate:" << rate;
+    set_repeat(rate, m_repeatDelay);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandKeyboardSettings::setRepeatDelay(int delay)
+{
+    if (!isInitialized())
+        return;
+    qCDebug(lcTreelandInput) << "KeyboardSettings::setRepeatDelay:" << delay;
+    set_repeat(m_repeatRate, delay);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandKeyboardSettings::setNumLock(bool on)
+{
+    if (!isInitialized())
+        return;
+    if (!(m_features & TREELAND_KEYBOARD_SETTINGS_V1_FEATURE_NUM_LOCK)) {
+        qCDebug(lcTreelandInput) << "KeyboardSettings::setNumLock ignored: feature not supported";
+        return;
+    }
+    qCDebug(lcTreelandInput) << "KeyboardSettings::setNumLock:" << on;
+    set_num_lock(on ? toggle_state_on : toggle_state_off);
+    apply();
+    m_priv->flush();
+}
+
+void TreelandKeyboardSettings::treeland_keyboard_settings_v1_feature(uint32_t feature)
+{
+    m_features = feature;
+}
+
+void TreelandKeyboardSettings::treeland_keyboard_settings_v1_repeat(int32_t rate, int32_t delay)
+{
+    if (m_repeatRate == rate && m_repeatDelay == delay)
+        return;
+    m_repeatRate = rate;
+    m_repeatDelay = delay;
+    Q_EMIT repeatChanged(m_repeatRate, m_repeatDelay);
+}
+
+void TreelandKeyboardSettings::treeland_keyboard_settings_v1_num_lock(uint32_t state)
+{
+    bool on = (state == toggle_state_on);
+    if (m_numLock == on)
+        return;
+    m_numLock = on;
+    Q_EMIT numLockChanged(m_numLock);
+}
+
+void TreelandKeyboardSettings::treeland_keyboard_settings_v1_failed()
+{
+    qCWarning(lcTreelandInput) << "KeyboardSettings: compositor failed to apply pending configuration";
+    Q_EMIT failed();
+}
+
+void TreelandKeyboardSettings::treeland_keyboard_settings_v1_done()
+{
+    qCDebug(lcTreelandInput) << "KeyboardSettings: state batch done";
+    Q_EMIT done();
+}
+
+void TreelandKeyboardSettings::releaseHandle()
+{
+    if (isInitialized())
+        destroy();
+}
+
+// ===========================================================================
+// TreelandInputManager
+// ===========================================================================
+
+TreelandInputManager::TreelandInputManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<TreelandInputManager>(1)
+    , d(std::make_unique<TreelandInputManagerPrivate>(this))
+{
+    setParent(parent);
+    d->initialize();
+
+    connect(this, &QWaylandClientExtension::activeChanged, this, [this]() {
+        const bool available = isActive();
+        qCDebug(lcTreelandInput) << "treeland_input_manager_v1 active changed:" << available;
+        Q_EMIT availableChanged(available);
+        if (available)
+            return;
+
+        const bool hadMouse = d->mouseAvail;
+        const bool hadTouchpad = d->touchpadAvail;
+        const bool hadKeyboard = d->keyboardAvail;
+        d->mouseAvail = false;
+        d->touchpadAvail = false;
+        d->keyboardAvail = false;
+        d->seat = nullptr;
+        d->releaseMouseSettings();
+        d->releaseTouchpadSettings();
+        d->releaseKeyboardSettings();
+        if (hadMouse)
+            Q_EMIT mouseAvailableChanged(false);
+        if (hadTouchpad)
+            Q_EMIT touchpadAvailableChanged(false);
+        if (hadKeyboard)
+            Q_EMIT keyboardAvailableChanged(false);
+    });
+
+    qCDebug(lcTreelandInput) << "Treeland input manager initializing";
+
+    // Destroy Wayland proxy objects while the display connection is still alive.
+    // Q_GLOBAL_STATIC destruction order is undefined — the wl_display may be
+    // gone by the time our destructor runs, causing a crash in wl_proxy_destroy.
+    connect(QCoreApplication::instance(), &QCoreApplication::aboutToQuit, this, [this]() {
+        d->shutdown();
+    });
+}
+
+TreelandInputManager::~TreelandInputManager() = default;
+
+bool TreelandInputManager::available() const
+{
+    return isActive();
+}
+
+bool TreelandInputManager::mouseAvailable() const
+{
+    return d->mouseAvail;
+}
+
+bool TreelandInputManager::touchpadAvailable() const
+{
+    return d->touchpadAvail;
+}
+
+bool TreelandInputManager::keyboardAvailable() const
+{
+    return d->keyboardAvail;
+}
+
+TreelandMouseSettings *TreelandInputManager::mouseSettings() const
+{
+    return d->mouseSettings;
+}
+
+TreelandTouchpadSettings *TreelandInputManager::touchpadSettings() const
+{
+    return d->touchpadSettings;
+}
+
+TreelandKeyboardSettings *TreelandInputManager::keyboardSettings() const
+{
+    return d->keyboardSettings;
+}
+
+void TreelandInputManager::refreshMouse()
+{
+    d->refreshMouse();
+}
+
+void TreelandInputManager::refreshKeyboard()
+{
+    d->refreshKeyboard();
+}
+
+void TreelandInputManager::treeland_input_manager_v1_capability_available(uint32_t type, wl_seat *seat)
+{
+    d->onCapabilityAvailable(type, seat);
+}
+
+void TreelandInputManager::treeland_input_manager_v1_capability_unavailable(uint32_t type, wl_seat *seat)
+{
+    d->onCapabilityUnavailable(type, seat);
+}
+
+} // namespace DCC_NAMESPACE

--- a/src/shared-utils/treelandinputmanager.h
+++ b/src/shared-utils/treelandinputmanager.h
@@ -1,0 +1,347 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QWaylandClientExtension>
+#include <memory>
+
+// Qt Wayland C++ bindings generated from the protocol XML.
+// Only included when Treeland support is enabled (treelandinputmanager.h is
+// only added to the build in that configuration).
+#include "qwayland-treeland-input-manager-unstable-v1.h"
+
+namespace DCC_NAMESPACE {
+
+class TreelandInputManagerPrivate;
+class TreelandMouseSettings;
+class TreelandTouchpadSettings;
+
+// ---------------------------------------------------------------------------
+// TreelandMouseSettings
+// ---------------------------------------------------------------------------
+/**
+ * @brief 鼠标完整设置，对应 treeland_mouse_settings_v1 工厂 + treeland_pointer_device_configuration_v1。
+ *
+ * 持有唯一的 treeland_pointer_device_configuration_v1 对象（符合协议"每 factory 最多一个"要求）。
+ * 同时处理共享指针事件（速度、自然滚动等）和鼠标专有事件（加速度模式等）。
+ */
+class TreelandMouseSettings
+    : public QObject
+    , public QtWayland::treeland_mouse_settings_v1
+    , public QtWayland::treeland_pointer_device_configuration_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(uint32_t accelerationProfile READ accelerationProfile NOTIFY accelerationProfileChanged)
+    Q_PROPERTY(uint32_t sendEventsMode READ sendEventsMode NOTIFY sendEventsModeChanged)
+    Q_PROPERTY(double scrollFactor READ scrollFactor NOTIFY scrollFactorChanged)
+    Q_PROPERTY(bool leftHanded READ leftHanded NOTIFY leftHandedChanged)
+    Q_PROPERTY(double speed READ speed NOTIFY speedChanged)
+    Q_PROPERTY(bool naturalScroll READ naturalScroll NOTIFY naturalScrollChanged)
+
+public:
+    /** Corresponds to treeland_pointer_device_configuration_v1::acceleration_profile */
+    enum class AccelerationProfile : uint32_t {
+        None     = 0,
+        Flat     = 1,
+        Adaptive = 2,
+        Custom   = 4,
+    };
+    Q_ENUM(AccelerationProfile)
+    explicit TreelandMouseSettings(TreelandInputManagerPrivate *priv, QObject *parent = nullptr);
+    ~TreelandMouseSettings() override;
+
+    uint32_t accelerationProfile() const;
+    uint32_t sendEventsMode() const;
+    double scrollFactor() const;
+    bool leftHanded() const;
+    double speed() const;
+    bool naturalScroll() const;
+
+public Q_SLOTS:
+    void setAccelerationProfile(uint32_t profile);
+    void setSendEventsMode(uint32_t mode);
+    void setScrollFactor(double factor);
+    void setLeftHanded(bool leftHanded);
+    void setSpeed(double speed);
+    void setNaturalScroll(bool enabled);
+
+Q_SIGNALS:
+    void accelerationProfileChanged(uint32_t profile);
+    void sendEventsModeChanged(uint32_t mode);
+    void scrollFactorChanged(double factor);
+    void leftHandedChanged(bool leftHanded);
+    void speedChanged(double speed);
+    void naturalScrollChanged(bool enabled);
+    void failed();
+    void done();
+
+protected:
+    void treeland_pointer_device_configuration_v1_feature(uint32_t feature) override;
+    void treeland_pointer_device_configuration_v1_scroll_factor(wl_fixed_t factor) override;
+    void treeland_pointer_device_configuration_v1_handed_mode(uint32_t mode) override;
+    void treeland_pointer_device_configuration_v1_accel_speed(wl_fixed_t accel_speed) override;
+    void treeland_pointer_device_configuration_v1_acceleration_profile(uint32_t profile) override;
+    void treeland_pointer_device_configuration_v1_send_events_mode(uint32_t mode) override;
+    void treeland_pointer_device_configuration_v1_natural_scroll(uint32_t state) override;
+    void treeland_pointer_device_configuration_v1_disable_while_typing(uint32_t state) override;
+    void treeland_pointer_device_configuration_v1_tap_to_click(uint32_t state) override;
+    void treeland_pointer_device_configuration_v1_failed() override;
+    void treeland_pointer_device_configuration_v1_done(uint32_t serial) override;
+
+private:
+    friend class TreelandInputManagerPrivate;
+
+    TreelandInputManagerPrivate *m_priv = nullptr;
+
+    uint32_t m_accelerationProfile = 0;
+    uint32_t m_sendEventsMode = 0;
+    double m_scrollFactor = 1.0;
+    bool m_leftHanded = false;
+    double m_speed = 0.0;
+    bool m_naturalScroll = false;
+    uint32_t m_features = 0;    // accumulated feature bitmask
+    uint32_t m_lastSerial = 0;
+
+    void initPointerConfiguration(uint32_t serial = 0);
+    void releaseHandle();
+};
+
+// ---------------------------------------------------------------------------
+// TreelandTouchpadSettings
+// ---------------------------------------------------------------------------
+/**
+ * @brief 触摸板完整设置，对应 treeland_touchpad_settings_v1 工厂 + treeland_pointer_device_configuration_v1。
+ *
+ * 持有唯一的 treeland_pointer_device_configuration_v1 对象。
+ * 同时处理共享指针事件（速度、自然滚动等）和触摸板专有事件（打字禁用、轻触点击等）。
+ */
+class TreelandTouchpadSettings
+    : public QObject
+    , public QtWayland::treeland_touchpad_settings_v1
+    , public QtWayland::treeland_pointer_device_configuration_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(bool enabled READ isEnabled NOTIFY enabledChanged)
+    Q_PROPERTY(uint32_t sendEventsMode READ sendEventsMode NOTIFY sendEventsModeChanged)
+    Q_PROPERTY(bool disableWhileTyping READ disableWhileTyping NOTIFY disableWhileTypingChanged)
+    Q_PROPERTY(bool tapToClick READ tapToClick NOTIFY tapToClickChanged)
+    Q_PROPERTY(uint32_t features READ features NOTIFY featuresChanged)
+    Q_PROPERTY(double scrollFactor READ scrollFactor NOTIFY scrollFactorChanged)
+    Q_PROPERTY(bool leftHanded READ leftHanded NOTIFY leftHandedChanged)
+    Q_PROPERTY(double speed READ speed NOTIFY speedChanged)
+    Q_PROPERTY(bool naturalScroll READ naturalScroll NOTIFY naturalScrollChanged)
+
+public:
+    explicit TreelandTouchpadSettings(TreelandInputManagerPrivate *priv, QObject *parent = nullptr);
+    ~TreelandTouchpadSettings() override;
+
+    bool isEnabled() const;
+    uint32_t sendEventsMode() const;
+    bool disableWhileTyping() const;
+    bool tapToClick() const;
+    uint32_t features() const;
+    double scrollFactor() const;
+    bool leftHanded() const;
+    double speed() const;
+    bool naturalScroll() const;
+
+public Q_SLOTS:
+    void setEnabled(bool enabled);
+    void setSendEventsMode(uint32_t mode);
+    void setDisableWhileTyping(bool enabled);
+    void setTapToClick(bool enabled);
+    void setScrollFactor(double factor);
+    void setLeftHanded(bool leftHanded);
+    void setSpeed(double speed);
+    void setNaturalScroll(bool enabled);
+
+Q_SIGNALS:
+    void enabledChanged(bool enabled);
+    void sendEventsModeChanged(uint32_t mode);
+    void disableWhileTypingChanged(bool enabled);
+    void tapToClickChanged(bool enabled);
+    void featuresChanged(uint32_t features);
+    void scrollFactorChanged(double factor);
+    void leftHandedChanged(bool leftHanded);
+    void speedChanged(double speed);
+    void naturalScrollChanged(bool enabled);
+    void failed();
+    void done();
+
+protected:
+    void treeland_pointer_device_configuration_v1_feature(uint32_t feature) override;
+    void treeland_pointer_device_configuration_v1_scroll_factor(wl_fixed_t factor) override;
+    void treeland_pointer_device_configuration_v1_handed_mode(uint32_t mode) override;
+    void treeland_pointer_device_configuration_v1_accel_speed(wl_fixed_t accel_speed) override;
+    void treeland_pointer_device_configuration_v1_acceleration_profile(uint32_t profile) override;
+    void treeland_pointer_device_configuration_v1_send_events_mode(uint32_t mode) override;
+    void treeland_pointer_device_configuration_v1_natural_scroll(uint32_t state) override;
+    void treeland_pointer_device_configuration_v1_disable_while_typing(uint32_t state) override;
+    void treeland_pointer_device_configuration_v1_tap_to_click(uint32_t state) override;
+    void treeland_pointer_device_configuration_v1_failed() override;
+    void treeland_pointer_device_configuration_v1_done(uint32_t serial) override;
+
+private:
+    friend class TreelandInputManagerPrivate;
+
+    TreelandInputManagerPrivate *m_priv = nullptr;
+
+    bool m_enabled = true;
+    uint32_t m_sendEventsMode = send_events_mode_enabled;
+    bool m_disableWhileTyping = false;
+    bool m_tapToClick = false;
+    uint32_t m_features = 0;    // accumulated feature bitmask
+    double m_scrollFactor = 1.0;
+    bool m_leftHanded = false;
+    double m_speed = 0.0;
+    bool m_naturalScroll = false;
+    uint32_t m_lastSerial = 0;
+
+    void initPointerConfiguration(uint32_t serial = 0);
+    void releaseHandle();
+};
+
+// ---------------------------------------------------------------------------
+// TreelandKeyboardSettings
+// ---------------------------------------------------------------------------
+/**
+ * @brief 键盘设置，对应 treeland_keyboard_settings_v1。
+ *
+ * 涵盖：重复速率/延迟、数字锁定、大写锁定 OSD。
+ */
+class TreelandKeyboardSettings
+    : public QObject
+    , public QtWayland::treeland_keyboard_settings_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(int repeatRate READ repeatRate NOTIFY repeatChanged)
+    Q_PROPERTY(int repeatDelay READ repeatDelay NOTIFY repeatChanged)
+    Q_PROPERTY(bool numLock READ numLock NOTIFY numLockChanged)
+
+public:
+    explicit TreelandKeyboardSettings(TreelandInputManagerPrivate *priv, QObject *parent = nullptr);
+    ~TreelandKeyboardSettings() override;
+
+    int repeatRate() const;
+    int repeatDelay() const;
+    bool numLock() const;
+
+public Q_SLOTS:
+    void setRepeatRate(int rate);
+    void setRepeatDelay(int delay);
+    void setNumLock(bool on);
+
+Q_SIGNALS:
+    void repeatChanged(int rate, int delay);
+    void numLockChanged(bool on);
+    void failed();
+    void done();
+
+protected:
+    // Qt Wayland virtual overrides — called by the generated listener dispatcher.
+    void treeland_keyboard_settings_v1_feature(uint32_t feature) override;
+    void treeland_keyboard_settings_v1_repeat(int32_t rate, int32_t delay) override;
+    void treeland_keyboard_settings_v1_num_lock(uint32_t state) override;
+    void treeland_keyboard_settings_v1_failed() override;
+    void treeland_keyboard_settings_v1_done() override;
+
+private:
+    friend class TreelandInputManagerPrivate;
+
+    TreelandInputManagerPrivate *m_priv = nullptr;
+
+    int m_repeatRate = 25;
+    int m_repeatDelay = 500;
+    bool m_numLock = false;
+    uint32_t m_features = 0;
+
+    void releaseHandle();
+};
+
+// ---------------------------------------------------------------------------
+// TreelandInputManager
+// ---------------------------------------------------------------------------
+/**
+ * @brief 封装 treeland_input_manager_v1 Wayland 协议的 Qt 管理器。
+ *
+ * 用法：
+ * @code
+ *   auto *mgr = new TreelandInputManager(this);
+ *   connect(mgr, &TreelandInputManager::mouseAvailableChanged, this, [mgr](bool avail) {
+ *       if (avail) {
+ *           auto *mouse = mgr->mouseSettings();
+ *           // 等待 done() 信号后读取初始值
+ *       }
+ *   });
+ * @endcode
+ *
+ * 当 mouseAvailable() 为 true 时，mouseSettings() 非空。
+ * 当 touchpadAvailable() 为 true 时，touchpadSettings() 非空。
+ * 当 keyboardAvailable() 为 true 时，keyboardSettings() 非空。
+ *
+ * @note 必须在 Wayland 会话（treeland 合成器）下运行，否则 available() 始终为 false。
+ */
+class TreelandInputManager
+    : public QWaylandClientExtensionTemplate<TreelandInputManager>
+    , public QtWayland::treeland_input_manager_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(bool available READ available NOTIFY availableChanged)
+    Q_PROPERTY(bool mouseAvailable READ mouseAvailable NOTIFY mouseAvailableChanged)
+    Q_PROPERTY(bool touchpadAvailable READ touchpadAvailable NOTIFY touchpadAvailableChanged)
+    Q_PROPERTY(bool keyboardAvailable READ keyboardAvailable NOTIFY keyboardAvailableChanged)
+
+public:
+    explicit TreelandInputManager(QObject *parent = nullptr);
+    ~TreelandInputManager() override;
+
+    /** 协议对象是否已成功绑定 */
+    bool available() const;
+
+    bool mouseAvailable() const;
+    bool touchpadAvailable() const;
+    bool keyboardAvailable() const;
+
+    /**
+     * 鼠标专有设置。仅在 mouseAvailable() 时非空。
+     */
+    TreelandMouseSettings *mouseSettings() const;
+
+    /**
+     * 触摸板专有设置。仅在 touchpadAvailable() 时非空。
+     */
+    TreelandTouchpadSettings *touchpadSettings() const;
+
+    /**
+     * 键盘设置。仅在 keyboardAvailable() 时非空。
+     */
+    TreelandKeyboardSettings *keyboardSettings() const;
+
+    /**
+     * 仅刷新鼠标/触摸板相关 settings。
+     * 键盘 settings 不受影响。
+     */
+    void refreshMouse();
+
+    /**
+     * 仅刷新键盘 settings。鼠标/触摸板 settings 不受影响。
+     */
+    void refreshKeyboard();
+
+protected:
+    void treeland_input_manager_v1_capability_available(uint32_t type, wl_seat *seat) override;
+    void treeland_input_manager_v1_capability_unavailable(uint32_t type, wl_seat *seat) override;
+
+Q_SIGNALS:
+    void availableChanged(bool available);
+    void mouseAvailableChanged(bool available);
+    void touchpadAvailableChanged(bool available);
+    void keyboardAvailableChanged(bool available);
+
+private:
+    std::unique_ptr<TreelandInputManagerPrivate> d;
+};
+
+} // namespace DCC_NAMESPACE


### PR DESCRIPTION
1. Implement TreelandInputManager wrapping treeland_input_manager_v1
protocol for keyboard, mouse, and touchpad settings
2. Add KeyboardWaylandProxy and MouseWaylandProxy to abstract Wayland vs
DBus session differences
3. Add IKeyboardDeviceProxy interface for keyboard device abstraction
(Strategy pattern)
4. Introduce KeyboardDBusProxyImpl adapter to convert KeyboardDBusProxy
to the new interface
5. Add refreshKeyboard() and refreshMouse() methods to re-read settings
from the compositor
6. Update DccManager::doShowPage to track changes and emit delayed
signals only when values actually change
7. Refactor KeyboardWorker and MouseWorker to select proxy based on
session type (DBus vs Wayland)
8. In keyboard plugin: remove hardcoded hidden visibility, show keyboard
settings in Wayland mode with DccDBusInterface only for NumLock
9. In mouse plugin: remove Treeland session hiding, split DBus property
monitoring for Wayland mode
10. Add TreelandMouseSettings, TreelandTouchpadSettings, and
TreelandKeyboardSettings with proper Wayland protocol wrapping
11. Handle protocol features, signal emission debouncing, and failed/
done states
12. Add shared-utils CMake support for Treeland protocol code generation

Log: Added Treeland Wayland native input device configuration for
keyboard, mouse, and touchpad settings with session-adaptive proxy
architecture

Influence:
1. Test keyboard repeat rate and delay settings in both X11/DBus and
Treeland/Wayland sessions
2. Verify NumLock toggle behavior and OSD notification in both sessions
3. Test mouse left-handed, natural scroll, acceleration, and pointer
speed in both sessions
4. Test touchpad enable/disable, disable-while-typing, tap-to-click,
natural scroll, and palm detection in both sessions
5. Verify mouse/touchpad scroll speed settings reflect immediately in
both sessions
6. Test device hotplug (plug/unplug mouse/touchpad) while settings page
is open in both sessions
7. Verify keyboard settings refresh when navigating to keyboard page
8. Verify mouse/touchpad settings refresh when navigating to mouse/
touchpad pages
9. Test DccManager signal correctness by navigating between pages and
verifying triggeredObjects changed
10. Test functionality when no mouse/touchpad/keyboard is present
(capability unavailable)
11. Verify acceleration profile switching between Flat and Adaptive
modes in both sessions
12. Ensure no crashes on application shutdown in Treeland/Wayland
session

feat: 添加 Treeland Wayland 输入设备支持，包括键盘和鼠标设置

1. 实现 TreelandInputManager，封装 treeland_input_manager_v1 协议，用于
键盘、鼠标和触摸板设置
2. 添加 KeyboardWaylandProxy 和 MouseWaylandProxy，抽象 Wayland 与 DBus
会话差异
3. 为键盘设备抽象添加 IKeyboardDeviceProxy 接口（策略模式）
4. 引入 KeyboardDBusProxyImpl 适配器，将 KeyboardDBusProxy 转换为新接口
5. 添加 refreshKeyboard() 和 refreshMouse() 方法，从合成器重新读取设置
6. 更新 DccManager::doShowPage，跟踪变化，仅在值实际改变时发出延迟信号
7. 重构 KeyboardWorker 和 MouseWorker，根据会话类型（DBus vs Wayland）选
择代理
8. 键盘插件：移除硬编码隐藏可见性，在 Wayland 模式下仅通过
DccDBusInterface 处理 NumLock 来显示键盘设置
9. 鼠标插件：移除 Treeland 会话隐藏，为 Wayland 模式拆分 DBus 属性监控
10. 添加 TreelandMouseSettings、TreelandTouchpadSettings 和
TreelandKeyboardSettings，正确封装 Wayland 协议
11. 处理协议特性、信号发射去抖和失败/完成状态
12. 为 shared-utils 添加 CMake 支持，用于 Treeland 协议代码生成

Log: 新增 Treeland Wayland 原生输入设备配置，支持键盘、鼠标和触摸板设
置，采用自适应会话的代理架构

Influence:
1. 在 X11/DBus 和 Treeland/Wayland 会话下测试键盘重复速率和延迟设置
2. 验证两种会话下 NumLock 切换行为和 OSD 通知
3. 在两种会话下测试鼠标左手模式、自然滚动、加速度和指针速度
4. 在两种会话下测试触摸板启用/禁用、打字时禁用、轻触点击、自然滚动和掌压
检测
5. 验证两种会话下鼠标/触摸板滚动速度设置即时生效
6. 在设置页面打开时测试设备热插拔（插拔鼠标/触摸板）
7. 验证导航到键盘页面时键盘设置刷新
8. 验证导航到鼠标/触摸板页面时鼠标/触摸板设置刷新
9. 通过页面导航测试 DccManager 信号正确性，验证 triggeredObjects 变化
10. 在没有鼠标/触摸板/键盘时测试功能（功能不可用）
11. 在两种会话下测试 Flat 和 Adaptive 模式之间的加速度配置文件切换
12. 确保在 Treeland/Wayland 会话下应用关闭时无崩溃

PMS: TASK-390457

## Summary by Sourcery

Add Treeland Wayland-native input management for keyboard and mouse, with session-aware proxies and page refresh, while keeping X11/DBus behavior intact.

New Features:
- Introduce a Treeland Wayland input manager and per-device settings wrappers for mouse, touchpad, and keyboard.
- Add Wayland-based MouseWaylandProxy and KeyboardWaylandProxy implementations and route mouse/keyboard workers through a session-adaptive device proxy interface.
- Expose refreshKeyboard() and refreshMouse() hooks from models/controllers to QML so device settings are re-synced when opening the corresponding pages.

Enhancements:
- Update DccManager navigation to emit currentObjectsChanged and triggeredObjectsChanged only when their values actually change.
- Refine mouse and touchpad DBus monitoring to avoid conflicting with Treeland Wayland handling while preserving shared palm/trackpoint logic.
- Ensure keyboard enabled state stays consistent with DConfig via explicit sync helpers and improved error handling.

Build:
- Extend shared-utils CMake configuration to generate and link Treeland Wayland protocol client code and define ENABLE_TREELAND_INPUT_MANAGER for consumers.