### PR TITLE
feat: adapt keyboard shortcuts and mouse gestures for Wayland

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends:
  qt6-wayland-private-dev,
  qt6-wayland-dev-tools,
  wlr-protocols,
- treeland-protocols(>=0.4.1),
+ treeland-protocols (>> 0.5.7),
  systemd,
  libdareader-dev,
  libdeepin-pw-check-dev,

--- a/src/plugin-keyboard/CMakeLists.txt
+++ b/src/plugin-keyboard/CMakeLists.txt
@@ -17,16 +17,31 @@ if (BUILD_PLUGIN)
         src/plugin-keyboard/operation
     )
     find_package(PolkitQt6-1 REQUIRED)
+    find_package(${QT_NS} COMPONENTS Quick Gui WaylandClient REQUIRED)
+    find_package(PkgConfig REQUIRED)
+    find_package(TreelandProtocols REQUIRED)
+    pkg_check_modules(WAYLAND_CLIENT REQUIRED wayland-client)
+
+    qt6_generate_wayland_protocol_client_sources(${Plugin_Name}
+        FILES
+            ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-shortcut-manager-v2.xml
+    )
+
     set(keyboard_Libraries
         ${DCC_FRAME_Library}
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
         ${QT_NS}::Gui
         ${QT_NS}::Qml
+        ${QT_NS}::Quick
+        ${QT_NS}::WaylandClient
         PolkitQt6-1::Agent
+        ${WAYLAND_CLIENT_LIBRARIES}
     )
     target_include_directories(${Plugin_Name} PUBLIC
         ${keyboard_Includes}
+        ${WAYLAND_CLIENT_INCLUDE_DIRS}
+        ${Qt6Gui_PRIVATE_INCLUDE_DIRS}
     )
     target_link_libraries(${Plugin_Name} PRIVATE
         ${keyboard_Libraries}

--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -5,9 +5,14 @@
 #include "keyboardcontroller.h"
 #include "dccfactory.h"
 #include "layoutsmodel.h"
+#include "treelandshortcutcapture.h"
 
 #include <PolkitQt1/Authority>
 #include <QFileInfo>
+#include <QGuiApplication>
+#include <QKeySequence>
+#include <QQuickItem>
+#include <QQuickWindow>
 
 namespace dccV25 {
 DCC_FACTORY_CLASS(KeyboardController)
@@ -19,6 +24,13 @@ KeyboardController::KeyboardController(QObject *parent)
     m_worker = new KeyboardWorker(m_model, this);
     m_shortcutModel = new ShortcutModel(this);
     m_worker->setShortcutModel(m_shortcutModel);
+
+    // Construct the Wayland capture manager eagerly so the global is bound
+    // before the user can click an edit row — otherwise the first
+    // captureNext() loses the bind race and silently fails.
+    if (QGuiApplication::platformName() == QLatin1String("wayland")) {
+        m_captureManager = new TreelandShortcutCaptureManager(this);
+    }
 
     connect(m_model, &KeyboardModel::repeatIntervalChanged, this, &KeyboardController::repeatIntervalChanged);
     connect(m_model, &KeyboardModel::repeatDelayChanged, this, &KeyboardController::repeatDelayChanged);
@@ -229,6 +241,11 @@ QStringList KeyboardController::formatKeys(const QString &shortcuts)
     return ShortcutModel::formatKeys(shortcuts);
 }
 
+QString KeyboardController::keyEventToAccels(int key, int modifiers)
+{
+    return QKeySequence(key | modifiers).toString(QKeySequence::PortableText);
+}
+
 QString KeyboardController::checkDesktopCmd(const QString &cmd)
 {
     // Check and process desktop commands, add dde-am prefix if desktop file exists
@@ -296,8 +313,12 @@ void KeyboardController::modifyShortcut(const QString &id, const QString &accels
         // Clear conflicting shortcuts when modifying
         if (auto conflict = m_shortcutModel->getInfo(accels)) {
             m_worker->onDisableShortcut(conflict);
-            shortcut->accels = accels;
         }
+        // Always update the target's accels so downstream modifyShortcutEditAux
+        // operates on the new value. The previous "only on conflict" placement
+        // left a stale accels when there was no conflict (e.g. Wayland path
+        // where the keyEvent lambda's pre-update doesn't run).
+        shortcut->accels = accels;
     }
 
     m_worker->modifyShortcutEdit(shortcut);
@@ -401,6 +422,126 @@ bool KeyboardController::isShortcutNameExists(const QString &name, const QString
     
     // Then check custom shortcut conflicts
     return isCustomShortcutNameExists(name, excludeId);
+}
+
+// Convert a Qt PortableText accel string ("Ctrl+Alt+T", "Meta+P") to the
+// X11/XKB form used internally by the shortcut model and the legacy wire
+// format ("<Control><Alt>T", "<Super>P"). Only handles modifier+key combos —
+// modifiable shortcuts are conventional combos, not media keys.
+static QString qtAccelToXkb(const QString &accel)
+{
+    if (accel.isEmpty())
+        return accel;
+    const QStringList parts = accel.split('+', Qt::SkipEmptyParts);
+    if (parts.size() <= 1)
+        return accel; // standalone key, no modifiers
+    QString out;
+    for (int i = 0; i < parts.size() - 1; ++i) {
+        const QString &p = parts.at(i);
+        if (p == QLatin1String("Ctrl") || p == QLatin1String("Control"))
+            out += QStringLiteral("<Control>");
+        else if (p == QLatin1String("Shift"))
+            out += QStringLiteral("<Shift>");
+        else if (p == QLatin1String("Alt"))
+            out += QStringLiteral("<Alt>");
+        else if (p == QLatin1String("Meta") || p == QLatin1String("Super"))
+            out += QStringLiteral("<Super>");
+        else
+            out += QLatin1Char('<') + p + QLatin1Char('>');
+    }
+    out += parts.last();
+    return out;
+}
+
+void KeyboardController::beginWaylandKeyCapture(QQuickItem *item, const QString &id, int type)
+{
+    // Silent no-op on non-Wayland — the X11 path captures via QML Keys.onPressed.
+    if (QGuiApplication::platformName() != QLatin1String("wayland")) {
+        return;
+    }
+    if (!item) {
+        Q_EMIT waylandKeyCaptureFailed(id, type, 0);
+        return;
+    }
+    QQuickWindow *window = item->window();
+    if (!window) {
+        Q_EMIT waylandKeyCaptureFailed(id, type, 0);
+        return;
+    }
+
+    if (!m_captureManager) {
+        // Cold path: KeyboardController was constructed before the platform
+        // resolved to wayland (shouldn't happen normally). Build lazily.
+        m_captureManager = new TreelandShortcutCaptureManager(this);
+    }
+
+    if (m_activeCapture) {
+        // The user is restarting edit. Disconnect first so any wayland event
+        // still in flight for the old session cannot land in this controller
+        // and modify the wrong row; then schedule the session for delete
+        // (its destructor cancels the wayland capture).
+        disconnect(m_activeCapture, nullptr, this, nullptr);
+        m_activeCapture->deleteLater();
+        m_activeCapture.clear();
+    }
+
+    TreelandShortcutCaptureSession *session = m_captureManager->captureNext(window);
+    if (!session) {
+        Q_EMIT waylandKeyCaptureFailed(id, type, 0);
+        return;
+    }
+    m_activeCapture = session;
+
+    connect(session, &TreelandShortcutCaptureSession::captured, this,
+            [this, id, type](const QString &key) {
+                submitWaylandKeystroke(id, type, key);
+                Q_EMIT waylandKeyCaptureFinished(id, type, key);
+            });
+    connect(session, &TreelandShortcutCaptureSession::failed, this,
+            [this, id, type](uint32_t reason) {
+                Q_EMIT waylandKeyCaptureFailed(id, type, static_cast<int>(reason));
+            });
+}
+
+void KeyboardController::submitWaylandKeystroke(const QString &id, int type, const QString &accels)
+{
+    if (accels.isEmpty()) {
+        Q_EMIT requestRestore();
+        return;
+    }
+    if (accels == QLatin1String("Backspace")
+        || accels == QLatin1String("Delete")
+        || accels == QLatin1String("Del")) {
+        Q_EMIT requestClear();
+        return;
+    }
+
+    ShortcutInfo *current = m_shortcutModel->findInfoIf([&](ShortcutInfo *info) {
+        return info->id == id && info->type == type;
+    });
+    if (current)
+        m_shortcutModel->setCurrentInfo(current);
+
+    const QString xkb = qtAccelToXkb(accels);
+
+    ShortcutInfo *conflict = m_shortcutModel->getInfo(xkb);
+
+    if (conflict) {
+        // Self-conflict (user pressed the same combo already bound to this row)
+        if (conflict == current && conflict->accels == xkb) {
+            Q_EMIT requestRestore();
+            return;
+        }
+        auto conflictName = QString("<font color=\"red\">%1</font>").arg(conflict->name.toHtmlEscaped());
+        const QString text = KeyboardController::tr("This shortcut conflicts with [%1]").arg(conflictName);
+        setConflictText(text);
+        Q_EMIT keyConflicted(current ? current->accels : QString(), xkb);
+        return;
+    }
+
+    if (current)
+        current->accels = xkb;
+    Q_EMIT keyDone(xkb);
 }
 
 }

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,9 +9,15 @@
 #include "keyboardwork.h"
 
 #include <QObject>
+#include <QPointer>
 #include <QSortFilterProxyModel>
 
+class QQuickItem;
+
 namespace dccV25 {
+
+class TreelandShortcutCaptureManager;
+class TreelandShortcutCaptureSession;
 
 class KeyboardController : public QObject
 {
@@ -63,6 +69,18 @@ public Q_SLOTS:
 
     void updateKey(const QString &id, const int &type);
     QStringList formatKeys(const QString &shortcuts);
+    Q_INVOKABLE QString keyEventToAccels(int key, int modifiers);
+    // Wayland entry point: capture is local (no SelectKeystroke). Performs
+    // the same conflict-check / emit pattern as the X11 KeyEvent lambda,
+    // but queries the server (LookupConflictShortcut) as the source of truth.
+    Q_INVOKABLE void submitWaylandKeystroke(const QString &id, int type, const QString &accels);
+
+    // Wayland edit entry: ask Treeland to forward the next shortcut input to
+    // this client (bypassing the dispatch-to-action path that swallowed keys
+    // before). On terminal event emits waylandKeyCaptureFinished or
+    // waylandKeyCaptureFailed. Requires the QML item to live in a focused
+    // window — the compositor validates that before starting capture.
+    Q_INVOKABLE void beginWaylandKeyCapture(QQuickItem *item, const QString &id, int type);
 
     void addCustomShortcut(const QString &name, const QString &cmd, const QString &accels);
     void modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels);
@@ -95,6 +113,9 @@ signals:
     void keyDone(const QString &accels);
     void keyEvent(const QString &accels);
 
+    void waylandKeyCaptureFinished(const QString &id, int type, const QString &accels);
+    void waylandKeyCaptureFailed(const QString &id, int type, int reason);
+
     void conflictTextChanged();
     void keyboardEnabledChanged();
 
@@ -112,6 +133,8 @@ private:
     QSortFilterProxyModel *m_layoutSearchModel = nullptr;
     QSortFilterProxyModel *m_shortcutSearchModel = nullptr;
     QString m_conflictText;
+    TreelandShortcutCaptureManager *m_captureManager = nullptr;
+    QPointer<TreelandShortcutCaptureSession> m_activeCapture;
 };
 
 }

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -8,8 +8,12 @@
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include <QDBusPendingReply>
+#include <QDBusPendingCallWatcher>
 #include <QDBusMetaType>
 #include <QDebug>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 const static QString LangSelectorService = "org.deepin.dde.LangSelector1";
 const static QString LangSelectorPath = "/org/deepin/dde/LangSelector1";
@@ -29,6 +33,8 @@ const static QString WMInterface = "com.deepin.wm";
 
 KeyboardDBusProxy::KeyboardDBusProxy(QObject *parent)
     : QObject(parent)
+    , m_isWayland((qgetenv("XDG_SESSION_TYPE").toLower() == QLatin1String("wayland"))
+                  || !qgetenv("WAYLAND_DISPLAY").isEmpty())
 {
     qRegisterMetaType<KeyboardLayoutList>("KeyboardLayoutList");
     qDBusRegisterMetaType<KeyboardLayoutList>();
@@ -39,7 +45,62 @@ KeyboardDBusProxy::KeyboardDBusProxy(QObject *parent)
     qRegisterMetaType<LocaleList>("LocaleList");
     qDBusRegisterMetaType<LocaleList>();
 
+    // Register new API types
+    qRegisterMetaType<ShortcutInfoNew>("ShortcutInfoNew");
+    qDBusRegisterMetaType<ShortcutInfoNew>();
+    qRegisterMetaType<QList<ShortcutInfoNew>>("QList<ShortcutInfoNew>");
+    qDBusRegisterMetaType<QList<ShortcutInfoNew>>();
+
     init();
+}
+
+bool KeyboardDBusProxy::isWayland() const
+{
+    return m_isWayland;
+}
+
+// Map new API category to section name (Wayland 3-category: System/App/Custom)
+static QString categoryToSection(int category)
+{
+    switch (category) {
+    case 1: return QStringLiteral("System");
+    case 2: return QStringLiteral("App");
+    case 3: return QStringLiteral("Custom");
+    default: return QString();
+    }
+}
+
+// Convert a single ShortcutInfo to old-API JSON object
+static QJsonObject shortcutInfoToJsonObject(const ShortcutInfoNew &info)
+{
+    QJsonObject obj;
+    obj["Id"] = info.id;
+    // Prefer translated name over raw displayName; fall back if empty
+    obj["Name"] = info.localLanguageName.isEmpty() ? info.displayName : info.localLanguageName;
+    // dde-services already emits hotkeys in X11/XKB form ("<Control><Alt>T",
+    // "XF86AudioMute"), so we just forward the first one to Accels.
+    obj["Accels"] = QJsonArray{info.hotkeys.isEmpty() ? QString() : info.hotkeys.first()};
+    // Type: 0=System, 1=Custom (old API). App(category==2) must map to 0,
+    // otherwise IsCustomRole would mark App shortcuts as editable.
+    obj["Type"] = (info.category == 3) ? 1 : 0;
+    obj["Exec"] = QString();
+    // New API section: overrides old hardcoded ID-based categorization
+    obj["Section"] = categoryToSection(info.category);
+    return obj;
+}
+
+QString KeyboardDBusProxy::convertShortcutListToJson(const QList<ShortcutInfoNew> &list) const
+{
+    QJsonArray array;
+    for (const auto &info : list) {
+        array.append(shortcutInfoToJsonObject(info));
+    }
+    return QJsonDocument(array).toJson(QJsonDocument::Compact);
+}
+
+QString KeyboardDBusProxy::convertShortcutToJson(const ShortcutInfoNew &info) const
+{
+    return QJsonDocument(shortcutInfoToJsonObject(info)).toJson(QJsonDocument::Compact);
 }
 
 void KeyboardDBusProxy::init()
@@ -50,6 +111,21 @@ void KeyboardDBusProxy::init()
     m_dBusWMInter = new DDBusInterface(WMService, WMPath, WMInterface, QDBusConnection::sessionBus(), this);
 
     QDBusConnection::sessionBus().connect(WMService, WMPath, WMInterface, "wmCompositingEnabledChanged", this, SIGNAL(compositingEnabledChanged(bool)));
+
+    // dde-services emits ShortcutChanged / ShortcutRemoved on the new API,
+    // which don't match the legacy Changed/Deleted names auto-wired by
+    // QDBusAbstractInterface. Subscribe by full signature so the model
+    // refreshes after server-side updates (e.g. Reset).
+    if (m_isWayland) {
+        QDBusConnection::sessionBus().connect(
+            KeybingdingService, KeybingdingPath, KeybingdingInterface,
+            "ShortcutChanged", this,
+            SLOT(onNewShortcutChanged(QString, ShortcutInfoNew)));
+        QDBusConnection::sessionBus().connect(
+            KeybingdingService, KeybingdingPath, KeybingdingInterface,
+            "ShortcutRemoved", this,
+            SLOT(onNewShortcutRemoved(QString)));
+    }
 }
 
 void KeyboardDBusProxy::langSelectorStartServiceProcess()
@@ -200,35 +276,155 @@ bool KeyboardDBusProxy::langSelectorIsValid()
     return m_dBusLangSelectorInter->isValid();
 }
 
+// ---- Keybinding methods ----
+// In Wayland mode, call new dde-services API and convert to old JSON format.
+// In X11 mode, keep existing old API calls.
+
 QDBusPendingReply<> KeyboardDBusProxy::KeybindingReset()
 {
     QList<QVariant> argumentList;
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Reset"), argumentList);
 }
 
+// Wayland: called when new API ListAllShortcuts() async reply arrives
+void KeyboardDBusProxy::onListAllShortcutsNewFinished(QDBusPendingCallWatcher *w)
+{
+    QDBusPendingReply<QList<ShortcutInfoNew>> reply = *w;
+    if (!reply.isError()) {
+        QString json = convertShortcutListToJson(reply.value());
+        Q_EMIT AllShortcutsReady(json);
+    } else {
+        qWarning() << "Wayland ListAllShortcuts failed:" << reply.error();
+    }
+    w->deleteLater();
+}
+
 QDBusPendingReply<QString> KeyboardDBusProxy::ListAllShortcuts()
 {
     QList<QVariant> argumentList;
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ListAllShortcuts"), argumentList);
+    if (isWayland()) {
+        // New API: ListAllShortcuts() → QList<ShortcutInfoNew>
+        // We fire-and-forget, result arrives in onListAllShortcutsNewFinished
+        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("ListAllShortcuts"), argumentList);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardDBusProxy::onListAllShortcutsNewFinished);
+        // Return dummy — actual data comes via Added signal
+        return QDBusPendingReply<QString>();
+    }
+    // Old API
+    return QDBusPendingReply<QString>(
+        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ListAllShortcuts"), argumentList));
+}
+
+// Wayland: called when new API GetShortcut() async reply arrives.
+// The result is delivered via shortcutQueried so the downstream
+// model-update path never re-enters onShortcutChanged → Query → ...
+void KeyboardDBusProxy::onGetShortcutNewFinished(QDBusPendingCallWatcher *w)
+{
+    QDBusPendingReply<ShortcutInfoNew> reply = *w;
+    if (!reply.isError()) {
+        QString json = convertShortcutToJson(reply.value());
+        Q_EMIT shortcutQueried(json);
+    }
+    w->deleteLater();
+}
+
+// Server emits ShortcutChanged after any in-memory + dconfig commit (Modify,
+// Reset, Disable, external dconfig writes). Forward via shortcutQueried so
+// the model updates without an extra GetShortcut round-trip — the signal
+// payload already carries the full info.
+void KeyboardDBusProxy::onNewShortcutChanged(const QString &id, const ShortcutInfoNew &info)
+{
+    Q_UNUSED(id);
+    Q_EMIT shortcutQueried(convertShortcutToJson(info));
+}
+
+void KeyboardDBusProxy::onNewShortcutRemoved(const QString &id)
+{
+    // Type isn't carried by the new-API signal. Pass 0 — current consumer
+    // (KeyboardWorker::removed) is an unused forward, so the value doesn't
+    // drive any behavior.
+    Q_EMIT Deleted(id, 0);
+}
+
+QDBusPendingReply<QString> KeyboardDBusProxy::GetShortcut(const QString &in0, int in1)
+{
+    Q_UNUSED(in1);
+    QList<QVariant> argumentList;
+    if (isWayland()) {
+        // New API: GetShortcut(id) → ShortcutInfoNew
+        argumentList << QVariant::fromValue(in0);
+        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("GetShortcut"), argumentList);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+        watcher->setProperty("shortcutId", in0);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardDBusProxy::onGetShortcutNewFinished);
+        return QDBusPendingReply<QString>();
+    }
+    // Old API
+    argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
+    return QDBusPendingReply<QString>(
+        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GetShortcut"), argumentList));
 }
 
 QString KeyboardDBusProxy::LookupConflictingShortcut(const QString &in0)
 {
     QList<QVariant> argumentList;
+    if (isWayland()) {
+        // New API: LookupConflictShortcut(hotkey) → ShortcutInfoNew
+        argumentList << QVariant::fromValue(in0);
+        QDBusPendingReply<ShortcutInfoNew> reply =
+            m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("LookupConflictShortcut"), argumentList);
+        reply.waitForFinished();
+        if (reply.isError())
+            return QString();
+        const ShortcutInfoNew info = reply.value();
+        // Preserve legacy X11 contract: empty string means "no conflict".
+        // The new API returns a default-constructed ShortcutInfo for that case,
+        // which would otherwise serialize to a non-empty JSON object and fool
+        // downstream "isEmpty()" checks.
+        if (info.id.isEmpty())
+            return QString();
+        return convertShortcutToJson(info);
+    }
+    // Old API
     argumentList << QVariant::fromValue(in0);
-    return QDBusPendingReply<QString>(m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("LookupConflictingShortcut"), argumentList));
+    return QDBusPendingReply<QString>(
+        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("LookupConflictingShortcut"), argumentList));
 }
 
 QDBusPendingReply<> KeyboardDBusProxy::ClearShortcutKeystrokes(const QString &in0, int in1)
 {
     QList<QVariant> argumentList;
+    if (isWayland()) {
+        // New API: Disable(id)
+        argumentList << QVariant::fromValue(in0);
+        return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Disable"), argumentList);
+    }
+    // Old API
     argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ClearShortcutKeystrokes"), argumentList);
+}
+
+QDBusPendingReply<bool> KeyboardDBusProxy::callModifyHotkeys(const QString &id, const QStringList &hotkeys)
+{
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(id) << QVariant::fromValue(hotkeys);
+    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ModifyHotkeys"), argumentList);
 }
 
 QDBusPendingReply<> KeyboardDBusProxy::AddShortcutKeystroke(const QString &in0, int in1, const QString &in2)
 {
     QList<QVariant> argumentList;
+    if (isWayland()) {
+        // New API: ModifyHotkeys(id, [keystroke])
+        argumentList << QVariant::fromValue(in0) << QVariant::fromValue(QStringList{in2});
+        return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ModifyHotkeys"), argumentList);
+    }
+    // Old API
     argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1) << QVariant::fromValue(in2);
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("AddShortcutKeystroke"), argumentList);
 }
@@ -257,6 +453,11 @@ QDBusPendingReply<> KeyboardDBusProxy::DeleteCustomShortcut(const QString &in0)
 QDBusPendingReply<> KeyboardDBusProxy::GrabScreen()
 {
     QList<QVariant> argumentList;
+    if (isWayland()) {
+        // Not supported in new API, return empty
+        qWarning() << "Wayland GrabScreen not supported";
+        return QDBusPendingReply<>();
+    }
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GrabScreen"), argumentList);
 }
 
@@ -267,29 +468,62 @@ void KeyboardDBusProxy::SetNumLockState(int in0)
     m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SetNumLockState"), argumentList);
 }
 
-QDBusPendingReply<QString> KeyboardDBusProxy::GetShortcut(const QString &in0, int in1)
+void KeyboardDBusProxy::onSearchShortcutsNewFinished(QDBusPendingCallWatcher *w)
 {
-    QList<QVariant> argumentList;
-    argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GetShortcut"), argumentList);
+    QDBusPendingReply<QList<ShortcutInfoNew>> reply = *w;
+    if (!reply.isError()) {
+        QString json = convertShortcutListToJson(reply.value());
+        Q_EMIT Added(json, 0);
+    }
+    w->deleteLater();
 }
 
 QDBusPendingReply<QString> KeyboardDBusProxy::SearchShortcuts(const QString &in0)
 {
     QList<QVariant> argumentList;
+    if (isWayland()) {
+        // New API: SearchShortcuts(keyword) → QList<ShortcutInfoNew>
+        argumentList << QVariant::fromValue(in0);
+        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("SearchShortcuts"), argumentList);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardDBusProxy::onSearchShortcutsNewFinished);
+        return QDBusPendingReply<QString>();
+    }
+    // Old API
     argumentList << QVariant::fromValue(in0);
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SearchShortcuts"), argumentList);
+    return QDBusPendingReply<QString>(
+        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SearchShortcuts"), argumentList));
 }
 
 QDBusPendingReply<QString> KeyboardDBusProxy::Query(const QString &in0, int in1)
 {
     QList<QVariant> argumentList;
+    if (isWayland()) {
+        // New API: GetShortcut(id) (Query was same as GetShortcut in old API)
+        argumentList << QVariant::fromValue(in0);
+        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("GetShortcut"), argumentList);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+        watcher->setProperty("shortcutId", in0);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardDBusProxy::onGetShortcutNewFinished);
+        return QDBusPendingReply<QString>();
+    }
+    // Old API
     argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Query"), argumentList);
+    return QDBusPendingReply<QString>(
+        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Query"), argumentList));
 }
 
 void KeyboardDBusProxy::SelectKeystroke()
 {
+    if (isWayland()) {
+        // Not supported — control center handles key capture via Qt keyPressEvent
+        qDebug() << "[Wayland] SelectKeystroke handled by control center natively";
+        return;
+    }
     QList<QVariant> argumentList;
     m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SelectKeystroke"), argumentList);
 }

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -63,6 +63,33 @@ public:
 typedef QList<LocaleInfo> LocaleList;
 namespace dccV25 {
 class DCCDBusInterface;
+}
+
+// New API ShortcutInfo struct (dde-services)
+struct ShortcutInfoNew {
+    QString id;
+    QString displayName;
+    int category;
+    QStringList hotkeys;
+    QString localLanguageName;
+};
+Q_DECLARE_METATYPE(ShortcutInfoNew)
+Q_DECLARE_METATYPE(QList<ShortcutInfoNew>)
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const ShortcutInfoNew &info) {
+    argument.beginStructure();
+    argument << info.id << info.displayName << info.category
+             << info.hotkeys << info.localLanguageName;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, ShortcutInfoNew &info) {
+    argument.beginStructure();
+    argument >> info.id >> info.displayName >> info.category
+             >> info.hotkeys >> info.localLanguageName;
+    argument.endStructure();
+    return argument;
 }
 
 class KeyboardDBusProxy : public QObject
@@ -152,6 +179,10 @@ signals:
     void Changed(const QString &in0, int in1);
     void Deleted(const QString &in0, int in1);
     void KeyEvent(bool in0, const QString &in1);
+    // Wayland new-API bridge: full shortcut list converted to old JSON format.
+    void AllShortcutsReady(const QString &json);
+    // Wayland: result of a GetShortcut query, already converted to old JSON.
+    void shortcutQueried(const QString &json);
 
     //wm
     void compositingEnabledChanged(bool enabled);
@@ -165,6 +196,9 @@ public slots:
     QString LookupConflictingShortcut(const QString &in0);
     QDBusPendingReply<> ClearShortcutKeystrokes(const QString &in0, int in1);
     QDBusPendingReply<> AddShortcutKeystroke(const QString &in0, int in1, const QString &in2);
+    // Wayland: direct ModifyHotkeys (returns bool success), so the caller
+    // can detect commit failures and roll back the UI.
+    QDBusPendingReply<bool> callModifyHotkeys(const QString &id, const QStringList &hotkeys);
     QDBusPendingReply<> AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2);
     QDBusPendingReply<> ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3);
     QDBusPendingReply<> DeleteCustomShortcut(const QString &in0);
@@ -189,14 +223,32 @@ public slots:
 
 private slots:
     void onLangSelectorStartServiceProcessFinished(QDBusPendingCallWatcher *w);
+    // New API -> Old API adapters (Wayland)
+    void onListAllShortcutsNewFinished(QDBusPendingCallWatcher *w);
+    void onGetShortcutNewFinished(QDBusPendingCallWatcher *w);
+    void onSearchShortcutsNewFinished(QDBusPendingCallWatcher *w);
+    // Bridge: new dde-services D-Bus signals (ShortcutChanged/ShortcutRemoved)
+    // are named differently from the legacy Changed/Deleted, so auto-wiring
+    // by QDBusAbstractInterface misses them. Subscribe explicitly and forward.
+    void onNewShortcutChanged(const QString &id, const ShortcutInfoNew &info);
+    void onNewShortcutRemoved(const QString &id);
+
 private:
     void init();
 
+public:
+    bool isWayland() const;
+
 private:
+    // Convert new ShortcutInfo list to old JSON format
+    QString convertShortcutListToJson(const QList<ShortcutInfoNew> &list) const;
+    QString convertShortcutToJson(const ShortcutInfoNew &info) const;
+
     DDBusInterface *m_dBusLangSelectorInter;
     DDBusInterface *m_dBusKeyboardInter;
     DDBusInterface *m_dBusKeybingdingInter;
     DDBusInterface *m_dBusWMInter;
+    const bool m_isWayland;
 };
 
 Q_DECLARE_METATYPE(KeyboardLayoutList)

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -42,6 +42,13 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
 {
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Added, this, &KeyboardWorker::onAdded);
+    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::AllShortcutsReady, this, &KeyboardWorker::onAllShortcutsReady);
+    // Wayland GetShortcut results arrive on this signal; route them
+    // directly to the model so they never re-enter onShortcutChanged.
+    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::shortcutQueried, this, [this](const QString &json) {
+        if (m_shortcutModel)
+            m_shortcutModel->onKeyBindingChanged(json);
+    });
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Deleted, this, &KeyboardWorker::removed);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::UserLayoutListChanged, this, &KeyboardWorker::onUserLayout);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::CurrentLayoutChanged, this, &KeyboardWorker::onCurrentLayout);
@@ -95,6 +102,11 @@ void KeyboardWorker::setShortcutModel(ShortcutModel *model)
 
 void KeyboardWorker::refreshShortcut()
 {
+    if (m_keyboardDBusProxy->isWayland()) {
+        // Wayland: result is delivered asynchronously via AllShortcutsReady signal.
+        m_keyboardDBusProxy->ListAllShortcuts();
+        return;
+    }
     QDBusPendingCallWatcher *result = new QDBusPendingCallWatcher(m_keyboardDBusProxy->ListAllShortcuts(), this);
     connect(result, SIGNAL(finished(QDBusPendingCallWatcher*)), this,
             SLOT(onRequestShortcut(QDBusPendingCallWatcher*)));
@@ -295,6 +307,11 @@ bool KeyboardWorker::checkAvaliable(const QString &key)
    return value.isEmpty();
 }
 
+QString KeyboardWorker::lookupConflictingShortcut(const QString &key)
+{
+    return m_keyboardDBusProxy->LookupConflictingShortcut(key);
+}
+
 void KeyboardWorker::delShortcut(ShortcutInfo* info)
 {
     m_keyboardDBusProxy->DeleteCustomShortcut(info->id);
@@ -382,12 +399,22 @@ void KeyboardWorker::onRequestShortcut(QDBusPendingCallWatcher *watch)
     QDBusPendingReply<QString> reply = *watch;
     if(reply.isError())
     {
+        qWarning() << "ListAllShortcuts failed:" << reply.error();
         watch->deleteLater();
         return;
     }
 
-    QString info = reply.value();
+    parseShortcutListJson(reply.value());
+    watch->deleteLater();
+}
 
+void KeyboardWorker::onAllShortcutsReady(const QString &info)
+{
+    parseShortcutListJson(info);
+}
+
+void KeyboardWorker::parseShortcutListJson(const QString &info)
+{
     QMap<QStringList,int> map;
     QJsonArray array = QJsonDocument::fromJson(info.toStdString().c_str()).array();
     Q_FOREACH(QJsonValue value, array) {
@@ -427,7 +454,6 @@ void KeyboardWorker::onRequestShortcut(QDBusPendingCallWatcher *watch)
     m_model->setAllShortcut(map);
     if (m_shortcutModel)
         m_shortcutModel->onParseInfo(info);
-    watch->deleteLater();
 }
 
 void KeyboardWorker::onAdded(const QString &in0, int in1)
@@ -703,7 +729,24 @@ void KeyboardWorker::cleanShortcutSlef(const QString &id, const int type, const 
 {
     QString key = makeShortcutKey(id, type);
     m_replacingShortcuts.insert(key);
-    
+
+    // Wayland: ModifyHotkeys is atomic (unregister + register in one
+    // transaction). Sending a preceding Disable would queue a second commit
+    // before the first finishes, which the compositor's protocol forbids and
+    // makes commitAndWait time out for both. Use callModifyHotkeys
+    // (QDBusPendingReply<bool>) so we can detect server-side failures
+    // (commit timeout, conflict, registerKey failure) and re-query the
+    // current state to keep the UI in sync.
+    if (m_keyboardDBusProxy->isWayland()) {
+        QDBusPendingReply<bool> reply = m_keyboardDBusProxy->callModifyHotkeys(id, QStringList{shortcut});
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+        watcher->setProperty("id", id);
+        watcher->setProperty("type", type);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardWorker::onModifyHotkeysFinished);
+        return;
+    }
+
     QDBusPendingCall call = m_keyboardDBusProxy->ClearShortcutKeystrokes(id, type);
 
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
@@ -739,6 +782,30 @@ void KeyboardWorker::onConflictShortcutCleanFinished(QDBusPendingCallWatcher *wa
         QString key = makeShortcutKey(id, type);
         m_replacingShortcuts.remove(key);
     }
+
+    watch->deleteLater();
+}
+
+void KeyboardWorker::onModifyHotkeysFinished(QDBusPendingCallWatcher *watch)
+{
+    QDBusPendingReply<bool> reply = *watch;
+    const QString id = watch->property("id").toString();
+    const int type = watch->property("type").toInt();
+    const QString key = makeShortcutKey(id, type);
+
+    const bool success = (!reply.isError() && reply.value());
+    if (!success) {
+        qWarning() << "ModifyHotkeys failed for" << id
+                   << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
+        m_replacingShortcuts.remove(key);
+        // Re-query the server. On commit-timeout the in-memory state was
+        // rolled back by dde-services, so the response carries the real
+        // (old) hotkeys and onKeyBindingChanged will revert the UI.
+        onShortcutChanged(id, type);
+    }
+    // On success the server emits ShortcutChanged, whose handler chain
+    // (onShortcutChanged → Query → onGetShortcutFinished →
+    //  onKeyBindingChanged) will update the model. No extra work needed here.
 
     watch->deleteLater();
 }

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -47,6 +47,7 @@ public:
 
     void grabScreen();
     bool checkAvaliable(const QString& key);
+    QString lookupConflictingShortcut(const QString &key);
     void delShortcut(ShortcutInfo *info);
 
     void setRepeatDelay(uint value);
@@ -80,6 +81,8 @@ public Q_SLOTS:
     void addUserLayout(const QString& value);
     void delUserLayout(const QString& value);
     void onRequestShortcut(QDBusPendingCallWatcher* watch);
+    void onAllShortcutsReady(const QString &info);
+    void onModifyHotkeysFinished(QDBusPendingCallWatcher *watch);
     void onAdded(const QString&in0, int in1);
     void onDisableShortcut(ShortcutInfo* info);
     void onAddedFinished(QDBusPendingCallWatcher *watch);
@@ -111,6 +114,7 @@ private:
     uint converToModelDelay(uint value);
     int converToDBusInterval(int value);
     uint converToModelInterval(uint value);
+    void parseShortcutListJson(const QString &info);
 
 private:
     QList<MetaData> m_datas;

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -111,6 +111,7 @@ ShortcutModel::~ShortcutModel()
     m_systemInfos.clear();
     m_windowInfos.clear();
     m_workspaceInfos.clear();
+    m_appInfos.clear();
     m_customInfos.clear();
     qDeleteAll(m_searchList);
     m_searchList.clear();
@@ -134,6 +135,11 @@ QList<ShortcutInfo *> ShortcutModel::workspaceInfo() const
 QList<ShortcutInfo *> ShortcutModel::assistiveToolsInfo() const
 {
     return m_assistiveToolsInfos;
+}
+
+QList<ShortcutInfo *> ShortcutModel::appInfo() const
+{
+    return m_appInfos;
 }
 
 QList<ShortcutInfo *> ShortcutModel::customInfo() const
@@ -173,6 +179,7 @@ ShortcutInfo *ShortcutModel::shortcutAt(int index, int *corners)
     CHECK_INDEX_DCC(m_windowInfos)
     CHECK_INDEX_DCC(m_workspaceInfos)
     CHECK_INDEX_DCC(m_assistiveToolsInfos)
+    CHECK_INDEX_DCC(m_appInfos)
     CHECK_INDEX_DCC(m_customInfos)
 
     return nullptr;
@@ -222,6 +229,7 @@ void ShortcutModel::onParseInfo(const QString &info)
     m_windowInfos.clear();
     m_workspaceInfos.clear();
     m_assistiveToolsInfos.clear();
+    m_appInfos.clear();
     m_customInfos.clear();
     
     // 清理系统快捷键名称缓存，因为数据即将更新
@@ -246,6 +254,28 @@ void ShortcutModel::onParseInfo(const QString &info)
 
         m_infos << info;
 
+        // Wayland: use Section field from new API (avoids hardcoded ID lists)
+        QString section = obj["Section"].toString();
+        if (!section.isEmpty()) {
+            if (section == QLatin1String("System")) {
+                info->sectionName = tr("System");
+                m_systemInfos << info;
+                continue;
+            }
+            if (section == QLatin1String("App")) {
+                info->sectionName = tr("App");
+                m_appInfos << info;
+                continue;
+            }
+            if (section == QLatin1String("Custom")) {
+                info->sectionName = tr("Custom");
+                m_customInfos << info;
+                continue;
+            }
+            qWarning() << "Unknown shortcut section:" << section << "id=" << info->id;
+        }
+
+        // X11: old ID-based categorization
         if (type != MEDIAKEY) {
             if (systemShortKeys.contains(info->id)) {
                 info->sectionName = tr("System");
@@ -323,6 +353,7 @@ void ShortcutModel::onParseInfo(const QString &info)
     Q_EMIT listChanged(m_windowInfos, InfoType::Window);
     Q_EMIT listChanged(m_workspaceInfos, InfoType::Workspace);
     Q_EMIT listChanged(m_assistiveToolsInfos, InfoType::AssistiveTools);
+    Q_EMIT listChanged(m_appInfos, InfoType::App);
     Q_EMIT listChanged(m_customInfos, InfoType::Custom);
 }
 
@@ -399,6 +430,11 @@ void ShortcutModel::onWindowSwitchChanged(bool value)
      QString accels = shortcut;
      accels = accels.replace("<", "");
      accels = accels.replace(">", "-");
+     // Wayland keystroke capture produces Qt PortableText ("Ctrl+Alt+T",
+     // "Meta+P") instead of the X11 XKB form. Normalize both so the split
+     // below produces one chip per token.
+     accels = accels.replace("+", "-");
+     accels = accels.replace("Meta", "Super");
      accels = accels.replace("_L", "");
      accels = accels.replace("_R", "");
      accels = accels.replace("Control", "Ctrl");
@@ -421,7 +457,7 @@ int ShortcutModel::indexOfShortcut(ShortcutInfo *info)
 
     const QList<ShortcutInfo*> *lists[] = {
         &m_systemInfos, &m_windowInfos, &m_workspaceInfos,
-        &m_assistiveToolsInfos, &m_customInfos
+        &m_assistiveToolsInfos, &m_appInfos, &m_customInfos
     };
 
     int row = 0;

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -57,19 +57,21 @@ public:
         Window,
         Workspace,
         AssistiveTools,
+        App, // Wayland-only (new D-Bus API)
     };
 
     QList<ShortcutInfo *> systemInfo() const;
     QList<ShortcutInfo *> windowInfo() const;
     QList<ShortcutInfo *> workspaceInfo() const;
     QList<ShortcutInfo *> assistiveToolsInfo() const;
+    QList<ShortcutInfo *> appInfo() const;
     QList<ShortcutInfo *> customInfo() const;
     QList<ShortcutInfo *> infos() const;
 
     inline int count()
     {
         int c = m_systemInfos.count() + m_windowInfos.count() + m_workspaceInfos.count()
-                + m_assistiveToolsInfos.count() + m_customInfos.count();
+                + m_assistiveToolsInfos.count() + m_appInfos.count() + m_customInfos.count();
         return c;
     }
 
@@ -120,6 +122,7 @@ private:
     QList<ShortcutInfo *> m_windowInfos;
     QList<ShortcutInfo *> m_workspaceInfos;
     QList<ShortcutInfo *> m_assistiveToolsInfos;
+    QList<ShortcutInfo *> m_appInfos;
     QList<ShortcutInfo *> m_customInfos;
     QList<ShortcutInfo *> m_searchList;
     QList<ShortcutInfo *> m_windowSwitchStateInfos;

--- a/src/plugin-keyboard/operation/treelandshortcutcapture.cpp
+++ b/src/plugin-keyboard/operation/treelandshortcutcapture.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#include "treelandshortcutcapture.h"
+
+#include <QDebug>
+#include <QGuiApplication>
+#include <QWindow>
+#include <qpa/qplatformnativeinterface.h>
+
+extern "C" {
+#include <wayland-client-core.h>
+}
+
+namespace dccV25 {
+
+TreelandShortcutCaptureSession::TreelandShortcutCaptureSession(
+    struct ::treeland_shortcut_capture_v1 *obj, QObject *parent)
+    : QObject(parent)
+    , QtWayland::treeland_shortcut_capture_v1(obj)
+{
+}
+
+TreelandShortcutCaptureSession::~TreelandShortcutCaptureSession()
+{
+    if (!m_finished && isInitialized()) {
+        // Destroying while pending cancels the capture per protocol.
+        QtWayland::treeland_shortcut_capture_v1::destroy();
+    }
+}
+
+void TreelandShortcutCaptureSession::treeland_shortcut_capture_v1_captured(const QString &key)
+{
+    m_finished = true;
+    emit captured(key);
+    QtWayland::treeland_shortcut_capture_v1::destroy();
+    deleteLater();
+}
+
+void TreelandShortcutCaptureSession::treeland_shortcut_capture_v1_failed(uint32_t reason)
+{
+    m_finished = true;
+    emit failed(reason);
+    QtWayland::treeland_shortcut_capture_v1::destroy();
+    deleteLater();
+}
+
+TreelandShortcutCaptureManager::TreelandShortcutCaptureManager(QObject *parent)
+    : QWaylandClientExtensionTemplate<TreelandShortcutCaptureManager>(2)
+{
+    setParent(parent);
+    initialize();
+}
+
+TreelandShortcutCaptureManager::~TreelandShortcutCaptureManager()
+{
+    // Mirror TreelandShortcutWrapper in dde-services: only destroy when the
+    // global was actually bound. isInitialized() can be true while the proxy
+    // was never created (compositor without v2 advertisement).
+    if (isActive()) {
+        QtWayland::treeland_shortcut_manager_v2::destroy();
+    }
+}
+
+TreelandShortcutCaptureSession *TreelandShortcutCaptureManager::captureNext(QWindow *window)
+{
+    if (!isActive()) {
+        qWarning() << "TreelandShortcutCaptureManager: protocol not active";
+        return nullptr;
+    }
+    if (!window) {
+        qWarning() << "TreelandShortcutCaptureManager: null window";
+        return nullptr;
+    }
+
+    QPlatformNativeInterface *iface = QGuiApplication::platformNativeInterface();
+    if (!iface) {
+        qWarning() << "TreelandShortcutCaptureManager: no platform native interface";
+        return nullptr;
+    }
+    auto *surface = static_cast<struct ::wl_surface *>(
+        iface->nativeResourceForWindow(QByteArrayLiteral("surface"), window));
+    if (!surface) {
+        qWarning() << "TreelandShortcutCaptureManager: window has no wl_surface" << window;
+        return nullptr;
+    }
+
+    struct ::treeland_shortcut_capture_v1 *obj = capture_next_shortcut(surface, nullptr);
+    if (!obj) {
+        qWarning() << "TreelandShortcutCaptureManager: capture_next_shortcut returned null";
+        return nullptr;
+    }
+    return new TreelandShortcutCaptureSession(obj, this);
+}
+
+} // namespace dccV25

--- a/src/plugin-keyboard/operation/treelandshortcutcapture.h
+++ b/src/plugin-keyboard/operation/treelandshortcutcapture.h
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+#include <QWaylandClientExtension>
+
+#include "qwayland-treeland-shortcut-manager-v2.h"
+
+class QWindow;
+
+namespace dccV25 {
+
+// One-shot session created by capture_next_shortcut. The compositor will
+// emit either `captured` (key bound to the next valid combo) or `failed`
+// (focus lost, interrupted, busy, aborted). After the terminal event the
+// wayland object is inert; the session destroys itself.
+class TreelandShortcutCaptureSession
+    : public QObject
+    , public QtWayland::treeland_shortcut_capture_v1
+{
+    Q_OBJECT
+public:
+    explicit TreelandShortcutCaptureSession(struct ::treeland_shortcut_capture_v1 *obj,
+                                            QObject *parent = nullptr);
+    ~TreelandShortcutCaptureSession() override;
+
+signals:
+    void captured(const QString &key);
+    void failed(uint32_t reason);
+
+protected:
+    void treeland_shortcut_capture_v1_captured(const QString &key) override;
+    void treeland_shortcut_capture_v1_failed(uint32_t reason) override;
+
+private:
+    bool m_finished = false;
+};
+
+// Wraps the treeland_shortcut_manager_v2 global for the capture-only use
+// case. The dde-services plugin already holds the manager's acquire lock
+// for binding shortcuts; capture_next_shortcut does NOT require acquire
+// per protocol, so this client only sends capture requests.
+class TreelandShortcutCaptureManager
+    : public QWaylandClientExtensionTemplate<TreelandShortcutCaptureManager>
+    , public QtWayland::treeland_shortcut_manager_v2
+{
+    Q_OBJECT
+public:
+    explicit TreelandShortcutCaptureManager(QObject *parent = nullptr);
+    ~TreelandShortcutCaptureManager() override;
+
+    // Returns nullptr if the protocol is not active or the window lacks a
+    // wl_surface. The returned session is parented to the manager and
+    // self-destructs after captured/failed.
+    TreelandShortcutCaptureSession *captureNext(QWindow *window);
+};
+
+} // namespace dccV25

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -137,9 +137,12 @@ D.DialogWindow {
                 else
                     return DS.Style.keySequenceEdit.background;
             }
+            // Wayland: ask Treeland to forward the next combo (capture protocol).
+            // No-op on X11; local Keys.onPressed handles capture there.
             onRequestKeys: {
                 keys = [];
                 dccData.updateKey(ddialog.keyId, 1);
+                dccData.beginWaylandKeyCapture(edit, ddialog.keyId, 1);
             }
         }
 
@@ -221,6 +224,14 @@ D.DialogWindow {
             function onKeyEvent(accels) {
                 edit.showAlertColor = false;
                 edit.keys = dccData.formatKeys(accels);
+            }
+            function onWaylandKeyCaptureFailed(id, type, reason) {
+                // Restrict to this dialog's own capture — id may be empty
+                // when wrapping a new custom shortcut.
+                if (id !== ddialog.keyId)
+                    return;
+                // Same recovery as a server-side requestRestore.
+                onRequestRestore();
             }
         }
     }

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -176,6 +176,13 @@ DccObject {
                                 }
                             }
 
+                            // On Wayland the compositor swallows key events
+                            // for already-registered global shortcuts, so we
+                            // ask Treeland (via capture_next_shortcut) to
+                            // forward the next combo here. On X11 the local
+                            // Keys.onPressed in KeySequenceDisplay handles
+                            // capture as before — beginWaylandKeyCapture
+                            // is a no-op there.
                             onRequestKeys: {
                                 if (shortcutView.editItem) {
                                     shortcutView.editItem.restore()
@@ -187,6 +194,7 @@ DccObject {
                                 shortcutView.editItem = edit
                                 shortcutView.conflictText = conflictText
                                 shortcutSettingsBody.isEditing = false
+                                dccData.beginWaylandKeyCapture(edit, model.id, model.type)
                             }
                             onRequestEditKeys: {
                                 dialogloader.active = true
@@ -377,6 +385,17 @@ DccObject {
 
                         shortcutView.editItem.focus = false
                         shortcutView.editItem.keys = dccData.formatKeys(accels)
+                    }
+                    function onWaylandKeyCaptureFailed(id, type, reason) {
+                        // not_active (3) / interrupted (4) / busy (1) / aborted (2).
+                        // Skip if nothing is being edited here — the dialog
+                        // path has its own handler and a stale event from a
+                        // session we've already cancelled (see disconnect in
+                        // beginWaylandKeyCapture) shouldn't tear down a fresh
+                        // edit.
+                        if (!shortcutView.editItem)
+                            return
+                        shortcutView.restoreShortcutView()
                     }
                 }
             }

--- a/src/plugin-mouse/operation/gesturedata.cpp
+++ b/src/plugin-mouse/operation/gesturedata.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "gesturedata.h"
@@ -14,6 +14,19 @@ void GestureData::setActionType(const QString &newActionType)
         return;
     m_actionType = newActionType;
     emit actionTypeChanged();
+}
+
+QString GestureData::gestureId() const
+{
+    return m_gestureId;
+}
+
+void GestureData::setGestureId(const QString &newGestureId)
+{
+    if (m_gestureId == newGestureId)
+        return;
+    m_gestureId = newGestureId;
+    emit gestureIdChanged();
 }
 
 QString GestureData::direction() const

--- a/src/plugin-mouse/operation/gesturedata.h
+++ b/src/plugin-mouse/operation/gesturedata.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef GESTUREDATA_H
@@ -10,6 +10,7 @@ class GestureData : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString actionType READ actionType WRITE setActionType NOTIFY actionTypeChanged FINAL)
+    Q_PROPERTY(QString gestureId READ gestureId WRITE setGestureId NOTIFY gestureIdChanged FINAL)
     Q_PROPERTY(QString direction READ direction WRITE setDirection NOTIFY directionChanged FINAL)
     Q_PROPERTY(int fingersNum READ fingersNum WRITE setFingersNum NOTIFY fingersNumChanged FINAL)
     Q_PROPERTY(QString actionName READ actionName WRITE setActionName NOTIFY actionNameChanged FINAL)
@@ -19,6 +20,9 @@ public:
 
     QString actionType() const;
     void setActionType(const QString &newActionType);
+
+    QString gestureId() const;
+    void setGestureId(const QString &newGestureId);
 
     QString direction() const;
     void setDirection(const QString &newDirection);
@@ -46,6 +50,8 @@ signals:
 
     void actionTypeChanged();
 
+    void gestureIdChanged();
+
     void directionChanged();
 
     void fingersNumChanged();
@@ -54,6 +60,7 @@ signals:
 
 private:
     QString m_actionType;
+    QString m_gestureId;
     QString m_direction;
     int m_fingersNum;
     QString m_actionName;

--- a/src/plugin-mouse/operation/gesturemodel.cpp
+++ b/src/plugin-mouse/operation/gesturemodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -28,6 +28,7 @@ void GestureModel::updateGestureData(const GestureData &data)
 {
     for (int i = 0; i < m_gestures.size(); i++) {
         if (data.direction() == m_gestures[i]->direction() && data.fingersNum() == m_gestures[i]->fingersNum()) {
+            m_gestures[i]->setGestureId(data.gestureId());
             m_gestures[i]->setActionName(data.actionName());
             QModelIndex modelIndex = createIndex(i, 0);
             emit dataChanged(modelIndex, modelIndex, {});

--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -4,6 +4,7 @@
 #include "mousedbusproxy.h"
 #include "gesturedata.h"
 
+#include <QCoreApplication>
 #include <QJsonArray>
 #include <QDBusArgument>
 #include <QDBusConnection>
@@ -11,10 +12,67 @@
 #include <QDBusPendingCall>
 #include <QDBusPendingCallWatcher>
 #include <QDBusReply>
+#include <QDBusMetaType>
 #include <QJsonDocument>
 #include <QJsonObject>
 
 using namespace DCC_NAMESPACE;
+
+// New API GestureInfo struct (dde-services)
+struct GestureInfoNew {
+    QString id;
+    QString displayName;
+    int category;
+    int gestureType;     // 1=Swipe, 2=Hold
+    int fingerCount;
+    int direction;       // 0=None, 1=Down, 2=Left, 3=Up, 4=Right
+    int triggerType;
+    QStringList triggerValue;
+    QString localLanguageName;
+};
+Q_DECLARE_METATYPE(GestureInfoNew)
+Q_DECLARE_METATYPE(QList<GestureInfoNew>)
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const GestureInfoNew &info) {
+    argument.beginStructure();
+    argument << info.id << info.displayName << info.category
+             << info.gestureType << info.fingerCount << info.direction
+             << info.triggerType << info.triggerValue << info.localLanguageName;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, GestureInfoNew &info) {
+    argument.beginStructure();
+    argument >> info.id >> info.displayName >> info.category
+             >> info.gestureType >> info.fingerCount >> info.direction
+             >> info.triggerType >> info.triggerValue >> info.localLanguageName;
+    argument.endStructure();
+    return argument;
+}
+
+// Map new API direction int to old API direction string
+static QString directionIntToString(int dir) {
+    switch (dir) {
+    case 1: return QStringLiteral("down");
+    case 2: return QStringLiteral("left");
+    case 3: return QStringLiteral("up");
+    case 4: return QStringLiteral("right");
+    case 0: return QStringLiteral("none");
+    }
+    qWarning() << "Wayland Unexpected gesture direction value:" << dir;
+    return QStringLiteral("none");
+}
+
+// Map new API gestureType to old API actionType string
+static QString gestureTypeToString(int type) {
+    switch (type) {
+    case 1: return QStringLiteral("swipe");
+    case 2: return QStringLiteral("tap");
+    }
+    qWarning() << "Wayland Unexpected gesture type value:" << type;
+    return QStringLiteral("swipe"); // safe fallback
+}
 
 const QString Service = "org.deepin.dde.InputDevices1";
 const QString MousePath = "/org/deepin/dde/InputDevice1/Mouse";
@@ -49,8 +107,20 @@ MouseDBusProxy::MouseDBusProxy(QObject *parent)
     , m_dbusDevices(nullptr)
     , m_dbusGesture(nullptr)
     , m_appearance(nullptr)
+    , m_isWayland((qgetenv("XDG_SESSION_TYPE").toLower() == QLatin1String("wayland"))
+                  || !qgetenv("WAYLAND_DISPLAY").isEmpty())
 {
+    qRegisterMetaType<GestureInfoNew>("GestureInfoNew");
+    qDBusRegisterMetaType<GestureInfoNew>();
+    qRegisterMetaType<QList<GestureInfoNew>>("QList<GestureInfoNew>");
+    qDBusRegisterMetaType<QList<GestureInfoNew>>();
+
     init();
+}
+
+bool MouseDBusProxy::isWayland() const
+{
+    return m_isWayland;
 }
 
 void MouseDBusProxy::active()
@@ -107,12 +177,24 @@ void MouseDBusProxy::active()
     bool lidIsPresent = getLidIsPresent();
     Q_EMIT lidIsPresentChanged(lidIsPresent);
 
-    QVariant gestureInfos = m_dbusGestureProperties->call("Get", GestureInterface, "Infos").arguments().at(0).value<QDBusVariant>().variant();
-    parseGesturesData(qvariant_cast<QDBusArgument>(gestureInfos));
+    if (isWayland()) {
+        refreshGestures();
+    } else {
+        QVariant gestureInfos = m_dbusGestureProperties->call("Get", GestureInterface, "Infos").arguments().at(0).value<QDBusVariant>().variant();
+        parseGesturesData(qvariant_cast<QDBusArgument>(gestureInfos));
+    }
 
     listCursor();
     auto cursorSize = m_appearance->property("CursorSize").toInt();
     Q_EMIT cursorSizeChanged(cursorSize);
+}
+
+void MouseDBusProxy::refreshGestures()
+{
+    QDBusPendingCall call = m_dbusGesture->asyncCall(QStringLiteral("ListAllGestures"));
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &MouseDBusProxy::onListAllGesturesNewFinished);
 }
 
 void MouseDBusProxy::deactive()
@@ -153,13 +235,23 @@ void MouseDBusProxy::init()
                                           "sa{sv}as",
                                           this,
                                           SLOT(onInputDevicesPathPropertiesChanged(QDBusMessage)));
-    QDBusConnection::sessionBus().connect(GestureService,
-                                          GesturePath,
-                                          PropertiesInterface,
-                                          "PropertiesChanged",
-                                          "sa{sv}as",
-                                          this,
-                                          SLOT(onGesturePropertiesChanged(QDBusMessage)));
+    if (!isWayland()) {
+        QDBusConnection::sessionBus().connect(GestureService,
+                                              GesturePath,
+                                              PropertiesInterface,
+                                              "PropertiesChanged",
+                                              "sa{sv}as",
+                                              this,
+                                              SLOT(onGesturePropertiesChanged(QDBusMessage)));
+    } else {
+        // Wayland: listen to GestureInfosChanged signal from new API
+        QDBusConnection::sessionBus().connect(GestureService,
+                                              GesturePath,
+                                              GestureInterface,
+                                              "GestureInfosChanged",
+                                              this,
+                                              SLOT(refreshGestures()));
+    }
 
     QDBusConnection::sessionBus().connect(AppearanceService,
                                           AppearancePath,
@@ -360,7 +452,14 @@ void MouseDBusProxy::setScrollSpeed(uint speed)
 
 void MouseDBusProxy::setGesture(const QString& name, const QString& direction, int fingers, const QString& action)
 {
-    m_dbusGesture->asyncCallWithArgumentList("SetGesture", { name, direction, fingers, action });
+    if (isWayland()) {
+        // New API: ModifyGesture(id, action)
+        Q_UNUSED(direction);
+        Q_UNUSED(fingers);
+        m_dbusGesture->asyncCallWithArgumentList("ModifyGesture", { name, QStringList{action} });
+    } else {
+        m_dbusGesture->asyncCallWithArgumentList("SetGesture", { name, direction, fingers, action });
+    }
 }
 
 void MouseDBusProxy::onMousePathPropertiesChanged(QDBusMessage msg)
@@ -483,6 +582,66 @@ void MouseDBusProxy::onGesturePropertiesChanged(QDBusMessage msg)
             }
         }
     }
+}
+
+namespace {
+struct GestureActionItem {
+    QString value;     // Treeland action enum as string ("11" etc.), or "Disable" sentinel
+    const char *trKey; // Source string for QCoreApplication::translate("MouseDBusProxy", ...)
+};
+
+static const QList<GestureActionItem> kThreeFingerActions = {
+    {"11",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Maximize window")},
+    {"12",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Restore window")},
+    {"10",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Show desktop")},
+    {"20",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Lock screen")},
+    {"16",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Multitasking view")},
+    {"Disable",  QT_TRANSLATE_NOOP("MouseDBusProxy", "Disable")},
+};
+
+static const QList<GestureActionItem> kFourFingerActions = {
+    {"8",        QT_TRANSLATE_NOOP("MouseDBusProxy", "Switch to previous workspace")},
+    {"9",        QT_TRANSLATE_NOOP("MouseDBusProxy", "Switch to next workspace")},
+    {"16",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Multitasking view")},
+    {"17",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Hide multitasking view")},
+    {"18",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Toggle multitasking view")},
+    {"10",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Show desktop")},
+    {"Disable",  QT_TRANSLATE_NOOP("MouseDBusProxy", "Disable")},
+};
+}  // namespace
+
+static void fillGestureData(GestureData *data, const GestureInfoNew &info)
+{
+    data->setActionType(gestureTypeToString(info.gestureType));
+    data->setGestureId(info.id);
+    data->setDirection(directionIntToString(info.direction));
+    data->setFingersNum(info.fingerCount);
+    // Empty triggerValue (corner case) is treated as Disable so the UI auto-selects it.
+    data->setActionName(info.triggerValue.isEmpty() ? QStringLiteral("Disable") : info.triggerValue.first());
+}
+
+static void fillGestureActionMaps(GestureData &data, int fingerCount)
+{
+    const auto &table = (fingerCount == 3) ? kThreeFingerActions : kFourFingerActions;
+    for (const auto &item : table) {
+        data.addActiosPair({item.value, QCoreApplication::translate("MouseDBusProxy", item.trKey)});
+    }
+}
+
+void MouseDBusProxy::onListAllGesturesNewFinished(QDBusPendingCallWatcher *w)
+{
+    QDBusPendingReply<QList<GestureInfoNew>> reply = *w;
+    if (!reply.isError()) {
+        for (const auto &info : reply.value()) {
+            GestureData data;
+            fillGestureData(&data, info);
+            fillGestureActionMaps(data, info.fingerCount);
+            Q_EMIT gestureDataChanged(data);
+        }
+    } else {
+        qWarning() << "Wayland ListAllGestures failed:" << reply.error();
+    }
+    w->deleteLater();
 }
 
 void MouseDBusProxy::onAppearancePropertiesChanged(QDBusMessage msg)

--- a/src/plugin-mouse/operation/mousedbusproxy.h
+++ b/src/plugin-mouse/operation/mousedbusproxy.h
@@ -93,7 +93,13 @@ public Q_SLOTS:
 
     void onGetGestureAvaiableActionsFinished(QDBusPendingCallWatcher *w);
 
+    // New API adapters (Wayland)
+    void refreshGestures();
+    void onListAllGesturesNewFinished(QDBusPendingCallWatcher *w);
+
 private:
+    bool isWayland() const;
+
     QDBusInterface *m_dbusMouseProperties;
     QDBusInterface *m_dbusTouchPadProperties;
     QDBusInterface *m_dbusTrackPointProperties;
@@ -106,6 +112,8 @@ private:
     QDBusInterface *m_dbusDevices;
     QDBusInterface *m_dbusGesture;
     QDBusInterface *m_appearance;
+
+    const bool m_isWayland;
 };
 }
 

--- a/src/plugin-mouse/operation/mousemodel.cpp
+++ b/src/plugin-mouse/operation/mousemodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "mousemodel.h"
@@ -286,6 +286,7 @@ void MouseModel::updateGesturesData(const GestureData &gestureData)
     } else {
         GestureData *data = new GestureData(this);
         data->setActionType(gestureData.actionType());
+        data->setGestureId(gestureData.gestureId());
         data->setDirection(gestureData.direction());
         data->setActionName(gestureData.actionName());
         data->setFingersNum(gestureData.fingersNum());
@@ -322,7 +323,8 @@ void MouseModel::setGestures(int fingerNum, int index, QString actionName)
             return;
 
         updateFigerAniPath(actionName, data);
-        Q_EMIT m_worker->requestSetGesture(data->actionType(),
+        const QString gestureName = data->gestureId().isEmpty() ? data->actionType() : data->gestureId();
+        Q_EMIT m_worker->requestSetGesture(gestureName,
                                            data->direction(),
                                            data->fingersNum(),
                                            actionName);

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Verspersoonlik</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Geen</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ak.ts
+++ b/translations/dde-control-center_ak.ts
@@ -4321,4 +4321,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
 </context>
+<context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>ማስተካከያ</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -2424,6 +2424,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">де فعالة</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2728,18 +2771,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>脆弱 (翻译错误，但在上下文中): كلاش</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>وتو</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>ساري</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2804,6 +2835,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>مخصص</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">脆弱 (翻译错误，但在上下文中): كلاش</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">وتو</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">ساري</translation>
     </message>
 </context>
 <context>
@@ -4401,6 +4444,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>لا شيء</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ast.ts
+++ b/translations/dde-control-center_ast.ts
@@ -4393,4 +4393,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
 </context>
+<context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -2424,6 +2424,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">تعطيل</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2728,18 +2771,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>ضوء</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>אוטומטי</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>ظلام</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2804,6 +2835,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>مخصص</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">ضوء</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">אוטומטי</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">ظلام</translation>
     </message>
 </context>
 <context>
@@ -4401,6 +4444,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>لا يوجد</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Потребителски</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Няма</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -2419,6 +2419,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">দেবু করা</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2723,18 +2766,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>আলো</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>টুকরো</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>ট্যাগ</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2799,6 +2830,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>মোটামুটি</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">আলো</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">টুকরো</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">ট্যাগ</translation>
     </message>
 </context>
 <context>
@@ -4420,6 +4463,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>কোনো একটি নেই</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>རང་སྒྲུབ།</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>None</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_bqi.ts
+++ b/translations/dde-control-center_bqi.ts
@@ -4393,4 +4393,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>کوئی نہیں</translation>
     </message>
 </context>
+<context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Personnelaet</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Hini ebet</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -2430,6 +2430,49 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Inhabilita</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2734,18 +2777,6 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Clar</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automàtic</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Fosc</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>El servei del selector no està disponible.</translation>
     </message>
@@ -2810,6 +2841,18 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>Custom</source>
         <translation>Personalitzat</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automàtic</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Fosc</translation>
     </message>
 </context>
 <context>
@@ -4407,6 +4450,10 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>None</source>
         <translation>Cap</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Uživatelsky určené</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Žádné</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Tilpasset</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Ingen</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Deaktivieren</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Anwenderspezifisch</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Keine</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Προσαρμογή</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Κανένα</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Custom</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>None</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Custom</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>None</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Personigo</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nenio</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -2432,6 +2432,49 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Desactivar</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2736,18 +2779,6 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Claro</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automático</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Oscuro</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>El servicio de selección no está disponible.</translation>
     </message>
@@ -2812,6 +2843,18 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>Custom</source>
         <translation>Personalizar</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Claro</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Oscuro</translation>
     </message>
 </context>
 <context>
@@ -4409,6 +4452,10 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>None</source>
         <translation>Ninguno</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -2419,6 +2419,49 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Pikaühendamise vältimine</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2723,18 +2766,6 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Lumine</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automaatne</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Tumeline</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2799,6 +2830,18 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>Custom</source>
         <translation>Tööskuju</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Lumine</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automaatne</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Tumeline</translation>
     </message>
 </context>
 <context>
@@ -4396,6 +4439,10 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>None</source>
         <translation> pole</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Bat ere ez</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>شخصی</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>هیچ</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -2423,6 +2423,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Pois</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2727,18 +2770,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Vaalea</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Autom.</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Tumma</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>Poimintapalvelu ei ole saatavilla</translation>
     </message>
@@ -2803,6 +2834,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Mukautettu</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Autom.</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Tumma</translation>
     </message>
 </context>
 <context>
@@ -4400,6 +4443,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Mitään</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Wala</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -2432,6 +2432,49 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Désactiver</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2736,18 +2779,6 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Clair</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automatique</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Sombre</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>Le service de ramassage n&apos;est pas disponible.</translation>
     </message>
@@ -2812,6 +2843,18 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>Custom</source>
         <translation>Personnalisé</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Clair</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automatique</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Sombre</translation>
     </message>
 </context>
 <context>
@@ -4409,6 +4452,10 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>None</source>
         <translation>Aucun</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -2419,6 +2419,49 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Desactivar</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2723,18 +2766,6 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Claro</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Auto</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Escur@</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2799,6 +2830,18 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>Custom</source>
         <translation>Personalizado</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Claro</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Escur@</translation>
     </message>
 </context>
 <context>
@@ -4420,6 +4463,10 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>None</source>
         <translation>Ningún</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"> Dezactiva</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2718,18 +2761,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>בהיר</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>אוטומטי</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>😉</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2794,6 +2825,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation> Cástom</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">בהיר</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">אוטומטי</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">😉</translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4434,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>לא</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>स्वयं के द्वारा</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>कोई नहीं</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Prilagođeno</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nijedan</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Kikapcsolás</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2718,18 +2761,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Kicsép</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automatikus</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Sötét</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2794,6 +2825,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Egyéni</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Kicsép</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automatikus</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Sötét</translation>
     </message>
 </context>
 <context>
@@ -4415,6 +4458,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nincs</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Ընտրովի</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>None</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Kustom</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Tidak ada</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Personalizzazione</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nessuno</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -2427,6 +2427,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">無効</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2731,18 +2774,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>ライト</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>自動</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>ダーク</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>ピッカーサービスが利用できません</translation>
     </message>
@@ -2807,6 +2838,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>カスタム</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">自動</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">ダーク</translation>
     </message>
 </context>
 <context>
@@ -4404,6 +4447,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>なし</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>არაფერი</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_kab.ts
+++ b/translations/dde-control-center_kab.ts
@@ -4397,4 +4397,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
 </context>
+<context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -2415,6 +2415,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Коркун</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2719,18 +2762,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Көркем</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Авто</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Күнімді</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Туғандаған</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Көркем</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Күнімді</translation>
     </message>
 </context>
 <context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Жоқ</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>គ្មេាំង</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>ಯಾವುದೂ ಇಲ್ಲ</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -2418,6 +2418,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">비활성화</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2722,18 +2765,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>밝은</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>자동</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>어둡게</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2798,6 +2829,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>사용자 정의</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">밝은</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">자동</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">어둡게</translation>
     </message>
 </context>
 <context>
@@ -4419,6 +4462,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>없음</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Tu tişt</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Taybet</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>هیچ</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Жок</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ky@Arab.ts
+++ b/translations/dde-control-center_ky@Arab.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -2418,6 +2418,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">ປິດການໃຊ້ງານ</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2722,18 +2765,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>ແສງສະຫວ່າງ</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>ອັດຕະໂນມັດ</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>ມືດ</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2798,6 +2829,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>ກຳນົດເອງ</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">ແສງສະຫວ່າງ</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">ອັດຕະໂນມັດ</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">ມືດ</translation>
     </message>
 </context>
 <context>
@@ -4395,6 +4438,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>ບໍ່ມີ</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nėra</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>കസ്റ്റം</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>ഒന്നുമില്ല</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Тусгайлсан</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Байхгүй</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>काहीही नाही</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Suai</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Tiada</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Egendefinert</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Ingen</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -2419,6 +2419,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">काम बाट घुमाउनुहोस्</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2723,18 +2766,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>लाम्बो</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>कार्यक्रमीय रूपमा</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>मोंको</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2799,6 +2830,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>सम्स्तता</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">लाम्बो</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">कार्यक्रमीय रूपमा</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">मोंको</translation>
     </message>
 </context>
 <context>
@@ -4396,6 +4439,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>कुनै पनि छैन</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -2417,6 +2417,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Uitschakelen</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2797,6 +2840,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Aangepast</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4394,6 +4449,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Geen</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pam.ts
+++ b/translations/dde-control-center_pam.ts
@@ -4393,4 +4393,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Ala</translation>
     </message>
 </context>
+<context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -2430,6 +2430,49 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Wyłącz</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2734,18 +2777,6 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Jasny</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automatycznie</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Ciemny</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>Usługa suplikanta nie jest dostępna</translation>
     </message>
@@ -2810,6 +2841,18 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
     <message>
         <source>Custom</source>
         <translation>Własne</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automatycznie</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Ciemny</translation>
     </message>
 </context>
 <context>
@@ -4407,6 +4450,10 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
     <message>
         <source>None</source>
         <translation>Brak</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2796,6 +2827,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>دوديز</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Personalizado</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -2425,6 +2425,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Desativar</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2729,18 +2772,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Tema claro</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automático</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Tema escuro</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>O serviço de seleção não está disponível</translation>
     </message>
@@ -2805,6 +2836,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Personalizar</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automático</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Tema escuro</translation>
     </message>
 </context>
 <context>
@@ -4402,6 +4445,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Nenhum</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Personalizare</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -2426,6 +2426,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Отключить</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2730,18 +2773,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Светлая</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Авто</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Темная</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2806,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Пользовательская</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Светлая</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Темная</translation>
     </message>
 </context>
 <context>
@@ -4403,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Нет</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>කිසිවක් නැත</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Vlastný</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Žiadne</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -2418,6 +2418,49 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Onemogoči</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2722,18 +2765,6 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Svetlo</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Automatično</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Temo</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2798,6 +2829,18 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>Custom</source>
         <translation>Napravljeno po meri</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Svetlo</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Automatično</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Temo</translation>
     </message>
 </context>
 <context>
@@ -4395,6 +4438,10 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>None</source>
         <translation>Nič</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -2430,6 +2430,49 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Çaktivizoje</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2734,18 +2777,6 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>E çelët</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Auto</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>E errët</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2810,6 +2841,18 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>Custom</source>
         <translation>Vetjake</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Auto</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">E errët</translation>
     </message>
 </context>
 <context>
@@ -4407,6 +4450,10 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>None</source>
         <translation>Asnjë</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Прилагођен</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Ништа</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -2418,6 +2418,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Avaktivera</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2798,6 +2841,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Anpassat</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Mörkt</translation>
     </message>
 </context>
 <context>
@@ -4395,6 +4450,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Ingen</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Hakuna</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>விருப்பம்</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>ஏதுமில்லை</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -2417,6 +2417,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">ปิดใช้งาน</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2721,18 +2764,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>สว่าง</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>อัตโนมัติ</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>มืด</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2797,6 +2828,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>กำหนดเอง</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">สว่าง</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">อัตโนมัติ</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">มืด</translation>
     </message>
 </context>
 <context>
@@ -4394,6 +4437,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>ไม่มี</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -2429,6 +2429,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Devre Dışı </translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2733,18 +2776,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Açık</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Otomatik</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Koyu</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>Toplayıcı hizmet mevcut değil</translation>
     </message>
@@ -2809,6 +2840,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Özel</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Açık</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Otomatik</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Koyu</translation>
     </message>
 </context>
 <context>
@@ -4406,6 +4449,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Hiçbiri</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_tzm.ts
+++ b/translations/dde-control-center_tzm.ts
@@ -4321,4 +4321,47 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
 </context>
+<context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"/>
+    </message>
+</context>
 </TS>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>بەلگىلەش</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>يوق</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -2424,6 +2424,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Вимкнути</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2728,18 +2771,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Світла</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Авто</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Темна</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation>Служба піпетки недоступна</translation>
     </message>
@@ -2804,6 +2835,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Користувацький</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Авто</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Темна</translation>
     </message>
 </context>
 <context>
@@ -4401,6 +4444,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Немає</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -2414,6 +2414,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2794,6 +2837,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -4391,6 +4446,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>کوئی نہیں</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -2416,6 +2416,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2720,18 +2763,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2795,6 +2826,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>PersonalizationWorker</name>
     <message>
         <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Dark</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4392,6 +4435,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>App</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -2421,6 +2421,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">Tắt</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2725,18 +2768,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>Sáng</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>Tự động</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>Đen</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2801,6 +2832,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>Tùy chỉnh</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished">Sáng</translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">Tự động</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">Đen</translation>
     </message>
 </context>
 <context>
@@ -4398,6 +4441,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>Không có</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -2427,6 +2427,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation>最大化窗口</translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation>还原窗口</translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation>显示桌面</translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation>锁定屏幕</translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation>显示多任务视图</translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation>隐藏多任务视图</translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation>切换多任务视图</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation>切换到上一工作区</translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation>切换到下一工作区</translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation>禁用</translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2731,18 +2774,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>浅色</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>自动</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>深色</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2807,6 +2838,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>自定义</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">自动</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">深色</translation>
     </message>
 </context>
 <context>
@@ -4400,6 +4443,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>自定义</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation>应用</translation>
     </message>
     <message>
         <source>None</source>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -2424,6 +2424,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">從不</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2728,18 +2771,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>淺色</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>自動</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>深色</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2804,6 +2835,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">自動</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">深色</translation>
     </message>
 </context>
 <context>
@@ -4401,6 +4444,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>無</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -2424,6 +2424,49 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>MouseDBusProxy</name>
+    <message>
+        <source>Maximize window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Restore window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Show desktop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Lock screen</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Disable</source>
+        <translation type="unfinished">從不</translation>
+    </message>
+    <message>
+        <source>Switch to previous workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Switch to next workspace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Hide multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Toggle multitasking view</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>MouseMain</name>
     <message>
         <source>Common</source>
@@ -2728,18 +2771,6 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
 <context>
     <name>PersonalizationInterface</name>
     <message>
-        <source>Light</source>
-        <translation>淺色</translation>
-    </message>
-    <message>
-        <source>Auto</source>
-        <translation>自動</translation>
-    </message>
-    <message>
-        <source>Dark</source>
-        <translation>深色</translation>
-    </message>
-    <message>
         <source>Picker service is not available</source>
         <translation type="unfinished"/>
     </message>
@@ -2804,6 +2835,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Custom</source>
         <translation>自定義</translation>
+    </message>
+    <message>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Auto</source>
+        <translation type="unfinished">自動</translation>
+    </message>
+    <message>
+        <source>Dark</source>
+        <translation type="unfinished">深色</translation>
     </message>
 </context>
 <context>
@@ -4401,6 +4444,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>None</source>
         <translation>無</translation>
+    </message>
+    <message>
+        <source>App</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
## Summary
- Adapt keyboard shortcut data paths to the new dde-services Wayland API while preserving the existing model JSON format.
- Enable Wayland shortcut editing through the Treeland capture protocol and reuse the existing conflict handling path.
- Adapt mouse gesture action lists and translations for Wayland, and refresh the UI after shortcut reset signals.

## Test
- Not run; metadata/message update only.