### PR TITLE
fix(touchpad): fix gesture display order inconsistent on first launch

### DIFF
--- a/src/plugin-mouse/operation/gesturedata.cpp
+++ b/src/plugin-mouse/operation/gesturedata.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "gesturedata.h"
@@ -53,6 +53,19 @@ void GestureData::setActionName(const QString &newActionName)
         return;
     m_actionName = newActionName;
     emit actionNameChanged();
+}
+
+int GestureData::sequence() const
+{
+    return m_sequence;
+}
+
+void GestureData::setSequence(int newSequence)
+{
+    if (m_sequence == newSequence)
+        return;
+    m_sequence = newSequence;
+    emit sequenceChanged();
 }
 
 QStringList GestureData::actionNameList() const

--- a/src/plugin-mouse/operation/gesturedata.h
+++ b/src/plugin-mouse/operation/gesturedata.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef GESTUREDATA_H
@@ -13,6 +13,7 @@ class GestureData : public QObject
     Q_PROPERTY(QString direction READ direction WRITE setDirection NOTIFY directionChanged FINAL)
     Q_PROPERTY(int fingersNum READ fingersNum WRITE setFingersNum NOTIFY fingersNumChanged FINAL)
     Q_PROPERTY(QString actionName READ actionName WRITE setActionName NOTIFY actionNameChanged FINAL)
+    Q_PROPERTY(int sequence READ sequence WRITE setSequence NOTIFY sequenceChanged FINAL)
 
 public:
     explicit GestureData(QObject *parent = nullptr);
@@ -28,6 +29,9 @@ public:
 
     QString actionName() const;
     void setActionName(const QString &newActionName);
+
+    int sequence() const;
+    void setSequence(int newSequence);
 
     QStringList actionNameList() const;
     void setActionNameList(const QStringList &newActionNameList);
@@ -52,11 +56,14 @@ signals:
 
     void actionNameChanged();
 
+    void sequenceChanged();
+
 private:
     QString m_actionType;
     QString m_direction;
     int m_fingersNum;
     QString m_actionName;
+    int m_sequence = -1;
 
 
     QList<QPair<QString, QString>> m_actionMaps;

--- a/src/plugin-mouse/operation/gesturemodel.cpp
+++ b/src/plugin-mouse/operation/gesturemodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -166,8 +166,16 @@ void GestureModel::addGestureData(GestureData *data)
         return;
     }
 
-    beginInsertRows(QModelIndex(), rowCount(), rowCount());
-    m_gestures.append(data);
+    int insertPos = m_gestures.size();
+    for (int i = 0; i < m_gestures.size(); ++i) {
+        if (m_gestures[i]->sequence() > data->sequence()) {
+            insertPos = i;
+            break;
+        }
+    }
+
+    beginInsertRows(QModelIndex(), insertPos, insertPos);
+    m_gestures.insert(insertPos, data);
     endInsertRows();
 }
 

--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -219,6 +219,7 @@ void MouseDBusProxy::parseGesturesData(const QDBusArgument &argument)
 {
     // 开始解析数组
     argument.beginArray();
+    int seq = 0;
     while (!argument.atEnd()) {
 
         QString actionType, direction, actionName;
@@ -238,6 +239,7 @@ void MouseDBusProxy::parseGesturesData(const QDBusArgument &argument)
         data.insert("direction", direction);
         data.insert("actionName", actionName);
         data.insert("fingerNum", fingerNum);
+        data.insert("sequence", seq++);
 
         QDBusPendingReply<QString> reply = m_dbusGesture->asyncCall("GetGestureAvaiableActions", actionType, fingerNum);
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
@@ -515,6 +517,7 @@ void MouseDBusProxy::onGetGestureAvaiableActionsFinished(QDBusPendingCallWatcher
     data.setDirection(dbusData.value("direction").toString());
     data.setActionName(dbusData.value("actionName").toString());
     data.setFingersNum(dbusData.value("fingerNum").toInt());
+    data.setSequence(dbusData.value("sequence", -1).toInt());
     QDBusPendingReply<QString> reply = *w;
     if (!reply.isError()) {
         QString actions = reply.value();

--- a/src/plugin-mouse/operation/mousemodel.cpp
+++ b/src/plugin-mouse/operation/mousemodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "mousemodel.h"
@@ -289,6 +289,7 @@ void MouseModel::updateGesturesData(const GestureData &gestureData)
         data->setDirection(gestureData.direction());
         data->setActionName(gestureData.actionName());
         data->setFingersNum(gestureData.fingersNum());
+        data->setSequence(gestureData.sequence());
         data->setActionMaps(gestureData.actionMaps());
         gestureModel->addGestureData(data);
     }


### PR DESCRIPTION
Async D-Bus calls complete in non-deterministic order, causing gesture iems to be appended to the model in a random sequence. Add a sequence field to GestureData that records the position in the D-Bus Infos array, and insert into the model at the correct sorted position instead of appending.

异步D-Bus调用的返回非确定性顺序，导致手势项被附加到随机序列中的模型。在手势数据中添加一个字段记录其在Infos数组中的位置，在插入模型时按照该字段排序。

Log: 手势数据按照Infos中的顺序进行显示
PMS: BUG-347539
Influence: 手势数据的显示顺序保持不变，与DConfig中顺序保持一致