### PR TITLE
refactor(datetime): replace hand-rolled Window popup with DTK Popup

### DIFF
--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -1,15 +1,21 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Lt
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Controls 2.0
+import QtQuick.Controls
 import QtQuick.Window
+import QtQuick.Layouts
 import org.deepin.dtk 1.0
-import QtQuick.Layouts 1.0
 import org.deepin.dtk.style 1.0 as DS
 
-Loader {
-    id: loader
-    active: false
+Popup {
+    id: control
+    width: calculatedWidth
+    height: 500
+    popupType: Popup.Window
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+    PopupHandle.enableBlurWindow: true
+
     required property var viewModel
     property int currentIndex: -1
     property string currentText
@@ -17,185 +23,138 @@ Loader {
     signal selectedRegion(string region)
 
     function show() {
-        active = true
+        if (mousePosition.x !== 0 || mousePosition.y !== 0) {
+            var w = Window.window
+            if (w) {
+                var localPos = w.mapFromGlobal(mousePosition.x, mousePosition.y)
+                x = localPos.x
+                y = localPos.y
+            }
+        }
+        calculateOptimalWidth()
+        open()
     }
 
     function isVisible() {
-        return active
+        return visible
     }
 
-    sourceComponent: Window {
-        id: searchWindow
-        property int calculatedWidth: 200
-        width: calculatedWidth
-        height: 500
-        minimumWidth: width
-        minimumHeight: height
-        maximumWidth: minimumWidth
-        maximumHeight: minimumHeight
-        DWindow.enabled: true
-        DWindow.enableSystemResize: false
-        DWindow.enableBlurWindow: true
-        // ensure show in center of mainwindow
-        // _NET_WM_WINDOW_TYPE will add Dialog when added Qt.WindowCloseButtonHint.
-        flags: Qt.Dialog | Qt.WindowCloseButtonHint
-        // default color is white
-        color: active ? DTK.palette.window : DTK.inactivePalette.window
-        palette: DTK.palette
+    onClosed: {
+        viewModel.setFilterWildcard("")
+    }
 
-        TextMetrics {
-            id: textMetrics
+    property int calculatedWidth: 200
+
+    TextMetrics {
+        id: textMetrics
+        font: DTK.fontManager.t6
+        text: ""
+    }
+
+    function calculateOptimalWidth() {
+        if (!viewModel || viewModel.rowCount() === 0) {
+            calculatedWidth = 200
+            return
+        }
+
+        var maxWidth = 0
+        for (var i = 0; i < viewModel.rowCount(); i++) {
+            var itemText = viewModel.data(viewModel.index(i, 0), Qt.DisplayRole) || ""
+            if (itemText.length > 0) {
+                textMetrics.text = itemText
+                maxWidth = Math.max(maxWidth, textMetrics.advanceWidth)
+            }
+        }
+
+        var finalWidth = Math.max(200, maxWidth + 40)
+        calculatedWidth = Math.min(finalWidth, 400)
+    }
+
+    Component.onCompleted: {
+        calculateOptimalWidth()
+    }
+
+    Connections {
+        target: viewModel
+        function onModelReset() { calculateOptimalWidth() }
+        function onRowsInserted() { calculateOptimalWidth() }
+        function onRowsRemoved() { calculateOptimalWidth() }
+    }
+
+    contentItem: ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 6
+        SearchEdit {
+            id: searchEdit
+            implicitHeight: Math.max(30, searchEditFontMetrics.height + (DS.Style.control.padding - DS.Style.control.borderWidth) * 2)
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignTop
+            placeholder: qsTr("Search")
+            palette: DTK.palette
             font: DTK.fontManager.t6
-            text: "" // Dynamically set text to measure actual width
-        }
-
-        function calculateOptimalWidth() {
-            if (!viewModel || viewModel.rowCount() === 0) {
-                calculatedWidth = 200
-                return
-            }
-
-            var maxWidth = 0
-            // Iterate through all items to find the longest text
-            for (var i = 0; i < viewModel.rowCount(); i++) {
-                var itemText = viewModel.data(viewModel.index(i, 0), Qt.DisplayRole) || ""
-                if (itemText.length > 0) {
-                    // Directly measure the actual width of the complete text
-                    textMetrics.text = itemText
-                    maxWidth = Math.max(maxWidth, textMetrics.advanceWidth)
-                }
-            }
-
-            // Calculate final width: text width + margins + scrollbar + indicators etc.
-            // Window margins 12px + MenuItem padding 20px + scrollbar 4px + buffer 4px = 40px
-            var finalWidth = Math.max(200, maxWidth + 40)
-            calculatedWidth = Math.min(finalWidth, 400) // Limit maximum width to 400px
-        }
-
-        Component.onCompleted: {
-            calculateOptimalWidth()
-        }
-
-        Connections {
-            target: viewModel
-            function onModelReset() {
-                calculateOptimalWidth()
-            }
-            function onRowsInserted() {
-                calculateOptimalWidth()
-            }
-            function onRowsRemoved() {
-                calculateOptimalWidth()
+            onTextChanged: { viewModel.setFilterWildcard(text) }
+            onEditingFinished: { viewModel.setFilterWildcard(text) }
+            FontMetrics {
+                id: searchEditFontMetrics
+                font: searchEdit.font
             }
         }
 
-        ColumnLayout {
-            id: contentLayout
-            anchors.fill: parent
-            anchors.margins: 6
-            SearchEdit {
-                id: searchEdit
-                implicitHeight: Math.max(30, searchEditFontMetrics.height + (DS.Style.control.padding - DS.Style.control.borderWidth) * 2)
-                Layout.fillWidth: true
-                Layout.alignment: Qt.AlignTop
-                placeholder: qsTr("Search")
-                palette: DTK.palette
-                font: DTK.fontManager.t6
-                onTextChanged: {
-                    viewModel.setFilterWildcard(text);
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+
+            ArrowListView {
+                anchors.fill: parent
+                id: itemsView
+                property string checkedRegion
+                clip: true
+                maxVisibleItems: 12
+                view.model: viewModel
+                view.currentIndex: control.currentIndex
+                view.ScrollBar.vertical: verticalScrollBar
+
+                ButtonGroup {
+                    id: regionGroup
                 }
-                onEditingFinished: {
-                    viewModel.setFilterWildcard(text);
-                }
-                FontMetrics {
-                    id: searchEditFontMetrics
-                    font: searchEdit.font
-                }
-            }
 
-            Item {
-                Layout.fillWidth: true
-                Layout.fillHeight: true
+                view.delegate: MenuItem {
+                    id: menuItem
+                    implicitWidth: itemsView.width
+                    implicitHeight: 30
+                    text: model.display
+                    checkable: true
+                    checked: text === control.currentText
+                    hoverEnabled: true
+                    highlighted: hovered
+                    autoExclusive: true
+                    ButtonGroup.group: regionGroup
+                    useIndicatorPadding: true
+                    font: DTK.fontManager.t6
 
-                ArrowListView {
-                    anchors.fill: parent
-                    id: itemsView
-                    property string checkedRegion
-                    clip: true
-                    maxVisibleItems: 12
-                    view.model: viewModel
-                    view.currentIndex: loader.currentIndex
-                    view.ScrollBar.vertical: verticalScrollBar
-
-                    ButtonGroup {
-                        id: regionGroup
-                    }
-
-                    view.delegate: MenuItem {
-                        id: menuItem
-                        implicitWidth: itemsView.width
-                        implicitHeight: 30
-                        text: model.display
-                        checkable: true
-                        checked: text === loader.currentText
-                        hoverEnabled: true
-                        highlighted: hovered
-                        autoExclusive: true
-                        ButtonGroup.group: regionGroup
-                        useIndicatorPadding: true
-                        font: DTK.fontManager.t6
-
-                        onCheckedChanged: {
-                            if (checked && loader.currentText !== model.display) {
-                                selectedRegion(model.display)
-                                closeWindow()
-                            }
-                        }
-                    }
-
-                    Component.onCompleted: {
-                        // Set initial scroll position
-                        if (currentIndex >= 0) {
-                            let delegateHeight = 30
-                            view.contentY = currentIndex * delegateHeight;
+                    onCheckedChanged: {
+                        if (checked && control.currentText !== model.display) {
+                            control.selectedRegion(model.display)
+                            control.close()
                         }
                     }
                 }
 
-                ScrollBar {
-                    id: verticalScrollBar
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
-                    anchors.rightMargin: -6
+                Component.onCompleted: {
+                    if (currentIndex >= 0) {
+                        let delegateHeight = 30
+                        view.contentY = currentIndex * delegateHeight
+                    }
                 }
             }
-        }
 
-        function closeWindow() {
-            loader.viewModel.setFilterWildcard("");
-            searchWindow.close()
-            loader.active = false
-        }
-
-        onActiveFocusItemChanged: {
-            if (!activeFocusItem) {
-                searchWindow.closeWindow()
+            ScrollBar {
+                id: verticalScrollBar
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                anchors.right: parent.right
+                anchors.rightMargin: -6
             }
         }
-        onActiveChanged: {
-            if (!active) {
-                searchWindow.closeWindow()
-            }
-        }
-    }
-
-    onLoaded: {
-        item.show()
-        if (loader.mousePosition.x !== 0 || loader.mousePosition.y !== 0) {
-            item.x = loader.mousePosition.x
-            item.y = loader.mousePosition.y
-        }
-        Qt.callLater(item.requestActivate);
     }
 }

--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -1,17 +1,23 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Lt
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Window
 import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DS
 import org.deepin.dtk.private 1.0 as P
 
-Loader {
-    id: loader
-    active: false
+Popup {
+    id: control
+    width: windowWidth
+    height: windowHeight
+    popupType: Popup.Window
+    closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+    PopupHandle.enableBlurWindow: true
+
     property int maxVisibleItems: 10
     property int highlightedIndex: 0
     property string searchText: ""
@@ -23,313 +29,244 @@ Loader {
     property bool contentScrolling: false
     required property DelegateModel delegateModel
 
+    function setViewIndex(viewIndex) {
+        if (!view) return
+
+        if (viewIndex < 0) {
+            viewIndex = 0
+        } else if (viewIndex >= view.count) {
+            viewIndex = view.count - 1
+        }
+
+        view.currentIndex = viewIndex
+        highlightedIndex = viewIndex
+    }
+
+    function show() {
+        if (anchorItem) {
+            positionWindow()
+        }
+        open()
+    }
+
+    function isVisible() {
+        return visible
+    }
+
+    function setPositionByItem(item) {
+        anchorItem = item
+        if (visible) {
+            positionWindow()
+        }
+    }
+
+    function positionWindow() {
+        if (!anchorItem) return
+
+        var globalPos = anchorItem.mapToGlobal(0, 0)
+        var w = Window.window
+        if (w) {
+            var localPos = w.mapFromGlobal(globalPos.x, globalPos.y)
+            x = localPos.x
+            y = localPos.y + anchorItem.height
+        }
+    }
+
+    onClosed: {
+        searchEdit.clear()
+    }
+
     TextMetrics {
         id: textMetrics
         font.family: DTK.fontManager.baseFont.family
         font.pixelSize: DTK.fontManager.baseFont.pixelSize
     }
 
-    signal opened()
-    signal closed()
-    
-    // 设置视图索引的函数（无循环版本）
-    function setViewIndex(viewIndex) {
-        if (!view) return
-        
-        // 限制在有效范围内，不循环
-        if (viewIndex < 0) {
-            viewIndex = 0
-        } else if (viewIndex >= view.count) {
-            viewIndex = view.count - 1
-        }
-        
-        view.currentIndex = viewIndex
-        highlightedIndex = viewIndex
-    }
+    contentItem: ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 6
+        spacing: control.delegateModel.count > 0 ? 14 : 0
 
-    function show() {
-        active = true
-    }
+        SearchEdit {
+            id: searchEdit
+            implicitHeight: Math.max(30, searchEditFontMetrics.height + (DS.Style.control.padding - DS.Style.control.borderWidth) * 2)
+            Layout.fillWidth: true
+            font: DTK.fontManager.t6
+            Layout.alignment: Qt.AlignTop
+            placeholder: qsTr("Search")
+            onTextChanged: {
+                control.searchText = text
+            }
+            onVisibleChanged: {
+                clear()
+            }
+            FontMetrics {
+                id: searchEditFontMetrics
+                font: searchEdit.font
+            }
 
-    function isVisible() {
-        return active
-    }
+            Keys.onReturnPressed: {
+                if (listView.visible && listView.count > 0) {
+                    if (listView.currentIndex < 0) {
+                        control.setViewIndex(0)
+                    }
 
-    function close() {
-        if (item) {
-            item.closeWindow()
-        }
-    }
+                    if (listView.currentIndex >= 0 && listView.currentItem) {
+                        listView.currentItem.checked = true
+                    }
+                }
+            }
 
-    function setPositionByItem(item) {
-        anchorItem = item
-        if (active && this.item) {
-            this.item.positionWindow()
-        }
-    }
+            Keys.onUpPressed: {
+                if (listView.visible && listView.count > 0) {
+                    listView.forceActiveFocus()
+                    if (listView.currentIndex < 0) {
+                        control.setViewIndex(listView.count - 1)
+                    } else {
+                        control.setViewIndex(listView.currentIndex - 1)
+                    }
+                }
+            }
 
-    sourceComponent: Window {
-        id: searchWindow
-        width: windowWidth
-        height: loader.windowHeight
-        minimumWidth: 300
-        minimumHeight: loader.windowHeight
-        maximumWidth: 500
-        maximumHeight: loader.windowHeight
-        DWindow.enabled: true
-        DWindow.enableSystemResize: false
-        DWindow.enableBlurWindow: true
-        // ensure show in center of mainwindow
-        // _NET_WM_WINDOW_TYPE will add Dialog when added Qt.WindowCloseButtonHint.
-        flags: Qt.Dialog | Qt.WindowCloseButtonHint
-        // default color is white
-        color: DTK.palette.window
-        palette: DTK.palette
-
-        Component.onCompleted: {
-            positionWindow()
-            loader.opened()
-        }
-
-        function positionWindow() {
-            if (!loader.anchorItem) return
-
-            var globalPos = loader.anchorItem.mapToGlobal(0, 0)
-            searchWindow.x = globalPos.x
-            searchWindow.y = globalPos.y + loader.anchorItem.height
+            Keys.onDownPressed: {
+                if (listView.visible && listView.count > 0) {
+                    listView.forceActiveFocus()
+                    if (listView.currentIndex < 0) {
+                        control.setViewIndex(0)
+                    } else {
+                        control.setViewIndex(listView.currentIndex + 1)
+                    }
+                }
+            }
         }
 
         ColumnLayout {
-            id: contentLayout
-            anchors.fill: parent
-            anchors.margins: 6
-            spacing: loader.delegateModel.count > 0 ? 14 : 0
+            Layout.fillWidth: true
+            Layout.preferredHeight: Math.min(listView.contentHeight + (listView.interactive ? upButton.height + downButton.height : 0),
+                                             control.maxVisibleItems * 36 + (listView.interactive ? upButton.height + downButton.height : 0))
+            visible: control.delegateModel.count > 0
+            spacing: 0
 
-            SearchEdit {
-                id: searchEdit
-                implicitHeight: Math.max(30, searchEditFontMetrics.height + (DS.Style.control.padding - DS.Style.control.borderWidth) * 2)
+            P.ArrowListViewButton {
+                id: upButton
+                visible: listView.interactive
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: width
+                Layout.preferredHeight: height
+                view: listView
+                direction: P.ArrowListViewButton.UpButton
+                focusPolicy: Qt.NoFocus
+                activeFocusOnTab: false
+            }
+
+            ListView {
+                id: listView
+                clip: true
                 Layout.fillWidth: true
-                font: DTK.fontManager.t6
-                Layout.alignment: Qt.AlignTop
-                placeholder: qsTr("Search")
-                onTextChanged: {
-                    loader.searchText = text
-                }
-                onVisibleChanged: {
-                    clear() // clear search text
-                }
-                FontMetrics {
-                    id: searchEditFontMetrics
-                    font: searchEdit.font
-                }
-                
-                // 键盘事件处理 - 回车直接选择
-                Keys.onReturnPressed: {
-                    if (listView.visible && listView.count > 0) {
-                        // 如果没有选中项，默认选中第一项
-                        if (listView.currentIndex < 0) {
-                            loader.setViewIndex(0)
-                        }
-                        
-                        // 直接设置checked状态触发选择
-                        if (listView.currentIndex >= 0 && listView.currentItem) {
-                            listView.currentItem.checked = true
-                        }
+                Layout.fillHeight: true
+                model: control.delegateModel
+                currentIndex: control.highlightedIndex
+                highlightMoveDuration: -1
+                highlightMoveVelocity: -1
+                highlightFollowsCurrentItem: true
+                focus: true
+                activeFocusOnTab: true
+                ScrollBar.vertical: verticalScrollBar
+
+                interactive: control.delegateModel.count > control.maxVisibleItems
+
+                property bool keyboardScrolling: control.contentScrolling
+
+                Timer {
+                    id: keyboardScrollTimer
+                    interval: 50
+                    onTriggered: {
+                        control.contentScrolling = false
                     }
                 }
-                
+
                 Keys.onUpPressed: {
-                    if (listView.visible && listView.count > 0) {
-                        listView.forceActiveFocus()
-                        // 如果没有选中项，选择最后一项，否则向上移动
-                        if (listView.currentIndex < 0) {
-                            loader.setViewIndex(listView.count - 1)
-                        } else {
-                            loader.setViewIndex(listView.currentIndex - 1)
-                        }
-                    }
+                    control.contentScrolling = true
+                    keyboardScrollTimer.restart()
+                    control.setViewIndex(currentIndex - 1)
                 }
-                
+
                 Keys.onDownPressed: {
-                    if (listView.visible && listView.count > 0) {
-                        listView.forceActiveFocus()
-                        // 如果没有选中项，选择第一项，否则向下移动
-                        if (listView.currentIndex < 0) {
-                            loader.setViewIndex(0)
-                        } else {
-                            loader.setViewIndex(listView.currentIndex + 1)
+                    control.contentScrolling = true
+                    keyboardScrollTimer.restart()
+                    control.setViewIndex(currentIndex + 1)
+                }
+
+                Keys.onEscapePressed: {
+                    searchEdit.forceActiveFocus()
+                }
+
+                Component.onCompleted: {
+                    control.view = listView
+                    control.viewWidth = listView.width
+
+                    var foundChecked = false
+                    for (var i = 0; i < count; i++) {
+                        var item = itemAtIndex(i)
+                        if (item && item.checked === true) {
+                            control.setViewIndex(i)
+                            positionViewAtIndex(i, ListView.Center)
+                            foundChecked = true
+                            break
                         }
                     }
+
+                    if (!foundChecked && control.highlightedIndex >= 0) {
+                        control.setViewIndex(control.highlightedIndex)
+                        positionViewAtIndex(control.highlightedIndex, ListView.Center)
+                    }
+
+                    forceActiveFocus()
+                }
+
+                onWidthChanged: {
+                    control.viewWidth = listView.width
                 }
             }
 
-            // ArrowListView 样式的容器
-            ColumnLayout {
-                Layout.fillWidth: true
-                Layout.preferredHeight: Math.min(listView.contentHeight + (listView.interactive ? upButton.height + downButton.height : 0), 
-                                                 loader.maxVisibleItems * 36 + (listView.interactive ? upButton.height + downButton.height : 0))
-                visible: loader.delegateModel.count > 0
-                spacing: 0
-                
-                // 上箭头按钮
-                P.ArrowListViewButton {
-                    id: upButton
-                    visible: listView.interactive
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.preferredWidth: width
-                    Layout.preferredHeight: height
-                    view: listView
-                    direction: P.ArrowListViewButton.UpButton
-                    focusPolicy: Qt.NoFocus
-                    activeFocusOnTab: false
-                }
-
-                ListView {
-                    id: listView
-                    clip: true
-                    Layout.fillWidth: true
-                    Layout.fillHeight: true
-                    model: loader.delegateModel
-                    currentIndex: loader.highlightedIndex
-                    highlightMoveDuration: -1
-                    highlightMoveVelocity: -1
-                    highlightFollowsCurrentItem: true
-                    focus: true
-                    activeFocusOnTab: true
-                    ScrollBar.vertical: verticalScrollBar
-                    
-                    // 根据内容确定是否需要交互（模仿ArrowListView逻辑）
-                    interactive: loader.delegateModel.count > loader.maxVisibleItems
-                    
-                    // 传递给delegate使用  
-                    property bool keyboardScrolling: loader.contentScrolling
-                    
-                    // 键盘滚动保护计时器
-                    Timer {
-                        id: keyboardScrollTimer
-                        interval: 50
-                        onTriggered: {
-                            loader.contentScrolling = false
-                        }
-                    }
-                    
-                    // 键盘事件处理（参考SearchBar模式）
-                    Keys.onUpPressed: {
-                        // 键盘导航时启用滚动保护
-                        loader.contentScrolling = true
-                        keyboardScrollTimer.restart()
-                        loader.setViewIndex(currentIndex - 1)
-                    }
-                    
-                    Keys.onDownPressed: {
-                        // 键盘导航时启用滚动保护
-                        loader.contentScrolling = true
-                        keyboardScrollTimer.restart()
-                        loader.setViewIndex(currentIndex + 1)
-                    }
-                    
-                    Keys.onEscapePressed: {
-                        // Escape键返回到搜索框
-                        searchEdit.forceActiveFocus()
-                    }
-
-                    Component.onCompleted: {
-                        loader.view = listView
-                        loader.viewWidth = listView.width
-                        
-                        // 查找checked为true的项目并设置为当前高亮
-                        var foundChecked = false
-                        for (var i = 0; i < count; i++) {
-                            var item = itemAtIndex(i)
-                            if (item && item.checked === true) {
-                                loader.setViewIndex(i)
-                                positionViewAtIndex(i, ListView.Center)
-                                foundChecked = true
-                                break
-                            }
-                        }
-                        
-                        // 如果没找到checked项，使用highlightedIndex作为备选
-                        if (!foundChecked && loader.highlightedIndex >= 0) {
-                            loader.setViewIndex(loader.highlightedIndex)
-                            positionViewAtIndex(loader.highlightedIndex, ListView.Center)
-                        }
-                        
-                        // 确保获得焦点
-                        forceActiveFocus()
-                    }
-
-                    onWidthChanged: {
-                        loader.viewWidth = listView.width
-                    }
-                }
-                
-                // 下箭头按钮
-                P.ArrowListViewButton {
-                    id: downButton
-                    visible: listView.interactive
-                    Layout.alignment: Qt.AlignHCenter
-                    Layout.preferredWidth: width
-                    Layout.preferredHeight: height
-                    view: listView
-                    direction: P.ArrowListViewButton.DownButton
-                    enabled: !listView.atYEnd
-                    focusPolicy: Qt.NoFocus
-                    activeFocusOnTab: false
-                }
-
-                ScrollBar {
-                    id: verticalScrollBar
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.right: parent.right
-                    anchors.rightMargin: -6
-                }
+            P.ArrowListViewButton {
+                id: downButton
+                visible: listView.interactive
+                Layout.alignment: Qt.AlignHCenter
+                Layout.preferredWidth: width
+                Layout.preferredHeight: height
+                view: listView
+                direction: P.ArrowListViewButton.DownButton
+                enabled: !listView.atYEnd
+                focusPolicy: Qt.NoFocus
+                activeFocusOnTab: false
             }
 
-            Item {
-                Layout.fillHeight: true
-                visible: loader.delegateModel.count > 0
-            }
-
-            Text {
-                id: noResultsText
-                text: qsTr("No search results")
-                horizontalAlignment: Text.AlignHCenter
-                verticalAlignment: Text.AlignVCenter
-                Layout.fillWidth: true
-                Layout.fillHeight: true
-                visible: loader.delegateModel.count === 0
-                color: this.palette.windowText
-                opacity: 0.4
-                font: DTK.fontManager.t6
+            ScrollBar {
+                id: verticalScrollBar
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+                anchors.right: parent.right
+                anchors.rightMargin: -6
             }
         }
 
-        function closeWindow() {
-            searchEdit.clear()
-            searchWindow.close()
-            loader.active = false
-            loader.closed()
+        Item {
+            Layout.fillHeight: true
+            visible: control.delegateModel.count > 0
         }
 
-        onActiveFocusItemChanged: {
-            if (!activeFocusItem) {
-                searchWindow.closeWindow()
-            }
+        Text {
+            id: noResultsText
+            text: qsTr("No search results")
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            visible: control.delegateModel.count === 0
+            color: this.palette.windowText
+            opacity: 0.4
+            font: DTK.fontManager.t6
         }
-
-        onActiveChanged: {
-            if (!active) {
-                searchWindow.closeWindow()
-            }
-        }
-    }
-
-    onLoaded: {
-        item.show()
-        Qt.callLater(function() {
-            item.requestActivate();
-        });
     }
 }


### PR DESCRIPTION
1. Refactor RegionsChooserWindow from Loader+Window to standard Popup with popupType: Popup.Window
2. Refactor SearchableListViewPopup from Loader+Window to standard Popup, removing redundant close() recursion
3. Use DTK PopupHandle for blur window and radius instead of DWindow on raw Window
4. Replace manual focus-lost close logic with closePolicy for unified dismiss behavior
5. Switch DTK imports to namespaced "as D" convention consistent with other modules
6. Remove hand-crafted window positioning via flags and focus-item-change handlers

Log: Replace custom Loader+Window popup implementations with DTK Popup components

refactor(datetime): 将手写 Window 弹窗重构为 DTK Popup

1. 将 RegionsChooserWindow 从 Loader+Window 重构为标准 Popup，设置 popupType: Popup.Window
2. 将 SearchableListViewPopup 从 Loader+Window 重构为标准 Popup，移除冗余 close() 递归调用
3. 使用 DTK PopupHandle 处理模糊窗口和圆角，替代原 Window 上的 DWindow 属性
4. 用 closePolicy 统一管理关闭行为，替代手动的焦点丢失关闭逻辑
5. DTK 导入统一改为命名空间 "as D" 风格，与其他模块保持一致
6. 移除手动的窗口定位标记和焦点项变化处理

Log: 将自定义 Loader+Window 弹窗实现替换为 DTK Popup 组件