### PR TITLE
fix(systeminfo): fix EULA path and remove hardcoded extension

### DIFF
--- a/src/plugin-systeminfo/operation/utils.h
+++ b/src/plugin-systeminfo/operation/utils.h
@@ -30,7 +30,7 @@ inline const static QString homeEnduserAgreement_old =
         "/usr/share/deepin-deepinid-client/privacy/End-User-License-Agreement-Home/"
         "End-User-License-Agreement-Home-CN-%1.%2";
 inline const static QString militaryEnduserAgreement =
-        "/usr/share/protocol/enduser-agreement/End-User-License-Agreement-Military-%1.%2";
+        "/usr/share/protocol/enduser-agreement/End-User-License-Agreement-Military-CN-%1.%2";
 inline const static QString professionalEnduserAgreement_new =
         "/usr/share/protocol/enduser-agreement/End-User-License-Agreement-Professional-CN-%1.%2";
 inline const static QString professionalEnduserAgreement_old =
@@ -188,30 +188,30 @@ inline LicenseSearchInfo isEndUserAgreementExist()
     QString candidate;
 
     if (DSysInfo::uosType() == DSysInfo::UosType::UosServer) {
-        candidate = pathIfExists(serverEnduserAgreement_new, "txt");
+        candidate = pathIfExists(serverEnduserAgreement_new);
         if (candidate.isEmpty())
-            candidate = pathIfExists(serverEnduserAgreement_old, "txt");
+            candidate = pathIfExists(serverEnduserAgreement_old);
     } else if (DSysInfo::uosEditionType() == DSysInfo::UosEdition::UosHome) {
-        candidate = pathIfExists(homeEnduserAgreement_new, "txt");
+        candidate = pathIfExists(homeEnduserAgreement_new);
         if (candidate.isEmpty())
-            candidate = pathIfExists(homeEnduserAgreement_old, "txt");
+            candidate = pathIfExists(homeEnduserAgreement_old);
     } else if (DSysInfo::isCommunityEdition()) {
         candidate = pathIfExists(
             "/usr/share/deepin-deepinid-client/privacy/End-User-License-Agreement-Community/"
             "End-User-License-Agreement-CN-%1.%2",
             "txt");
     } else if (DSysInfo::uosEditionType() == DSysInfo::UosEdition::UosEducation) {
-        candidate = pathIfExists(educationEnduserAgreement, "txt");
+        candidate = pathIfExists(educationEnduserAgreement);
     } else if (DSysInfo::uosEditionType() == DSysInfo::UosEdition::UosMilitary) {
-        candidate = pathIfExists(militaryEnduserAgreement, "txt");
+        candidate = pathIfExists(militaryEnduserAgreement);
     } else {
         candidate = pathIfExists(professionalEnduserAgreement_new);
         if (candidate.isEmpty())
-            candidate = pathIfExists(professionalEnduserAgreement_old, "txt");
+            candidate = pathIfExists(professionalEnduserAgreement_old);
     }
 
     if (candidate.isEmpty())
-        candidate = pathIfExists(oldAgreement, "txt");
+        candidate = pathIfExists(oldAgreement);
 
     if (!candidate.isEmpty())
         return { true, candidate };


### PR DESCRIPTION
1. Add missing "CN-" prefix to military EULA filename
2. Remove hardcoded "txt" suffix from pathIfExists calls
3. Keep "txt" only for Community edition which uses literal path

Log: fix military EULA path and clean up file extension handling

fix(systeminfo): 修复最终用户协议路径并移除硬编码扩展名

1. 军工版最终用户协议文件名补充 "CN-" 前缀
2. 移除 pathIfExists 调用中硬编码的 "txt" 后缀
3. 仅社区版保留 "txt" 参数（使用字面路径）

Log: 修复军工版EULA路径并清理文件扩展名处理逻辑
PMS: TASK-390591