### PR TITLE
fix: restore DccQuickRepeater to prevent timer warning on quit

### DIFF
--- a/src/dde-control-center/plugin/dccquickrepeater.cpp
+++ b/src/dde-control-center/plugin/dccquickrepeater.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#include "dccquickrepeater.h"
+
+namespace dccV25 {
+DccQuickRepeater::DccQuickRepeater(QQuickItem *parent)
+    : QQuickRepeater(parent)
+{
+    connect(this, &QQuickRepeater::itemAdded, this, &DccQuickRepeater::updateItemParent);
+}
+
+DccQuickRepeater::~DccQuickRepeater() { }
+
+void DccQuickRepeater::updateItemParent([[maybe_unused]] int index, QQuickItem *item)
+{
+    if (item && !item->parent()) {
+        item->setParent(this);
+    }
+}
+} // namespace dccV25

--- a/src/dde-control-center/plugin/dccquickrepeater.h
+++ b/src/dde-control-center/plugin/dccquickrepeater.h
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#ifndef DCCQUICKREPEATER_H
+#define DCCQUICKREPEATER_H
+
+#include "private/qquickrepeater_p.h"
+
+namespace dccV25 {
+class DccQuickRepeater : public QQuickRepeater
+{
+    Q_OBJECT
+    QML_NAMED_ELEMENT(Repeater)
+public:
+    explicit DccQuickRepeater(QQuickItem *parent = nullptr);
+    ~DccQuickRepeater() override;
+
+private Q_SLOTS:
+    void updateItemParent(int index, QQuickItem *item);
+};
+} // namespace dccV25
+#endif // DCCQUICKREPEATER_H


### PR DESCRIPTION
1. Restore DccQuickRepeater which wraps QQuickRepeater and sets QObject parent on dynamically created items via onItemAdded
2. Without this, Repeater items are orphaned in the Qt object tree and their internal timers trigger "QObject::startTimer: Timers can only be used with threads started with QThread" during application shutdown

PMS: TASK-390613

fix: 恢复 DccQuickRepeater 防止退出时定时器警告

1. 恢复 DccQuickRepeater，包装 QQuickRepeater 并通过 onItemAdded 为动态创建的 item 设置 QObject parent
2. 缺少此组件时，Repeater 创建的 item 在 Qt 对象树中成为孤儿， 应用退出时其内部定时器触发 "QObject::startTimer" 警告

PMS: TASK-390613