### PR TITLE
feat: set control-center as singleton application

### DIFF
--- a/misc/org.deepin.dde.control-center.desktop
+++ b/misc/org.deepin.dde.control-center.desktop
@@ -11,6 +11,7 @@ Terminal=false
 Type=Application
 X-Deepin-TurboType=dtkwidget
 X-Deepin-Vendor=deepin
+X-Deepin-Singleton=true
 X-MultipleArgs=false
 
 # Translations:


### PR DESCRIPTION
Mark the control-center desktop file with X-Deepin-Singleton=true to
ensure only one instance runs at a time, preventing duplicate UI windows
and resource conflicts.

Log: Set control-center as singleton application

Influence:
1. Launch control-center multiple times and verify only one window
exists
2. Test closing the window and reopening to ensure normal behavior
3. Verify no duplicate processes in system monitor

feat: 设置控制中心为单例应用

在控制中心的桌面文件中添加 X-Deepin-Singleton=true 标记，确保同一时间只
运行一个实例，避免重复的UI窗口和资源冲突。

Log: 设置控制中心为单例应用

Influence:
1. 多次启动控制中心，验证只存在一个窗口
2. 测试关闭窗口后重新打开，确保行为正常
3. 在系统监视器中验证没有重复进程

## Summary by Sourcery

New Features:
- Ensure the control-center desktop application runs as a single instance via the desktop entry configuration.