### PR TITLE
feat: adapt color temperature for Treeland

### DIFF
--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -549,22 +549,14 @@ void DisplayModule::setColorTemperatureMode(int mode)
 int DisplayModule::colorTemperature() const
 {
     Q_D(const DisplayModule);
-    int kelvin = d->m_model->colorTemperature();
-
-    if (kelvin >= 6500)
-        return 50 - (kelvin - 6500) / 300;
-    else if (kelvin < 6500 && kelvin >= 1000)
-        return 50 - (kelvin - 6500) / 100;
-    else
-        return 0;
+    return d->m_model->colorTemperature();
 }
 
 void DisplayModule::setColorTemperature(int pos)
 {
-    int kelvin = pos > 50 ? (6500 - (pos - 50) * 100) : (6500 + (50 - pos) * 300);
     Q_D(DisplayModule);
-    if (d->m_model->colorTemperature() != kelvin) {
-        d->m_worker->setColorTemperature(kelvin);
+    if (d->m_model->colorTemperature() != pos) {
+        d->m_worker->setColorTemperature(pos);
     }
 }
 

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -15,14 +15,17 @@
 
 #include <QDateTime>
 #include <QDebug>
+#include <QFile>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLoggingCategory>
+#include <QXmlStreamReader>
 
 Q_LOGGING_CATEGORY(DdcDisplayWorker, "dcc-display-worker")
 
 const QString DisplayInterface("org.deepin.dde.Display1");
 constexpr const char *const CONCAT_SCREEN_NAME = "DDE-CONCAT-SCREEN";
+static const QString EyeProtectionConfig = "/usr/share/dde-wloutput-daemon/eyeprotection.xml";
 
 Q_DECLARE_METATYPE(QList<QDBusObjectPath>)
 using namespace dccV25;
@@ -31,15 +34,23 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
     : QObject(parent)
     , m_model(model)
     , m_displayInter(new DisplayDBusProxy(this))
+    , m_reg(nullptr)
     , m_updateScale(false)
     , m_timer(new QTimer(this))
     , m_dconfig(DTK_CORE_NAMESPACE::DConfig::create("org.deepin.dde.control-center", QStringLiteral("org.deepin.dde.control-center.display"), QString(), this))
-    , m_reg(nullptr)
+    , m_displayDConf(DTK_CORE_NAMESPACE::DConfig::create("org.deepin.dde.daemon", QStringLiteral("org.deepin.Display"), QString(), this))
+    , m_tcMaxValue(6500)
+    , m_tcMinValue(2000)
+    , m_defaultMode(3500)
 {
     // NOTE: what will it be used?
     Q_UNUSED(isSync)
     m_timer->setSingleShot(true);
     m_timer->setInterval(200);
+    initCTMData();
+    if (m_displayDConf && m_displayDConf->keyList().contains("defaultTemperatureManual")){
+        m_defaultMode = m_displayDConf->value("defaultTemperatureManual").toInt();
+    }
 
     if (WQt::Utils::isTreeland()) {
         QMetaObject::invokeMethod(this, "initTreeland", Qt::QueuedConnection);
@@ -57,7 +68,9 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
         connect(m_displayInter, &DisplayDBusProxy::MaxBacklightBrightnessChanged, model, &DisplayModel::setmaxBacklightBrightness);
         connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureEnabledChanged, model, &DisplayModel::setColorTemperatureEnabled);
         connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureModeChanged, model, &DisplayModel::setAdjustCCTmode);
-        connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureManualChanged, model, &DisplayModel::setColorTemperature);
+        connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureManualChanged, this, [this](int kelvin) {
+            m_model->setColorTemperature(toColorTempPos(kelvin));
+        });
         connect(m_displayInter, &DisplayDBusProxy::CustomColorTempTimePeriodChanged, model, &DisplayModel::setCustomColorTempTimePeriod);
         connect(m_displayInter, static_cast<void (DisplayDBusProxy::*)(const QString &) const>(&DisplayDBusProxy::PrimaryChanged), model, &DisplayModel::setPrimary);
 
@@ -111,7 +124,7 @@ void DisplayWorker::active()
         m_model->setScreenWidth(m_displayInter->screenWidth());
         m_model->setAdjustCCTmode(m_displayInter->colorTemperatureMode());
         m_model->setColorTemperatureEnabled(m_displayInter->colorTemperatureEnabled());
-        m_model->setColorTemperature(m_displayInter->colorTemperatureManual());
+        m_model->setColorTemperature(toColorTempPos(m_displayInter->colorTemperatureManual()));
         m_model->setCustomColorTempTimePeriod(m_displayInter->customColorTempTimePeriod());
         m_model->setmaxBacklightBrightness(m_displayInter->maxBacklightBrightness());
         m_model->setAutoLightAdjustIsValid(m_displayInter->hasAmbientLightSensor());
@@ -379,6 +392,13 @@ void DisplayWorker::onInterfaceRegistered(WQt::Registry::Interface interface)
 {
     switch (interface) {
     case WQt::Registry::OutputManagerInterface: {
+        m_model->setResolutionRefreshEnable(true);
+        m_model->setBrightnessEnable(false);
+
+        m_model->setColorTemperatureEnabled(true);
+        m_model->setAdjustCCTmode(0);
+        m_model->setColorTemperature(toColorTempPos(m_defaultMode));
+        m_model->setRedshiftIsValid(true);
         auto *opMgr = m_reg->outputManager();
         if (!opMgr) {
             qCCritical(DdcDisplayWorker) << "Unable to start the output manager";
@@ -438,11 +458,66 @@ void DisplayWorker::onWlOutputManagerDone()
             m_model->setPrimary(m_reg->treeLandOutputManager()->mPrimaryOutput);
         });
     }
-
-    m_model->setResolutionRefreshEnable(true);
-    m_model->setBrightnessEnable(false); // TODO: support gamma effects
 }
 
+uint32_t DisplayWorker::toColorTemp(int pos)
+{
+    int kelvin = pos > 50 ? (m_defaultMode - (m_defaultMode - m_tcMinValue) * (pos - 50) * 0.02) : (m_defaultMode + (m_tcMaxValue - m_defaultMode) * (50 - pos) * 0.02);
+    if (kelvin < 1000)
+        kelvin = 1000;
+    else if (kelvin > 20000)
+        kelvin = 20000;
+    return static_cast<uint32_t>(kelvin);
+}
+
+int DisplayWorker::toColorTempPos(uint32_t temperature)
+{
+    int kelvin = static_cast<int>(temperature);
+    if ((m_tcMaxValue <= m_defaultMode && kelvin >= m_defaultMode ) || (m_defaultMode <= m_tcMinValue && kelvin <= m_defaultMode)) {
+        qCWarning(DdcDisplayWorker) << "Invalid color temperature range, returning mid-point";
+        return 50;
+    }
+    int pos = kelvin >= m_defaultMode ? (m_tcMaxValue - kelvin) * 50.0 / (m_tcMaxValue - m_defaultMode) : 50 + (m_defaultMode - kelvin) * 50.0 / (m_defaultMode - m_tcMinValue);
+    if (pos < 0) {
+        pos = 0;
+    } else if (pos > 100) {
+        pos = 100;
+    }
+    return pos;
+}
+void DisplayWorker::initCTMData()
+{
+    QFile file(EyeProtectionConfig);
+    if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
+        qCWarning(DdcDisplayWorker) << "Config file is not exist: " << EyeProtectionConfig;
+        return;
+    }
+    QXmlStreamReader xml(&file);
+    QVector<int> val;
+    while (!xml.atEnd() && !xml.hasError()) {
+        QXmlStreamReader::TokenType token = xml.readNext();
+        if (token == QXmlStreamReader::StartElement) {
+            // 获取PanelCCT和RgbGammaLut的值
+            if (xml.name() == "param") {
+                QString paramName = xml.attributes().value("name").toString();
+                QString paramValue = xml.readElementText();
+                if (paramName == "PanelCCT") {
+                    val.push_back(paramValue.toInt());
+                }
+            }
+        }
+    }
+    // 关闭文件
+    file.close();
+    if (val.isEmpty()) {
+        qCWarning(DdcDisplayWorker) << "No PanelCCT param found in config:" << EyeProtectionConfig;
+        return;
+    }
+    std::sort(val.begin(), val.end());
+    m_tcMinValue = val.first();
+    m_tcMaxValue = val.last();
+    m_defaultMode = 4500;
+}
 #ifndef DCC_DISABLE_ROTATE
 
 constexpr static int wlRotate2dcc(int wlRotate)
@@ -563,26 +638,38 @@ void DisplayWorker::applyChanges()
 
 void DisplayWorker::setColorTemperatureEnabled(bool enabled)
 {
-    m_displayInter->setColorTemperatureEnabled(enabled);
+    if (WQt::Utils::isTreeland()) {
+        uint32_t temp = enabled ? toColorTemp(m_model->colorTemperature()) : toColorTemp(m_defaultMode);
+        for (auto it(m_control_monitors.cbegin()); it != m_control_monitors.cend(); ++it) {
+            if (it.value())
+                it.value()->setColorTemperature(temp);
+        }
+    } else {
+        m_displayInter->setColorTemperatureEnabled(enabled);
+    }
 }
 
-void DisplayWorker::setColorTemperature(int value)
+void DisplayWorker::setColorTemperature(int pos)
 {
     if (WQt::Utils::isTreeland()) {
-#if GAMMA_SUPPORT
-        auto *gammaEffect = m_wl_gammaEffects->value(mon);
-        auto *gammaConfig = m_wl_gammaConfig->value(mon);
-        gammaConfig->temperature = value;
-        gammaEffect->setConfiguration(*gammaConfig);
-#endif
+        uint32_t temp = toColorTemp(pos);
+        for (auto it(m_control_monitors.cbegin()); it != m_control_monitors.cend(); ++it) {
+            if (it.value()) {
+                it.value()->setColorTemperature(temp);
+            }
+        }
     } else {
-        m_displayInter->SetColorTemperature(value).waitForFinished();
+        m_displayInter->SetColorTemperature(toColorTemp(pos)).waitForFinished();
     }
 }
 
 void DisplayWorker::SetMethodAdjustCCT(int mode)
 {
-    m_displayInter->SetMethodAdjustCCT(mode);
+    if (WQt::Utils::isTreeland()) {
+        qCDebug(DdcDisplayWorker) << "==treeland==" << "SetMethodAdjustCCT:" << mode;
+    } else {
+        m_displayInter->SetMethodAdjustCCT(mode);
+    }
 }
 
 void DisplayWorker::setCustomColorTempTimePeriod(const QString &timePeriod)
@@ -1092,6 +1179,9 @@ void DisplayWorker::updateControl()
                         if (control) {
                             connect(control, &WQt::ColorControl::brightnessChanged, this, [this, control](double brightness) {
                                 onBrightnessChanged(control, brightness);
+                            });
+                            connect(control, &WQt::ColorControl::colorTemperatureChanged, this, [this](uint32_t temperature) {
+                                m_model->setColorTemperature(toColorTempPos(temperature));
                             });
                         }
                         m_control_monitors.insert(it.key(), control);

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -52,7 +52,7 @@ public Q_SLOTS:
     void setMonitorEnable(Monitor *monitor, const bool enable);
     void applyChanges();
     void setColorTemperatureEnabled(bool enabled);
-    void setColorTemperature(int value);
+    void setColorTemperature(int pos);
     void SetMethodAdjustCCT(int mode);
     void setCustomColorTempTimePeriod(const QString &timePeriod);
 #ifndef DCC_DISABLE_ROTATE
@@ -112,6 +112,11 @@ private:
     void updateControl();
     void initAutoBacklight();
 
+    uint32_t toColorTemp(int pos);
+    int toColorTempPos(uint32_t kelvin);
+    // task 264375
+    void initCTMData();
+
 Q_SIGNALS:
     void requestUpdateModeList();
 
@@ -134,6 +139,11 @@ private:
     QTimer *m_timer;
     DTK_CORE_NAMESPACE::DConfig *m_dconfig;
     QString m_displayConfig;
+
+    DTK_CORE_NAMESPACE::DConfig *m_displayDConf;
+    int m_tcMaxValue;
+    int m_tcMinValue;
+    int m_defaultMode;
 };
 }
 

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -498,7 +498,7 @@ DccObject {
                 RowLayout {
                     anchors.fill: parent
                     anchors.leftMargin: 14
-                    anchors.rightMargin:14
+                    anchors.rightMargin: 14
 
                     D.Label {
                         text: dccObj.displayName
@@ -653,10 +653,10 @@ DccObject {
         function getBuiltinScreenIndex() {
             for (var i = 0; i < screen.screenItems.length; i++) {
                 if (screen.screenItems[i].name === dccData.builtinMonitorName) {
-                    return i;
+                    return i
                 }
             }
-            return -1;
+            return -1
         }
 
         DccRepeater {
@@ -1011,6 +1011,7 @@ DccObject {
         displayName: qsTr("Enable eye comfort")
         description: qsTr("Adjust screen display to warmer colors, reducing screen blue light")
         weight: 100
+        visible: dccData.isX11
         backgroundType: DccObject.Normal
         pageType: DccObject.Editor
         onParentItemChanged: item => { if (item) { item.rightItemTopMargin = 6; item.rightItemBottomMargin = 6 } }
@@ -1023,7 +1024,7 @@ DccObject {
         name: "eyeComfortGroup"
         parentName: "display"
         weight: 110
-        visible: dccData.colorTemperatureEnabled
+        // visible: dccData.colorTemperatureEnabled
         pageType: DccObject.Item
         onParentItemChanged: item => { if (item) { item.rightItemTopMargin = 6; item.rightItemBottomMargin = 6 } }
         page: DccGroupView {}
@@ -1032,6 +1033,7 @@ DccObject {
             parentName: "display/eyeComfortGroup"
             displayName: qsTr("Time")
             weight: 10
+            visible: dccData.colorTemperatureEnabled && dccData.isX11
             pageType: DccObject.Editor
             page: ComboBox {
                 flat: true
@@ -1044,7 +1046,7 @@ DccObject {
             name: "timeFrame"
             parentName: "display/eyeComfortGroup"
             weight: 20
-            visible: dccData.colorTemperatureMode === 2
+            visible: dccData.colorTemperatureMode === 2 && dccData.colorTemperatureEnabled
             pageType: DccObject.Editor
             page: RowLayout {
                 Label {
@@ -1082,12 +1084,13 @@ DccObject {
             parentName: "display/eyeComfortGroup"
             displayName: qsTr("Color Temperature")
             weight: 30
+            visible: dccData.colorTemperatureEnabled
             pageType: DccObject.Editor
             page: RowLayout {
                 property var screenItem
                 Label {
                     Layout.alignment: Qt.AlignVCenter
-                    text: Math.round(colorTemperatureSlider.value) + "%"
+                    text: colorTemperatureSlider.value + "%"
                     font: D.DTK.fontManager.t10
                     opacity: 0.5
                 }


### PR DESCRIPTION
1. Replace hardcoded kelvin-range with configurable min/max read from /usr/share/dde-wloutput-daemon/eyeprotection.xml PanelCCT params, falling back to sensible defaults (2000-6500K).
2. Add bidirectional pos↔kelvin conversion (toColorTemp / toColorTempPos) so the UI slider (0-100%) maps correctly to the hardware color temperature range on both X11 and Wayland.
3. Wire setColorTemperature in DisplayWorker to use WQt::ColorControl::setColorTemperature for Treeland output monitors instead of the legacy D-Bus gamma path.
4. Read default manual color temperature from DConfig (org.deepin.dde.daemon / org.deepin.Display) and use it as the initial value when enabling eye comfort on Wayland.
5. Hide X11-only eye comfort controls (time mode selector, custom time frame) on Wayland via visible: dccData.isX11.
6. Guard initCTMData against empty XML config to prevent val.first()/val.last() crash on malformed eyeprotection.xml.

Log: adapt color temperature slider and eye comfort settings for Wayland/Treeland sessions

Influence:
1. Verify color temperature slider works on Treeland session
2. Verify toggling eye comfort enables/disables color temperature correctly on both X11 and Wayland
3. Verify default color temperature loads from DConfig on Wayland

feat: 适配 Treeland 色温调节功能

1. 将硬编码的色温范围替换为从 /usr/share/dde-wloutput-daemon/eyeprotection.xml PanelCCT 参数读取的动态范围（默认 2000-6500K）。
2. 新增 pos↔kelvin 双向转换函数（toColorTemp / toColorTempPos），使 UI 滑块（0-100%）能正确映射到硬件 色温范围，兼容 X11 和 Wayland。
3. 在 DisplayWorker 中使用 WQt::ColorControl 替代旧的 D-Bus gamma 路径来设置 Treeland 输出的色温。
4. 从 DConfig（org.deepin.dde.daemon / org.deepin.Display）读取默认手动色温值，作为 Wayland 下启用护眼模式的初始值。
5. 通过 visible: dccData.isX11 在 Wayland 下隐藏仅 X11 支持的护眼模式控件（时间模式选择、自定义时间段）。
6. 在 initCTMData 中添加空 XML 配置的守卫，防止 eyeprotection.xml 格式错误时 val.first()/val.last() 崩溃。

Log: 适配 Wayland/Treeland 会话下的色温滑块和护眼模式设置

Influence:
1. 验证 Treeland 会话下色温滑块调节正常
2. 验证开关护眼模式在 X11 和 Wayland 下均正确启用/禁用色温
3. 验证 Wayland 下默认色温从 DConfig 正确加载

PMS: TASK-390677