### PR TITLE
feat: use ReplaceHotkey for atomic conflict resolution on Wayland

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -563,6 +563,18 @@ void KeyboardController::beginWaylandKeyCapture(QQuickItem *item, const QString 
             });
 }
 
+void KeyboardController::endWaylandKeyCapture()
+{
+    if (!m_activeCapture)
+        return;
+
+    // Disconnect first so any pending wayland event cannot deliver a
+    // captured() signal after we've already moved on (Replace / Cancel).
+    disconnect(m_activeCapture, nullptr, this, nullptr);
+    m_activeCapture->deleteLater();
+    m_activeCapture.clear();
+}
+
 void KeyboardController::submitWaylandKeystroke(const QString &id, int type, const QString &accels)
 {
     if (accels.isEmpty()) {

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -82,6 +82,11 @@ public Q_SLOTS:
     // window — the compositor validates that before starting capture.
     Q_INVOKABLE void beginWaylandKeyCapture(QQuickItem *item, const QString &id, int type);
 
+    // Cancel an in-progress Wayland capture session.  Safe to call when
+    // no capture is active (no-op).  QML should call this when the user
+    // clicks Replace or Cancel so the compositor stops forwarding keys.
+    Q_INVOKABLE void endWaylandKeyCapture();
+
     void addCustomShortcut(const QString &name, const QString &cmd, const QString &accels);
     void modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels);
     void modifyShortcut(const QString &id, const QString &accels, const int &type);

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -418,6 +418,13 @@ QDBusPendingReply<bool> KeyboardDBusProxy::callModifyHotkeys(const QString &id, 
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ModifyHotkeys"), argumentList);
 }
 
+QDBusPendingReply<bool> KeyboardDBusProxy::callReplaceHotkey(const QString &targetId, const QString &newHotkey, const QString &conflictId)
+{
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(targetId) << QVariant::fromValue(newHotkey) << QVariant::fromValue(conflictId);
+    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ReplaceHotkey"), argumentList);
+}
+
 QDBusPendingReply<> KeyboardDBusProxy::AddShortcutKeystroke(const QString &in0, int in1, const QString &in2)
 {
     QList<QVariant> argumentList;

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -210,6 +210,8 @@ public slots:
     // Wayland: direct ModifyHotkeys (returns bool success), so the caller
     // can detect commit failures and roll back the UI.
     QDBusPendingReply<bool> callModifyHotkeys(const QString &id, const QStringList &hotkeys);
+    // Wayland: replace hotkey — remove newHotkey from conflictId, add to targetId.
+    QDBusPendingReply<bool> callReplaceHotkey(const QString &targetId, const QString &newHotkey, const QString &conflictId);
     QDBusPendingReply<> AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2);
     QDBusPendingReply<> ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3);
     QDBusPendingReply<> DeleteCustomShortcut(const QString &in0);

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -926,6 +926,9 @@ void KeyboardWorker::onConflictShortcutCleanFinished(QDBusPendingCallWatcher *wa
             m_keyboardDBusProxy->AddShortcutKeystroke(id, type, shortcut);
         }
     } else {
+        // X11 path only — onDisableShortcut's blocking waitForFinished
+        // already handled failure inline.  Just clean up the flicker guard.
+        qWarning() << "Disable failed for conflicting shortcut:" << watch->error().message();
         const QString &id = watch->property("id").toString();
         const int type = watch->property("type").toInt();
         QString key = makeShortcutKey(id, type);
@@ -945,17 +948,17 @@ void KeyboardWorker::onLookupConflictForShortcutFinished(QDBusPendingCallWatcher
 
     const ShortcutInfoNew conflict = reply.isError() ? ShortcutInfoNew() : reply.value();
     if (!reply.isError() && !conflict.id.isEmpty()) {
+        // Wayland: use ReplaceHotkey to remove the conflicting hotkey from
+        // the conflict shortcut and assign it to the target in one commit.
         const QString targetKey = makeShortcutKey(id, type);
         m_replacingShortcuts.insert(targetKey);
 
-        QDBusPendingCall call = m_keyboardDBusProxy->ClearShortcutKeystrokes(conflict.id, 0);
-        QDBusPendingCallWatcher *cleanWatcher = new QDBusPendingCallWatcher(call, this);
-        cleanWatcher->setProperty("id", id);
-        cleanWatcher->setProperty("type", type);
-        cleanWatcher->setProperty("shortcut", shortcut);
-        cleanWatcher->setProperty("clean", !isKPDelete);
-        connect(cleanWatcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardWorker::onConflictShortcutCleanFinished);
+        QDBusPendingReply<bool> replaceReply = m_keyboardDBusProxy->callReplaceHotkey(id, shortcut, conflict.id);
+        QDBusPendingCallWatcher *replaceWatcher = new QDBusPendingCallWatcher(replaceReply, this);
+        replaceWatcher->setProperty("id", id);
+        replaceWatcher->setProperty("type", type);
+        connect(replaceWatcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardWorker::onReplaceHotkeyFinished);
     } else {
         if (reply.isError()) {
             qWarning() << "LookupConflictShortcut failed:" << reply.error();
@@ -995,6 +998,28 @@ void KeyboardWorker::onModifyHotkeysFinished(QDBusPendingCallWatcher *watch)
     }
     // On success the server emits ShortcutChanged, which the proxy forwards via
     // shortcutQueried → onKeyBindingChanged to update the model. No extra work here.
+
+    watch->deleteLater();
+}
+
+void KeyboardWorker::onReplaceHotkeyFinished(QDBusPendingCallWatcher *watch)
+{
+    QDBusPendingReply<bool> reply = *watch;
+    const QString id = watch->property("id").toString();
+    const int type = watch->property("type").toInt();
+    const QString key = makeShortcutKey(id, type);
+
+    m_replacingShortcuts.remove(key);
+
+    const bool success = (!reply.isError() && reply.value());
+    if (!success) {
+        qWarning() << "ReplaceHotkey failed for" << id
+                   << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
+        // Re-query to restore the UI to the server's actual state.
+        onShortcutChanged(id, type);
+    }
+    // On success the server emits two ShortcutChanged signals (one per
+    // shortcut), which the proxy forwards to update both model rows.
 
     watch->deleteLater();
 }

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -96,6 +96,7 @@ public Q_SLOTS:
     void onRequestShortcut(QDBusPendingCallWatcher* watch);
     void onAllShortcutsReady(const QString &info);
     void onModifyHotkeysFinished(QDBusPendingCallWatcher *watch);
+    void onReplaceHotkeyFinished(QDBusPendingCallWatcher *watch);
     void onAdded(const QString&in0, int in1);
     void onDisableShortcut(ShortcutInfo* info);
     void onAddedFinished(QDBusPendingCallWatcher *watch);

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -223,6 +223,7 @@ DccObject {
                             }
 
                             function restore() {
+                                dccData.endWaylandKeyCapture()
                                 edit.keys = model.keySequence
                                 conflictText.visible = false
 
@@ -236,6 +237,7 @@ DccObject {
                                 active: false
                                 sourceComponent: ShortcutSettingDialog {
                                     onClosing: {
+                                        dccData.endWaylandKeyCapture()
                                         dialogloader.active = false
 
                                         conflictText.visible = false
@@ -322,6 +324,7 @@ DccObject {
                                         anchors.fill: parent
                                         onClicked: {
                                             var newAccels = shortcutSettingsBody.conflictAccels
+                                            dccData.endWaylandKeyCapture()
                                             edit.modifyShortcut(newAccels)
                                             shortcutSettingsBody.conflictAccels = ""
 


### PR DESCRIPTION
feat: use ReplaceHotkey for atomic conflict resolution on Wayland

Replace the two-step clear-and-reassign conflict resolution with
ReplaceHotkey, a single atomic D-Bus call that removes the conflicting
hotkey from the conflict shortcut and assigns it to the target shortcut
in one compositor commit. This eliminates the window where a shortcut
is briefly disabled if the second commit fails.

Also add endWaylandKeyCapture() to properly cancel in-progress key
capture sessions when the user clicks Replace or Cancel, preventing
stale captured() signals from being delivered after the dialog is gone.

X11 path is unaffected — the Wayland-specific code is gated behind
isWayland() checks.

使用 ReplaceHotkey 原子性地将冲突快捷键的绑定移除并分配给目标
快捷键，替换原有的两步冲突解决流程（先清除冲突快捷键、再分配
新快捷键），避免中间状态导致的快捷键短暂失效。

新增 endWaylandKeyCapture() 方法，在用户点击 Replace 或 Cancel 时
取消进行中的 Wayland 按键捕获会话，防止对话框关闭后收到过期的
captured 信号。

X11 路径不受影响，所有改动均在 isWayland() 分支内。

Log: use ReplaceHotkey for atomic conflict resolution on Wayland