### PR TITLE
fix: enable PIC for shared-utils on aarch64

### DIFF
--- a/src/shared-utils/CMakeLists.txt
+++ b/src/shared-utils/CMakeLists.txt
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 add_library(dcc-shared-utils OBJECT)
+set_target_properties(dcc-shared-utils PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 find_package(ICU COMPONENTS i18n uc)
 


### PR DESCRIPTION
Force POSITION_INDEPENDENT_CODE property for dcc-shared-utils library to
fix aarch64 compilation errors. Static libraries on aarch64 require PIC
enabled by default to be linked into shared libraries.

Log: Fixed aarch64 compilation errors by enabling PIC for shared-utils

Influence:
1. Verify compilation succeeds on aarch64 architecture
2. Confirm no regression on x86/x86_64 builds
3. Test linking with dependent shared libraries

fix: 为共享工具库启用位置无关代码以修复aarch64编译错误

强制设置dcc-shared-utils库的POSITION_INDEPENDENT_CODE属性，以修复aarch64
架构上的编译错误。aarch64平台上静态库默认需要启用PIC才能正确链接到共享
库中。

Log: 修复aarch64架构编译错误，为shared-utils启用PIC

Influence:
1. 验证aarch64架构编译是否成功
2. 确认不影响x86/x86_64架构的正常编译
3. 测试与依赖共享库的链接是否正常

## Summary by Sourcery

Build:
- Set POSITION_INDEPENDENT_CODE to ON for the dcc-shared-utils CMake target to ensure compatibility with aarch64 shared library linking.