### PR TITLE
chore: update changelog to 6.1.91

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+dde-control-center (6.1.91) unstable; urgency=medium
+
+  * fix: enable PIC for shared-utils on aarch64
+  * feat: use ReplaceHotkey for atomic conflict resolution on Wayland
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 04 Jun 2026 21:50:52 +0800
+
 dde-control-center (6.1.90) unstable; urgency=medium
 
   * feat: adapt color temperature for Treeland


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.91

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.91
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh Debian changelog to document the 6.1.91 release.