### PR TITLE
fix: handle treeland restart crash and prevent double connections

### DIFF
--- a/src/plugin-keyboard/operation/keyboardwaylandproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboardwaylandproxy.cpp
@@ -45,6 +45,7 @@ void KeyboardWaylandProxy::connectKeyboardSettings(TreelandKeyboardSettings *kbd
 {
     if (!kbd || m_keyboardSettings == kbd)
         return;
+    disconnectKeyboardSettings();
     m_keyboardSettings = kbd;
     qCDebug(lcKeyboardWaylandProxy) << "Connecting to TreelandKeyboardSettings";
 

--- a/src/plugin-keyboard/operation/keyboardwaylandproxy.h
+++ b/src/plugin-keyboard/operation/keyboardwaylandproxy.h
@@ -7,6 +7,7 @@
 #include "treelandinputmanager.h"
 
 #include <QObject>
+#include <QPointer>
 
 namespace DCC_NAMESPACE {
 
@@ -74,7 +75,7 @@ private:
     static int   intervalToRate(uint intervalValue);
 
     TreelandInputManager *m_inputManager = nullptr;
-    TreelandKeyboardSettings *m_keyboardSettings = nullptr;
+    QPointer<TreelandKeyboardSettings> m_keyboardSettings;
 };
 
 } // namespace DCC_NAMESPACE

--- a/src/plugin-mouse/operation/mousewaylandproxy.h
+++ b/src/plugin-mouse/operation/mousewaylandproxy.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <QObject>
+#include <QPointer>
 
 namespace DCC_NAMESPACE {
 
@@ -96,8 +97,8 @@ private:
     static uint32_t stateToProfile(bool state);
 
     TreelandInputManager *m_inputManager = nullptr;
-    TreelandMouseSettings *m_connectedMouseSettings = nullptr;
-    TreelandTouchpadSettings *m_connectedTouchpadSettings = nullptr;
+    QPointer<TreelandMouseSettings> m_connectedMouseSettings;
+    QPointer<TreelandTouchpadSettings> m_connectedTouchpadSettings;
     bool m_leftHandedInitialized = false;
     bool m_leftHanded = false;
     bool m_mouseNaturalScrollInitialized = false;

--- a/src/shared-utils/treelandinputmanager.cpp
+++ b/src/shared-utils/treelandinputmanager.cpp
@@ -891,8 +891,6 @@ TreelandInputManager::TreelandInputManager(QObject *parent)
         const bool available = isActive();
         qCDebug(lcTreelandInput) << "treeland_input_manager_v1 active changed:" << available;
         Q_EMIT availableChanged(available);
-        if (available)
-            return;
 
         const bool hadMouse = d->mouseAvail;
         const bool hadTouchpad = d->touchpadAvail;
@@ -904,12 +902,20 @@ TreelandInputManager::TreelandInputManager(QObject *parent)
         d->releaseMouseSettings();
         d->releaseTouchpadSettings();
         d->releaseKeyboardSettings();
-        if (hadMouse)
-            Q_EMIT mouseAvailableChanged(false);
-        if (hadTouchpad)
-            Q_EMIT touchpadAvailableChanged(false);
-        if (hadKeyboard)
-            Q_EMIT keyboardAvailableChanged(false);
+
+        if (available) {
+            // Re-initialize after compositor restart
+            d->initialized = false;
+            d->shutDown = false;
+            d->initialize();
+        } else {
+            if (hadMouse)
+                Q_EMIT mouseAvailableChanged(false);
+            if (hadTouchpad)
+                Q_EMIT touchpadAvailableChanged(false);
+            if (hadKeyboard)
+                Q_EMIT keyboardAvailableChanged(false);
+        }
     });
 
     qCDebug(lcTreelandInput) << "Treeland input manager initializing";


### PR DESCRIPTION
1. Fix crash when Treeland compositor restarts by properly re-
initializing device settings
2. Add QPointer checks to prevent use-after-free when keyboard settings
are deleted
3. Disconnect old keyboard settings before connecting to new ones to
avoid signal duplication
4. Ensure all input devices (mouse, touchpad, keyboard) are re-
initialized after compositor restart
5. Reset initialization flags to allow clean re-initialization flow

Log: Fixed control center crash after Treeland compositor restart

Influence:
1. Test restarting Treeland compositor while control center is open
2. Verify keyboard settings are correctly reconnected
3. Verify mouse settings are correctly reconnected
4. Verify touchpad settings are correctly reconnected
5. Test device availability signals after compositor restart
6. Verify no crashes when rapidly restarting compositor

fix: 修复重启 Treeland 后控制中心崩溃问题

1. 修复当 Treeland 显示服务重启时，通过正确重新初始化设备设置来防止崩溃
2. 添加 QPointer 检查防止键盘设置被删除后出现悬垂指针
3. 在连接新的键盘设置前先断开旧的连接，避免信号重复
4. 确保所有输入设备（鼠标、触摸板、键盘）在显示服务重启后都能重新初始化
5. 重置初始化标志以允许干净的重新初始化流程

Log: 修复 Treeland 显示服务重启后控制中心崩溃问题

Influence:
1. 在控制中心打开状态下重启 Treeland 显示服务
2. 验证键盘设置是否正确重新连接
3. 验证鼠标设置是否正确重新连接
4. 验证触摸板设置是否正确重新连接
5. 测试显示服务重启后的设备可用性信号是否正常
6. 验证快速重启显示服务时不会崩溃

## Summary by Sourcery

Handle Treeland compositor restarts by reinitializing input devices and making keyboard/mouse connections safer

Bug Fixes:
- Prevent crashes when Treeland compositor restarts by reinitializing input device settings instead of only emitting availability changes
- Avoid use-after-free scenarios by tracking keyboard and mouse settings with guarded pointers and disconnecting previous keyboard settings before reconnecting