### PR TITLE
fix: add tap support for hover-only buttons

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -112,6 +112,7 @@ DccObject {
                     weight: 30 + index
                     page: RowLayout {
                         id: layout
+                        property bool showActions: false
 
                         function requestRename(id, newName) {
                             switch (itemRep.authType) {
@@ -259,7 +260,7 @@ DccObject {
                         }
                         D.ActionButton {
                             id: editButton
-                            visible: hoverHandler.hovered
+                            visible: hoverHandler.hovered || layout.showActions
                             implicitWidth: 30
                             implicitHeight: 30
                             icon.name: "dcc_edit"
@@ -288,7 +289,7 @@ DccObject {
                         }
                         D.ActionButton {
                             id: deleteButton
-                            visible: hoverHandler.hovered
+                            visible: hoverHandler.hovered || layout.showActions
                             implicitWidth: 30
                             implicitHeight: 30
                             icon.name: "dcc_delete"
@@ -317,6 +318,12 @@ DccObject {
 
                         HoverHandler {
                             id: hoverHandler
+                        }
+                        
+                        TapHandler {
+                            id: touchHandler
+                            acceptedDevices: PointerDevice.TouchScreen
+                            onTapped: layout.showActions = !layout.showActions
                         }
                     }
                 }

--- a/src/plugin-personalization/qml/ScreenSaverPage.qml
+++ b/src/plugin-personalization/qml/ScreenSaverPage.qml
@@ -33,6 +33,8 @@ DccObject {
             pageType: DccObject.Item
             page: RowLayout {
                 Item {
+                    id: screenSaverItem
+                    property bool showPreviewButton: false
                     implicitWidth: 197
                     implicitHeight: 108
 
@@ -81,7 +83,7 @@ DccObject {
                             return previewFm.advanceWidth(text) + leftPadding + rightPadding
                         }
                         implicitHeight: 24
-                        visible: hoverHandler.hovered
+                        visible: hoverHandler.hovered || screenSaverItem.showPreviewButton
                         text: qsTr("preview")
                         FontMetrics {
                             id: previewFm
@@ -139,6 +141,11 @@ DccObject {
 
                     HoverHandler {
                         id: hoverHandler
+                    }
+                    
+                    TapHandler {
+                        acceptedDevices: PointerDevice.TouchScreen
+                        onTapped: screenSaverItem.showPreviewButton = !screenSaverItem.showPreviewButton
                     }
                 }
             }


### PR DESCRIPTION
1. Add TapHandler to authentication edit/delete buttons for touch screen access
2. Add TapHandler to screensaver preview button for touch screen support
3. Replace hover-only visibility with toggleable state for touch devices

Log: Enable hover-only action buttons to work on touch screens by adding tap toggle support

fix: 为仅悬停显示的按钮添加点击支持

1. 为认证模块编辑/删除按钮添加点击手势，使其在触屏设备上可操作
2. 为屏保预览按钮添加点击手势，支持触屏操作
3. 将悬停可见改为可切换状态，兼容触屏设备

Log: 为仅悬停可见的操作按钮添加点击切换功能，使其在触屏设备上可用
PMS: BUG-361289

## Summary by Sourcery

Add tap-based toggling for previously hover-only action buttons to support touch screens in authentication and screensaver pages.

Bug Fixes:
- Make authentication edit/delete action buttons accessible on touch devices by adding tap handlers and a toggleable visibility state.
- Make the screensaver preview button accessible on touch devices by adding a tap handler and a toggleable visibility state.