### PR TITLE
fix: fix region format dialog showing behind parent window

### DIFF
--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -298,6 +298,10 @@ Loader {
         }
     }
     onLoaded: {
+        var parentWin = Window.window
+        if (parentWin) {
+            item.transientParent = parentWin
+        }
         item.show()
     }
 }


### PR DESCRIPTION
1. Set transientParent to the parent window in onLoaded callback
2. This ensures the dialog appears in front of its parent window
3. Fixes the z-order issue where dialog appeared behind then jumped forward

PMS: BUG-296659

Log: Fix region format dialog appearing behind parent window in treeland

Influence:
1. Open Control Center > Language & Region > Region Format - dialog should appear in front
2. In treeland environment, verify dialog z-order is correct on display

fix: 修复区域格式弹框显示在父窗口后面的问题

1. 在 onLoaded 回调中设置 transientParent 指向父窗口
2. 确保弹框显示在父窗口前方
3. 修复了 treeland 环境下弹框先显示在后面再跳到前面的 z-order 问题

PMS: BUG-296659

Log: 修复 treeland 环境下区域格式弹框显示在父窗口后面的问题

Influence:
1. 打开控制中心 > 语言和区域 > 区域格式 - 弹框应正确显示在前方
2. 在 treeland 环境下，验证弹框的 z-order 是否正确