### PR TITLE
feat: integrate deepin-security-loader for privileged service access

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,6 +54,7 @@ Depends:
  libdtk6declarative(>> 6.7.40),
  netselect,
  dde-daemon (>> 6.1.88),
+ deepin-security-loader,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock
 Replaces: dde-control-center-dock

--- a/debian/dde-control-center.install
+++ b/debian/dde-control-center.install
@@ -1,4 +1,5 @@
 usr/bin/
+usr/libexec/deepin
 usr/lib/*/*.so*
 usr/lib/*/dde-control-center/
 usr/share

--- a/misc/dde-control-center-loader-wrapper
+++ b/misc/dde-control-center-loader-wrapper
@@ -1,0 +1,29 @@
+#!/bin/bash
+# dde-control-center wrapper for deepin-security-loader
+# Launches control center through security loader to get authorization
+# for calling protected system services without polkit popup.
+
+REAL_BINARY="/usr/libexec/deepin/dde-control-center"
+LOADER="/usr/bin/deepin-security-loader"
+LOADER_EXEC="/usr/bin/deepin-security-loader-exec"
+
+# Log to systemd journal with tag "dde-control-center"
+log_to_journal() {
+    logger -t dde-control-center -p user.info "$1"
+}
+
+# Log startup
+log_to_journal "dde-control-center launched with args: $*"
+
+# Check if loader is available and has proper capabilities
+if [ -x "$LOADER" ] && [ -x "$LOADER_EXEC" ]; then
+    if getcap "$LOADER_EXEC" 2>/dev/null | grep -q cap_setgid; then
+        # Launch via loader with authorization groups
+        log_to_journal "Using deepin-security-loader with authorization groups"
+        exec "$LOADER" --group deepin-daemon -- "$REAL_BINARY" "$@"
+    fi
+fi
+
+# Fallback: direct launch without loader (no polkit-free authorization)
+log_to_journal "Fallback: launching directly without security loader"
+exec "$REAL_BINARY" "$@"

--- a/misc/org.deepin.dde.control-center.desktop
+++ b/misc/org.deepin.dde.control-center.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Categories=Application;System;Settings
 Comment=Deepin Desktop Environment Control Center
-Exec=dde-control-center --show %f
+Exec=/usr/bin/dde-control-center --show %f
 GenericName=Control Center
 Icon=preferences-system
 Name=Deepin Control Center

--- a/misc/systemd/dde-control-center.service.in
+++ b/misc/systemd/dde-control-center.service.in
@@ -3,6 +3,6 @@ Description=DDE Control Center background service
 
 [Service]
 ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/dde-control-center -d
-Type=dbus
+Type=forking
 BusName=org.deepin.dde.ControlCenter1
 Slice=app.slice

--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -77,8 +77,19 @@ endif()
 file(GLOB_RECURSE DCC_Translation_QML_FILES ${DCC_PROJECT_ROOT_DIR}/qml/*.qml ${DCC_PROJECT_ROOT_DIR}/src/*.qml)
 file(GLOB_RECURSE DCC_Translation_SOURCE_FILES ${DCC_PROJECT_ROOT_DIR}/src/*.cpp ${DCC_PROJECT_ROOT_DIR}/src/*.h)
 dcc_handle_plugin_translation(NAME ${Control_Center_Name} SOURCE_DIR ${DCC_PROJECT_ROOT_DIR} QML_FILES ${DCC_Translation_QML_FILES} SOURCE_FILES ${DCC_Translation_SOURCE_FILES})
-# bin
-install(TARGETS ${Control_Center_Name} DESTINATION ${CMAKE_INSTALL_BINDIR})
+# bin → libexec (launched via wrapper through security loader)
+install(TARGETS ${Control_Center_Name} DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/deepin)
+
+# Copy wrapper to build dir for local testing (install phase renames it to dde-control-center)
+configure_file("${DCC_PROJECT_ROOT_DIR}/misc/dde-control-center-loader-wrapper"
+               "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/dde-control-center-loader-wrapper"
+               COPYONLY)
+
+# wrapper script (installed as /usr/bin/dde-control-center, replaces original binary)
+install(PROGRAMS "${DCC_PROJECT_ROOT_DIR}/misc/dde-control-center-loader-wrapper"
+    DESTINATION ${CMAKE_INSTALL_BINDIR}
+    RENAME dde-control-center
+    PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
 #----------------------------install config------------------------------
 #desktop
 install(FILES ${DCC_PROJECT_ROOT_DIR}/misc/org.deepin.dde.control-center.desktop DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/applications)

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "controlcenterdbusadaptor.h"
 #include "dccmanager.h"
+#include "securityloaderhelper.h"
 
 #include <DDBusSender>
 #include <DIconTheme>
@@ -96,6 +97,12 @@ int main(int argc, char *argv[])
 
     refreshQmlCache(app->applicationVersion());
 
+    DLogManager::setLogFormat("%{time}{yy-MM-ddTHH:mm:ss.zzz} [%{type}] [%{category}] <%{function}:%{line}> %{message}");
+
+    DLogManager::registerJournalAppender();
+    DLogManager::registerConsoleAppender();
+    DLogManager::registerFileAppender();    
+
     // take care of command line options
     QCommandLineOption showOption(QStringList() << "s" << "show", "show control center(hide for default).");
     QCommandLineOption toggleOption(QStringList() << "t" << "toggle", "toggle control center visible.");
@@ -105,6 +112,8 @@ int main(int argc, char *argv[])
     QCommandLineOption showTime(QStringList() << "z" << "time", "show control center exe time."); // 新增time参数自动测试启动速度
     QCommandLineOption loggingModuleOption(QStringList() << "l" << "logging-module", "Only output logs for the specified module", "loggingModule");
     QCommandLineOption pluginDir("spec", "load plugins from specialdir", "plugindir");
+    QCommandLineOption fd1Opt("fd1", "fd1 from security loader", "fd1");
+    QCommandLineOption fd2Opt("fd2", "fd2 from security loader", "fd2");
 
     QCommandLineParser parser;
     parser.setApplicationDescription("DDE Control Center");
@@ -118,7 +127,14 @@ int main(int argc, char *argv[])
     parser.addOption(showTime);
     parser.addOption(loggingModuleOption);
     parser.addOption(pluginDir);
+    parser.addOption(fd1Opt);
+    parser.addOption(fd2Opt);
     parser.process(*app);
+
+    int fd1 = -1, fd2 = -1;
+    if (parser.isSet(fd1Opt)) fd1 = parser.value(fd1Opt).toInt();
+    if (parser.isSet(fd2Opt)) fd2 = parser.value(fd2Opt).toInt();
+    SecurityLoaderHelper::instance().doSecurityLoader(fd1, fd2);
 
     auto parseReqPage = [&]() -> QString {
          QString reqPage = parser.value(pageOption);
@@ -149,12 +165,6 @@ int main(int argc, char *argv[])
         if (!rules.isEmpty())
             QLoggingCategory::setFilterRules(rules);
     }
-
-    DLogManager::setLogFormat("%{time}{yy-MM-ddTHH:mm:ss.zzz} [%{type}] [%{category}] <%{function}:%{line}> %{message}");
-
-    DLogManager::registerJournalAppender();
-    DLogManager::registerConsoleAppender();
-    DLogManager::registerFileAppender();
 
     auto dirs = QStandardPaths::standardLocations(QStandardPaths::GenericDataLocation);
     QStringList fallbacks = QIcon::fallbackSearchPaths();

--- a/src/dde-control-center/securityloaderhelper.cpp
+++ b/src/dde-control-center/securityloaderhelper.cpp
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "securityloaderhelper.h"
+
+#include <QDir>
+#include <QDirIterator>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonParseError>
+#include <QLoggingCategory>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusInterface>
+#include <QDBusReply>
+#include <unistd.h>
+
+Q_LOGGING_CATEGORY(secLoader, "org.deepin.dde.control-center.securityloader")
+
+const QString SecurityLoaderHelper::DEFAULT_CONFIG_DIR = "/usr/share/dde-control-center/permission-interfaces";
+
+SecurityLoaderHelper::SecurityLoaderHelper(QObject *parent)
+    : QObject(parent)
+{
+}
+
+SecurityLoaderHelper::~SecurityLoaderHelper() {}
+
+SecurityLoaderHelper &SecurityLoaderHelper::instance()
+{
+    static SecurityLoaderHelper instance;
+    return instance;
+}
+
+void SecurityLoaderHelper::doSecurityLoader(int fd1, int fd2)
+{
+    if (fd1 < 0 || fd2 < 0) {
+        qCWarning(secLoader) << "Not loaded by loader, skipping handshake";
+        return;
+    }
+
+    qCInfo(secLoader) << "Detected loader injection: fd1=" << fd1 << "fd2=" << fd2;
+
+    loadConfigFromDirectory();
+    // appendCurrentUserAccountsUserDest();
+    if (!performHandshake(fd1, fd2)) {
+        qCWarning(secLoader) << "Security loader handshake failed";
+    }
+}
+
+void SecurityLoaderHelper::loadConfigFromDirectory(const QString &configDir)
+{
+    QString dir = configDir.isEmpty() ? DEFAULT_CONFIG_DIR : configDir;
+    QDir directory(dir);
+
+    if (!directory.exists()) {
+        qCWarning(secLoader) << "Config directory does not exist:" << dir;
+        return;
+    }
+
+    qCInfo(secLoader) << "Loading permission configs from:" << dir;
+
+    m_destList = QJsonArray();
+    QDirIterator it(dir, {"*.json"}, QDir::Files);
+
+    while (it.hasNext()) {
+        QString filePath = it.next();
+        qCInfo(secLoader) << "Parsing config file:" << filePath;
+        parseJsonFile(filePath);
+    }
+
+    qCInfo(secLoader) << "Loaded" << m_destList.size() << "D-Bus interfaces to authorize";
+}
+
+void SecurityLoaderHelper::parseJsonFile(const QString &filePath)
+{
+    QFile file(filePath);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qCWarning(secLoader) << "Cannot open file:" << filePath;
+        return;
+    }
+
+    QJsonParseError error;
+    QJsonDocument doc = QJsonDocument::fromJson(file.readAll(), &error);
+    file.close();
+
+    if (error.error != QJsonParseError::NoError) {
+        qCWarning(secLoader) << "JSON parse error in" << filePath << ":" << error.errorString();
+        return;
+    }
+
+    QJsonObject root = doc.object();
+    if (!root.contains("DestList") || !root["DestList"].isArray()) {
+        qCWarning(secLoader) << "Invalid config format in" << filePath << ": missing DestList";
+        return;
+    }
+
+    for (const auto &item : root["DestList"].toArray()) {
+        appendDest(item.toObject());
+    }
+}
+
+void SecurityLoaderHelper::appendDest(const QJsonObject &dest)
+{
+    const QString dbusName = dest["DbusName"].toString();
+    const QString dbusPath = dest["DbusPath"].toString();
+    const QString dbusInterface = dest["DbusInterface"].toString();
+
+    if (dbusName.isEmpty() || dbusPath.isEmpty() || dbusInterface.isEmpty()) {
+        qCWarning(secLoader) << "Skip invalid D-Bus destination:" << dest;
+        return;
+    }
+
+    for (const auto &existing : m_destList) {
+        const QJsonObject current = existing.toObject();
+        if (current["DbusName"] == dbusName &&
+            current["DbusPath"] == dbusPath &&
+            current["DbusInterface"] == dbusInterface) {
+            return;
+        }
+    }
+
+    m_destList.append(dest);
+    qCInfo(secLoader) << "  Added:" << dbusName << dbusPath << dbusInterface;
+}
+
+void SecurityLoaderHelper::appendCurrentUserAccountsUserDest()
+{
+    const QString userPath = currentUserAccountsPath();
+    if (userPath.isEmpty()) {
+        qCWarning(secLoader) << "Cannot resolve current user's Accounts.User path";
+        return;
+    }
+
+    QJsonObject dest;
+    dest["DbusName"] = QStringLiteral("org.deepin.dde.Accounts1");
+    dest["DbusPath"] = userPath;
+    dest["DbusInterface"] = QStringLiteral("org.deepin.dde.Accounts1.User");
+    appendDest(dest);
+}
+
+QString SecurityLoaderHelper::currentUserAccountsPath() const
+{
+    QDBusConnection systemBus = QDBusConnection::systemBus();
+    if (!systemBus.isConnected()) {
+        qCWarning(secLoader) << "Cannot connect to system bus when resolving current user path";
+        return {};
+    }
+
+    QDBusInterface accountsInterface(QStringLiteral("org.deepin.dde.Accounts1"),
+                                     QStringLiteral("/org/deepin/dde/Accounts1"),
+                                     QStringLiteral("org.deepin.dde.Accounts1"),
+                                     systemBus);
+    if (!accountsInterface.isValid()) {
+        qCWarning(secLoader) << "Accounts interface invalid when resolving current user path:"
+                             << accountsInterface.lastError().message();
+        return {};
+    }
+
+    QDBusReply<QString> reply = accountsInterface.call(QStringLiteral("FindUserById"), QString::number(getuid()));
+    if (!reply.isValid()) {
+        qCWarning(secLoader) << "FindUserById failed when resolving current user path:"
+                             << reply.error().message();
+        return {};
+    }
+
+    return reply.value();
+}
+
+bool SecurityLoaderHelper::performHandshake(int fd1, int fd2)
+{
+    if (fd1 < 0 || fd2 < 0) {
+        qCInfo(secLoader) << "Invalid fd, skipping handshake";
+        return true;
+    }
+
+    if (m_destList.isEmpty()) {
+        qCInfo(secLoader) << "No D-Bus interfaces loaded, skipping handshake";
+        return true;
+    }
+
+    qCInfo(secLoader) << "Performing loader handshake...";
+
+    QDBusConnection systemBus = QDBusConnection::systemBus();
+    if (!systemBus.isConnected()) {
+        qCWarning(secLoader) << "Cannot connect to system bus";
+        return false;
+    }
+    QString uniqueName = systemBus.baseService();
+    qCInfo(secLoader) << "System Bus UniqueName:" << uniqueName;
+
+    QJsonObject request;
+    request["UniqueName"] = uniqueName;
+    request["DestList"] = m_destList;
+
+    QJsonDocument doc(request);
+    QByteArray jsonData = doc.toJson(QJsonDocument::Compact);
+
+    qCInfo(secLoader) << "Send request with" << m_destList.size() << "interfaces";
+
+    QFile fd1File;
+    if (!fd1File.open(fd1, QIODevice::WriteOnly)) {
+        qCWarning(secLoader) << "Cannot open fd1 for writing";
+        return false;
+    }
+    fd1File.write(jsonData);
+    fd1File.close();
+
+    QFile fd2File;
+    if (!fd2File.open(fd2, QIODevice::ReadOnly)) {
+        qCWarning(secLoader) << "Cannot open fd2 for reading";
+        return false;
+    }
+
+    QByteArray response = fd2File.readAll();
+    fd2File.close();
+
+    QJsonParseError parseError;
+    QJsonDocument responseDoc = QJsonDocument::fromJson(response, &parseError);
+    if (parseError.error != QJsonParseError::NoError) {
+        qCWarning(secLoader) << "Invalid JSON response from loader:" << parseError.errorString();
+        return false;
+    }
+
+    QJsonObject result = responseDoc.object();
+    if (result["Result"].toBool()) {
+        qCInfo(secLoader) << "Loader handshake completed successfully";
+        return true;
+    } else {
+        qCWarning(secLoader) << "Loader authorization response:" << result["Message"].toString();
+        return false;
+    }
+}

--- a/src/dde-control-center/securityloaderhelper.h
+++ b/src/dde-control-center/securityloaderhelper.h
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef SECURITYLOADERHELPER_H
+#define SECURITYLOADERHELPER_H
+
+#include <QObject>
+#include <QJsonArray>
+
+class SecurityLoaderHelper : public QObject
+{
+    Q_OBJECT
+
+public:
+    static SecurityLoaderHelper &instance();
+    void doSecurityLoader(int fd1, int fd2);
+
+private:
+    explicit SecurityLoaderHelper(QObject *parent = nullptr);
+    ~SecurityLoaderHelper();
+
+    SecurityLoaderHelper(const SecurityLoaderHelper &) = delete;
+    SecurityLoaderHelper &operator=(const SecurityLoaderHelper &) = delete;
+
+    void loadConfigFromDirectory(const QString &configDir = QString());
+    void parseJsonFile(const QString &filePath);
+    void appendDest(const QJsonObject &dest);
+    void appendCurrentUserAccountsUserDest();
+    QString currentUserAccountsPath() const;
+    bool performHandshake(int fd1, int fd2);
+
+private:
+    QJsonArray m_destList;
+    static const QString DEFAULT_CONFIG_DIR;
+};
+
+#endif // SECURITYLOADERHELPER_H


### PR DESCRIPTION
1. Add shell wrapper (`dde-control-center-loader-wrapper`) to launch control center via deepin-security-loader
2. The wrapper checks if security loader is available and has proper capabilities (cap_setgid)
3. If available, it launches using `deepin-security-loader --group deepin-daemon` to obtain authorization for protected D-Bus services
4. If unavailable, it falls back to direct launch without the loader
5. Install the real binary to `/usr/libexec/deepin/` and the wrapper to `/usr/bin/dde-control-center`
6. Add `SecurityLoaderHelper` class to handle handshake with the loader via passed file descriptors
7. Load permission configuration from JSON files in `/usr/share/dde- control-center/permission-interfaces/`
8. During handshake, send D-Bus unique name and list of authorized interfaces to the loader
9. Update systemd service type from `dbus` to `forking` to accommodate the wrapper launch
10. Move log initialization earlier in `main.cpp` for better startup debugging
11. Add dependency on `deepin-security-loader` package in debian control
12. Install libexec files via debian install rules

Log: Improved security by using deepin-security-loader for D-Bus authorization

Influence:
1. Verify control center launches correctly via `dde-control-center` command
2. Test desktop file execution: `gtk-launch org.deepin.dde.control- center`
3. Verify wrapper falls back gracefully when deepin-security-loader is not installed
4. Test with deepin-security-loader present: check systemd journal for logging messages
5. Verify D-Bus service authorization works by calling protected interfaces (e.g., Accounts, NetworkManager)
6. Test permission config loading: add/remove JSON files in `/usr/share/ dde-control-center/permission-interfaces/`
7. Verify systemd service starts correctly with Type=forking
8. Test daemon mode: `dde-control-center -d` and check it registers on D-Bus as `org.deepin.dde.ControlCenter1`
9. Validate that file descriptors (fd1, fd2) are properly passed by the loader
10. Check for regression: verify all control center features still work without security loader

feat: 集成deepin-security-loader以访问特权服务

1. 添加shell包装脚本(dde-control-center-loader-wrapper)，通过deepin- security-loader启动控制中心
2. 包装脚本检查安全加载器是否可用且具有cap_setgid能力
3. 如果可用，通过`deepin-security-loader --group deepin-daemon`启动，获 取受保护D-Bus服务的授权
4. 如果不可用，回退到直接启动，不使用加载器
5. 将实际二进制文件安装到`/usr/libexec/deepin/`，包装脚本安装到`/usr/ bin/dde-control-center`
6. 添加`SecurityLoaderHelper`类，通过传入的文件描述符处理与加载器的握手
7. 从`/usr/share/dde-control-center/permission-interfaces/`目录加载权限 配置文件
8. 握手期间，发送D-Bus唯一名称和已授权接口列表给加载器
9. 将systemd服务类型从`dbus`改为`forking`以适配包装脚本启动
10. 将日志初始化提前到`main.cpp`中，便于启动调试
11. 在debian控制文件中添加`deepin-security-loader`包依赖
12. 通过debian安装规则安装libexec文件

Log: 通过deepin-security-loader提升D-Bus授权安全性

Influence:
1. 验证控制中心通过`dde-control-center`命令正常启动
2. 测试桌面文件执行：`gtk-launch org.deepin.dde.control-center`
3. 验证未安装deepin-security-loader时包装脚本正常回退
4. 测试deepin-security-loader存在时，检查systemd日志中的输出信息
5. 验证D-Bus服务授权正常工作，调用受保护接口（如Accounts、 NetworkManager）
6. 测试权限配置加载：在`/usr/share/dde-control-center/permission- interfaces/`中添加/删除JSON文件
7. 验证systemd服务以Type=forking正确启动
8. 测试守护进程模式：`dde-control-center -d`，检查是否在D-Bus上注册为 `org.deepin.dde.ControlCenter1`
9. 验证文件描述符(fd1, fd2)是否正确由加载器传递
10. 检查回归：验证无安全加载器时控制中心所有功能仍正常工作

PMS: TASK-390841
Change-Id: I05848626cd62c47a560aa06f2ba0f64aa2293b9d