### PR TITLE
fix: use layer-shell for screen indicator on wayland

### DIFF
--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -14,6 +14,7 @@ DccObject {
     property var activeDialogs: []
     property bool screensFormRect: dccData.screensFormRect
     property bool isExtendMode: dccData.displayMode === "EXTEND"
+    property var indicatorScreen: null // 用于显示屏幕边框指示器的属性
     property var scaleModelConst: [{
             "text": qsTr("100%"),
             "value": 1.0
@@ -141,14 +142,6 @@ DccObject {
             closeInvalidDialogs()
         }
     }
-    Component {
-        id: indicator
-        ScreenIndicator {}
-    }
-    Component {
-        id: recognize
-        ScreenRecognize {}
-    }
     DccTitleObject {
         name: "multipleDisplays"
         parentName: "display"
@@ -245,11 +238,9 @@ DccObject {
                     function pressedItem(item) {
                         hasMove = false
                         root.screen = item.screen
-                        if (dccData.isX11) {
-                            indicator.createObject(this, {
-                                                       "screen": getQtScreen(item.screen)
-                                                   }).show()
-                        }
+                        // 使用 indicatorScreen 属性统一显示边框指示器
+                        root.indicatorScreen = null
+                        root.indicatorScreen = getQtScreen(item.screen)
                     }
                     function positionChangedItem(item) {
                         monitorControl.effective = false
@@ -359,42 +350,37 @@ DccObject {
                 }
                 D.Button {
                     id: identifyBut
-                    property var recognizes: []
+                    property bool identifyActive: false
                     implicitHeight: 24
                     implicitWidth: 72
                     anchors.right: parent.right
                     anchors.verticalCenter: parent.verticalCenter
                     anchors.rightMargin: 7
                     text: dccObj.displayName
-                    function closeWindow() {
-                        recognizeTimer.stop()
-                        for (var obj of identifyBut.recognizes) {
-                            obj.close()
-                        }
-                        identifyBut.recognizes = []
-                    }
                     Timer {
                         id: recognizeTimer
                         repeat: false
                         interval: 5000
-                        onTriggered: identifyBut.closeWindow()
+                        onTriggered: identifyBut.identifyActive = false
                     }
                     onClicked: {
-                        // if (!dccData.isX11) {
-                        //     return
-                        // }
-                        identifyBut.closeWindow()
-                        for (var i = 0; i < dccData.virtualScreens.length; i++) {
-                            var item = dccData.virtualScreens[i]
-                            var obj = recognize.createObject(this, {
-                                                                 "screen": getQtScreen(item),
-                                                                 "name": item.name
-                                                             })
-                            obj.show()
-                            obj.escPressed.connect(identifyBut.closeWindow)
-                            recognizes.push(obj)
-                        }
+                        identifyBut.identifyActive = true
                         recognizeTimer.restart()
+                    }
+                    // 使用 Repeater + Loader 创建多个 ScreenRecognize 窗口
+                    Repeater {
+                        id: recognizeRepeater
+                        model: identifyBut.identifyActive ? dccData.virtualScreens : []
+                        Loader {
+                            sourceComponent: ScreenRecognize {
+                                onEscPressed: identifyBut.identifyActive = false
+                            }
+                            onLoaded: {
+                                item.screen = getQtScreen(modelData)
+                                item.name = modelData.name
+                                item.show()
+                            }
+                        }
                     }
                 }
             }
@@ -595,13 +581,15 @@ DccObject {
             onScreenClicked: function (screen) {
                 if (screen && screen !== root.screen) {
                     root.screen = screen
-                    if (dccData.isX11) {
-                        indicator.createObject(this, {
-                                                   "screen": getQtScreen(root.screen)
-                                               }).show()
-                    }
+                    // 设置 indicatorScreen 属性显示边框指示器
+                    root.indicatorScreen = null
+                    root.indicatorScreen = getQtScreen(root.screen)
                 }
             }
+        }
+        ScreenIndicator{
+            screen: root.indicatorScreen
+            onClosed: root.indicatorScreen = null
         }
     }
     component BrightnessComponent: RowLayout {

--- a/src/plugin-display/qml/ScreenIndicator.qml
+++ b/src/plugin-display/qml/ScreenIndicator.qml
@@ -1,51 +1,51 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 
+import org.deepin.ds 1.0 as DS
 import org.deepin.dcc 1.0
 
-Window {
+Loader {
     id: root
-    flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-    color: "#2ca7f8"
-    x: screen.virtualX
-    y: screen.virtualY
-    width: screen.width
-    height: 10
-    onClosing: destroy(10)
+    property var screen: null
+    signal closed
+    active: screen !== null
     Timer {
         interval: 1000
-        running: root.visible
-        onTriggered: root.close()
+        running: root.active
+        onTriggered: root.closed()
     }
-    Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-        visible: root.visible
-        color: root.color
+
+    component IndicatorBorder: Window {
         screen: root.screen
-        x: screen.virtualX
-        y: screen.virtualY + screen.height - 10
-        width: screen.width
+        color: "#2ca7f8"
+
+        flags: Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint
+        DS.DLayerShellWindow.layer: DS.DLayerShellWindow.LayerOverlay
+        DS.DLayerShellWindow.exclusionZone: -1
+        Component.onCompleted: show()
         height: 10
-    }
-    Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-        visible: root.visible
-        color: root.color
-        screen: root.screen
-        x: screen.virtualX
-        y: screen.virtualY
         width: 10
-        height: screen.height
     }
-    Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-        visible: root.visible
-        color: root.color
-        screen: root.screen
-        x: screen.virtualX + screen.width - 10
-        y: screen.virtualY
-        width: 10
-        height: screen.height
+
+    sourceComponent: IndicatorBorder {
+        DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorTop
+                                      | DS.DLayerShellWindow.AnchorLeft
+                                      | DS.DLayerShellWindow.AnchorRight
+        IndicatorBorder {
+            DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorBottom
+                                          | DS.DLayerShellWindow.AnchorLeft
+                                          | DS.DLayerShellWindow.AnchorRight
+        }
+        IndicatorBorder {
+            DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorLeft
+                                          | DS.DLayerShellWindow.AnchorTop
+                                          | DS.DLayerShellWindow.AnchorBottom
+        }
+        IndicatorBorder {
+            DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorRight
+                                          | DS.DLayerShellWindow.AnchorTop
+                                          | DS.DLayerShellWindow.AnchorBottom
+        }
     }
 }

--- a/src/plugin-display/qml/ScreenRecognize.qml
+++ b/src/plugin-display/qml/ScreenRecognize.qml
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
 import org.deepin.dtk 1.0 as D
+import org.deepin.ds 1.0 as DS
 import org.deepin.dcc 1.0
 
 Window {
@@ -10,20 +11,26 @@ Window {
     property string name: "screen"
     signal escPressed
 
-    flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
+    flags: Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint
     D.DWindow.enabled: true
-    x: screen.virtualX + (screen.width - width) * 0.5
-    y: screen.virtualY + screen.height - height - 220
-    width: control.implicitWidth + 44
-    height: control.implicitHeight + 24
-    minimumWidth: 200
+    color: D.DTK.palette.window
+    // 使用 DLayerShellWindow 定位窗口：X轴居中，Y轴锚定底部偏上1/4处
+    DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorBottom
+    DS.DLayerShellWindow.layer: DS.DLayerShellWindow.LayerOverlay
+    DS.DLayerShellWindow.bottomMargin: (root.screen && root.screen.height > 0) ? Math.max(0, root.screen.height * 0.25 - height * 0.5) : 400
+
+    width: control.implicitWidth
+    height: control.implicitHeight
     onClosing: destroy(10)
     Text {
         id: control
-        anchors.centerIn: parent
+        leftPadding: 22
+        topPadding: 12
+        rightPadding: leftPadding
+        bottomPadding: topPadding
         text: root.name
         font: D.DTK.fontManager.t4
-        color: control.palette.brightText
+        color: D.DTK.palette.brightText
     }
     Shortcut {
         sequence: "Esc"

--- a/src/plugin-personalization/qml/ScreenIndicator.qml
+++ b/src/plugin-personalization/qml/ScreenIndicator.qml
@@ -1,51 +1,51 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-
 import QtQuick 2.15
+
+import org.deepin.ds 1.0 as DS
 import org.deepin.dcc 1.0
 
-Window {
+Loader {
     id: root
-    flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-    color: "#2ca7f8"
-    x: screen.virtualX
-    y: screen.virtualY
-    width: screen.width
-    height: 10
-    onClosing: destroy(10)
+    property var screen: null
+    signal closed
+    active: screen !== null
     Timer {
         interval: 1000
-        running: root.visible
-        onTriggered: root.close()
+        running: root.active
+        onTriggered: root.closed()
     }
-    Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-        visible: root.visible
-        color: root.color
+
+    component IndicatorBorder: Window {
         screen: root.screen
-        x: screen.virtualX
-        y: screen.virtualY + screen.height - 10
-        width: screen.width
+        color: "#2ca7f8"
+
+        flags: Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint
+        DS.DLayerShellWindow.layer: DS.DLayerShellWindow.LayerOverlay
+        DS.DLayerShellWindow.exclusionZone: -1
+        Component.onCompleted: show()
         height: 10
-    }
-    Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-        visible: root.visible
-        color: root.color
-        screen: root.screen
-        x: screen.virtualX
-        y: screen.virtualY
         width: 10
-        height: screen.height
     }
-    Window {
-        flags: Qt.CoverWindow | Qt.WindowStaysOnTopHint | Qt.SplashScreen | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
-        visible: root.visible
-        color: root.color
-        screen: root.screen
-        x: screen.virtualX + screen.width - 10
-        y: screen.virtualY
-        width: 10
-        height: screen.height
+
+    sourceComponent: IndicatorBorder {
+        DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorTop
+                                      | DS.DLayerShellWindow.AnchorLeft
+                                      | DS.DLayerShellWindow.AnchorRight
+        IndicatorBorder {
+            DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorBottom
+                                          | DS.DLayerShellWindow.AnchorLeft
+                                          | DS.DLayerShellWindow.AnchorRight
+        }
+        IndicatorBorder {
+            DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorLeft
+                                          | DS.DLayerShellWindow.AnchorTop
+                                          | DS.DLayerShellWindow.AnchorBottom
+        }
+        IndicatorBorder {
+            DS.DLayerShellWindow.anchors: DS.DLayerShellWindow.AnchorRight
+                                          | DS.DLayerShellWindow.AnchorTop
+                                          | DS.DLayerShellWindow.AnchorBottom
+        }
     }
 }

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -29,22 +29,19 @@ DccObject {
         visible: dccData.model.screens.length > 1
         page: ScreenTab {
             id: screemTab
+            property var indicatorScreen: null
             model: dccData.model.screens
             screen: dccData.model.currentSelectScreen
             onScreenChanged: {
                 if (screen !== dccData.model.currentSelectScreen) {
                     dccData.model.currentSelectScreen = screen
-                    if (true) {
-                        indicator.createObject(this, {
-                                                "screen": getQtScreen(screemTab.screen)
-                                            }).show()
-                    }
+                    indicatorScreen = null
+                    indicatorScreen = getQtScreen(screemTab.screen)
                 }
             }
-
-            Component {
-                id: indicator
-                ScreenIndicator {}
+            ScreenIndicator{
+                screen: screemTab.indicatorScreen
+                onClosed: screemTab.indicatorScreen = null
             }
 
             function getQtScreen(screenName) {


### PR DESCRIPTION
1. Replace absolute x/y positioning with DLayerShellWindow anchors in ScreenIndicator.qml (both display and personalization)
2. Use AnchorTop/Bottom/Left/Right for border indicator windows instead of virtualX/virtualY coordinates
3. Migrate ScreenRecognize.qml to use AnchorBottom with margin for centered-bottom positioning
4. Remove isX11 guard in DisplayMain.qml so indicators work on Wayland/Treeland
5. Add DDEShell dependency in CMakeLists.txt

PMS: BUG-351883

Log: Fix screen indicator and recognition dialog not working on Treeland Wayland environment

Influence:
1. Connect external monitor, open Display settings, click Identify
   - border indicators should correctly highlight each screen edge
2. On Treeland, drag to change screen arrangement and click Identify
   - indicator borders should appear on the correct monitor

fix: 使用 layer-shell 实现屏幕指示器在 Wayland 下的正确定位

1. 将 ScreenIndicator.qml 中的绝对 x/y 坐标定位替换为 DLayerShellWindow 锚定方式（display 和 personalization 模块）
2. 使用 AnchorTop/Bottom/Left/Right 锚定边框指示窗口， 替代 virtualX/virtualY 坐标
3. 将 ScreenRecognize.qml 迁移到使用 AnchorBottom + margin 实现底部居中定位
4. 移除 DisplayMain.qml 中的 isX11 条件判断， 使指示器在 Wayland 下也能正常显示
5. 在 CMakeLists.txt 中添加 DDEShell 依赖

PMS: BUG-351883

Log: 修复 Treeland Wayland 环境下屏幕指示器和识别弹框不生效的问题

Influence:
1. 接入外接显示器，打开控制中心显示设置，点击识别 - 边框指示器应正确高亮各屏幕边缘
2. 在 Treeland 环境下，拖动切换屏幕拼接位置后点击识别 - 指示器边框应出现在正确的显示器上