### PR TITLE
fix: request authorization for folder privacy permissions

### DIFF
--- a/src/plugin-privacy/operation/privacysecurityworker.cpp
+++ b/src/plugin-privacy/operation/privacysecurityworker.cpp
@@ -31,7 +31,15 @@ static const QString DESKTOP_ENTRY_ICON_KEY = "Desktop Entry";
 static const QString DEEPIN_WINE_TEAM = "Deepin WINE Team";
 
 const QString DataVersion = "1.0";
-static QList<int> s_systemPrem = { ApplicationItem::CameraPermission };
+static QList<int> s_systemPrem = {
+    ApplicationItem::CameraPermission,
+    ApplicationItem::DocumentFoldersPermission,
+    ApplicationItem::PictureFoldersPermission,
+    ApplicationItem::DesktopFoldersPermission,
+    ApplicationItem::VideoFoldersPermission,
+    ApplicationItem::MusicFoldersPermission,
+    ApplicationItem::DownloadFoldersPermission,
+};
 
 static QString getDpkgArch()
 {


### PR DESCRIPTION
## Summary
- Add folder privacy permissions to the system permission authorization list.
- Ensure changing file and folder privacy switches requests local polkit authorization before updating usec policies.

## Test
- Built privacy plugin: `cmake --build obj-x86_64-linux-gnu --target privacy -j100`
- Built and deployed `dde-control-center_6.1.91_amd64.deb` to debug machine 10.20.9.188
- Verified remote `privacy.so` md5 matches package: `9478e1914e83ae46fb8d9ec718df5f13`
- Manually verified file and folder privacy switches show authorization and work normally

PMS: BUG-365511
