### PR TITLE
fix(dock): keep dock size slider responsive

### DIFF
--- a/src/plugin-dock/operation/dockdbusproxy.cpp
+++ b/src/plugin-dock/operation/dockdbusproxy.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -145,7 +145,7 @@ bool DockDBusProxy::showRecent()
 
 void DockDBusProxy::resizeDock(int offset, bool dragging)
 {
-    m_dockInter->call(QDBus::CallMode::Block, QStringLiteral("resizeDock"), QVariant::fromValue(offset), QVariant::fromValue(dragging));
+    m_dockInter->asyncCall(QStringLiteral("resizeDock"), QVariant::fromValue(offset), QVariant::fromValue(dragging));
 }
 
 QDBusPendingReply<QStringList> DockDBusProxy::GetLoadedPlugins()

--- a/src/plugin-dock/qml/DockMain.qml
+++ b/src/plugin-dock/qml/DockMain.qml
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -155,12 +155,20 @@ DccObject {
                     implicitHeight: 24
                     highlightedPassedGroove: true
                     stepSize: 1
-                    value: dccData.dockInter.DisplayMode === 2 ? dccData.dockInter.WindowSizeFashion : dccData.dockInter.WindowSizeEfficient 
+                    value: {
+                        if (balanceSlider.pressed) {
+                            return balanceSlider.value
+                        }
+
+                        return dccData.dockInter.DisplayMode === 2 ? dccData.dockInter.WindowSizeFashion : dccData.dockInter.WindowSizeEfficient
+                    } 
                     from: 37
                     to: 100
 
                     onValueChanged: {
-                        dccData.dockInter.resizeDock(value, true)
+                        if (pressed) {
+                            dccData.dockInter.resizeDock(value, true)
+                        }
                     }
 
                     onPressedChanged: {


### PR DESCRIPTION
## Summary

- Fix PMS BUG-294757 / Multica issue DDE-7.
- Send dock resize requests asynchronously to avoid blocking the control center UI thread.
- Only send continuous resize requests while the dock size slider is pressed, avoiding feedback from backend property updates.

## Verification

- git diff --check HEAD~1..HEAD
- make -C /home/ut005580@uos/Dev/dde-control-center/build dock_qml -j4
- make -C /home/ut005580@uos/Dev/dde-control-center/build dock -j4 reached link stage, but local DTK 6.7.42 libraries are missing.

PMS: BUG-294757
Issue: DDE-7
