### PR TITLE
fix(display): migrate concat screen management to daemon

### DIFF
--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -179,9 +179,6 @@ void DisplayModulePrivate::updateVirtualScreens()
 
 void DisplayModulePrivate::updateMonitorList()
 {
-    if (m_model->isConcatScreenMode()) {
-        resetConcatScreenMode();
-    }
     bool changed = false;
     QList<Monitor *> addMonitorList = m_model->monitorList();
     for (auto it = m_screens.cbegin(); it != m_screens.cend();) {
@@ -264,6 +261,12 @@ void DisplayModulePrivate::updateDisplayMode()
     default:
         break;
     }
+    // 非扩展模式时确保本地模型退出拼接（兼容快捷键等非控制中心触发的模式切换）
+    if (m_model->displayMode() != EXTEND_MODE && m_model->isConcatScreenMode()) {
+        m_model->setIsConcatScreenMode(false);
+        m_worker->setConcatScreenMode(false);
+    }
+
     if (displayMode != m_displayMode) {
         m_displayMode = displayMode;
         Q_EMIT q_ptr->displayModeChanged();
@@ -324,18 +327,9 @@ void DisplayModulePrivate::updateConcatScreenMode()
     m_worker->updateConcatScreenMode();
 }
 
-void DisplayModulePrivate::mergeToConcatScreen()
+void DisplayModulePrivate::setConcatScreenMode(bool enable)
 {
-    QStringList outputs;
-    for (auto s : enabledScreens()) {
-        outputs << s->name();
-    }
-    m_worker->mergeToConcatScreen(outputs);
-}
-
-void DisplayModulePrivate::resetConcatScreenMode()
-{
-    m_worker->resetConcatScreenMode();
+    m_worker->setConcatScreenMode(enable);
 }
 
 DccScreen *DisplayModulePrivate::primary() const
@@ -474,8 +468,10 @@ void DisplayModule::setDisplayMode(const QString &mode)
         name = mode;
     }
     Q_D(DisplayModule);
+
     if (d->m_model->isConcatScreenMode() && modeType != EXTEND_MODE) {
-        d->resetConcatScreenMode();
+        d->m_model->setIsConcatScreenMode(false);
+        d->m_worker->setConcatScreenMode(false);
     }
     d->m_worker->switchMode(modeType, name);
 }
@@ -664,16 +660,10 @@ bool DisplayModule::isConcatScreenMode() const
     return d->m_model->isConcatScreenMode();
 }
 
-void DisplayModule::mergeToConcatScreen()
+void DisplayModule::setConcatScreenMode(bool enable)
 {
     Q_D(DisplayModule);
-    d->mergeToConcatScreen();
-}
-
-void DisplayModule::resetConcatScreenMode()
-{
-    Q_D(DisplayModule);
-    d->resetConcatScreenMode();
+    d->setConcatScreenMode(enable);
 }
 
 void DisplayModule::saveChanges()

--- a/src/plugin-display/operation/displaymodule.h
+++ b/src/plugin-display/operation/displaymodule.h
@@ -71,8 +71,7 @@ public Q_SLOTS:
     void executemultiScreenAlgo(QList<QObject *> listItems, QObject *pw, qreal scale);
     void applySettings(QList<QObject *> listItems, qreal scale);
     void applyChanged(); // 修改分辨率、方向时，要重新处理下拼接
-    Q_INVOKABLE void mergeToConcatScreen();
-    Q_INVOKABLE void resetConcatScreenMode();
+    Q_INVOKABLE void setConcatScreenMode(bool enable);
 
 Q_SIGNALS:
     void virtualScreensChanged();

--- a/src/plugin-display/operation/private/displaydbusproxy.cpp
+++ b/src/plugin-display/operation/private/displaydbusproxy.cpp
@@ -130,6 +130,11 @@ bool DisplayDBusProxy::hasChanged()
     return qvariant_cast<bool>(m_dBusDisplayInter->property("HasChanged"));
 }
 
+bool DisplayDBusProxy::isConcatScreenEnabled()
+{
+    return qvariant_cast<bool>(m_dBusDisplayInter->property("ConcatScreenEnabled"));
+}
+
 uint DisplayDBusProxy::maxBacklightBrightness()
 {
     return qvariant_cast<uint>(m_dBusDisplayInter->property("MaxBacklightBrightness"));
@@ -360,6 +365,13 @@ QDBusPendingReply<> DisplayDBusProxy::SetPrimary(const QString &in0)
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0);
     return m_dBusDisplayInter->asyncCallWithArgumentList(QStringLiteral("SetPrimary"), argumentList);
+}
+
+QDBusPendingReply<> DisplayDBusProxy::SetConcatScreen(bool enable)
+{
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(enable);
+    return m_dBusDisplayInter->asyncCallWithArgumentList(QStringLiteral("SetConcatScreen"), argumentList);
 }
 
 QDBusPendingReply<> DisplayDBusProxy::SwitchMode(uchar in0, const QString &in1)

--- a/src/plugin-display/operation/private/displaydbusproxy.h
+++ b/src/plugin-display/operation/private/displaydbusproxy.h
@@ -99,6 +99,10 @@ public:
     Q_PROPERTY(QString WallpaperURls READ wallpaperURls NOTIFY WallpaperURlsChanged FINAL)
     QString wallpaperURls() const;
 
+    // concat screen
+    Q_PROPERTY(bool ConcatScreenEnabled READ isConcatScreenEnabled NOTIFY ConcatScreenChanged FINAL)
+    bool isConcatScreenEnabled();
+
 private:
     void init();
 
@@ -126,6 +130,7 @@ public Q_SLOTS: // METHODS
     QDBusPendingReply<> SetMethodAdjustCCT(int in0);
     QDBusPendingReply<> SetPrimary(const QString &in0);
     QDBusPendingReply<> SwitchMode(uchar in0, const QString &in1);
+    QDBusPendingReply<> SetConcatScreen(bool enable);
     QDBusReply<bool> CanSetBrightnessSync(const QString &name);
     QDBusReply<bool> SupportSetColorTemperatureSync();
     // Appearance
@@ -168,6 +173,9 @@ Q_SIGNALS: // SIGNALS
     void AutoBrightnessEnabledChanged(bool value) const;
     void WallpaperURlsChanged(const QString &value) const;
     void WorkspaceSwitched(int oldIndex,int newIndex);
+
+    // concat screen
+    void ConcatScreenChanged(bool value) const;
 
 private:
     Dtk::Core::DDBusInterface *m_dBusDisplayInter;

--- a/src/plugin-display/operation/private/displaymodule_p.h
+++ b/src/plugin-display/operation/private/displaymodule_p.h
@@ -31,8 +31,7 @@ public:
     void updateDisplayMode();
     void updateMaxGlobalScale();
     void updateScreensFormRect();
-    void mergeToConcatScreen();
-    void resetConcatScreenMode();
+    void setConcatScreenMode(bool enable);
     void updateConcatScreenMode();
     DccScreen *primary() const;
     QList<DccScreen *> enabledScreens() const;

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -14,6 +14,7 @@
 #include <dconfig.h>
 
 #include <QDateTime>
+#include <QDBusPendingCallWatcher>
 #include <QDebug>
 #include <QFile>
 #include <QJsonDocument>
@@ -24,7 +25,6 @@
 Q_LOGGING_CATEGORY(DdcDisplayWorker, "dcc-display-worker")
 
 const QString DisplayInterface("org.deepin.dde.Display1");
-constexpr const char *const CONCAT_SCREEN_NAME = "DDE-CONCAT-SCREEN";
 static const QString EyeProtectionConfig = "/usr/share/dde-wloutput-daemon/eyeprotection.xml";
 
 Q_DECLARE_METATYPE(QList<QDBusObjectPath>)
@@ -73,6 +73,9 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
         });
         connect(m_displayInter, &DisplayDBusProxy::CustomColorTempTimePeriodChanged, model, &DisplayModel::setCustomColorTempTimePeriod);
         connect(m_displayInter, static_cast<void (DisplayDBusProxy::*)(const QString &) const>(&DisplayDBusProxy::PrimaryChanged), model, &DisplayModel::setPrimary);
+
+        // concat screen
+        connect(m_displayInter, &DisplayDBusProxy::ConcatScreenChanged, model, &DisplayModel::setIsConcatScreenMode);
 
         // display redSfit/autoLight
         connect(m_displayInter, &DisplayDBusProxy::HasAmbientLightSensorChanged, m_model, &DisplayModel::autoLightAdjustVaildChanged);
@@ -1273,43 +1276,25 @@ void DisplayWorker::setMonitorResolutionBySize(Monitor *mon, const int width, co
     }
 }
 
-void DisplayWorker::mergeToConcatScreen(const QStringList &outputs)
+void DisplayWorker::setConcatScreenMode(bool enable)
 {
     if (WQt::Utils::isTreeland()) {
         return;
     }
 
-    if (outputs.size() < 2) {
-        return;
-    }
-
-    QString outputsStr = outputs.join(",");
-    qCDebug(DdcDisplayWorker) << "[ConcatScreen] mergeToConcatScreen: xrandr --setmonitor" << CONCAT_SCREEN_NAME << "auto" << outputsStr;
-    QProcess p;
-    p.start("xrandr", { "--setmonitor", CONCAT_SCREEN_NAME, "auto", outputsStr });
-    p.waitForFinished(5000);
-    if (p.exitCode() != 0) {
-        qCWarning(DdcDisplayWorker) << "[ConcatScreen] mergeToConcatScreen failed:" << p.readAllStandardError();
-        return;
-    }
-    m_model->setIsConcatScreenMode(true);
-}
-
-void DisplayWorker::resetConcatScreenMode()
-{
-    if (WQt::Utils::isTreeland()) {
-        return;
-    }
-
-    QProcess p;
-    p.start("xrandr", { "--delmonitor", CONCAT_SCREEN_NAME });
-    p.waitForFinished(5000);
-    if (p.exitCode() != 0) {
-        qCWarning(DdcDisplayWorker) << "[ConcatScreen] delmonitor failed:" << p.readAllStandardError();
-        return;
-    }
-
-    m_model->setIsConcatScreenMode(false);
+    qCDebug(DdcDisplayWorker) << "[ConcatScreen] setConcatScreenMode" << enable;
+    QDBusPendingReply<> reply = m_displayInter->SetConcatScreen(enable);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, enable](QDBusPendingCallWatcher *w) {
+        QDBusPendingReply<> r = *w;
+        if (r.isError()) {
+            qCWarning(DdcDisplayWorker) << "[ConcatScreen] setConcatScreenMode failed:" << r.error().message();
+            m_model->setIsConcatScreenMode(m_displayInter->isConcatScreenEnabled());
+        } else {
+            m_model->setIsConcatScreenMode(enable);
+        }
+        w->deleteLater();
+    });
 }
 
 void DisplayWorker::updateConcatScreenMode()
@@ -1318,12 +1303,6 @@ void DisplayWorker::updateConcatScreenMode()
         return;
     }
 
-    QProcess p;
-    p.start("xrandr", { "--listmonitors" });
-    p.waitForFinished(3000);
-    if (p.exitCode() != 0) {
-        qCWarning(DdcDisplayWorker) << "[ConcatScreen] listmonitors failed:" << p.readAllStandardError();
-    }
-    QByteArray output = p.readAllStandardOutput();
-    m_model->setIsConcatScreenMode(output.contains(CONCAT_SCREEN_NAME));
+    qCDebug(DdcDisplayWorker) << "[ConcatScreen] updateConcatScreenMode via DBus property";
+    m_model->setIsConcatScreenMode(m_displayInter->isConcatScreenEnabled());
 }

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -13,7 +13,6 @@
 
 #include <QObject>
 #include <QTimer>
-#include <QProcess>
 
 #define GAMMA_SUPPORT false
 /*
@@ -70,8 +69,7 @@ public Q_SLOTS:
     void setCurrentFillMode(Monitor *mon, const QString fillMode);
     void setAutoBacklightEnabled(const bool value);
 
-    void mergeToConcatScreen(const QStringList &outputs);
-    void resetConcatScreenMode();
+    void setConcatScreenMode(bool enable);
     void updateConcatScreenMode();
 
     void backupConfig();

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -536,11 +536,7 @@ DccObject {
                         checked: dccData.isConcatScreenMode
                         enabled: root.screensFormRect || dccData.isConcatScreenMode
                         onCheckedChanged: {
-                            if (checked) {
-                                dccData.mergeToConcatScreen()
-                            } else {
-                                dccData.resetConcatScreenMode()
-                            }
+                            dccData.setConcatScreenMode(checked)
                         }
                     }
                 }


### PR DESCRIPTION
Add DBus method SetConcatScreen and manage RANDR Monitor via XCB/RANDR protocol directly. The daemon owns the concat screen lifecycle: auto cleanup on mode switch, hotplug, and layout changes.

新增 DBus 接口 SetConcatScreen，通过 XCB/RANDR 协议直接管理拼接。daemon 接管拼接生命周期：模式切换时自动清理，热插拔/布局变更时退出。

Log: 将跨屏拼接逻辑迁移至dde-daemon
PMS: BUG-363737
Influence: 1.开启跨屏拼接后，使用系统快捷键切换到其他多屏模式，能自动退出拼接；
	    2.控制中心切换多屏模式，开/关跨屏拼接，状态正确；
	    3.热插拔显示器、更改显示器坐标、自动退出拼接