### PR TITLE
chore: update changelog to 6.1.92

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+dde-control-center (6.1.92) unstable; urgency=medium
+
+  * fix(display): migrate concat screen management to daemon
+  * fix(dock): keep dock size slider responsive
+  * fix: request authorization for folder privacy permissions
+  * fix: fix region format dialog showing behind parent window
+  * i18n: Updates for project Deepin Desktop Environment (#3284)
+  * fix: add tap support for hover-only buttons
+  * fix: handle treeland restart crash and prevent double connections
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 11 Jun 2026 21:45:06 +0800
+
 dde-control-center (6.1.91) unstable; urgency=medium
 
   * fix: enable PIC for shared-utils on aarch64


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.92

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.92
- 目标分支: master

## Summary by Sourcery

Build:
- Bump debian/changelog entry to version 6.1.92 for the master branch.