### PR TITLE
chore: update changelog to 6.1.93

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+dde-control-center (6.1.93) unstable; urgency=medium
+
+  * feat: integrate deepin-security-loader for privileged service access
+
+ -- zhangkun <zhangkun2@uniontech.com>  Fri, 12 Jun 2026 09:22:53 +0800
+
 dde-control-center (6.1.92) unstable; urgency=medium
 
   * fix(display): migrate concat screen management to daemon


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.93

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.93
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump recorded package version in debian/changelog to 6.1.93.