### PR TITLE
fix(treeland): guard wallpaper output lifecycle

### DIFF
--- a/misc/dde-control-center-loader-wrapper
+++ b/misc/dde-control-center-loader-wrapper
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 # dde-control-center wrapper for deepin-security-loader
 # Launches control center through security loader to get authorization
 # for calling protected system services without polkit popup.

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -292,42 +292,49 @@ void DisplayWorker::updateWallpaperFromWayland()
         return;
 
     for (auto *output : m_reg->waylandOutputs()) {
+        if (!output || !output->get())
+            continue;
+
         auto *wp = wpMgr->getWallpaper(output->get());
         if (!wp)
             continue;
-        connect(wp, &WQt::Wallpaper::changed, this, [this, output](const QString &fileSource, uint32_t sourceType, uint32_t role) {
-            Q_UNUSED(sourceType);
-            Q_UNUSED(role);
-            for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
-                if (it.key()->name() == output->name()) {
-                    it.key()->setWallpaper(fileSource);
-                    break;
-                }
-            }
-        });
+        connect(wp, &WQt::Wallpaper::changed, this, &DisplayWorker::onWallpaperChanged, Qt::UniqueConnection);
     }
 }
 
 void DisplayWorker::onOutputWallpaperReady(WQt::Output *output)
 {
     auto *wpMgr = m_reg->wallpaperManager();
-    if (!wpMgr || !wpMgr->isActive())
+    if (!output || !output->get() || !wpMgr || !wpMgr->isActive())
         return;
 
     auto *wp = wpMgr->getWallpaper(output->get());
     if (wp) {
-        connect(wp, &WQt::Wallpaper::changed, this, [this, output, wp]() {
-            onWallpaperChanged(output, wp->fileSource(), wp->sourceType(), 0);
-        });
+        connect(wp, &WQt::Wallpaper::changed, this, &DisplayWorker::onWallpaperChanged, Qt::UniqueConnection);
     }
 }
 
-void DisplayWorker::onWallpaperChanged(WQt::Output *output, const QString &fileSource, uint32_t sourceType, uint32_t role)
+void DisplayWorker::onWallpaperChanged(const QString &fileSource, uint32_t sourceType, uint32_t role)
 {
     Q_UNUSED(sourceType);
     Q_UNUSED(role);
+    auto *wp = qobject_cast<WQt::Wallpaper *>(sender());
+    if (!wp || !wp->output() || !m_reg)
+        return;
+
+    QString outputName;
+    for (auto *output : m_reg->waylandOutputs()) {
+        if (output && output->get() == wp->output()) {
+            outputName = output->name();
+            break;
+        }
+    }
+
+    if (outputName.isEmpty())
+        return;
+
     for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
-        if (it.key()->name() == output->name()) {
+        if (it.key()->name() == outputName) {
             it.key()->setWallpaper(fileSource);
             break;
         }
@@ -1155,6 +1162,9 @@ void DisplayWorker::wlMonitorRemoved(WQt::OutputHead *head)
 
 void DisplayWorker::wlOutputAdded(WQt::Output *output)
 {
+    if (!output)
+        return;
+
     connect(output, &WQt::Output::done, this, &DisplayWorker::updateControl);
     connect(output, &WQt::Output::done, this, [this, output]() {
         onOutputWallpaperReady(output);
@@ -1163,8 +1173,9 @@ void DisplayWorker::wlOutputAdded(WQt::Output *output)
 
 void DisplayWorker::wlOutputRemoved(WQt::Output *output)
 {
-    Q_UNUSED(output);
-    // TODO:
+    auto *wpMgr = m_reg ? m_reg->wallpaperManager() : nullptr;
+    if (output && wpMgr)
+        wpMgr->removeWallpaper(output->get());
 }
 
 void DisplayWorker::updateControl()

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -90,7 +90,7 @@ private Q_SLOTS:
     void updateMonitorWallpaper(Monitor *mon);
     void updateWallpaperFromWayland();
     void onOutputWallpaperReady(WQt::Output *output);
-    void onWallpaperChanged(WQt::Output *output, const QString &fileSource, uint32_t sourceType, uint32_t role);
+    void onWallpaperChanged(const QString &fileSource, uint32_t sourceType, uint32_t role);
     void updateVirtualOutputs();
 
     void onBrightnessChanged(WQt::ColorControl *colorControl, double brightness);

--- a/src/plugin-display/wayland/libwayqt/Registry.cpp
+++ b/src/plugin-display/wayland/libwayqt/Registry.cpp
@@ -238,6 +238,7 @@ void WQt::Registry::handleRemove(uint32_t name)
     if (mOutputs.keys().contains(name)) {
         WQt::Output *output = mOutputs.take(name);
         emitOutput(output, false);
+        output->deleteLater();
     }
 }
 

--- a/src/plugin-display/wayland/libwayqt/WallpaperManager.cpp
+++ b/src/plugin-display/wayland/libwayqt/WallpaperManager.cpp
@@ -76,6 +76,10 @@ WQt::WallpaperManager::~WallpaperManager()
 
 WQt::Wallpaper *WQt::WallpaperManager::getWallpaper(wl_output *output)
 {
+    if (!output) {
+        return nullptr;
+    }
+
     void *key = reinterpret_cast<void *>(output);
     if (mWallpapers.contains(key)) {
         return mWallpapers.value(key);
@@ -92,4 +96,20 @@ WQt::Wallpaper *WQt::WallpaperManager::getWallpaper(wl_output *output)
     });
     mWallpapers.insert(key, wallpaper);
     return wallpaper;
+}
+
+void WQt::WallpaperManager::removeWallpaper(wl_output *output)
+{
+    if (!output) {
+        return;
+    }
+
+    void *key = reinterpret_cast<void *>(output);
+    auto *wallpaper = mWallpapers.take(key);
+    if (!wallpaper) {
+        return;
+    }
+
+    disconnect(wallpaper, &QObject::destroyed, this, nullptr);
+    wallpaper->deleteLater();
 }

--- a/src/plugin-display/wayland/libwayqt/WallpaperManager.h
+++ b/src/plugin-display/wayland/libwayqt/WallpaperManager.h
@@ -58,6 +58,7 @@ public:
     ~WallpaperManager() override;
 
     WQt::Wallpaper *getWallpaper(wl_output *output);
+    void removeWallpaper(wl_output *output);
 
 private:
     QMap<void *, WQt::Wallpaper *> mWallpapers;

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -355,17 +355,23 @@ void TreeLandWorker::setWallpaper(const QString &monitorName, const QString &url
     if (dest.isEmpty())
         return;
 
-    // Update wallpaper metadata
-    if (!m_wallpapers.contains(monitorName)) {
-        m_wallpapers.insert(monitorName, new WallpaperMetaData);
-    }
+    auto updateWallpaperMetaData = [monitorName, url, isDark](QMap<QString, WallpaperMetaData *> &wallpapers) {
+        if (!wallpapers.contains(monitorName)) {
+            wallpapers.insert(monitorName, new WallpaperMetaData);
+        }
 
-    auto meta_data = m_wallpapers.value(monitorName);
+        auto *metaData = wallpapers.value(monitorName);
+        if (metaData) {
+            metaData->isDark = isDark;
+            metaData->url = url;
+            metaData->monitorName = monitorName;
+        }
+    };
 
-    if (meta_data != nullptr) {
-        meta_data->isDark = isDark;
-        meta_data->url = url;
-        meta_data->monitorName = monitorName;
+    if (role == WallpaperContext::wallpaper_role_desktop) {
+        updateWallpaperMetaData(m_wallpapers);
+    } else if (role == WallpaperContext::wallpaper_role_lockscreen) {
+        updateWallpaperMetaData(m_lockWallpapers);
     }
 
     if (m_wallpaperManager && m_wallpaperManager->isActive()) {
@@ -534,6 +540,15 @@ void TreeLandWorker::active()
         delete m_wallpaperContexts.take(name);
         delete m_wallpapers.take(name);
         delete m_lockWallpapers.take(name);
+    });
+
+    connect(qApp, &QGuiApplication::screenAdded, this, [this](QScreen *screen) {
+        if (!screen || !m_wallpaperManager || !m_wallpaperManager->isActive()) {
+            return;
+        }
+
+        qCDebug(DdcPersonnalizationTreelandWorker) << "Screen added, initializing wallpaper context for:" << screen->name();
+        getOrCreateWallpaperContext(screen->name());
     });
 
     PersonalizationWorker::active();


### PR DESCRIPTION
1. Guard Wayland wallpaper updates against null and removed outputs.
2. Remove cached wallpaper contexts when outputs are unplugged.
3. Update personalization wallpaper metadata by desktop and lockscreen roles.
4. Initialize wallpaper contexts when new screens are added.

Log: Prevent invalid wallpaper output access and keep Treeland wallpaper metadata consistent.

fix(treeland): 保护壁纸输出生命周期

1. 防止 Wayland 壁纸更新访问空的或已移除的输出。
2. 屏幕拔出时清理缓存的壁纸上下文。
3. 按桌面和锁屏角色分别更新个性化壁纸元数据。
4. 新增屏幕时初始化对应的壁纸上下文。

Log: 避免无效壁纸输出访问，并保持 Treeland 壁纸元数据一致。
PMS: BUG-365765

## Summary by Sourcery

Guard wallpaper handling against invalid Wayland outputs and keep Treeland wallpaper state in sync with screen lifecycle and wallpaper roles.

Bug Fixes:
- Prevent wallpaper updates from accessing null or removed Wayland outputs by validating and guarding output references.
- Ensure cached Wayland wallpapers are removed when outputs are unplugged or destroyed to avoid stale references and leaks.

Enhancements:
- Track wallpapers by output name instead of raw output objects to decouple wallpaper updates from output lifetimes.
- Separate and update personalization wallpaper metadata for desktop and lockscreen roles.
- Initialize wallpaper contexts automatically when new screens are added to maintain consistent wallpaper behavior.