### PR TITLE
refactor: remove unused PersonalizationWallpaperContext class

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -28,7 +28,7 @@ Build-Depends:
  qt6-wayland-private-dev,
  qt6-wayland-dev-tools,
  wlr-protocols,
- treeland-protocols (>> 0.5.7),
+ treeland-protocols (>>0.5.8),
  systemd,
  libdareader-dev,
  libdeepin-pw-check-dev,

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -654,19 +654,6 @@ void PersonalizationAppearanceContext::treeland_personalization_appearance_conte
     m_model->setTitleBarHeight(height);
 }
 
-PersonalizationWallpaperContext::PersonalizationWallpaperContext(struct ::treeland_personalization_wallpaper_context_v1 *context)
-    : QWaylandClientExtensionTemplate<PersonalizationWallpaperContext>(1)
-    , QtWayland::treeland_personalization_wallpaper_context_v1(context)
-{
-
-}
-
-void PersonalizationWallpaperContext::treeland_personalization_wallpaper_context_v1_metadata(
-    const QString &metadata)
-{
-    Q_EMIT metadataChanged(metadata);
-}
-
 PersonalizationCursorContext::PersonalizationCursorContext(struct ::treeland_personalization_cursor_context_v1 *context, PersonalizationModel *model)
     : QWaylandClientExtensionTemplate<PersonalizationCursorContext>(1)
     , QtWayland::treeland_personalization_cursor_context_v1(context)

--- a/src/plugin-personalization/operation/treelandworker.h
+++ b/src/plugin-personalization/operation/treelandworker.h
@@ -24,7 +24,6 @@
 
 class PersonalizationManager;
 class PersonalizationAppearanceContext;
-class PersonalizationWallpaperContext;
 class PersonalizationCursorContext;
 class PersonalizationFontContext;
 class WallpaperManager;
@@ -172,20 +171,6 @@ signals:
 
 private:
     PersonalizationModel *m_model;
-};
-
-class PersonalizationWallpaperContext : public QWaylandClientExtensionTemplate<PersonalizationWallpaperContext>,
-                                        public QtWayland::treeland_personalization_wallpaper_context_v1
-{
-    Q_OBJECT
-public:
-    explicit PersonalizationWallpaperContext(struct ::treeland_personalization_wallpaper_context_v1 *context);
-
-Q_SIGNALS:
-    void metadataChanged(const QString &meta);
-
-protected:
-    void treeland_personalization_wallpaper_context_v1_metadata(const QString &metadata) override;
 };
 
 class PersonalizationCursorContext : public QWaylandClientExtensionTemplate<PersonalizationCursorContext>,


### PR DESCRIPTION
Remove the PersonalizationWallpaperContext class and its associated
metadata handling, as this wallpaper context functionality is no longer
needed. The class was previously used for receiving wallpaper metadata
from the compositor, but this feature has been deprecated in favor of
direct wallpaper management through the existing WallpaperManager.

Log: Removed unused wallpaper context functionality

Influence:
1. Verify wallpaper functionality still works correctly
2. Test wallpaper switching and metadata handling
3. Ensure no regressions in personalization settings

refactor: 移除未使用的 PersonalizationWallpaperContext 类

移除 PersonalizationWallpaperContext 类及其相关的元数据处理功能，因为该
壁纸上下文功能不再需要。该类之前用于从合成器接收壁纸元数据，但此功能已被
弃用，转而通过现有的 WallpaperManager 进行直接壁纸管理。

Log: 移除未使用的壁纸上下文功能

Influence:
1. 验证壁纸功能是否正常工作
2. 测试壁纸切换和元数据处理
3. 确保个性化设置没有回归问题
