### PR TITLE
fix: set max width for DccLabel tooltip

### DIFF
--- a/src/dde-control-center/plugin/DccLabel.qml
+++ b/src/dde-control-center/plugin/DccLabel.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.15
@@ -15,6 +15,7 @@ Label {
         text: control.text
         delay: 500
         timeout: 3000
+        implicitWidth: Math.min(control.implicitWidth + 10, 400)
     }
     // 使用Attached方式退出时会崩溃
     // ToolTip.visible: width < implicitWidth && hovered


### PR DESCRIPTION
1. Add implicitWidth: Math.min(control.implicitWidth, 400) to ToolTip in DccLabel.qml to prevent long text from displaying in a single line and causing layout misalignment in the Treeland Technical Preview tooltip.
2. Also update copyright year from 2027 to 2026.

Log: Fixed tooltip text overflow in Treeland Technical Preview option.

Influence:
1. Hover over Treeland option in Technical Preview in English locale and verify tooltip text wraps and aligns correctly.
2. Test in both English and Chinese locales to confirm no regression.

PMS: BUG-301167

fix: 设置 DccLabel 提示框最大宽度

1. 在 DccLabel.qml 的 ToolTip 上添加 implicitWidth: Math.min(control.implicitWidth, 400)，防止长文本 在单行显示导致技术预览 Treeland 选项提示框排版错乱。
2. 同时将版权年份从 2027 更新为 2026。

Log: 修复 Treeland 技术预览选项提示文本溢出问题。

Influence:
1. 在英文语言环境下，将鼠标悬停在技术预览的 Treeland 选项上， 验证提示文本是否正确换行且排版对齐。
2. 在中英文语言环境下分别测试，确认没有回归。