### PR TITLE
fix: release fingerprint claim after enrollment completion or failure

### DIFF
--- a/src/plugin-authentication/operation/charamangerworker.cpp
+++ b/src/plugin-authentication/operation/charamangerworker.cpp
@@ -377,6 +377,10 @@ void CharaMangerWorker::stopFingerEnroll(const QString &userName)
 {
     qDebug() << "stopEnroll";
     m_charaMangerInter->StopEnroll();
+}
+
+void CharaMangerWorker::releaseFingerClaim(const QString &userName)
+{
     auto callClaim = m_charaMangerInter->Claim(userName, false);
     callClaim.waitForFinished();
     if (callClaim.isError()) {

--- a/src/plugin-authentication/operation/charamangerworker.h
+++ b/src/plugin-authentication/operation/charamangerworker.h
@@ -79,6 +79,7 @@ public Q_SLOTS:
     void tryEnroll(const QString &name, const QString &thumb);
     void refreshFingerEnrollList(const QString &id);
     void stopFingerEnroll(const QString& userName);
+    void releaseFingerClaim(const QString& userName);
     void deleteFingerItem(const QString& userName, const QString& finger);
     void renameFingerItem(const QString& userName, const QString& finger, const QString& newName);
     void onDefaultDeviceChanged(const QString &device);

--- a/src/plugin-authentication/operation/fingerprintauthcontroller.cpp
+++ b/src/plugin-authentication/operation/fingerprintauthcontroller.cpp
@@ -161,6 +161,7 @@ void FingerprintAuthController::onFingerEnrollFailed(const QString &title, const
     setAddStage(CharaMangerModel::Fail);
     emit fingerTipsChanged();
     stopEnroll();
+    m_worker->releaseFingerClaim(m_model->userName());
 }
 
 void FingerprintAuthController::onFingerEnrollCompleted()
@@ -169,6 +170,7 @@ void FingerprintAuthController::onFingerEnrollCompleted()
     setAddStage(CharaMangerModel::Success);
     emit enrollCompleted();
     stopEnroll();
+    m_worker->releaseFingerClaim(m_model->userName());
 }
 
 void FingerprintAuthController::onFingerEnrollDisconnected()
@@ -178,6 +180,7 @@ void FingerprintAuthController::onFingerEnrollDisconnected()
     setAddStage(CharaMangerModel::Fail);
     emit fingerTipsChanged();
     stopEnroll();
+    m_worker->releaseFingerClaim(m_model->userName());
 }
 
 void FingerprintAuthController::onFingerLiftTimerTimeout()


### PR DESCRIPTION
1. Add new releaseFingerClaim method to CharaMangerWorker
2. Call releaseFingerClaim after enrollment success, failure, and disconnection
3. Ensure proper resource cleanup when fingerprint enrollment ends
4. Prevent fingerprint device from remaining locked after use

Log: Improved fingerprint enrollment reliability by releasing device claims properly

Influence:
1. Test fingerprint enrollment success scenario to verify claim is released
2. Test enrollment failure scenario to ensure proper cleanup
3. Test enrollment disconnection to confirm resource release
4. Verify no memory leaks or device locks after enrollment completion
5. Test multiple enrollment cycles to check consistent behavior
6. Validate system stability after repeated enrollment attempts

fix: 在指纹登记完成或失败后释放指纹声明

1. 向 CharaMangerWorker 添加新的 releaseFingerClaim 方法
2. 在登记成功、失败和断开连接后调用 releaseFingerClaim
3. 确保指纹登记结束时正确清理资源
4. 防止指纹设备在使用后保持锁定状态

Log: 通过正确释放设备声明来提高指纹登记可靠性

Influence:
1. 测试指纹登记成功场景，验证声明是否被释放
2. 测试登记失败场景，确保正确清理
3. 测试登记断开连接，确认资源释放
4. 验证登记完成后无内存泄漏或设备锁
5. 测试多次登记周期，检查行为一致性
6. 验证重复登记尝试后的系统稳定性

PMS: BUG-364881