### PR TITLE
fix: fingerprint enrollment dialog becomes unresponsive after losing …

### DIFF
--- a/src/plugin-authentication/operation/charamangerworker.cpp
+++ b/src/plugin-authentication/operation/charamangerworker.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -377,6 +377,10 @@ void CharaMangerWorker::stopFingerEnroll(const QString &userName)
 {
     qDebug() << "stopEnroll";
     m_charaMangerInter->StopEnroll();
+}
+
+void CharaMangerWorker::releaseFingerClaim(const QString &userName)
+{
     auto callClaim = m_charaMangerInter->Claim(userName, false);
     callClaim.waitForFinished();
     if (callClaim.isError()) {

--- a/src/plugin-authentication/operation/charamangerworker.h
+++ b/src/plugin-authentication/operation/charamangerworker.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -79,6 +79,7 @@ public Q_SLOTS:
     void tryEnroll(const QString &name, const QString &thumb);
     void refreshFingerEnrollList(const QString &id);
     void stopFingerEnroll(const QString& userName);
+    void releaseFingerClaim(const QString& userName);
     void deleteFingerItem(const QString& userName, const QString& finger);
     void renameFingerItem(const QString& userName, const QString& finger, const QString& newName);
     void onDefaultDeviceChanged(const QString &device);

--- a/src/plugin-authentication/operation/fingerprintauthcontroller.cpp
+++ b/src/plugin-authentication/operation/fingerprintauthcontroller.cpp
@@ -161,6 +161,7 @@ void FingerprintAuthController::onFingerEnrollFailed(const QString &title, const
     setAddStage(CharaMangerModel::Fail);
     emit fingerTipsChanged();
     stopEnroll();
+    m_worker->releaseFingerClaim(m_model->userName());
 }
 
 void FingerprintAuthController::onFingerEnrollCompleted()
@@ -169,6 +170,7 @@ void FingerprintAuthController::onFingerEnrollCompleted()
     setAddStage(CharaMangerModel::Success);
     emit enrollCompleted();
     stopEnroll();
+    m_worker->releaseFingerClaim(m_model->userName());
 }
 
 void FingerprintAuthController::onFingerEnrollDisconnected()
@@ -178,6 +180,7 @@ void FingerprintAuthController::onFingerEnrollDisconnected()
     setAddStage(CharaMangerModel::Fail);
     emit fingerTipsChanged();
     stopEnroll();
+    m_worker->releaseFingerClaim(m_model->userName());
 }
 
 void FingerprintAuthController::onFingerLiftTimerTimeout()


### PR DESCRIPTION
…focus

Root cause:
It's a timing/race condition. After stopEnroll(), Claim(false) was called immediately, causing DA to release the fingerprint device. However, the EnrollStatus state update from DA arrives after the device is released. Since the device is already released, DA discards the pending state change and does not emit the signal. As a result, the control center never receives the state update, leaving the UI stuck in Processing state with no error message or retry option.

Changes:
1. Move Claim(false) from stopFingerEnroll() to signal handlers (onFingerEnrollFailed, onFingerEnrollCompleted, onFingerEnrollDisconnected), ensuring it is called only after DA's state change signal is received
2. Add releaseFingerClaim() to CharaMangerWorker for device claim release after enrollment ends
3. Add Suspended state to represent enrollment interrupted by focus loss, showing grayed icon and retry option
4. Reset addStage to StartState when dialog is closed

fix: 指纹录入界面失去焦点后不可操作

问题根因：
这是一个时序/竞态条件问题。stopEnroll() 之后立即调用了 Claim(false)，
导致 DA 立即释放指纹设备。但 DA 的 EnrollStatus 状态更新比设备释放
晚到达，由于设备已释放，DA 丢弃了该状态变更，不会发出状态变更信号。
因此控制中心收不到 DA 的状态更新，界面停留在 Processing 状态，没有
错误信息也没有重试选项。

修改内容：
1. 将 Claim(false) 从 stopFingerEnroll() 移至信号回调 (onFingerEnrollFailed、onFingerEnrollCompleted、 onFingerEnrollDisconnected) 中，确保在收到 DA 状态变更信号后 才释放设备声明
2. 新增 releaseFingerClaim() 方法，在录入结束后释放设备声明
3. 新增 Suspended 状态表示焦点中断的录入，显示置灰图标和重试选项
4. 关闭对话框时重置 addStage 为 StartState

PMS: BUG-364881