### PR TITLE
chore: bump version to 6.1.94

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-control-center (6.1.94) unstable; urgency=medium
+
+  * fix: set max width for DccLabel tooltip
+  * fix: use layer-shell for screen indicator on wayland
+  * refactor: remove unused PersonalizationWallpaperContext class
+  * fix(personalization): fix treeland theme switching logic
+  * fix(treeland): guard wallpaper output lifecycle
+
+ -- YeShanShan <yeshanshan@uniontech.com>  Wed, 17 Jun 2026 13:23:25 +0800
+
 dde-control-center (6.1.93) unstable; urgency=medium
 
   * feat: integrate deepin-security-loader for privileged service access


### PR DESCRIPTION
update changelog to 6.1.94

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 6.1.94.