### PR TITLE
fix(accounts): fix IME input and highlight color in password field

### DIFF
--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -509,14 +509,18 @@ ColumnLayout {
                 property bool hasErrorBorder: false
                 // Cache the normal focus color so we can restore it.
                 property color normalHighlight: "transparent"
-                Component.onCompleted: normalHighlight = palette.highlight
-                palette.highlight: (hasErrorBorder || showAlert) ? "#FF5736" : normalHighlight
+                Component.onCompleted: {
+                    normalHighlight = palette.highlight
+                    palette.highlight = Qt.binding(function() {
+                        return ((hasErrorBorder || showAlert) ? "#FF5736" : normalHighlight)
+                    })
+                }
                 topPadding: 0
                 bottomPadding: 0
                 font: D.DTK.fontManager.t7
                 canCopy: false
                 canCut: false
-                inputMethodHints: Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase
+                inputMethodHints: echoButtonVisible ? (Qt.ImhHiddenText | Qt.ImhNoPredictiveText | Qt.ImhNoAutoUppercase) : Qt.ImhNone
                 verticalAlignment: TextInput.AlignVCenter
                 echoMode: echoButtonVisible ? TextInput.Password :  TextInput.Normal
                 alertDuration: 3000


### PR DESCRIPTION
1. Fix normalHighlight initialization timing to avoid wrong color flash
2. Conditionally apply password input method hints based on echo state
3. Allow IME input (e.g. Chinese) when password is shown as plain text

Log: Fix Chinese IME input not working in password field when PIN is visible

fix(accounts): 修复密码框输入法和高亮颜色问题

1. 修复 normalHighlight 初始化时机，避免颜色闪烁
2. 根据密码可见状态条件应用输入法提示
3. 明文显示时允许输入法（如中文）正常输入

Log: 修复密码明文显示时无法使用中文输入法的问题
PMS: BUG-366507

## Summary by Sourcery

Fix password field behavior for highlight color and input method handling when toggling visibility.

Bug Fixes:
- Prevent incorrect highlight color flash in the password field by initializing the normal highlight color immediately.
- Allow IME text input (e.g. Chinese) when the password is shown as plain text instead of being treated as hidden text.
- Apply password input method hints only when the password is masked, avoiding unnecessary restrictions when it is visible.