### PR TITLE
fix: move fallback timer stop to after page show completes

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -796,7 +796,7 @@ void DccManager::waitShowPage(const QString &url, const QDBusMessage message)
 {
     qCInfo(dccLog()) << "show page:" << url;
     clearShowParam();
-    m_showFallbackTimer->stop();
+
     if (m_plugins->isDeleting()) {
         return;
     }
@@ -882,7 +882,6 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     if (m_plugins->isDeleting() || !obj) {
         return;
     }
-    m_showFallbackTimer->stop();
     qCInfo(dccLog) << "ShowPage:" << obj << " have cmd:" << !cmd.isEmpty();
     // 禁用首页
     if (obj == m_root) {
@@ -991,6 +990,8 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
         Q_EMIT currentObjectsChanged(m_currentObjects);
     if (triggeredObjectsUpdated)
         Q_EMIT triggeredObjectsChanged(m_triggeredObjects);
+
+    m_showFallbackTimer->stop();
 }
 
 QSet<QString> findAddItems(QSet<QString> *oldSet, QSet<QString> *newSet)


### PR DESCRIPTION
1. Remove m_showFallbackTimer->stop() from waitShowPage() and doShowPage() entry, move it to doShowPage() after all return statements so the timer is only stopped when the page has successfully been shown.
2. This prevents the fallback mechanism from being interrupted when the user quickly clicks the control center icon after logout, fixing the issue where the control center fails to open.

Log: Fixed control center failing to open after quick click post-logout.

Influence:
1. Logout and quickly click the control center icon on the taskbar repeatedly to verify it opens successfully each time.
2. Test the same scenario on both X11 and Wayland sessions.

PMS: BUG-366579

fix: 将 fallback 定时器停止移至页面展示完成后

1. 从 waitShowPage() 和 doShowPage() 开头移除 m_showFallbackTimer->stop()，将其移至 doShowPage() 所有 return 语句之后，确保只有在页面成功展示后才停止定时器。
2. 这防止了在快速点击任务栏控制中心图标后，fallback 机制被提前打断， 解决了注销后控制中心打开失败的问题。

Log: 修复注销后快速点击控制中心图标打开失败的问题。

Influence:
1. 注销后快速连续点击任务栏上的控制中心图标，验证每次都能 正常打开。
2. 分别在 X11 和 Wayland 会话下测试上述场景。

## Summary by Sourcery

Bug Fixes:
- Fix control center failing to open when the control center icon is clicked quickly after logout by deferring fallback timer shutdown.