### PR TITLE
fix(personalization): remove all files filter from wallpaper dialog

### DIFF
--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -225,7 +225,7 @@ DccObject {
             FileDialog {
                 id: customWallpaperFileDialog
                 title: "Choose an Image File"
-                nameFilters: ["Image files (*.png *.jpg *.jpeg *.bmp *.tiff)", "All files (*)"]
+                nameFilters: ["Image files (*.png *.jpg *.jpeg *.bmp *.tiff)"]
                 fileMode: FileDialog.OpenFile
                 onAccepted: {
                     dccData.worker.addCustomWallpaper(customWallpaperFileDialog.selectedFile)


### PR DESCRIPTION
1. Remove "All files (*)" option from wallpaper file dialog
2. Only allow image file types to be selected (*.png, *.jpg, etc.)
3. Prevent users from accidentally selecting non-image files

Log: Remove "All files" filter from wallpaper file chooser dialog

fix(personalization): 移除壁纸对话框的全部文件筛选项

1. 移除壁纸文件对话框中的"所有文件"选项
2. 仅允许选择图片文件类型（*.png, *.jpg 等）
3. 防止用户意外选择非图片文件

Log: 移除壁纸文件选择对话框中的"全部文件"筛选项

## Summary by Sourcery

Bug Fixes:
- Prevent selecting non-image files when choosing a custom wallpaper by limiting the file dialog filter to image file types only.