### PR TITLE
chore: update changelog to 6.1.95

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+dde-control-center (6.1.95) unstable; urgency=medium
+
+  * fix: fingerprint enrollment dialog becomes unresponsive after losing
+    focus
+  * fix(personalization): remove all files filter from wallpaper dialog
+  * fix: move fallback timer stop to after page show completes
+  * fix(accounts): fix password field binding and input hints
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:28:20 +0800
+
 dde-control-center (6.1.94) unstable; urgency=medium
 
   * fix: set max width for DccLabel tooltip


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 6.1.95

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 6.1.95
- 目标分支: master

## Summary by Sourcery

Documentation:
- Refresh debian/changelog entries to document version 6.1.95.