### PR TITLE
fix(authentication): improve name editor layout to fill available width

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -146,9 +146,11 @@ DccObject {
                             id: nameEditor
                             property int maxLength: 15
                             Layout.leftMargin: 10
-                            Layout.minimumWidth: contentWidth + leftPadding + rightPadding
-                            Layout.maximumWidth: 200
-                            implicitHeight: DS.Style.itemDelegate.height
+                            Layout.rightMargin: 10
+                            Layout.fillWidth: true
+                            implicitHeight: 30
+                            Layout.topMargin: 5
+                            Layout.bottomMargin: 5
                             horizontalAlignment: TextInput.AlignLeft
                             text: modelData
                             readOnly: true
@@ -157,7 +159,7 @@ DccObject {
                             background: D.EditPanel {
                                 id: nameEditPanel
                                 control: nameEditor
-                                showBorder: false
+                                showBorder: nameEditor.activeFocus && !nameEditor.readOnly
                                 alertDuration: 3000
                                 backgroundColor: D.Palette {
                                     normal: Qt.rgba(1, 1, 1, 0)
@@ -255,9 +257,6 @@ DccObject {
                             }
                         }
 
-                        Item {
-                            Layout.fillWidth: true
-                        }
                         D.ActionButton {
                             id: editButton
                             visible: hoverHandler.hovered || layout.showActions


### PR DESCRIPTION
Replace fixed maximum width with fillWidth for the name editor input, and remove redundant spacer item before edit button.

修复用户名输入框的布局方式，使用 fillWidth 自适应填充
替代固定的最大宽度限制，并移除编辑按钮前冗余的占位元素。

Log: 修复认证模块用户名输入框布局，支持自适应宽度
PMS: BUG-365807
Influence: 在控制中心认证模块中编辑用户名时，输入框将自适应填充可用宽度，不再局限于最大200px