### PR TITLE
fix: hide window instead of quitting when closing control center

### DIFF
--- a/src/dde-control-center/controlcenterdbusadaptor.cpp
+++ b/src/dde-control-center/controlcenterdbusadaptor.cpp
@@ -141,15 +141,20 @@ void ControlCenterDBusAdaptor::updateRect()
 DBusControlCenterGrandSearchService::DBusControlCenterGrandSearchService(DccManager *parent)
     : QDBusAbstractAdaptor(parent)
     , m_autoExitTimer(new QTimer(this))
+    , m_hasEverShown(false)
 {
     m_autoExitTimer->setInterval(10000);
     m_autoExitTimer->setSingleShot(true);
     connect(m_autoExitTimer, &QTimer::timeout, this, [this]() {
-        // 当主界面show出来之后不再执行自动退出
-        if (!this->parent()->mainWindow()->isVisible())
+        if (!m_hasEverShown && !this->parent()->mainWindow()->isVisible())
             QCoreApplication::quit();
     });
     m_autoExitTimer->start();
+    connect(this->parent()->mainWindow(), &QWindow::visibleChanged, this, [this](bool visible) {
+        if (visible) {
+            m_hasEverShown = true;
+        }
+    });
 }
 
 DBusControlCenterGrandSearchService::~DBusControlCenterGrandSearchService() { }

--- a/src/dde-control-center/controlcenterdbusadaptor.h
+++ b/src/dde-control-center/controlcenterdbusadaptor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
@@ -75,7 +75,9 @@ public Q_SLOTS: // METHODS
 
 private:
     QTimer *m_autoExitTimer;
+    bool m_hasEverShown = false;
     QString m_jsonCache; // 缓存下对重复请求不处理(规避全局搜索会调两次Search)
 };
 
 } // namespace dccV25
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.

--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -29,10 +29,9 @@ D.ApplicationWindow {
     color: "transparent"
     D.DWindow.enabled: true
     onClosing: {
-        Qt.callLater(function () {
-            console.info("DccWindow closed")
-            Qt.quit()
-        })
+        close.accepted = false
+        DccApp.mainWindow().hide()
+        console.info("DccWindow hidden")
     }
     MouseArea {
         anchors.fill: parent


### PR DESCRIPTION
When the control center window is closed, hide it instead of calling Qt.quit() so the D-Bus service stays registered. This allows the update notification's "View" button to reopen the control center.

Also fix DBusControlCenterGrandSearchService's auto-exit timer to not kill the process after the window has been shown at least once, using a m_hasEverShown flag set via QWindow::visibleChanged signal.

PMS: BUG-253878