### PR TITLE
fix(desktop): add trailing semicolon to Categories field

### DIFF
--- a/misc/org.deepin.dde.control-center.desktop
+++ b/misc/org.deepin.dde.control-center.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Categories=Application;System;Settings
+Categories=Application;System;Settings;
 Comment=Deepin Desktop Environment Control Center
 Exec=/usr/bin/dde-control-center --show %f
 GenericName=Control Center


### PR DESCRIPTION
Add trailing semicolon to the Categories key in the desktop entry file to comply with the freedesktop.org Desktop Entry Specification.

修复 desktop 文件 Categories 字段末尾缺少分号的问题，
使其符合 freedesktop.org 桌面项规范。

Log: 修复 desktop 文件 Categories 字段缺少末尾分号
PMS: BUG-366913
Influence: 修复后桌面项文件符合 freedesktop.org 规范，确保应用在桌面菜单中正确分类显示。

## Summary by Sourcery

Bug Fixes:
- Add the missing trailing semicolon to the Categories key in the desktop entry file so applications are correctly categorized in desktop menus.