### PR TITLE
fix: handle setTimezone failure by updating model with current zone

### DIFF
--- a/src/plugin-datetime/operation/datetimeworker.cpp
+++ b/src/plugin-datetime/operation/datetimeworker.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "datetimeworker.h"
@@ -175,7 +175,15 @@ void DatetimeWorker::setTimezone(const QString &timezone)
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, timezone, isNeedUpdateProp](QDBusPendingCallWatcher *w) {
         QDBusPendingReply<> reply = *w;
         if (reply.isError()) {
-            qCWarning(DdcDateTimeWorkder) << "SetTimezone failed:" << reply.error().message();
+            qCWarning(DdcDateTimeWorkder) << "SetTimezone failed:" << reply.error().message()
+                                        << "timezone:" << timezone;
+
+            ZoneInfo actualZoneInfo = GetZoneInfo(m_timedateInter->timezone());
+            if (!actualZoneInfo.getZoneName().isEmpty()) {
+                m_model->setCurrentUseTimeZone(actualZoneInfo);
+                Q_EMIT m_model->currentSystemTimeZoneChanged(actualZoneInfo);
+            }
+            w->deleteLater();
             return;
         }
 

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -457,6 +457,7 @@ DccObject {
                                 onCheckedChanged: {
                                     if (checked && model.zoneId != systemTimezoneItem.saveZoneId) {
                                         let zoneId = model.zoneId
+                                        systemTimezoneItem.saveZoneId = zoneId
                                         dccData.setSystemTimeZone(zoneId)
                                         timezoneWindow.close()
                                     }


### PR DESCRIPTION
1. Added detailed error logging including the attempted timezone value
2. On timezone setting failure, retrieve and display the actual current timezone info
3. Prevent data inconsistency between the UI and system timezone after a failed operation
4. Fixed a bug in QML where the saveZoneId was not updated when clicking a zone item, causing incorrect state tracking
5. Ensure the model emits proper signals to update UI components when timezone setting fails

Log: Fixed timezone setting failure handling to prevent UI state inconsistency

Influence:
1. Test setting an invalid timezone and verify the UI reverts to the actual system timezone
2. Test timezone setting failures with network/dbus errors and confirm proper error logging
3. Verify that clicking a timezone item correctly updates saveZoneId before applying
4. Ensure UI displays the correct current timezone after a failed operation
5. Test multiple rapid timezone changes and verify consistent state

fix: 处理设置时区失败时通过当前时区更新模型

1. 增强错误日志，包含失败的时区信息
2. 设置时区失败时获取并显示实际当前时区信息
3. 防止UI与系统时区之间因设置失败导致数据不一致
4. 修复QML中点击时区项时未更新saveZoneId导致状态跟踪错误的问题
5. 确保模型在时区设置失败时发出正确信号更新UI组件

Log: 修复时区设置失败导致UI状态不一致的问题

Influence:
1. 测试设置无效时区，验证UI回退到系统实际时区
2. 测试网络/dbus错误导致时区设置失败，确认错误日志正确输出
3. 验证点击时区项时在应用前正确更新saveZoneId
4. 确保设置失败后UI显示正确的当前时区
5. 测试多次快速切换时区，验证状态一致性

PMS: BUG-366077

## Summary by Sourcery

Improve robustness of timezone setting by syncing the model and UI with the actual system timezone when applying a new timezone fails.

Bug Fixes:
- Log the attempted timezone on DBus timezone setting errors and update the model with the current system timezone to avoid UI desynchronization.
- Ensure the QML timezone selection updates the saved zone identifier when clicking an item so subsequent operations track the correct selection.

Enhancements:
- Emit model signals after recovering the current system timezone so dependent UI components reflect the accurate timezone state.