### PR TITLE
fix(sound): improve bluetooth audio mode switching debounce mechanism

### DIFF
--- a/src/plugin-sound/operation/sounddbusproxy.cpp
+++ b/src/plugin-sound/operation/sounddbusproxy.cpp
@@ -263,6 +263,14 @@ uint SoundDBusProxy::cardSink()
     return 0;
 }
 
+QString SoundDBusProxy::nameSink()
+{
+    if (m_defaultSink) {
+        return qvariant_cast<QString>(m_defaultSink->property("NameSink"));
+    }
+    return QString();
+}
+
 void SoundDBusProxy::setSourceDevicePath(const QString &path)
 {
     if (m_defaultSource) {

--- a/src/plugin-sound/operation/sounddbusproxy.h
+++ b/src/plugin-sound/operation/sounddbusproxy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef SOUNDDBUSPROXY_H
@@ -111,6 +111,7 @@ public:
     double volumeSink();
     Q_PROPERTY(AudioPort ActivePortSink READ activePortSink NOTIFY ActivePortSinkChanged)
     AudioPort activePortSink();
+    QString nameSink();
     // Source
     Q_PROPERTY(bool MuteSource READ muteSource NOTIFY MuteSourceChanged)
     bool muteSource();

--- a/src/plugin-sound/operation/soundmodel.cpp
+++ b/src/plugin-sound/operation/soundmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "soundmodel.h"
@@ -131,7 +131,11 @@ void SoundModel::updatePortCombo()
     }
 
     setInPutPortCombo(inPutPortCombo);
-    setOutPutPortCombo(outPutPortCombo);
+
+    // 防抖期间跳过Output Device列表更新，已记录的值保持不变
+    if (!m_debounceOutputDeviceList) {
+        setOutPutPortCombo(outPutPortCombo);
+    }
 }
 
 int SoundModel::inPutPortComboIndex() const
@@ -167,8 +171,13 @@ int SoundModel::outPutPortComboIndex() const
 
 void SoundModel::setOutPutPortComboIndex(int newOutPutPortComboIndex)
 {
+    // 防抖期间跳过索引更新，防止闪烁
+    if (m_debounceOutputDeviceList) {
+        return;
+    }
     if (newOutPutPortComboIndex < 0 || m_outPutPortComboIndex == newOutPutPortComboIndex)
         return;
+
     m_outPutPortComboIndex = newOutPutPortComboIndex;
     emit outPutPortComboIndexChanged();
 }
@@ -216,6 +225,10 @@ void SoundModel::setMicrophoneOn(bool microphoneOn)
 
 void SoundModel::setSpeakerBalance(double speakerBalance)
 {
+    // 防抖期间跳过balance更新，防止闪烁
+    if (m_debounceOutputDeviceList) {
+        return;
+    }
     if (!qFuzzyCompare(speakerBalance, m_speakerBalance)) {
 
 
@@ -256,11 +269,13 @@ void SoundModel::addPort(Port *port)
         if (port->direction() == Port::Out) {
             m_outputPorts.append(port);
             setOutPutCount(static_cast<int>(m_outputPorts.count()));
-            if (port->isEnabled()) {
-                m_outPutPortCombo.append(port->name() + "(" + port->cardName() + ")");
+            // 防抖期间不更新UI可见数据，防止闪烁
+            if (!m_debounceOutputDeviceList) {
+                if (port->isEnabled()) {
+                    m_outPutPortCombo.append(port->name() + "(" + port->cardName() + ")");
+                }
+                m_soundOutputDeviceModel->addData(port);
             }
-
-            m_soundOutputDeviceModel->addData(port);
         } else {
             m_inputPorts.append(port);
             setInPutPortCount(static_cast<int>(m_inputPorts.count()));
@@ -286,10 +301,11 @@ void SoundModel::removePort(const QString &portId, const uint &cardId)
         if (port->direction() == Port::Out) {
             m_outputPorts.removeOne(port);
             setOutPutCount(static_cast<int>(m_outputPorts.count()));
-            m_outPutPortCombo.removeOne(port->name() + "(" + port->cardName() + ")");
-
-            m_soundOutputDeviceModel->removeData(port);
-
+            // 防抖期间不更新UI可见数据，防止闪烁
+            if (!m_debounceOutputDeviceList) {
+                m_outPutPortCombo.removeOne(port->name() + "(" + port->cardName() + ")");
+                m_soundOutputDeviceModel->removeData(port);
+            }
         } else {
             m_inputPorts.removeOne(port);
             setInPutPortCount(static_cast<int>(m_inputPorts.count()));
@@ -467,6 +483,10 @@ void SoundModel::setIncreaseVolume(bool value)
 
 void SoundModel::setBluetoothAudioModeOpts(const QStringList &modes)
 {
+    // 防抖期间跳过Mode选项列表更新，防止闪烁
+    if (m_debounceOutputDeviceList) {
+        return;
+    }
     if (modes != m_bluetoothModeOpts) {
         m_bluetoothModeOpts = modes;
         Q_EMIT bluetoothModeOptsChanged(modes);
@@ -611,6 +631,10 @@ bool SoundModel::showBluetoothMode() const
 
 void SoundModel::setShowBluetoothMode(bool newShowBluetoothMode)
 {
+    // 防抖期间跳过Mode可见性更新，防止Mode选项消失
+    if (m_debounceOutputDeviceList) {
+        return;
+    }
     if (m_showBluetoothMode == newShowBluetoothMode)
         return;
     m_showBluetoothMode = newShowBluetoothMode;
@@ -711,6 +735,16 @@ void SoundModel::setAudioServer(const QString &audioServer)
 
 void SoundModel::setOutPutPortCombo(const QStringList& outPutPort)
 {
+    // 防抖期间跳过Output Device列表更新，防止闪烁
+    if (m_debounceOutputDeviceList) {
+        return;
+    }
+
+    // 只在内容真正变化时才触发信号，避免冗余更新
+    if (m_outPutPortCombo == outPutPort) {
+        return;
+    }
+
     m_outPutPortCombo = outPutPort;
     Q_EMIT outPutPortComboChanged(m_outPutPortCombo);
 }
@@ -732,5 +766,13 @@ void SoundModel::setShowInputBluetoothMode(bool newShowInputBluetoothMode)
         return;
     m_showInputBluetoothMode = newShowInputBluetoothMode;
     emit showInputBluetoothModeChanged();
+}
+
+void SoundModel::setDebounceOutputDeviceList(bool debounce)
+{
+    if (m_debounceOutputDeviceList == debounce)
+        return;
+    m_debounceOutputDeviceList = debounce;
+    emit debounceOutputDeviceListChanged();
 }
 

--- a/src/plugin-sound/operation/soundmodel.h
+++ b/src/plugin-sound/operation/soundmodel.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef DCC_SOUND_SOUNDMODEL_H
@@ -216,6 +216,10 @@ public:
     bool showInputBluetoothMode() const;
     void setShowInputBluetoothMode(bool newShowInputBluetoothMode);
 
+    // 防抖：Mode切换期间阻止Output Device列表更新
+    void setDebounceOutputDeviceList(bool debounce);
+    bool debounceOutputDeviceList() const { return m_debounceOutputDeviceList; }
+
 private:
 
 
@@ -281,6 +285,8 @@ Q_SIGNALS:
 
     void showInputBluetoothModeChanged();
 
+    void debounceOutputDeviceListChanged();
+
 private:
     QString m_audioServer;     // 当前使用音频框架
     bool m_audioServerStatus{true};  // 设置音频时的状态
@@ -339,6 +345,7 @@ private:
     bool m_audioMono;
     bool m_showBluetoothMode;
     bool m_showInputBluetoothMode;
+    bool m_debounceOutputDeviceList{false};
 };
 
 #endif // DCC_SOUND_SOUNDMODEL_H

--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -6,6 +6,7 @@
 #include <DGuiApplicationHelper>
 
 #include <QAudioDevice>
+#include <QDateTime>
 #include <QDebug>
 #include <QJsonArray>
 #include <QJsonDocument>
@@ -45,6 +46,9 @@ SoundWorker::SoundWorker(SoundModel *model, QObject *parent)
     m_waitInputReceiptTimer->setSingleShot(true);
     m_waitOutputReceiptTimer->setSingleShot(true);
 
+    m_debounceChangeModeTimer = new QTimer(this);
+    m_debounceChangeModeTimer->setSingleShot(true);
+
     updatePlayAniIconPath();
 
     initConnect();
@@ -59,6 +63,7 @@ void SoundWorker::initConnect()
     connect(m_model, &SoundModel::bluetoothModeChanged, this, &SoundWorker::changeOutputDeviceComboxStatus);
 
     connect(m_soundDBusInter, &SoundDBusProxy::DefaultSinkChanged, m_model, &SoundModel::setDefaultSink);
+    connect(m_soundDBusInter, &SoundDBusProxy::DefaultSinkChanged, this, &SoundWorker::onDefaultSinkChangedForDebounce);
     connect(m_soundDBusInter, &SoundDBusProxy::DefaultSourceChanged, m_model, &SoundModel::setDefaultSource);
     connect(m_soundDBusInter, &SoundDBusProxy::MaxUIVolumeChanged, m_model, &SoundModel::setMaxUIVolume);
     connect(m_soundDBusInter, &SoundDBusProxy::IncreaseVolumeChanged, m_model, &SoundModel::setIncreaseVolume);
@@ -88,6 +93,8 @@ void SoundWorker::initConnect()
 
     connect(Dtk::Gui::DGuiApplicationHelper::instance(), &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
         this, &SoundWorker::updatePlayAniIconPath);
+
+    connect(m_debounceChangeModeTimer, &QTimer::timeout, this, &SoundWorker::onBluetoothModeDebounceTimeout);
 }
 
 void SoundWorker::activate()
@@ -309,6 +316,17 @@ void SoundWorker::stopSoundEffectPlayback()
 
 void SoundWorker::setBluetoothMode(const QString &mode)
 {
+    // 记录期望的输出设备Name
+    m_expectedSinkName = m_soundDBusInter->nameSink();
+
+    // 停止可能正在运行的其他定时器，避免干扰防抖
+    m_waitOutputReceiptTimer->stop();
+
+    // 启动防抖：阻止Output Device列表更新，禁用相关控件
+    m_model->setDebounceOutputDeviceList(true);
+    m_model->setOutPutPortComboEnable(false);
+    m_debounceChangeModeTimer->start(1500);  // 蓝牙Mode切换需要更长时间
+
     m_soundDBusInter->SetBluetoothAudioMode(mode);
 }
 
@@ -438,9 +456,15 @@ void SoundWorker::cardsChanged(const QString &cards)
         }
     }
 
-    m_model->updatePortCombo();
-    m_model->updateAllDeviceModel();
-    m_model->updateActiveComboIndex();
+    // 提取公共调用，简化分支逻辑
+    m_model->updatePortCombo();  // output部分已在内部被防抖跳过
+
+    // 防抖期间跳过Output Device相关UI更新，防止闪烁
+    // 内部port数据仍然保持准确，UI延迟到防抖超时或匹配到期望设备后恢复
+    if (!m_model->debounceOutputDeviceList()) {
+        m_model->updateAllDeviceModel();
+        m_model->updateActiveComboIndex();
+    }
 }
 
 void SoundWorker::activeSinkPortChanged(const AudioPort &activeSinkPort)
@@ -578,8 +602,44 @@ void SoundWorker::updatePlayAniIconPath()
     m_playAniIconPath = QString("qrc:/icons/deepin/builtin/icons/%1/volume_sound_wave_ani.webp").arg(themeTypeStr);
 }
 
+void SoundWorker::onDefaultSinkChangedForDebounce(const QDBusObjectPath &)
+{
+    if (!m_model->debounceOutputDeviceList() || !m_debounceChangeModeTimer->isActive()) {
+        return;
+    }
+
+    QString currentSinkName = m_soundDBusInter->nameSink();
+
+    // 如果切换到的设备就是期望的设备，提前结束防抖
+    if (currentSinkName == m_expectedSinkName && !m_expectedSinkName.isEmpty()) {
+        m_debounceChangeModeTimer->stop();
+        onBluetoothModeDebounceTimeout();
+    } else {
+        // 设备仍在切换中，重启定时器
+        m_debounceChangeModeTimer->start(1500);
+    }
+}
+
+void SoundWorker::onBluetoothModeDebounceTimeout()
+{
+    // 停止防抖期间启动的延迟定时器，防止它们超时后触发更新
+    m_waitOutputReceiptTimer->stop();
+
+    m_model->setDebounceOutputDeviceList(false);
+
+    m_model->updatePortCombo();
+    m_model->updateAllDeviceModel();
+    m_model->updateActiveComboIndex();
+
+    m_model->setOutPutPortComboEnable(true);
+}
+
 void SoundWorker::changeOutputDeviceComboxStatus()
 {
+    // 防抖期间不干涉，由防抖定时器统一管理控件的启用/禁用
+    if (m_model->debounceOutputDeviceList()) {
+        return;
+    }
     m_model->setOutPutPortComboEnable(false);
     m_waitOutputReceiptTimer->setInterval(m_model->currentWaitSoundReceiptTime());
     m_waitOutputReceiptTimer->start();

--- a/src/plugin-sound/operation/soundworker.h
+++ b/src/plugin-sound/operation/soundworker.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef SOUNDWORKER_H
@@ -78,6 +78,8 @@ private Q_SLOTS:
     void updatePlayAniIconPath();
     void changeOutputDeviceComboxStatus();
     void changeInputDeviceComboxStatus();
+    void onBluetoothModeDebounceTimeout();
+    void onDefaultSinkChangedForDebounce(const QDBusObjectPath &path);
 
 private:
     void initConnect();
@@ -103,8 +105,10 @@ private:
     QMediaDevices* m_mediaDevices;
 
     QTimer* m_playAnimationTime;
+    QTimer* m_debounceChangeModeTimer;
     int m_upateSoundEffectsIndex;
     QString m_playAniIconPath;
+    QString m_expectedSinkName;
 };
 
 #endif // SOUNDWORKER_H

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -228,6 +228,7 @@ DccObject {
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: 10
                 flat: true
+                enabled: dccData.model().outPutPortComboEnable
                 textRole: "name"
                 currentIndex: dccData.model().outPutPortComboIndex
                 model: dccData.model().soundOutputDeviceModel()
@@ -352,6 +353,7 @@ DccObject {
                 Layout.alignment: Qt.AlignRight
                 Layout.rightMargin: 10
                 flat: true
+                enabled: dccData.model().outPutPortComboEnable
                 model: dccData.model().bluetoothModeOpts
                 currentIndex: count > 0 ? Math.max(0, indexOfValue(dccData.model().currentBluetoothAudioMode)) : 0
                 property bool isInitialized: false


### PR DESCRIPTION
… to prevent UI flicker

修复蓝牙音频模式切换时输出设备列表闪烁问题

- Add debounce flag and timer in SoundModel/SoundWorker to block UI updates during mode switching
- Skip output device list, balance, and bluetooth mode options updates when debounce is active
- Disable output device combobox during transition and re-enable after stabilization
- Use 500ms debounce timer with retry mechanism to ensure device switching completion
- Prevent intermediate device states from causing UI flicker in SpeakerPage

PMS: BUG-362189