### PR TITLE
fix(personalization): reset wallpaper state per backend

### DIFF
--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -732,7 +732,6 @@ void PersonalizationWorker::setWallpaperForMonitor(const QString &screenName, Wa
     if (wallpaper.isNull()) {
         return;
     }
-    m_wallpaperWorker->setWantToSetWallpaper(nullptr);
     PersonalizationExport::WallpaperSetType setType;
     if (wallpaper->type == WallpaperEnums::Wallpaper_Live) {
         setType = PersonalizationExport::WallpaperSetType::Type_Video;

--- a/src/plugin-personalization/operation/personalizationworker.h
+++ b/src/plugin-personalization/operation/personalizationworker.h
@@ -117,9 +117,9 @@ private:
 protected:
     PersonalizationModel *m_model;
     PersonalizationDBusProxy *m_personalizationDBusProxy;
+    WallpaperProvider *m_wallpaperWorker = nullptr;
 
 private:
-    WallpaperProvider *m_wallpaperWorker = nullptr;
     ScreensaverProvider *m_screenSaverProvider = nullptr;
     Dtk::Core::DConfig *m_personalizationConfig = nullptr;
     Dtk::Core::DConfig *m_dtkConfig = nullptr;

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -78,6 +78,7 @@ void TreeLandWorker::setWallpaperForMonitor(const QString &screen, const QString
 
 void TreeLandWorker::setBackgroundForMonitor(const QString &monitorName, const QString &url, PersonalizationExport::WallpaperSetType type)
 {
+    m_wallpaperWorker->setWantToSetWallpaper(nullptr);
     setWallpaper(monitorName, url, WallpaperContext::wallpaper_role_desktop, type);
 }
 

--- a/src/plugin-personalization/operation/x11worker.cpp
+++ b/src/plugin-personalization/operation/x11worker.cpp
@@ -151,6 +151,7 @@ void X11Worker::setBackgroundForMonitor(const QString &screenName, const QString
 {
     Q_UNUSED(type)
     qCDebug(DdcPersonnalizationX11Worker) << "setMonitorBackground " << screenName << url;
+    m_wallpaperWorker->setWantToSetWallpaper(nullptr);
     if (screenName.isEmpty() || url.isEmpty())
         return;
 

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -138,7 +138,7 @@ DccObject {
                         Layout.preferredWidth: 14
                         Layout.preferredHeight: 14
                         progress: dccData.model.wantToSetWallpaperProgress
-                        visible: dccData.model.wantToSetWallpaperStatus === WallpaperEnums.Download_Installing
+                        visible: dccData.model.wantToSetWallpaper && dccData.model.wantToSetWallpaperStatus === WallpaperEnums.Download_Installing
                     }
                 }
             }


### PR DESCRIPTION
1. Move wallpaper selection reset into backend background handlers.
2. Allow derived workers to access the wallpaper provider directly.
3. Keep monitor wallpaper setup behavior consistent across X11 and Treeland.

Log: Reset pending wallpaper state in each personalization backend before applying monitor backgrounds.

fix(personalization): 按后端重置壁纸状态

1. 将壁纸选择状态重置移动到后端背景设置处理中。
2. 允许派生工作类直接访问壁纸提供器。
3. 保持 X11 和 Treeland 的显示器壁纸设置行为一致。

Log: 在各个个性化后端应用显示器背景前重置待设置壁纸状态。
PMS: TASK-392001

## Summary by Sourcery

Reset wallpaper state per personalization backend before applying monitor backgrounds and expose the wallpaper provider to derived workers.

Bug Fixes:
- Clear pending wallpaper selection in X11 and Treeland monitor background handlers to avoid stale wallpaper state across backends.

Enhancements:
- Promote wallpaper provider from private to protected member to allow access from derived personalization workers.