### PR TITLE
fix: optimize timezone data access and add display name caching

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -74,14 +74,10 @@ static QString getDisplayText(const ZoneInfo &zoneInfo)
 
 static QStringList timeZoneList(const installer::ZoneInfoList &zoneInfoList, QMap<QString, QString> &cache)
 {
-    using namespace installer;
-    if (g_totalZones.empty())
-        g_totalZones =  GetZoneInfoList();
-
     const QString locale = QLocale::system().name();
     QStringList timezoneList;
     for (const auto& info : zoneInfoList) {
-        auto localzone = GetLocalTimezoneName(info.timezone, locale);
+        auto localzone = installer::GetLocalTimezoneName(info.timezone, locale);
 
         if (!cache.contains(localzone)) {
             // "上海": "Asia/Shanghai"
@@ -291,11 +287,10 @@ void DatetimeModel::setDateTime(const QDateTime &dateTime)
 QStringList DatetimeModel::zones(int x, int y, int map_width, int map_height)
 {
     using namespace installer;
-    if (g_totalZones.empty())
-        g_totalZones =  GetZoneInfoList();
+    const auto &zoneList = getTotalZones();
 
     const double kDistanceThreshold = 64.0;
-    auto zonelist = GetNearestZones(g_totalZones, kDistanceThreshold, x, y, map_width, map_height);
+    auto zonelist = GetNearestZones(zoneList, kDistanceThreshold, x, y, map_width, map_height);
 
     return timeZoneList(zonelist, m_timezoneCache);
 }
@@ -303,43 +298,55 @@ QStringList DatetimeModel::zones(int x, int y, int map_width, int map_height)
 QPoint DatetimeModel::zonePosition(const QString &timezone, int map_width, int map_height)
 {
     using namespace installer;
-    if (g_totalZones.empty())
-        g_totalZones =  GetZoneInfoList();
+    const auto &zoneList = getTotalZones();
 
     auto enZone = m_timezoneCache.value(timezone, timezone);
 
-    int index = GetZoneInfoByZone(g_totalZones, enZone);
+    int index = GetZoneInfoByZone(zoneList, enZone);
     if (index < 0)
         return QPoint();
 
-    auto currentZone = g_totalZones.at(index);
+    auto currentZone = zoneList.at(index);
 
     const int x = int(ConvertLongitudeToX(currentZone.longitude) * map_width);
     const int y = int(ConvertLatitudeToY(currentZone.latitude) * map_height);
     return QPoint(x, y);
 }
 
-QStringList DatetimeModel::zoneIdList()
+const installer::ZoneInfoList &DatetimeModel::getTotalZones() const
 {
     using namespace installer;
+    // Lazy-initialize the static cache on first access. Modifying g_totalZones
+    // does not affect the observable state of this DatetimeModel instance.
     if (g_totalZones.empty())
-        g_totalZones =  GetZoneInfoList();
+        g_totalZones = GetZoneInfoList();
+    return g_totalZones;
+}
 
+QStringList DatetimeModel::zoneIdList()
+{
+    const auto &zones = getTotalZones();
     QStringList list;
-    for (const auto& info : g_totalZones) {
+    list.reserve(zones.size());
+    for (const auto& info : zones) {
         list << info.timezone;
     }
-
     return list;
 }
 
 QString DatetimeModel::zoneDisplayName(const QString &zoneName)
 {
+    auto it = m_zoneDisplayNameCache.constFind(zoneName);
+    if (it != m_zoneDisplayNameCache.constEnd())
+        return it.value();
+
     if (m_work) {
         auto zoneInfo = m_work->GetZoneInfo(zoneName);
         QString utcOffsetText = zoneInfo.getUtcOffsetText();
         QString cityName = zoneInfo.getZoneCity().isEmpty() ? zoneInfo.getZoneName() : zoneInfo.getZoneCity();
-        return QString("%1 %2").arg(cityName).arg(utcOffsetText);
+        const QString displayName = QString("%1 %2").arg(cityName).arg(utcOffsetText);
+        m_zoneDisplayNameCache.insert(zoneName, displayName);
+        return displayName;
     }
     return QString();
 }
@@ -1255,14 +1262,12 @@ QString DatetimeModel::timeZoneDispalyName() const
 
 int DatetimeModel::currentTimeZoneIndex() const
 {
-    using namespace installer;
-    if (g_totalZones.empty())
-        g_totalZones =  GetZoneInfoList();
+    const auto &zoneList = getTotalZones();
 
     int index = -1;
     const QString &zoneName = m_currentSystemTimeZone.getZoneName();
-    for (int i = 0; i < g_totalZones.size(); ++i) {
-        const auto &zoneInfo = g_totalZones.value(i);
+    for (int i = 0; i < zoneList.size(); ++i) {
+        const auto &zoneInfo = zoneList.at(i);
         if (zoneName == zoneInfo.timezone) {
             index = i;
             break;

--- a/src/plugin-datetime/operation/datetimemodel.h
+++ b/src/plugin-datetime/operation/datetimemodel.h
@@ -11,6 +11,7 @@
 #include "zoneinfo.h"
 #include "regionproxy.h"
 #include "zoneinfomodel.h"
+#include "timezoneMap/timezone.h"
 
 class DatetimeWorker;
 namespace dccV25 {
@@ -215,6 +216,7 @@ public Q_SLOTS:
     void setDateTime(const QDateTime &dateTime);
     QStringList zones(int x, int y, int map_width, int map_height);
     QPoint zonePosition(const QString &timezone, int map_width, int map_height);
+    const installer::ZoneInfoList &getTotalZones() const;
     QStringList zoneIdList();
     QString zoneDisplayName(const QString &zoneName);
     QAbstractListModel *userTimezoneModel();
@@ -308,6 +310,7 @@ private:
     QString m_paperFormat;
     RegionFormat m_regionFormat;
     QMap<QString, QString> m_timezoneCache;
+    QMap<QString, QString> m_zoneDisplayNameCache;
     DatetimeWorker *m_work = nullptr;
     dccV25::UserTimezoneModel *m_userTimezoneModel = nullptr;
     QSortFilterProxyModel *m_zoneSearchModel = nullptr;

--- a/src/plugin-datetime/operation/zoneinfomodel.cpp
+++ b/src/plugin-datetime/operation/zoneinfomodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -88,27 +88,25 @@ ZoneInfoModel::~ZoneInfoModel()
 
 int ZoneInfoModel::rowCount(const QModelIndex &) const
 {
-    DatetimeModel *sourceMode = dynamic_cast<DatetimeModel *>(parent());
+    DatetimeModel *sourceMode = qobject_cast<DatetimeModel *>(parent());
     if (!sourceMode)
         return 0;
 
-    auto list = sourceMode->zoneIdList();
-
-    return list.size();
+    return sourceMode->getTotalZones().size();
 }
 
 QVariant ZoneInfoModel::data(const QModelIndex &index, int role) const
 {
-    DatetimeModel *sourceMode = dynamic_cast<DatetimeModel *>(parent());
+    DatetimeModel *sourceMode = qobject_cast<DatetimeModel *>(parent());
     if (!sourceMode)
         return QVariant();
 
-    auto list = sourceMode->zoneIdList();
+    const auto &list = sourceMode->getTotalZones();
 
     if (!index.isValid() || index.row() >= list.size())
         return QVariant();
 
-    const QString &zoneId = list.value(index.row());   // "Asia/Shanghai"
+    const QString &zoneId = list.at(index.row()).timezone;   // "Asia/Shanghai"
     const QString &zoneDisplay = sourceMode->zoneDisplayName(zoneId); // (UTC+08:00)上海
 
     switch (role) {

--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -94,8 +94,16 @@ Popup {
             font: DTK.fontManager.t6
             Layout.alignment: Qt.AlignTop
             placeholder: qsTr("Search")
+            Timer {
+                id: searchDebounceTimer
+                interval: 100
+                onTriggered: {
+                    control.searchText = searchEdit.text
+                }
+            }
+
             onTextChanged: {
-                control.searchText = text
+                searchDebounceTimer.restart()
             }
             onVisibleChanged: {
                 clear()


### PR DESCRIPTION
1. Extract lazy initialization of g_totalZones into a dedicated getTotalZones() method to eliminate code duplication across multiple functions
2. Add m_zoneDisplayNameCache to cache zone display names, reducing redundant worker calls
3. Replace dynamic_cast with qobject_cast for type safety
4. Update ZoneInfoModel to directly use getTotalZones() instead of zoneIdList() for better performance
5. Add search debounce timer with 100ms delay to reduce filtering calls during typing
6. Use list.reserve() for memory optimization in zoneIdList()

Log: Optimized timezone data loading and search performance

Influence:
1. Test timezone map interaction: verify zone highlighting and position still correct
2. Verify timezone list display and search functionality
3. Test timezone display names in different locales and timezones
4. Verify search debounce behavior with rapid typing
5. Test timezone selection and timezone change flow
6. Verify no memory leaks or crashes from caching mechanisms

refactor: 优化时区数据访问并添加显示名称缓存

1. 将 g_totalZones 的懒加载逻辑抽取为独立的 getTotalZones() 方法，消除多 处代码重复
2. 添加 m_zoneDisplayNameCache 用于缓存时区显示名称，减少重复的工作线程 调用
3. 将 dynamic_cast 替换为 qobject_cast 以提高类型安全性
4. 更新 ZoneInfoModel 直接使用 getTotalZones() 而非 zoneIdList() 以获得 更好性能
5. 添加 100ms 防抖定时器，减少打字过程中的搜索过滤调用次数
6. 在 zoneIdList() 中使用 list.reserve() 进行内存优化

Log: 优化了时区数据加载和搜索性能

Influence:
1. 测试时区地图交互：确认时区高亮和定位功能正常
2. 验证时区列表显示和搜索功能
3. 测试不同语言环境和时区下的时区显示名称
4. 测试快速输入时的搜索防抖行为
5. 测试时区选择和切换流程
6. 确认缓存机制没有导致内存泄漏或崩溃

PMS: BUG-367165