### PR TITLE
fix: resolve DciIcon animation jitter due to subpixel rendering

### DIFF
--- a/src/plugin-authentication/qml/AddFaceinfoDialog.qml
+++ b/src/plugin-authentication/qml/AddFaceinfoDialog.qml
@@ -231,6 +231,9 @@ To ensure successful entry:\n\
                         anchors.centerIn: parent
                         name: dccData.faceController.faceImgContent
                         sourceSize: Qt.size(210, 210)
+                        layer.enabled: true
+                        width: 210
+                        height: 210
                     }
 
                     Control {

--- a/src/plugin-authentication/qml/AddFingerDialog.qml
+++ b/src/plugin-authentication/qml/AddFingerDialog.qml
@@ -141,6 +141,9 @@ D.DialogWindow {
                         name: dccData.fingerprintController.fingertipImagePath
                         retainWhileLoading: true
                         sourceSize: Qt.size(150, 150)
+                        layer.enabled: true
+                        width: 150
+                        height: 150
                     }
                 }
 


### PR DESCRIPTION
1. Enable layer rendering for DciIcon in AddFaceinfoDialog.qml to prevent subpixel rendering artifacts
2. Add layer rendering with explicit textureSize in AddFingerDialog.qml to fix animation jitter
3. Both changes ensure icons are rendered to texture first, avoiding floating point precision issues
4. This resolves visual jitter during animation playback caused by subpixel calculations

Log: Fixed animation jitter in DciIcon elements across authentication dialogs

Influence:
1. Test animation smoothness of face icon in AddFaceinfoDialog after the change
2. Verify fingerprint icon animation stability in AddFingerDialog
3. Check visual consistency across different display scaling factors
4. Test icon rendering quality at various screen resolutions
5. Verify no performance degradation with layer rendering enabled
6. Test animation behavior during dialog open/close transitions

fix: 解决DciIcon动画因亚像素渲染导致的抖动问题

1. 在AddFaceinfoDialog.qml中为DciIcon启用图层渲染，防止亚像素渲染伪影
2. 在AddFingerDialog.qml中添加带显式textureSize的图层渲染，修复动画抖动
3. 两项更改确保图标先渲染到纹理上，避免浮点精度问题
4. 这解决了由亚像素计算引起的动画播放过程中的视觉抖动

Log: 修复认证对话框中DciIcon元素的动画抖动问题

Influence:
1. 测试修改后AddFaceinfoDialog中人脸图标的动画平滑度
2. 验证AddFingerDialog中指纹图标的动画稳定性
3. 检查不同显示缩放因子下的视觉一致性
4. 测试不同屏幕分辨率下的图标渲染质量
5. 验证启用图层渲染后没有性能下降
6. 测试对话框打开/关闭过渡期间的动画行为

PMS: BUG-364877