### PR TITLE
fix(personalization): handle custom wallpapers

### DIFF
--- a/src/plugin-personalization/operation/personalizationdbusproxy.cpp
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.cpp
@@ -10,6 +10,7 @@
 #include <QDBusUnixFileDescriptor>
 #include <QFile>
 #include <QFileInfo>
+#include <QImageReader>
 
 DCORE_USE_NAMESPACE
 
@@ -285,6 +286,11 @@ QString PersonalizationDBusProxy::saveCustomWallpaper(const QString &userName, c
 {
     QFileInfo wallpaperInfo(url);
     if (!wallpaperInfo.isFile() || !wallpaperInfo.isReadable()) {
+        return "";
+    }
+
+    QImageReader reader(url);
+    if (!reader.canRead()) {
         return "";
     }
 

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -520,7 +520,7 @@ void PersonalizationWorker::setActiveColors(const QString &activeColors)
     m_personalizationDBusProxy->setActiveColors(activeColors);
 }
 
-void PersonalizationWorker::addCustomWallpaper(const QString &url)
+QString PersonalizationWorker::addCustomWallpaper(const QString &url, bool autoSet)
 {
     QString lastHashPath;
     if (isURI(url)) {
@@ -528,7 +528,10 @@ void PersonalizationWorker::addCustomWallpaper(const QString &url)
     } else {
         lastHashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), url, WALLPAPER_TYPE_CUSTOM);
     }
-    setWallpaperForMonitor(m_model->getCurrentSelectScreen(), lastHashPath, PersonalizationExport::Option_All);
+    if (autoSet) {
+        setWallpaperForMonitor(m_model->getCurrentSelectScreen(), lastHashPath, PersonalizationExport::Option_All);
+    }
+    return lastHashPath;
 }
 
 void PersonalizationWorker::addSolidWallpaper(const QColor &color)

--- a/src/plugin-personalization/operation/personalizationworker.h
+++ b/src/plugin-personalization/operation/personalizationworker.h
@@ -43,7 +43,7 @@ public Q_SLOTS:
 
     // 设置给Appearance分别在深色和浅色下的活动色
     void setActiveColors(const QString &activeColors);
-    void addCustomWallpaper(const QString &url);
+    QString addCustomWallpaper(const QString &url, bool autoSet = true);
     void addSolidWallpaper(const QColor &color);
     void deleteWallpaper(const QString &str);
     void setScreenSaver(const QString &value);

--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -404,11 +404,22 @@ bool TreeLandWorker::setWallpaper(const QString &monitorName, const QString &url
     }
 
     QString dest;
+    QUrl destUrl;
+
     if (QFile::exists(url)) {
         dest = url;
+        destUrl = QUrl::fromLocalFile(url);
     } else {
-        QUrl destUrl(url);
+        destUrl = QUrl::fromUserInput(url);
         dest = destUrl.toLocalFile();
+    }
+
+    if (type == WallpaperContext::wallpaper_source_type_image && Q_LIKELY(m_wallpaperWorker)) {
+        if (m_wallpaperWorker->findWallpaperItem(destUrl.toString(), WallpaperEnums::Wallpaper_all) == std::nullopt) {
+            qInfo(DdcPersonnalizationTreelandWorker) << "cannot find wallpaper item for url:" << dest << ", adding as custom wallpaper.";
+            dest = addCustomWallpaper(destUrl.toString(), false);
+            qInfo(DdcPersonnalizationTreelandWorker) << "added custom wallpaper, new path:" << dest;
+        }
     }
 
     if (dest.isEmpty())

--- a/src/plugin-personalization/operation/wallpaperprovider.cpp
+++ b/src/plugin-personalization/operation/wallpaperprovider.cpp
@@ -584,9 +584,10 @@ void WallpaperProvider::installWallpaper(const QString &itemId, WallpaperType ty
 
     auto wallpaper = findWallpaperItem(itemId, type);
     if (wallpaper.has_value() && !wallpaper.value()->packageName.isEmpty()) {
+        const auto wallpaperType = wallpaper.value()->type;
         wallpaper.value()->installStatus = Download_Installing;
         wallpaper.value()->installProgress = 0;
-        auto model = getModel(type);
+        auto model = getModel(wallpaperType);
         if (!model) {
             qCWarning(DdcPersonalizationWallpaperWorker()) << "get model error";
             return;
@@ -595,7 +596,7 @@ void WallpaperProvider::installWallpaper(const QString &itemId, WallpaperType ty
             Item_InstallStatus_Role, Item_InstallProgress_Role
         });
 
-        const QString jobName = QString(LASTORE_BASE_FLAG) + SPLIT_SYMBOL + QString::number(static_cast<int>(type));
+        const QString jobName = QString(LASTORE_BASE_FLAG) + SPLIT_SYMBOL + QString::number(static_cast<int>(wallpaperType));
 
         auto call = m_personalizationProxy->InstallPackage(jobName, wallpaper.value()->packageName);
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
@@ -745,18 +746,32 @@ void WallpaperProvider::setWantToSetWallpaper(WallpaperItemPtr wallpaper)
 
 std::optional<WallpaperItemPtr> WallpaperProvider::findWallpaperItem(const QString &url, WallpaperType type)
 {
+    const auto findInItems = [&url](const QList<WallpaperItemPtr> &items) -> std::optional<WallpaperItemPtr> {
+        for (const auto &wallpaperItem : items) {
+            if (wallpaperItem && wallpaperItem->url == url) {
+                return wallpaperItem;
+            }
+        }
+
+        return std::nullopt;
+    };
+
+    if (type == WallpaperType::Wallpaper_all) {
+        for (const auto &items : m_wallpaperList) {
+            if (auto wallpaperItem = findInItems(items); wallpaperItem.has_value()) {
+                return wallpaperItem;
+            }
+        }
+
+        return std::nullopt;
+    }
+
     const auto it = m_wallpaperList.find(type);
     if (it == m_wallpaperList.end()) {
         return std::nullopt;
     }
 
-    for (const auto &wallpaperItem : it.value()) {
-        if (wallpaperItem && wallpaperItem->url == url) {
-            return wallpaperItem;
-        }
-    }
-
-    return std::nullopt;
+    return findInItems(it.value());
 }
 
 WallpaperModel *WallpaperProvider::getModel(WallpaperType type) const


### PR DESCRIPTION
修复Treeland设置自定义壁纸的时候，Treeland 可能没有权限去读， 以及原始资源如果删除，则Treeland会找不到壁纸资源的问题

## Summary by Sourcery

Improve handling of custom wallpapers and wallpaper lookup, ensuring Treeland can set and track wallpapers even when using arbitrary image paths or previously unknown resources.

New Features:
- Support adding and using custom wallpapers on-the-fly when Treeland sets a wallpaper that is not yet tracked by the personalization system.

Bug Fixes:
- Ensure wallpaper installation uses the actual wallpaper item type, preventing mismatches in model selection and job naming.
- Allow wallpaper lookup across all wallpaper lists when requested, fixing cases where existing wallpapers could not be found by URL.

Enhancements:
- Make custom wallpaper saving return the stored path and optionally avoid auto-applying it, enabling more flexible reuse by Treeland and other callers.