### PR TITLE
fix: prevent numLock write-back on keyboard page re-entry

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -144,6 +144,9 @@ bool KeyboardController::numLock() const
 
 void KeyboardController::setNumLock(bool newNumLock)
 {
+    if (numLock() == newNumLock)
+        return;
+
     m_worker->setNumLock(newNumLock);
 }
 

--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -27,7 +27,7 @@ DccObject {
         pageType: DccObject.Editor
         page: D.Switch {
             checked: dccData.keyboardEnabled
-            onCheckedChanged: {
+            onToggled: {
                 dccData.keyboardEnabled = checked
             }
         }
@@ -291,7 +291,7 @@ DccObject {
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.numLock
-                onCheckedChanged: {
+                onToggled: {
                     dccData.numLock = checked
                 }
             }
@@ -306,7 +306,7 @@ DccObject {
             pageType: DccObject.Editor
             page: D.Switch {
                 checked: dccData.capsLock
-                onCheckedChanged: {
+                onToggled: {
                     dccData.capsLock = checked
                 }
             }


### PR DESCRIPTION
## 问题描述

关闭数字键盘开关后，在控制中心内切换到其他页面再重新进入键盘页面时，数字键盘状态被错误地重置。

## 根因

1. `KeyboardController::setNumLock()` 缺少相等守卫，当页面重入时 compositor 回写触发 `onCheckedChanged` 信号后，会向 compositor 发送冗余的 `setNumLock` 调用，覆盖用户之前的正确设置
2. QML Switch 使用 `onCheckedChanged` 而非 `onToggled`，导致绑定更新（非用户操作）也会触发回写

## 修改内容

1. **核心修复**：为 `KeyboardController::setNumLock()` 添加相等守卫（`if (numLock() == newNumLock) return;`），与 `setCapsLock`、`setRepeatDelay` 等其他 setter 保持一致的防御模式
2. **语义优化**：将 `Common.qml` 中 3 处 Switch 的 `onCheckedChanged` 替换为 `onToggled`，使仅用户操作触发回写，而非绑定更新

## 影响范围

- `src/plugin-keyboard/operation/keyboardcontroller.cpp`：1 处相等守卫
- `src/plugin-keyboard/qml/Common.qml`：3 处信号处理器名称替换

PMS: BUG-367617

## Summary by Sourcery

Prevent redundant num lock updates when re-entering the keyboard settings page.

Bug Fixes:
- Avoid re-sending num lock state changes when the requested value matches the current state.
- Ensure keyboard, num lock, and caps lock switches only propagate changes on user toggles rather than on binding updates.