### PR TITLE
fix: adjust focus policy for group edit button in account settings

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -885,7 +885,7 @@ DccObject {
                             Layout.rightMargin: 10
                             text: groupSettings.isEditing ? qsTr("done") : qsTr("edit")
                             font: DTK.fontManager.t8
-                            focusPolicy: Qt.StrongFocus
+                            focusPolicy: Qt.TabFocus
                             activeFocusOnTab: true
                             background: Rectangle {
                                 radius: addGroupButton.background.radius


### PR DESCRIPTION
Changed the focus policy from `Qt.StrongFocus` to `Qt.TabFocus` for the group edit button in account settings UI. This fixes the issue where the button could capture focus via mouse click unnecessarily, ensuring focus is only gained through tab navigation as intended while maintaining the button's accessibility for keyboard users.

Log: Fixed focus behavior of group edit button in account settings

Influence:
1. Verify tab navigation order through account settings page
2. Test clicking on the edit button and confirm no unwanted focus capture
3. Test keyboard-only navigation to ensure the button remains accessible
4. Verify that the edit/done button function works correctly after focus change

fix: 调整账户设置中分组编辑按钮的焦点策略

将分组编辑按钮的焦点策略从 `Qt.StrongFocus` 修改为 `Qt.TabFocus`，修复了 按钮通过鼠标点击不必要地获取焦点的问题，确保焦点仅通过Tab键导航获得，同
时保持按钮对键盘用户的可访问性。

Log: 修复账户设置中编辑按钮的焦点行为

Influence:
1. 验证账户设置页面的Tab键导航顺序
2. 测试点击编辑按钮，确认不会不必要地捕获焦点
3. 测试仅通过键盘导航，确保按钮依然可访问
4. 验证焦点策略修改后编辑/完成按钮功能正常

PMS: BUG-361555