### PR TITLE
fix: stop fallback timer when showing page normally

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -67,6 +67,7 @@ DccManager::DccManager(QObject *parent)
     , m_sidebarWidth(-1)
     , m_showTimer(nullptr)
     , m_showFallbackTimer(nullptr)
+    , m_showPagePending(false)
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -288,11 +289,13 @@ void DccManager::showPage(const QString &url)
 
 void DccManager::showPage(DccObject *obj)
 {
+    m_showPagePending = true;
     QMetaObject::invokeMethod(this, "doShowPage", Qt::QueuedConnection, QPointer<DccObject>(obj), QString());
 }
 
 void DccManager::showPage(DccObject *obj, const QString &cmd)
 {
+    m_showPagePending = true;
     QMetaObject::invokeMethod(this, "doShowPage", Qt::QueuedConnection, QPointer<DccObject>(obj), cmd);
 }
 
@@ -834,7 +837,7 @@ void DccManager::handleShowReady()
 {
     if (!m_showUrl.isEmpty()) {
         tryShow();
-    } else if (m_showFallbackTimer->isActive() && !m_activeObject) {
+    } else if (m_showFallbackTimer->isActive() && !m_activeObject && !m_showPagePending) {
         tryShowFallback();
     }
 }
@@ -869,7 +872,7 @@ void DccManager::tryShow()
 
 void DccManager::tryShowFallback()
 {
-    if (m_plugins->isDeleting() || !m_showUrl.isEmpty() || m_activeObject) {
+    if (m_plugins->isDeleting() || !m_showUrl.isEmpty() || m_activeObject || m_showPagePending) {
         return;
     }
 
@@ -879,6 +882,12 @@ void DccManager::tryShowFallback()
 
 void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
 {
+    struct PendingGuard
+    {
+        DccManager *manager;
+        ~PendingGuard() { manager->m_showPagePending = false; }
+    } pendingGuard{ this };
+
     if (m_plugins->isDeleting() || !obj) {
         return;
     }

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -151,6 +151,7 @@ private:
     QTimer *m_showFallbackTimer;
     QString m_showUrl;
     QDBusMessage m_showMessage;
+    bool m_showPagePending;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
 


### PR DESCRIPTION
fix: prevent fallback page from overriding pending showPage requests
Add a pending flag to prevent the fallback timer from triggering
while a queued showPage call is still pending execution. Previously,
when showPage was called with a QueuedConnection, the fallback timer
could fire before the queued method executed, incorrectly showing
the fallback page instead of the requested page. The fix introduces a
`m_showPagePending` flag that is set before invoking the queued method
and cleared after execution via RAII guard, preventing the fallback
logic from running during that window.

Log: Fixed an issue where the fallback page could override a pending
page navigation request

Influence:
1. Test navigation to various pages via showPage QML/API
2. Verify fallback page does not appear when navigating between pages
3. Test rapid page navigation requests
4. Verify fallback page appears correctly when no specific page is
requested
5. Test page navigation while plugins are being loaded

fix: 防止回退页面覆盖待处理的 showPage 请求

添加一个待处理标志，以防止当存在尚未执行的 showPage 请求时，回退定时器被
触发。之前，当使用 QueuedConnection 调用 showPage 时，回退定时器可能在排
队的页面请求执行之前触发，导致错误地显示回退页面而不是请求的页面。修复方
案引入了一个 `m_showPagePending` 标志，在调用排队方法之前设置，并在执行
后通过 RAII 守卫清除，从而在该窗口期内阻止回退逻辑运行。

Log: 修复了回退页面可能覆盖待处理的页面导航请求的问题

Influence:
1. 通过 showPage QML/API 测试页面导航功能
2. 验证页面间导航时不会出现回退页面
3. 测试快速连续发起页面导航请求
4. 验证在没有特定页面请求时，回退页面能正确显示
5. 测试在插件加载过程中进行页面导航

PMS: BUG-368015 BUG-368177