### PR TITLE
fix(wallpaper): pass custom wallpaper by fd

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -53,7 +53,7 @@ Depends:
  qml6-module-qtquick-effects,
  libdtk6declarative(>> 6.7.40),
  netselect,
- dde-daemon (>> 6.1.88),
+ dde-daemon (>> 6.1.99),
  deepin-security-loader,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock

--- a/src/plugin-personalization/operation/personalizationdbusproxy.cpp
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.cpp
@@ -7,6 +7,9 @@
 #include <QMetaObject>
 #include <QDBusConnection>
 #include <QDBusPendingReply>
+#include <QDBusUnixFileDescriptor>
+#include <QFile>
+#include <QFileInfo>
 
 DCORE_USE_NAMESPACE
 
@@ -278,9 +281,24 @@ void PersonalizationDBusProxy::deleteCustomWallpaper(const QString &userName, co
     m_DaemonInter->asyncCall(QStringLiteral("DeleteCustomWallPaper"), QVariant::fromValue(userName), QVariant::fromValue(url));
 }
 
-QString PersonalizationDBusProxy::saveCustomWallpaper(const QString &userName, const QString &url)
+QString PersonalizationDBusProxy::saveCustomWallpaper(const QString &userName, const QString &url, const QString &wallpaperType)
 {
-    return QDBusPendingReply<QString>(m_DaemonInter->asyncCall(QStringLiteral("SaveCustomWallPaper"), QVariant::fromValue(userName), QVariant::fromValue(url)));
+    QFileInfo wallpaperInfo(url);
+    if (!wallpaperInfo.isFile() || !wallpaperInfo.isReadable()) {
+        return "";
+    }
+
+    QFile wallpaper(url);
+    if (!wallpaper.open(QIODevice::ReadOnly)) {
+        return "";
+    }
+
+    QDBusUnixFileDescriptor fd(wallpaper.handle());
+    if (!fd.isValid()) {
+        return "";
+    }
+
+    return QDBusPendingReply<QString>(m_DaemonInter->asyncCall(QStringLiteral("SaveCustomWallPaper"), QVariant::fromValue(userName), QVariant::fromValue(fd), QVariant::fromValue(wallpaperType)));
 }
 
 QStringList PersonalizationDBusProxy::getCustomWallpaper(const QString &userName)

--- a/src/plugin-personalization/operation/personalizationdbusproxy.h
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.h
@@ -91,7 +91,7 @@ public:
     void SetGreeterBackground(const QString &url);
     
     // daemon
-    QString saveCustomWallpaper(const QString &userName, const QString &url);
+    QString saveCustomWallpaper(const QString &userName, const QString &url, const QString &wallpaperType);
     void deleteCustomWallpaper(const QString &userName, const QString &url);
     QStringList getCustomWallpaper(const QString &userName);
 

--- a/src/plugin-personalization/operation/personalizationworker.cpp
+++ b/src/plugin-personalization/operation/personalizationworker.cpp
@@ -32,8 +32,6 @@
 DCORE_USE_NAMESPACE
 Q_LOGGING_CATEGORY(DdcPersonalWorker, "dcc-personal-worker")
 
-#define SOLID_PREFIX "solid::"
-
 static const std::vector<int> OPACITY_SLIDER{ 0, 25, 40, 55, 70, 85, 100 };
 
 const QList<int> FontSizeList{ 11, 12, 13, 14, 15, 16, 18, 20 };
@@ -45,6 +43,8 @@ constexpr auto SCROLLBAR_POLICY_CONFIG_KEY = "scrollbarPolicyStatus";
 constexpr auto COMPACT_MODE_DISPLAY_KEY = "compactDisplayStatus";
 constexpr auto TITLE_BAR_HEIGHT_SUPPORT_COMPACT_DISPLAY = "titleBarHeightSupportCompactDisplay";
 constexpr auto SIZE_MODE_KEY = "sizeMode";
+constexpr auto WALLPAPER_TYPE_CUSTOM = "custom";
+constexpr auto WALLPAPER_TYPE_SOLID = "solid";
 constexpr auto SCROLLBAR_POLICY_KEY = "scrollBarPolicy";
 
 PersonalizationWorker::PersonalizationWorker(PersonalizationModel *model, QObject *parent)
@@ -524,9 +524,9 @@ void PersonalizationWorker::addCustomWallpaper(const QString &url)
 {
     QString lastHashPath;
     if (isURI(url)) {
-        lastHashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), QUrl(url).toLocalFile());
+        lastHashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), QUrl(url).toLocalFile(), WALLPAPER_TYPE_CUSTOM);
     } else {
-        lastHashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), url);
+        lastHashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), url, WALLPAPER_TYPE_CUSTOM);
     }
     setWallpaperForMonitor(m_model->getCurrentSelectScreen(), lastHashPath, PersonalizationExport::Option_All);
 }
@@ -548,8 +548,7 @@ void PersonalizationWorker::addSolidWallpaper(const QColor &color)
 
     img.save(&file, "JPG");
 
-    //set to dde, and prefix solid:: to tell dde this is a solid color wallpaper.
-    const QString &hashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), SOLID_PREFIX + file.fileName());
+    const QString &hashPath = m_personalizationDBusProxy->saveCustomWallpaper(currentUserName(), file.fileName(), WALLPAPER_TYPE_SOLID);
     setWallpaperForMonitor(m_model->getCurrentSelectScreen(), hashPath, PersonalizationExport::Option_All);
 }
 


### PR DESCRIPTION
1. Open custom wallpaper files in control center before calling dde-daemon.
2. Pass a DBus Unix fd with the original filename metadata to SaveCustomWallPaper.
3. Replace the solid wallpaper path prefix with an explicit isSolid flag.
4. Require a dde-daemon version that provides the fd-based wallpaper API.

Log: Adapt custom wallpaper saving to the fd-based dde-daemon interface.

fix(wallpaper): 通过fd传递自定义壁纸

1. 在控制中心调用 dde-daemon 前先打开自定义壁纸文件。
2. 调用 SaveCustomWallPaper 时传递 DBus Unix fd 和原始文件名元数据。
3. 将纯色壁纸路径前缀替换为显式的 isSolid 标志。
4. 依赖提供 fd 壁纸接口的 dde-daemon 版本。

Log: 适配 dde-daemon 基于 fd 的自定义壁纸保存接口。
PMS: BUG-368175