### PR TITLE
fix: listen keyboard-state-notify for NumLock sync

### DIFF
--- a/src/plugin-keyboard/operation/ikeyboarddeviceproxy.h
+++ b/src/plugin-keyboard/operation/ikeyboarddeviceproxy.h
@@ -13,6 +13,7 @@ public:
     virtual ~IKeyboardDeviceProxy() = default;
 
     virtual void active() = 0;
+    virtual void deactive() = 0;
 
     virtual uint repeatDelay() const = 0;
     virtual uint repeatInterval() const = 0;

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -100,6 +100,7 @@ class KeyboardDBusProxy : public QObject, public DCC_NAMESPACE::IKeyboardDeviceP
 public:
     explicit KeyboardDBusProxy(QObject *parent = nullptr);
     void active() override {}
+    void deactive() override {}
 
     //Keyboard
     Q_PROPERTY(bool CapslockToggle READ capslockToggle WRITE setCapslockToggle NOTIFY CapslockToggleChanged)

--- a/src/plugin-keyboard/operation/keyboardwaylandproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboardwaylandproxy.cpp
@@ -4,6 +4,7 @@
 #include "keyboardwaylandproxy.h"
 
 #include "treelandinputmanager.h"
+#include "keyboardstatenotify.h"
 
 #include <QLoggingCategory>
 
@@ -39,6 +40,23 @@ void KeyboardWaylandProxy::active()
         qCDebug(lcKeyboardWaylandProxy) << "Keyboard not yet available, waiting for signal";
     }
     Q_EMIT KeyboardAvailableChanged(m_inputManager->keyboardAvailable());
+
+    if (!m_keyboardStateNotify) {
+        m_keyboardStateNotify = new KeyboardStateNotify(this);
+        connect(m_keyboardStateNotify, &KeyboardStateNotify::numLockChanged, this,
+                [this](bool on) {
+                    qCDebug(lcKeyboardWaylandProxy) << "numLockChanged (global state notify):" << on;
+                    Q_EMIT NumLockStateChanged(on ? 1 : 0);
+                });
+        qCDebug(lcKeyboardWaylandProxy) << "KeyboardStateNotify initialized";
+    }
+}
+
+void KeyboardWaylandProxy::deactive()
+{
+    qCDebug(lcKeyboardWaylandProxy) << "KeyboardWaylandProxy::deactive()";
+    delete m_keyboardStateNotify;
+    m_keyboardStateNotify = nullptr;
 }
 
 void KeyboardWaylandProxy::connectKeyboardSettings(TreelandKeyboardSettings *kbd)

--- a/src/plugin-keyboard/operation/keyboardwaylandproxy.h
+++ b/src/plugin-keyboard/operation/keyboardwaylandproxy.h
@@ -13,6 +13,7 @@ namespace DCC_NAMESPACE {
 
 class TreelandInputManager;
 class TreelandKeyboardSettings;
+class KeyboardStateNotify;
 
 /**
  * @brief 封装 treeland 输入管理协议的键盘代理类，对外提供与 KeyboardDBusProxy 相同的信号/槽接口，
@@ -32,6 +33,7 @@ public:
 
     /** 初始化并连接 TreelandInputManager 信号，发射当前初始状态 */
     void active() override;
+    void deactive() override;
     bool keyboardAvailable() const;
 
     // ---- 同步读取当前缓存值（与 KeyboardDBusProxy 接口保持兼容）----
@@ -76,7 +78,7 @@ private:
 
     TreelandInputManager *m_inputManager = nullptr;
     QPointer<TreelandKeyboardSettings> m_keyboardSettings;
+    KeyboardStateNotify *m_keyboardStateNotify = nullptr;
 };
 
 } // namespace DCC_NAMESPACE
-

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -217,6 +217,8 @@ void KeyboardWorker::active()
 void KeyboardWorker::deactive()
 {
     m_keyboardDBusProxy->blockSignals(true);
+    if (m_deviceProxy)
+        m_deviceProxy->deactive();
 }
 
 void KeyboardWorker::refreshKeyboard()

--- a/src/shared-utils/CMakeLists.txt
+++ b/src/shared-utils/CMakeLists.txt
@@ -37,6 +37,7 @@ if (Enable_TreelandSupport)
     qt6_generate_wayland_protocol_client_sources(dcc-shared-utils
         FILES
             ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-input-manager-unstable-v1.xml
+            ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-keyboard-state-notify-unstable-v1.xml
     )
 
     target_include_directories(dcc-shared-utils PUBLIC
@@ -46,6 +47,8 @@ if (Enable_TreelandSupport)
     target_sources(dcc-shared-utils PRIVATE
         treelandinputmanager.h
         treelandinputmanager.cpp
+        keyboardstatenotify.h
+        keyboardstatenotify.cpp
     )
 
     if(${QT_NS}_VERSION VERSION_GREATER_EQUAL 6.10)

--- a/src/shared-utils/keyboardstatenotify.cpp
+++ b/src/shared-utils/keyboardstatenotify.cpp
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "keyboardstatenotify.h"
+
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <wayland-client.h>
+
+namespace DCC_NAMESPACE {
+
+Q_LOGGING_CATEGORY(lcKbdStateNotify, "dde.dcc.keyboard.statenotify")
+
+// ---------------------------------------------------------------------------
+// Watcher
+// ---------------------------------------------------------------------------
+
+KeyboardStateNotify::Watcher::Watcher(KeyboardStateNotify *parent,
+                                      struct ::treeland_keyboard_state_watcher_v1 *obj)
+    : QObject(parent)
+    , QtWayland::treeland_keyboard_state_watcher_v1(obj)
+{
+    qCDebug(lcKbdStateNotify) << "Watcher created, configuring to watch num_lock with all flags";
+
+    // Watch num_lock modifier
+    set_modifiers(modifier_num_lock);
+
+    // Receive both locked and unlocked events
+    set_flags(watch_flag_locked | watch_flag_unlocked);
+
+    apply();
+}
+
+KeyboardStateNotify::Watcher::~Watcher()
+{
+    if (isInitialized())
+        destroy();
+}
+
+void KeyboardStateNotify::Watcher::treeland_keyboard_state_watcher_v1_current_state(
+    uint32_t modifier, uint32_t state)
+{
+    qCDebug(lcKbdStateNotify) << "current_state: modifier=" << modifier << "state=" << state;
+
+    if (modifier == modifier_num_lock) {
+        bool on = (state == modifier_state_locked);
+        Q_EMIT numLockChanged(on);
+    }
+}
+
+void KeyboardStateNotify::Watcher::treeland_keyboard_state_watcher_v1_state_changed(
+    uint32_t modifier, uint32_t state)
+{
+    qCDebug(lcKbdStateNotify) << "state_changed: modifier=" << modifier << "state=" << state;
+
+    if (modifier == modifier_num_lock) {
+        bool on = (state == modifier_state_locked);
+        Q_EMIT numLockChanged(on);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// KeyboardStateNotify
+// ---------------------------------------------------------------------------
+
+KeyboardStateNotify::KeyboardStateNotify(QObject *parent)
+    : QWaylandClientExtensionTemplate<KeyboardStateNotify>(1)
+    , QtWayland::treeland_keyboard_state_notify_manager_v1()
+{
+    setParent(parent);
+
+    qCDebug(lcKbdStateNotify) << "KeyboardStateNotify initializing";
+
+    connect(this, &QWaylandClientExtension::activeChanged, this, [this]() {
+        const bool avail = isActive();
+        qCDebug(lcKbdStateNotify) << "active changed:" << avail;
+
+        if (m_available != avail) {
+            m_available = avail;
+            Q_EMIT availableChanged(avail);
+        }
+
+        if (avail) {
+            auto *waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+            if (waylandApp) {
+                createWatcher(nullptr);
+            }
+        } else {
+            delete m_watcher;
+            m_watcher = nullptr;
+        }
+    });
+
+
+}
+
+KeyboardStateNotify::~KeyboardStateNotify()
+{
+    delete m_watcher;
+    m_watcher = nullptr;
+}
+
+bool KeyboardStateNotify::available() const
+{
+    return m_available;
+}
+
+void KeyboardStateNotify::createWatcher(wl_seat *seat)
+{
+    if (m_watcher) {
+        delete m_watcher;
+        m_watcher = nullptr;
+    }
+
+    if (!isActive() || !QtWayland::treeland_keyboard_state_notify_manager_v1::isInitialized())
+        return;
+
+    // Pass null seat to monitor all seats
+    auto *watcherObj = get_keyboard_state_watcher(seat);
+    m_watcher = new Watcher(this, watcherObj);
+
+    connect(m_watcher, &Watcher::numLockChanged, this, &KeyboardStateNotify::numLockChanged);
+
+    // Flush the Wayland display to ensure the request is sent
+    auto *waylandApp = qGuiApp->nativeInterface<QNativeInterface::QWaylandApplication>();
+    if (waylandApp && waylandApp->display())
+        wl_display_flush(waylandApp->display());
+
+    qCDebug(lcKbdStateNotify) << "Watcher created and configured";
+}
+
+} // namespace DCC_NAMESPACE

--- a/src/shared-utils/keyboardstatenotify.h
+++ b/src/shared-utils/keyboardstatenotify.h
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QWaylandClientExtension>
+#include <memory>
+
+// Qt Wayland C++ bindings generated from the protocol XML.
+#include "qwayland-treeland-keyboard-state-notify-unstable-v1.h"
+
+namespace DCC_NAMESPACE {
+
+/**
+ * @brief 封装 treeland_keyboard_state_notify_v1 Wayland 协议，监听键盘修饰键状态变化。
+ *
+ * 用法：
+ * @code
+ *   auto *notify = new KeyboardStateNotify(this);
+ *   connect(notify, &KeyboardStateNotify::numLockChanged, this, [](bool on) {
+ *       // 处理 NumLock 状态变化
+ *   });
+ * @endcode
+ *
+ * 自动创建 watcher 并订阅 NumLock 状态变化。
+ */
+class KeyboardStateNotify
+    : public QWaylandClientExtensionTemplate<KeyboardStateNotify>
+    , public QtWayland::treeland_keyboard_state_notify_manager_v1
+{
+    Q_OBJECT
+    Q_PROPERTY(bool available READ available NOTIFY availableChanged)
+
+public:
+    explicit KeyboardStateNotify(QObject *parent = nullptr);
+    ~KeyboardStateNotify() override;
+
+    bool available() const;
+
+Q_SIGNALS:
+    void availableChanged(bool available);
+    void numLockChanged(bool on);
+
+private:
+    class Watcher;
+    Watcher *m_watcher = nullptr;
+    bool m_available = false;
+
+    void createWatcher(wl_seat *seat);
+};
+
+/**
+ * @brief 封装 treeland_keyboard_state_watcher_v1，负责具体的修饰键监听。
+ */
+class KeyboardStateNotify::Watcher
+    : public QObject
+    , public QtWayland::treeland_keyboard_state_watcher_v1
+{
+    Q_OBJECT
+public:
+    explicit Watcher(KeyboardStateNotify *parent, struct ::treeland_keyboard_state_watcher_v1 *obj);
+    ~Watcher() override;
+
+Q_SIGNALS:
+    void numLockChanged(bool on);
+
+protected:
+    void treeland_keyboard_state_watcher_v1_current_state(uint32_t modifier, uint32_t state) override;
+    void treeland_keyboard_state_watcher_v1_state_changed(uint32_t modifier, uint32_t state) override;
+};
+
+} // namespace DCC_NAMESPACE


### PR DESCRIPTION
## Summary
Fix NumLock state synchronization issue in Treeland mode by listening to the `keyboard-state-notify` protocol.

## Problem
In Treeland mode, when users press the physical NumLock key on an external USB keyboard, the control center's "Enable numeric keypad" switch doesn't update its state. This is because the control center only receives NumLock state changes when it actively sets the state via the settings API, not when the state changes due to physical key presses.

## Solution
Add support for the `treeland_keyboard_state_notify_unstable_v1` Wayland protocol:
1. Add protocol XML generation for `treeland-keyboard-state-notify-unstable-v1.xml`
2. Add `KeyboardStateNotify` class to wrap the keyboard state notify protocol
3. Integrate `KeyboardStateNotify` into `KeyboardWaylandProxy` to receive global NumLock state changes

## Changes
- `src/shared-utils/CMakeLists.txt` — Add treeland-keyboard-state-notify-unstable-v1.xml protocol generation
- `src/shared-utils/keyboardstatenotify.h/.cpp` — New KeyboardStateNotify class
- `src/plugin-keyboard/operation/keyboardwaylandproxy.h` — Add KeyboardStateNotify member
- `src/plugin-keyboard/operation/keyboardwaylandproxy.cpp` — Initialize and connect signals

## Testing
1. Toggle NumLock via physical key, verify control center UI syncs
2. Toggle NumLock via control center switch, verify keyboard LED syncs  
3. Verify NumLock state displays correctly after reconnecting USB keyboard

Fixes [WM-68](mention://issue/cf5ea93b-ce80-4820-b9de-c54a81189349)
PMS: BUG-367621