### PR TITLE
feat(keyboard): wire Wayland custom shortcut CRUD

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -218,12 +218,24 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
     connect(m_shortcutModel, &ShortcutModel::addCustomInfo, sourceModel, &ShortcutListModel::reset);
     connect(m_shortcutModel, &ShortcutModel::shortcutChanged, sourceModel, &ShortcutListModel::onUpdateShortcut);
     connect(m_shortcutModel, &ShortcutModel::windowSwitchChanged, sourceModel, &ShortcutListModel::reset);
+    // Wayland: re-layout rows when category ordering metadata arrives.
+    connect(m_shortcutModel, &ShortcutModel::categoryMetaChanged, sourceModel, &ShortcutListModel::reset);
 
     m_shortcutSearchModel->setSourceModel(sourceModel);
     m_shortcutSearchModel->setFilterRole(ShortcutListModel::SearchedTextRole);
     m_shortcutSearchModel->setFilterCaseSensitivity(Qt::CaseInsensitive);
 
     return m_shortcutSearchModel;
+}
+
+QString KeyboardController::sectionDisplayName(const QString &key) const
+{
+    return m_shortcutModel ? m_shortcutModel->sectionDisplayName(key) : key;
+}
+
+QString KeyboardController::customCategoryKey() const
+{
+    return m_shortcutModel ? m_shortcutModel->customCategoryKey() : QString();
 }
 
 void KeyboardController::updateKey(const QString &id, const int &type)

--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -279,12 +279,7 @@ QString KeyboardController::checkDesktopCmd(const QString &cmd)
 void KeyboardController::addCustomShortcut(const QString &name, const QString &cmd, const QString &accels)
 {
     if (m_worker->isWayland()) {
-        // dde-services' Keybinding1 has no AddCustomShortcut yet (the service's
-        // own CONTROL_CENTER_INTEGRATION.md marks custom-shortcut CRUD as 服务侧需补齐).
-        // Bail out before any side effect (the conflict Disable below, the
-        // optimistic model insert in the worker) so the row doesn't flicker.
-        // TODO: wire up once AddCustomShortcut/ModifyCustomShortcut/DeleteCustomShortcut land.
-        qWarning() << "[Wayland] addCustomShortcut not yet supported by dde-services; ignoring";
+        m_worker->addCustomShortcut(name, checkDesktopCmd(cmd), accels);
         return;
     }
 
@@ -300,18 +295,18 @@ void KeyboardController::addCustomShortcut(const QString &name, const QString &c
 
 void KeyboardController::modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels)
 {
-    if (m_worker->isWayland()) {
-        // No ModifyCustomShortcut on the Wayland service yet — return before
-        // mutating the local model or triggering the conflict Disable below,
-        // so the UI is unchanged rather than showing an edit that won't persist.
-        // TODO: wire up once dde-services implements custom-shortcut CRUD.
-        qWarning() << "[Wayland] modifyCustomShortcut not yet supported by dde-services; ignoring";
-        return;
-    }
-
     ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id](ShortcutInfo *info){ return id == info->id; });
     if (!shortcut) {
         qWarning() << "shortcut not found..." << id << name;
+        return;
+    }
+
+    if (m_worker->isWayland()) {
+        ShortcutInfo updated = *shortcut;
+        updated.name = name;
+        updated.command = checkDesktopCmd(cmd);
+        updated.accels = accels;
+        m_worker->modifyCustomShortcut(&updated);
         return;
     }
 
@@ -329,15 +324,6 @@ void KeyboardController::modifyCustomShortcut(const QString &id, const QString &
 
 void KeyboardController::deleteCustomShortcut(const QString &id)
 {
-    if (m_worker->isWayland()) {
-        // No DeleteCustomShortcut on the Wayland service yet. Return before
-        // delShortcut's optimistic delInfo() (which removes + deletes the row);
-        // otherwise the row would vanish then reappear on the next refresh.
-        // TODO: wire up once dde-services implements custom-shortcut CRUD.
-        qWarning() << "[Wayland] deleteCustomShortcut not yet supported by dde-services; ignoring";
-        return;
-    }
-
     ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id](ShortcutInfo *info){ return id == info->id; });
     if (!shortcut) {
         qWarning() << "shortcut not found..." << id;

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -67,6 +67,13 @@ public Q_SLOTS:
     QSortFilterProxyModel *layoutSearchModel();
     QSortFilterProxyModel *shortcutSearchModel();
 
+    // Wayland: category metadata is supplied by the service (ListCategories).
+    // Exposed to QML so the section delegate can render the display name for
+    // a section key and detect the user-editable (Custom) group without any
+    // hardcoded category strings.
+    Q_INVOKABLE QString sectionDisplayName(const QString &key) const;
+    Q_INVOKABLE QString customCategoryKey() const;
+
     void updateKey(const QString &id, const int &type);
     QStringList formatKeys(const QString &shortcuts);
     Q_INVOKABLE QString keyEventToAccels(int key, int modifiers);

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -100,6 +100,24 @@ QString KeyboardDBusProxy::convertShortcutToJson(const ShortcutInfoNew &info) co
     return QJsonDocument(shortcutInfoToJsonObject(info)).toJson(QJsonDocument::Compact);
 }
 
+void KeyboardDBusProxy::requestShortcutCommand(const ShortcutInfoNew &info)
+{
+    if (!isWayland() || !info.isCustom || info.id.isEmpty())
+        return;
+
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(info.id);
+    QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+        QStringLiteral("GetShortcutCommand"), argumentList);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+    // Stash the full JSON object built from info; the finished handler only
+    // needs to overlay the Exec field from the reply. Avoids re-listing the
+    // field names here and reconstructing the object key-by-key on reply.
+    watcher->setProperty("shortcutJson", shortcutInfoToJsonObject(info));
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardDBusProxy::onGetShortcutCommandFinished);
+}
+
 void KeyboardDBusProxy::init()
 {
     m_dBusLangSelectorInter = new DDBusInterface(LangSelectorService, LangSelectorPath, LangSelectorInterface, QDBusConnection::sessionBus(), this);
@@ -293,8 +311,11 @@ void KeyboardDBusProxy::onListAllShortcutsNewFinished(QDBusPendingCallWatcher *w
 {
     QDBusPendingReply<QList<ShortcutInfoNew>> reply = *w;
     if (!reply.isError()) {
-        QString json = convertShortcutListToJson(reply.value());
+        const QList<ShortcutInfoNew> shortcuts = reply.value();
+        QString json = convertShortcutListToJson(shortcuts);
         Q_EMIT AllShortcutsReady(json);
+        for (const ShortcutInfoNew &info : shortcuts)
+            requestShortcutCommand(info);
     } else {
         qWarning() << "Wayland ListAllShortcuts failed:" << reply.error();
     }
@@ -354,8 +375,10 @@ void KeyboardDBusProxy::onGetShortcutNewFinished(QDBusPendingCallWatcher *w)
 {
     QDBusPendingReply<ShortcutInfoNew> reply = *w;
     if (!reply.isError()) {
-        QString json = convertShortcutToJson(reply.value());
+        const ShortcutInfoNew info = reply.value();
+        QString json = convertShortcutToJson(info);
         Q_EMIT shortcutQueried(json);
+        requestShortcutCommand(info);
     }
     w->deleteLater();
 }
@@ -368,6 +391,18 @@ void KeyboardDBusProxy::onNewShortcutChanged(const QString &id, const ShortcutIn
 {
     Q_UNUSED(id);
     Q_EMIT shortcutQueried(convertShortcutToJson(info));
+    requestShortcutCommand(info);
+}
+
+void KeyboardDBusProxy::onGetShortcutCommandFinished(QDBusPendingCallWatcher *w)
+{
+    QDBusPendingReply<QString> reply = *w;
+    if (!reply.isError()) {
+        QJsonObject obj = w->property("shortcutJson").toJsonObject();
+        obj["Exec"] = reply.value();
+        Q_EMIT shortcutQueried(QJsonDocument(obj).toJson(QJsonDocument::Compact));
+    }
+    w->deleteLater();
 }
 
 void KeyboardDBusProxy::onNewShortcutRemoved(const QString &id)
@@ -462,21 +497,21 @@ QDBusPendingReply<> KeyboardDBusProxy::AddShortcutKeystroke(const QString &in0, 
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("AddShortcutKeystroke"), argumentList);
 }
 
-QDBusPendingReply<> KeyboardDBusProxy::AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2)
+QDBusPendingReply<QString> KeyboardDBusProxy::AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2)
 {
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1) << QVariant::fromValue(in2);
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("AddCustomShortcut"), argumentList);
 }
 
-QDBusPendingReply<> KeyboardDBusProxy::ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3)
+QDBusPendingReply<bool> KeyboardDBusProxy::ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3)
 {
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1) << QVariant::fromValue(in2) << QVariant::fromValue(in3);
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ModifyCustomShortcut"), argumentList);
 }
 
-QDBusPendingReply<> KeyboardDBusProxy::DeleteCustomShortcut(const QString &in0)
+QDBusPendingReply<bool> KeyboardDBusProxy::DeleteCustomShortcut(const QString &in0)
 {
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0);
@@ -505,8 +540,11 @@ void KeyboardDBusProxy::onSearchShortcutsNewFinished(QDBusPendingCallWatcher *w)
 {
     QDBusPendingReply<QList<ShortcutInfoNew>> reply = *w;
     if (!reply.isError()) {
-        QString json = convertShortcutListToJson(reply.value());
+        const QList<ShortcutInfoNew> shortcuts = reply.value();
+        QString json = convertShortcutListToJson(shortcuts);
         Q_EMIT searchShortcutsReady(json);
+        for (const ShortcutInfoNew &info : shortcuts)
+            requestShortcutCommand(info);
     }
     w->deleteLater();
 }

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -51,23 +51,17 @@ KeyboardDBusProxy::KeyboardDBusProxy(QObject *parent)
     qRegisterMetaType<QList<ShortcutInfoNew>>("QList<ShortcutInfoNew>");
     qDBusRegisterMetaType<QList<ShortcutInfoNew>>();
 
+    qRegisterMetaType<CategoryInfoNew>("CategoryInfoNew");
+    qDBusRegisterMetaType<CategoryInfoNew>();
+    qRegisterMetaType<QList<CategoryInfoNew>>("QList<CategoryInfoNew>");
+    qDBusRegisterMetaType<QList<CategoryInfoNew>>();
+
     init();
 }
 
 bool KeyboardDBusProxy::isWayland() const
 {
     return m_isWayland;
-}
-
-// Map new API category to section name (Wayland 3-category: System/App/Custom)
-static QString categoryToSection(int category)
-{
-    switch (category) {
-    case 1: return QStringLiteral("System");
-    case 2: return QStringLiteral("App");
-    case 3: return QStringLiteral("Custom");
-    default: return QString();
-    }
 }
 
 // Convert a single ShortcutInfo to old-API JSON object
@@ -80,12 +74,15 @@ static QJsonObject shortcutInfoToJsonObject(const ShortcutInfoNew &info)
     // dde-services already emits hotkeys in X11/XKB form ("<Control><Alt>T",
     // "XF86AudioMute"), so we just forward the first one to Accels.
     obj["Accels"] = QJsonArray{info.hotkeys.isEmpty() ? QString() : info.hotkeys.first()};
-    // Type: 0=System, 1=Custom (old API). App(category==2) must map to 0,
-    // otherwise IsCustomRole would mark App shortcuts as editable.
-    obj["Type"] = (info.category == 3) ? 1 : 0;
+    // Type is now driven by the explicit isCustom flag from dde-services
+    // (was derived from category==3). 0=System, 1=Custom.
+    obj["Type"] = info.isCustom ? 1 : 0;
     obj["Exec"] = QString();
-    // New API section: overrides old hardcoded ID-based categorization
-    obj["Section"] = categoryToSection(info.category);
+    // Section carries the stable logical category key (for grouping/ordering
+    // and Custom detection); SectionName carries the already-resolved display
+    // text for direct rendering — dcc no longer translates categories.
+    obj["Section"] = info.category;
+    obj["SectionName"] = info.localLanguageCategory;
     return obj;
 }
 
@@ -321,6 +318,33 @@ QDBusPendingReply<QString> KeyboardDBusProxy::ListAllShortcuts()
     // Old API
     return QDBusPendingReply<QString>(
         m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ListAllShortcuts"), argumentList));
+}
+
+// Wayland: fetch category metadata (key/displayName/order/isCustom) so the
+// model can group, order, and identify the Custom group without hardcoding
+// any category strings.
+QDBusPendingReply<> KeyboardDBusProxy::ListCategories()
+{
+    QList<QVariant> argumentList;
+    if (isWayland()) {
+        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("ListCategories"), argumentList);
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardDBusProxy::onListCategoriesFinished);
+    }
+    return QDBusPendingReply<>();
+}
+
+void KeyboardDBusProxy::onListCategoriesFinished(QDBusPendingCallWatcher *w)
+{
+    QDBusPendingReply<QList<CategoryInfoNew>> reply = *w;
+    if (!reply.isError()) {
+        Q_EMIT categoriesReady(reply.value());
+    } else {
+        qWarning() << "Wayland ListCategories failed:" << reply.error();
+    }
+    w->deleteLater();
 }
 
 // Wayland: called when new API GetShortcut() async reply arrives.

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -247,9 +247,9 @@ public slots:
     QDBusPendingReply<bool> callModifyHotkeys(const QString &id, const QStringList &hotkeys);
     // Wayland: replace hotkey — remove newHotkey from conflictId, add to targetId.
     QDBusPendingReply<bool> callReplaceHotkey(const QString &targetId, const QString &newHotkey, const QString &conflictId);
-    QDBusPendingReply<> AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2);
-    QDBusPendingReply<> ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3);
-    QDBusPendingReply<> DeleteCustomShortcut(const QString &in0);
+    QDBusPendingReply<QString> AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2);
+    QDBusPendingReply<bool> ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3);
+    QDBusPendingReply<bool> DeleteCustomShortcut(const QString &in0);
     QDBusPendingReply<> GrabScreen();
     void SetNumLockState(int in0);
     QDBusPendingReply<QString> GetShortcut(const QString &in0, int in1);
@@ -275,6 +275,7 @@ private slots:
     void onListAllShortcutsNewFinished(QDBusPendingCallWatcher *w);
     void onListCategoriesFinished(QDBusPendingCallWatcher *w);
     void onGetShortcutNewFinished(QDBusPendingCallWatcher *w);
+    void onGetShortcutCommandFinished(QDBusPendingCallWatcher *w);
     void onSearchShortcutsNewFinished(QDBusPendingCallWatcher *w);
     // Bridge: new dde-services D-Bus signals (ShortcutChanged/ShortcutRemoved)
     // are named differently from the legacy Changed/Deleted, so auto-wiring
@@ -292,6 +293,7 @@ private:
     // Convert new ShortcutInfo list to old JSON format
     QString convertShortcutListToJson(const QList<ShortcutInfoNew> &list) const;
     QString convertShortcutToJson(const ShortcutInfoNew &info) const;
+    void requestShortcutCommand(const ShortcutInfoNew &info);
 
     DDBusInterface *m_dBusLangSelectorInter;
     DDBusInterface *m_dBusKeyboardInter;

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -71,9 +71,11 @@ class DCCDBusInterface;
 struct ShortcutInfoNew {
     QString id;
     QString displayName;
-    int category;
+    QString category;               // Logical category key (e.g. "System", app-defined)
     QStringList hotkeys;
     QString localLanguageName;
+    QString localLanguageCategory;  // Resolved display text for the category
+    bool isCustom = false;          // True for runtime-added (service API) shortcuts
 };
 Q_DECLARE_METATYPE(ShortcutInfoNew)
 Q_DECLARE_METATYPE(QList<ShortcutInfoNew>)
@@ -81,7 +83,8 @@ Q_DECLARE_METATYPE(QList<ShortcutInfoNew>)
 inline QDBusArgument &operator<<(QDBusArgument &argument, const ShortcutInfoNew &info) {
     argument.beginStructure();
     argument << info.id << info.displayName << info.category
-             << info.hotkeys << info.localLanguageName;
+             << info.hotkeys << info.localLanguageName
+             << info.localLanguageCategory << info.isCustom;
     argument.endStructure();
     return argument;
 }
@@ -89,7 +92,34 @@ inline QDBusArgument &operator<<(QDBusArgument &argument, const ShortcutInfoNew 
 inline const QDBusArgument &operator>>(const QDBusArgument &argument, ShortcutInfoNew &info) {
     argument.beginStructure();
     argument >> info.id >> info.displayName >> info.category
-             >> info.hotkeys >> info.localLanguageName;
+             >> info.hotkeys >> info.localLanguageName
+             >> info.localLanguageCategory >> info.isCustom;
+    argument.endStructure();
+    return argument;
+}
+
+// New API category metadata (dde-services ListCategories()). The control
+// center treats this as the single source of truth for grouping/ordering/
+// display/custom-detection — it never hardcodes category strings.
+struct CategoryInfoNew {
+    QString key;
+    QString displayName;
+    int order = 0;
+    bool isCustom = false;
+};
+Q_DECLARE_METATYPE(CategoryInfoNew)
+Q_DECLARE_METATYPE(QList<CategoryInfoNew>)
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const CategoryInfoNew &info) {
+    argument.beginStructure();
+    argument << info.key << info.displayName << info.order << info.isCustom;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, CategoryInfoNew &info) {
+    argument.beginStructure();
+    argument >> info.key >> info.displayName >> info.order >> info.isCustom;
     argument.endStructure();
     return argument;
 }
@@ -193,6 +223,9 @@ signals:
     // never reuse Deleted, whose X11 auto-wiring → KeyboardWorker::removed is a
     // dead-end relay. Carries only the id (the new-API signal has no type).
     void shortcutRemovedById(const QString &id);
+    // Wayland: category metadata from ListCategories() — drives grouping,
+    // ordering, display names, and custom-group identity in the model.
+    void categoriesReady(const QList<CategoryInfoNew> &categories);
 
     //wm
     void compositingEnabledChanged(bool enabled);
@@ -203,6 +236,8 @@ public slots:
     // Keybinding
     QDBusPendingReply<>  KeybindingReset();
     QDBusPendingReply<QString> ListAllShortcuts();
+    // Wayland: fetch category metadata (ordering/display/custom flag).
+    QDBusPendingReply<> ListCategories();
     QString LookupConflictingShortcut(const QString &in0);
     QDBusPendingReply<ShortcutInfoNew> LookupConflictShortcut(const QString &in0);
     QDBusPendingReply<> ClearShortcutKeystrokes(const QString &in0, int in1);
@@ -238,6 +273,7 @@ private slots:
     void onLangSelectorStartServiceProcessFinished(QDBusPendingCallWatcher *w);
     // New API -> Old API adapters (Wayland)
     void onListAllShortcutsNewFinished(QDBusPendingCallWatcher *w);
+    void onListCategoriesFinished(QDBusPendingCallWatcher *w);
     void onGetShortcutNewFinished(QDBusPendingCallWatcher *w);
     void onSearchShortcutsNewFinished(QDBusPendingCallWatcher *w);
     // Bridge: new dde-services D-Bus signals (ShortcutChanged/ShortcutRemoved)

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -348,11 +348,34 @@ void KeyboardWorker::modifyShortcutEdit(ShortcutInfo *info) {
 
 void KeyboardWorker::addCustomShortcut(const QString &name, const QString &command, const QString &accels)
 {
-    m_keyboardDBusProxy->AddCustomShortcut(name, command, accels);
+    QDBusPendingReply<QString> reply = m_keyboardDBusProxy->AddCustomShortcut(name, command, accels);
+    if (!m_keyboardDBusProxy->isWayland())
+        return;
+
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardWorker::onAddCustomShortcutFinished);
+}
+
+void KeyboardWorker::callModifyCustomShortcut(const QString &id, const QString &name,
+                                              const QString &command, const QString &accels,
+                                              int type)
+{
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->ModifyCustomShortcut(id, name, command, accels);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+    watcher->setProperty("id", id);
+    watcher->setProperty("type", type);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardWorker::onModifyCustomShortcutFinished);
 }
 
 void KeyboardWorker::modifyCustomShortcut(ShortcutInfo *info)
 {
+    if (m_keyboardDBusProxy->isWayland()) {
+        callModifyCustomShortcut(info->id, info->name, info->command, info->accels, info->type);
+        return;
+    }
+
     if (info->replace) {
         onDisableShortcut(info->replace);
     }
@@ -360,9 +383,6 @@ void KeyboardWorker::modifyCustomShortcut(ShortcutInfo *info)
     // reset replace shortcut
     info->replace = nullptr;
 
-    // Wayland custom-shortcut CRUD is stubbed at the controller layer
-    // (KeyboardController::modifyCustomShortcut early-returns) until
-    // dde-services implements ModifyCustomShortcut, so this body is X11-only.
     const QString &result = m_keyboardDBusProxy->LookupConflictingShortcut(info->accels);
 
     if (!result.isEmpty()) {
@@ -406,7 +426,16 @@ QString KeyboardWorker::lookupConflictingShortcut(const QString &key)
 
 void KeyboardWorker::delShortcut(ShortcutInfo* info)
 {
-    m_keyboardDBusProxy->DeleteCustomShortcut(info->id);
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->DeleteCustomShortcut(info->id);
+    if (m_keyboardDBusProxy->isWayland()) {
+        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+        watcher->setProperty("id", info->id);
+        watcher->setProperty("type", info->type);
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardWorker::onDeleteCustomShortcutFinished);
+        return;
+    }
+
     if (m_shortcutModel)
         m_shortcutModel->delInfo(info);
 }
@@ -929,6 +958,11 @@ void KeyboardWorker::cleanShortcutSlef(const QString &id, const int type, const 
 
 void KeyboardWorker::setNewCustomShortcut(const QString &id, const QString &name, const QString &command, const QString &accles)
 {
+    if (m_keyboardDBusProxy->isWayland()) {
+        callModifyCustomShortcut(id, name, command, accles, ShortcutModel::Custom);
+        return;
+    }
+
     m_keyboardDBusProxy->ModifyCustomShortcut(id, name, command, accles);
 }
 
@@ -1088,6 +1122,51 @@ void KeyboardWorker::onCustomConflictCleanFinished(QDBusPendingCallWatcher *w)
     }
 
     w->deleteLater();
+}
+
+void KeyboardWorker::onAddCustomShortcutFinished(QDBusPendingCallWatcher *watch)
+{
+    QDBusPendingReply<QString> reply = *watch;
+    if (reply.isError() || reply.value().isEmpty()) {
+        qWarning() << "AddCustomShortcut failed:"
+                   << (reply.isError() ? reply.error().message() : QStringLiteral("server returned empty id"));
+        refreshShortcut();
+    } else {
+        onAdded(reply.value(), ShortcutModel::Custom);
+    }
+
+    watch->deleteLater();
+}
+
+void KeyboardWorker::onModifyCustomShortcutFinished(QDBusPendingCallWatcher *watch)
+{
+    QDBusPendingReply<bool> reply = *watch;
+    const QString id = watch->property("id").toString();
+    const int type = watch->property("type").toInt();
+    const bool success = (!reply.isError() && reply.value());
+    if (!success) {
+        qWarning() << "ModifyCustomShortcut failed for" << id
+                   << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
+        refreshShortcut();
+    } else if (!id.isEmpty()) {
+        onShortcutChanged(id, type);
+    }
+
+    watch->deleteLater();
+}
+
+void KeyboardWorker::onDeleteCustomShortcutFinished(QDBusPendingCallWatcher *watch)
+{
+    QDBusPendingReply<bool> reply = *watch;
+    const QString id = watch->property("id").toString();
+    const bool success = (!reply.isError() && reply.value());
+    if (!success) {
+        qWarning() << "DeleteCustomShortcut failed for" << id
+                   << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
+    }
+    refreshShortcut();
+
+    watch->deleteLater();
 }
 
 QString KeyboardWorker::makeShortcutKey(const QString &id, int type)

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -73,6 +73,24 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Added, this, &KeyboardWorker::onAdded);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::AllShortcutsReady, this, &KeyboardWorker::onAllShortcutsReady);
+    // Wayland: category metadata (ordering/display/custom flag) from the
+    // service's ListCategories(). Feeds the model so it never hardcodes
+    // category strings for grouping or Custom detection.
+    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::categoriesReady, this, [this](const QList<CategoryInfoNew> &cats) {
+        if (!m_shortcutModel)
+            return;
+        QList<ShortcutModel::CategoryMeta> meta;
+        meta.reserve(cats.size());
+        for (const auto &c : cats) {
+            ShortcutModel::CategoryMeta m;
+            m.key = c.key;
+            m.displayName = c.displayName;
+            m.order = c.order;
+            m.isCustom = c.isCustom;
+            meta.append(m);
+        }
+        m_shortcutModel->setCategoryMeta(meta);
+    });
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::searchShortcutsReady, this, [this](const QString &json) {
         if (m_shortcutModel)
             m_shortcutModel->setSearchResult(json);
@@ -146,6 +164,8 @@ void KeyboardWorker::refreshShortcut()
     if (m_keyboardDBusProxy->isWayland()) {
         // Wayland: result is delivered asynchronously via AllShortcutsReady signal.
         m_keyboardDBusProxy->ListAllShortcuts();
+        // Also refresh category metadata (ordering/display/custom flag).
+        m_keyboardDBusProxy->ListCategories();
         return;
     }
     QDBusPendingCallWatcher *result = new QDBusPendingCallWatcher(m_keyboardDBusProxy->ListAllShortcuts(), this);

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -49,6 +49,13 @@ public:
     void modifyShortcutEdit(ShortcutInfo* info);
     void addCustomShortcut(const QString& name, const QString& command, const QString& accels);
     void modifyCustomShortcut(ShortcutInfo *info);
+    // Fire ModifyCustomShortcut on the Wayland service and wire the reply to
+    // onModifyCustomShortcutFinished. Shared by modifyCustomShortcut (Wayland
+    // branch) and setNewCustomShortcut so the watcher/id/type setup stays in
+    // one place.
+    void callModifyCustomShortcut(const QString &id, const QString &name,
+                                  const QString &command, const QString &accels,
+                                  int type);
 
     void grabScreen();
     bool checkAvaliable(const QString& key);
@@ -122,6 +129,9 @@ public Q_SLOTS:
     void onLookupConflictForShortcutFinished(QDBusPendingCallWatcher *watch);
     void onShortcutCleanFinished(QDBusPendingCallWatcher *watch);
     void onCustomConflictCleanFinished(QDBusPendingCallWatcher *w);
+    void onAddCustomShortcutFinished(QDBusPendingCallWatcher *watch);
+    void onModifyCustomShortcutFinished(QDBusPendingCallWatcher *watch);
+    void onDeleteCustomShortcutFinished(QDBusPendingCallWatcher *watch);
 
 private:
     static QString makeShortcutKey(const QString &id, int type);

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -144,6 +144,13 @@ QList<ShortcutInfo *> ShortcutModel::appInfo() const
 
 QList<ShortcutInfo *> ShortcutModel::customInfo() const
 {
+    // Wayland dynamic grouping: the custom group lives in m_groupInfos under
+    // the service-reported custom key (falls back to the legacy list on X11).
+    if (!m_groupInfos.isEmpty()) {
+        const QString key = customCategoryKey();
+        if (!key.isEmpty())
+            return m_groupInfos.value(key);
+    }
     return m_customInfos;
 }
 
@@ -157,7 +164,7 @@ ShortcutInfo *ShortcutModel::shortcutAt(int index, int *corners)
     if (index < 0)
         return nullptr;
 
-    auto getCorners = [](QList<ShortcutInfo *>&list, int index) {
+    auto getCorners = [](const QList<ShortcutInfo *> &list, int index) {
         if (index == 0)
             return TopCorner;
         else if (index == list.count() - 1)
@@ -165,6 +172,20 @@ ShortcutInfo *ShortcutModel::shortcutAt(int index, int *corners)
         else
             return NoneCorner;
     };
+
+    // Wayland dynamic grouping: walk groups in service-supplied order.
+    if (!m_groupInfos.isEmpty()) {
+        for (const QString &key : groupOrder()) {
+            const auto &list = m_groupInfos[key];
+            if (index < list.count()) {
+                if (corners)
+                    *corners = getCorners(list, index);
+                return list.value(index);
+            }
+            index -= list.count();
+        }
+        return nullptr;
+    }
 
 #define CHECK_INDEX_DCC(List) \
     if (index < List.count()) { \
@@ -193,6 +214,9 @@ void ShortcutModel::delInfo(ShortcutInfo *info)
     if (m_customInfos.contains(info)) {
         m_customInfos.removeOne(info);
     }
+    // Wayland dynamic-grouping container: sweep by section key too.
+    for (auto it = m_groupInfos.begin(); it != m_groupInfos.end(); ++it)
+        it.value().removeOne(info);
 
     Q_EMIT delCustomInfo(info);
 
@@ -221,6 +245,10 @@ void ShortcutModel::removeShortcutById(const QString &id)
     };
     for (auto *list : lists)
         list->removeOne(info);
+
+    // Wayland dynamic-grouping container: sweep by section key too.
+    for (auto it = m_groupInfos.begin(); it != m_groupInfos.end(); ++it)
+        it.value().removeOne(info);
 
     invalidateSystemShortcutNamesCache();
     // Reuse the optimistic-delete UI path: delCustomInfo → ShortcutListModel::reset.
@@ -260,6 +288,8 @@ void ShortcutModel::onParseInfo(const QString &info)
     m_assistiveToolsInfos.clear();
     m_appInfos.clear();
     m_customInfos.clear();
+    // Wayland dynamic grouping containers
+    m_groupInfos.clear();
     
     // 清理系统快捷键名称缓存，因为数据即将更新
     invalidateSystemShortcutNamesCache();
@@ -283,51 +313,55 @@ void ShortcutModel::onParseInfo(const QString &info)
 
         m_infos << info;
 
-        // Wayland: use Section field from new API (avoids hardcoded ID lists)
-        QString section = obj["Section"].toString();
-        if (!section.isEmpty()) {
-            if (section == QLatin1String("System")) {
-                info->sectionName = tr("System");
-                m_systemInfos << info;
-                continue;
-            }
-            if (section == QLatin1String("App")) {
-                info->sectionName = tr("App");
-                m_appInfos << info;
-                continue;
-            }
-            if (section == QLatin1String("Custom")) {
-                info->sectionName = tr("Custom");
-                m_customInfos << info;
-                continue;
-            }
-            qWarning() << "Unknown shortcut section:" << section << "id=" << info->id;
+        // Wayland: group by the stable category key from the new API. dcc
+        // knows nothing about specific category values — ordering, display
+        // names, and which group is the user-editable (Custom) one all come
+        // from the service's ListCategories() metadata (see setCategoryMeta).
+        // Section = logical key (grouping); SectionName = already-resolved
+        // display text (rendered directly, dcc no longer translates).
+        QString sectionKey = obj["Section"].toString();
+        if (!sectionKey.isEmpty()) {
+            info->sectionKey = sectionKey;
+            info->sectionName = obj["SectionName"].toString();
+            if (info->sectionName.isEmpty())
+                info->sectionName = sectionKey;   // fallback to raw key
+            m_groupInfos[sectionKey].append(info);
+            continue;
         }
 
-        // X11: old ID-based categorization
+        // X11: old ID-based categorization. sectionKey mirrors sectionName
+        // (the translated text) so the QML section.property:"sectionKey"
+        // grouping reproduces the legacy group-by-translated-name behavior.
+        // The Wayland path above instead uses stable English keys from the
+        // service; X11 is legacy and single-locale, so this is equivalent.
         if (type != MEDIAKEY) {
             if (systemShortKeys.contains(info->id)) {
                 info->sectionName = tr("System");
+                info->sectionKey = info->sectionName;
                 m_systemInfos << info;
                 continue;
             }
             if (windowFilter.contains(info->id)) {
                 info->sectionName = tr("Window");
+                info->sectionKey = info->sectionName;
                 m_windowInfos << info;
                 continue;
             }
             if (workspaceFilter.contains(info->id)) {
                 info->sectionName = tr("Workspace");
+                info->sectionKey = info->sectionName;
                 m_workspaceInfos << info;
                 continue;
             }
             if (assistiveToolsFilter.contains(info->id)) {
                 info->sectionName = tr("AssistiveTools");
+                info->sectionKey = info->sectionName;
                 m_assistiveToolsInfos << info;
                 continue;
             }
             if (type == 1) {
                 info->sectionName = tr("Custom");
+                info->sectionKey = info->sectionName;
                 m_customInfos << info;
             }
         }
@@ -384,6 +418,15 @@ void ShortcutModel::onParseInfo(const QString &info)
     Q_EMIT listChanged(m_assistiveToolsInfos, InfoType::AssistiveTools);
     Q_EMIT listChanged(m_appInfos, InfoType::App);
     Q_EMIT listChanged(m_customInfos, InfoType::Custom);
+
+    // Wayland: items are in m_groupInfos, not the legacy fixed lists above.
+    // listChanged has no consumers on Wayland, so emit categoryMetaChanged
+    // to trigger ShortcutListModel::reset() — the view updates immediately
+    // with the data we just populated, even if ListCategories hasn't arrived
+    // yet. A later ListCategories reply will re-sort groups into their final
+    // order when setCategoryMeta fires categoryMetaChanged again.
+    if (!m_groupInfos.isEmpty())
+        Q_EMIT categoryMetaChanged();
 }
 
 void ShortcutModel::onCustomInfo(const QString &json)
@@ -400,6 +443,7 @@ void ShortcutModel::onCustomInfo(const QString &json)
     info->id      = obj["Id"].toString();
     info->command = obj["Exec"].toString();
     info->sectionName = tr("Custom");
+    info->sectionKey = info->sectionName;   // X11: mirror translated name
 
     m_infos.append(info);
     m_customInfos.append(info);
@@ -496,6 +540,19 @@ int ShortcutModel::indexOfShortcut(ShortcutInfo *info)
     if (!info)
         return -1;
 
+    // Wayland dynamic grouping: search groups in display order.
+    if (!m_groupInfos.isEmpty()) {
+        int row = 0;
+        for (const QString &key : groupOrder()) {
+            const auto &list = m_groupInfos[key];
+            const int idx = list.indexOf(info);
+            if (idx >= 0)
+                return row + idx;
+            row += list.size();
+        }
+        return -1;
+    }
+
     const QList<ShortcutInfo*> *lists[] = {
         &m_systemInfos, &m_windowInfos, &m_workspaceInfos,
         &m_assistiveToolsInfos, &m_appInfos, &m_customInfos
@@ -510,6 +567,75 @@ int ShortcutModel::indexOfShortcut(ShortcutInfo *info)
     }
 
     return -1;
+}
+
+void ShortcutModel::setCategoryMeta(const QList<CategoryMeta> &meta)
+{
+    m_categoryMeta.clear();
+    m_customCategoryKey.clear();
+    for (const auto &m : meta) {
+        m_categoryMeta.insert(m.key, m);
+        if (m.isCustom)
+            m_customCategoryKey = m.key;
+    }
+    invalidateSystemShortcutNamesCache();
+    Q_EMIT categoryMetaChanged();
+}
+
+QString ShortcutModel::sectionDisplayName(const QString &key) const
+{
+    // Service metadata is authoritative; fall back to the per-item resolved
+    // text carried in the group, then to the raw key.
+    auto it = m_categoryMeta.constFind(key);
+    if (it != m_categoryMeta.constEnd() && !it.value().displayName.isEmpty())
+        return it.value().displayName;
+
+    auto git = m_groupInfos.constFind(key);
+    if (git != m_groupInfos.constEnd() && !git.value().isEmpty()) {
+        const QString &name = git.value().first()->sectionName;
+        if (!name.isEmpty())
+            return name;
+    }
+    return key;
+}
+
+QString ShortcutModel::customCategoryKey() const
+{
+    // Wayland: from service metadata (setCategoryMeta).
+    if (!m_customCategoryKey.isEmpty())
+        return m_customCategoryKey;
+    // X11 fallback: the custom group's key is the section key of any
+    // type==Custom item (legacy items carry sectionKey == sectionName).
+    for (const auto *info : m_infos) {
+        if (info->type == Custom && !info->sectionKey.isEmpty())
+            return info->sectionKey;
+    }
+    return QString();
+}
+
+QList<QString> ShortcutModel::groupOrder() const
+{
+    // Order by service-supplied order; keys not in the metadata (e.g. items
+    // arriving before metadata) append by first-seen. The custom group is
+    // already last via its high order value from the service.
+    QList<QString> known, unknown;
+    for (const auto &m : m_categoryMeta) {
+        if (!m_groupInfos.contains(m.key))
+            continue;
+        known.append(m.key);
+    }
+    std::sort(known.begin(), known.end(),
+              [this](const QString &a, const QString &b) {
+        return m_categoryMeta.value(a).order < m_categoryMeta.value(b).order;
+    });
+    for (auto it = m_groupInfos.constBegin(); it != m_groupInfos.constEnd(); ++it) {
+        if (!m_categoryMeta.contains(it.key()))
+            unknown.append(it.key());
+    }
+    // Sort unknown keys for deterministic ordering across runs (QHash
+    // iteration is seed-dependent). Known keys are already sorted above.
+    unknown.sort();
+    return known + unknown;
 }
 
 ShortcutInfo *ShortcutModel::currentInfo() const
@@ -630,15 +756,15 @@ bool ShortcutModel::searchResultContains(const QString &id)
 QStringList ShortcutModel::getSystemShortcutNames() const
 {
     QStringList names;
-    
+
     // 合并所有系统相关的快捷键列表
     QList<QList<ShortcutInfo *>> systemLists = {
         m_systemInfos,
-        m_windowInfos, 
+        m_windowInfos,
         m_workspaceInfos,
         m_assistiveToolsInfos
     };
-    
+
     for (const auto &list : systemLists) {
         for (const auto *info : list) {
             if (info && !info->name.trimmed().isEmpty()) {
@@ -646,7 +772,22 @@ QStringList ShortcutModel::getSystemShortcutNames() const
             }
         }
     }
-    
+
+    // Wayland: items live in m_groupInfos rather than the legacy fixed lists.
+    // Collect names from all groups except the user-editable (Custom) one so
+    // that name-conflict detection works for system/app/workspace shortcuts.
+    if (names.isEmpty() && !m_groupInfos.isEmpty()) {
+        const QString customKey = customCategoryKey();
+        for (auto it = m_groupInfos.constBegin(); it != m_groupInfos.constEnd(); ++it) {
+            if (!customKey.isEmpty() && it.key() == customKey)
+                continue;
+            for (const auto *info : it.value()) {
+                if (info && !info->name.trimmed().isEmpty())
+                    names.append(info->name.trimmed());
+            }
+        }
+    }
+
     return names;
 }
 
@@ -747,6 +888,8 @@ QVariant ShortcutListModel::data(const QModelIndex &index, int role) const
         return info->accels;
     case SectionNameRole:
         return info->sectionName;
+    case SectionKeyRole:
+        return info->sectionKey;
     case CornersRole:
         return corners;
     case IsCustomRole:
@@ -766,7 +909,8 @@ QHash<int, QByteArray> ShortcutListModel::roleNames() const
     names[TypeRole] = "type";
     names[KeySequenceRole] = "keySequence";
     names[CommandRole] = "command";
-    names[SectionNameRole] = "section";
+    names[SectionNameRole] = "sectionName";
+    names[SectionKeyRole] = "sectionKey";
     names[AccelsRole] = "accels";
     names[CornersRole] = "corners";
     names[IsCustomRole] = "isCustom";

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -95,6 +95,28 @@ static QString toPinyin(const QString &name)
     return pinyin(name, TS_NoneTone).join(FieldSeparator) + FieldSeparator + firstLetters(name).join(FieldSeparator);
 }
 
+static void fillShortcutInfoFromJson(dccV25::ShortcutInfo *info, const QJsonObject &obj)
+{
+    if (!info)
+        return;
+
+    info->type = obj["Type"].toInt();
+    const QJsonArray accels = obj["Accels"].toArray();
+    info->accels = accels.isEmpty() ? QString() : accels.first().toString();
+    info->name = obj["Name"].toString();
+    info->pinyin = toPinyin(info->name);
+    info->id = obj["Id"].toString();
+    info->command = obj["Exec"].toString();
+
+    const QString sectionKey = obj["Section"].toString();
+    if (!sectionKey.isEmpty()) {
+        info->sectionKey = sectionKey;
+        info->sectionName = obj["SectionName"].toString();
+        if (info->sectionName.isEmpty())
+            info->sectionName = sectionKey;
+    }
+}
+
 using namespace dccV25;
 DCORE_USE_NAMESPACE
 ShortcutModel::ShortcutModel(QObject *parent)
@@ -455,25 +477,61 @@ void ShortcutModel::onKeyBindingChanged(const QString &value)
     const QJsonObject &obj       = QJsonDocument::fromJson(value.toStdString().c_str()).object();
     const QString     &update_id = obj["Id"].toString();
     const int     &update_type = obj["Type"].toInt();
+    if (update_id.isEmpty())
+        return;
+
     auto res = std::find_if(m_infos.begin(), m_infos.end(), [ = ] (const ShortcutInfo *info)->bool{
         return info->id == update_id && info->type == update_type;
     });
 
     if (res != m_infos.end()) {
-        (*res)->type = obj["Type"].toInt();
-        (*res)->accels  = obj["Accels"].toArray().first().toString();
-        (*res)->name    = obj["Name"].toString();
-        (*res)->command = obj["Exec"].toString();
+        const QString oldSectionKey = (*res)->sectionKey;
+        fillShortcutInfoFromJson(*res, obj);
+        if (!oldSectionKey.isEmpty() && oldSectionKey != (*res)->sectionKey)
+            m_groupInfos[oldSectionKey].removeOne(*res);
+        if (!(*res)->sectionKey.isEmpty() && !m_groupInfos[(*res)->sectionKey].contains(*res))
+            m_groupInfos[(*res)->sectionKey].append(*res);
+
+        bool searchUpdated = false;
+        for (ShortcutInfo *searchInfo : m_searchList) {
+            if (searchInfo && searchInfo->id == update_id && searchInfo->type == update_type) {
+                fillShortcutInfoFromJson(searchInfo, obj);
+                searchUpdated = true;
+            }
+        }
 
         Q_EMIT shortcutChanged((*res));
+        if (searchUpdated)
+            Q_EMIT searchFinished(m_searchList);
+        if (!m_groupInfos.isEmpty())
+            Q_EMIT categoryMetaChanged();
+        return;
     }
-    // NOTE: update-in-place only — no insert branch. A change signal for an id
-    // not yet in m_infos is dropped. On X11 new shortcuts arrive via Added →
-    // onCustomInfo (the insert path); on Wayland that path is unused (custom
-    // CRUD is stubbed) and a brand-new id would only appear through the next
-    // full ListAllShortcuts refresh. Tolerated because no realistic Wayland flow
-    // surfaces an unknown id via ShortcutChanged alone; revisit if dde-services
-    // grows dynamic shortcut registration.
+
+    ShortcutInfo *info = new ShortcutInfo();
+    fillShortcutInfoFromJson(info, obj);
+
+    if (!info->sectionKey.isEmpty()) {
+        m_infos.append(info);
+        m_groupInfos[info->sectionKey].append(info);
+        if (info->type == Custom)
+            m_customInfos.append(info);
+        invalidateSystemShortcutNamesCache();
+        Q_EMIT addCustomInfo(info);
+        Q_EMIT categoryMetaChanged();
+        return;
+    }
+
+    if (info->type != Custom) {
+        delete info;
+        return;
+    }
+
+    info->sectionName = tr("Custom");
+    info->sectionKey = info->sectionName;
+    m_infos.append(info);
+    m_customInfos.append(info);
+    Q_EMIT addCustomInfo(info);
 }
 
 void ShortcutModel::onWindowSwitchChanged(bool value)
@@ -682,6 +740,13 @@ void ShortcutModel::setSearchResult(const QString &searchResult)
     QJsonArray array = QJsonDocument::fromJson(searchResult.toStdString().c_str()).array();
     for (auto value : array) {
         QJsonObject obj  = value.toObject();
+        if (!obj["Section"].toString().isEmpty()) {
+            ShortcutInfo *info = new ShortcutInfo();
+            fillShortcutInfoFromJson(info, obj);
+            m_searchList << info;
+            continue;
+        }
+
         int         type = obj["Type"].toInt();
         ShortcutInfo *info = new ShortcutInfo();
         info->type         = type;

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -25,7 +25,8 @@ struct ShortcutInfo
     int type;
     ShortcutInfo *replace = nullptr;
     ShortcutItem *item = nullptr;
-    QString sectionName;
+    QString sectionKey;            // Stable logical category key (never translated)
+    QString sectionName;           // Resolved translated display text for section
     QString pinyin;
     int index = 0;
 
@@ -70,6 +71,13 @@ public:
 
     inline int count()
     {
+        // Wayland dynamic grouping: rows come from m_groupInfos in groupOrder.
+        if (!m_groupInfos.isEmpty()) {
+            int c = 0;
+            for (const auto &list : m_groupInfos)
+                c += list.count();
+            return c;
+        }
         int c = m_systemInfos.count() + m_windowInfos.count() + m_workspaceInfos.count()
                 + m_assistiveToolsInfos.count() + m_appInfos.count() + m_customInfos.count();
         return c;
@@ -104,8 +112,30 @@ public:
     static QStringList formatKeys(const QString &shortcut);
     int indexOfShortcut(ShortcutInfo *info);
 
+    // Wayland (new API): category metadata is supplied entirely by the
+    // service's ListCategories() — dcc never hardcodes category strings.
+    struct CategoryMeta {
+        QString key;
+        QString displayName;
+        int order = 0;
+        bool isCustom = false;
+    };
+    void setCategoryMeta(const QList<CategoryMeta> &meta);
+    // Display name for a section key (service metadata, then per-item
+    // resolved text, then the raw key).
+    QString sectionDisplayName(const QString &key) const;
+    // Keys in display order, per service metadata.
+    QList<QString> groupOrder() const;
+    // The user-editable (Custom) category key, per service metadata.
+    // On X11 (no service metadata) it is derived from the section key of a
+    // type==Custom item, so the QML Custom-button check still works.
+    QString customCategoryKey() const;
+
 Q_SIGNALS:
     void listChanged(QList<ShortcutInfo *>, InfoType);
+    // Wayland: category metadata (ordering/display/custom) changed — the list
+    // model resets so rows re-layout in the new order.
+    void categoryMetaChanged();
     void addCustomInfo(ShortcutInfo *info);
     void delCustomInfo(ShortcutInfo *info);
     void shortcutChanged(ShortcutInfo *info);
@@ -130,6 +160,11 @@ private:
     QList<ShortcutInfo *> m_assistiveToolsInfos;
     QList<ShortcutInfo *> m_appInfos;
     QList<ShortcutInfo *> m_customInfos;
+    // Wayland dynamic grouping: sectionKey -> items, plus service-supplied
+    // category metadata (ordering / display names / custom-group identity).
+    QHash<QString, QList<ShortcutInfo *>> m_groupInfos;
+    QHash<QString, CategoryMeta> m_categoryMeta;
+    QString m_customCategoryKey;
     QList<ShortcutInfo *> m_searchList;
     QList<ShortcutInfo *> m_windowSwitchStateInfos;
     ShortcutInfo *m_currentInfo = nullptr;
@@ -154,6 +189,7 @@ public:
         KeySequenceRole,
         AccelsRole,
         SectionNameRole,
+        SectionKeyRole,
         CornersRole,
         IsCustomRole
 

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -91,7 +91,7 @@ DccObject {
 
                 model: dccData.shortcutSearchModel()
 
-                section.property: "section"
+                section.property: "sectionKey"
                 section.criteria: ViewSection.FullString
                 section.delegate: RowLayout {
                     width: ListView.view.width
@@ -100,7 +100,7 @@ DccObject {
                     required property string section
 
                     Label {
-                        text: parent.section
+                        text: dccData.sectionDisplayName(parent.section)
                         font.bold: true
                         font.pointSize: 13
                         leftPadding: 20
@@ -111,7 +111,7 @@ DccObject {
                     D.Button {
                         id: button
                         focusPolicy: Qt.NoFocus
-                        visible: parent.section === qsTranslate("dccV25::ShortcutModel", "Custom")
+                        visible: parent.section === dccData.customCategoryKey()
                         checkable: true
                         checked: shortcutSettingsBody.isEditing
                         Layout.alignment: Qt.AlignRight | Qt.AlignVCenter

--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -24,13 +24,15 @@ using namespace DCC_NAMESPACE;
 struct GestureInfoNew {
     QString id;
     QString displayName;
-    int category;
-    int gestureType;     // 1=Swipe, 2=Hold
+    QString category;               // Logical category key (mirrors dde-services GestureInfo)
+    int gestureType;                // 1=Swipe, 2=Hold
     int fingerCount;
-    int direction;       // 0=None, 1=Down, 2=Left, 3=Up, 4=Right
+    int direction;                  // 0=None, 1=Down, 2=Left, 3=Up, 4=Right
     int triggerType;
     QStringList triggerValue;
     QString localLanguageName;
+    QString localLanguageCategory;  // Resolved display text for the category
+    bool isCustom = false;          // True for runtime-added gestures
 };
 Q_DECLARE_METATYPE(GestureInfoNew)
 Q_DECLARE_METATYPE(QList<GestureInfoNew>)
@@ -39,7 +41,8 @@ inline QDBusArgument &operator<<(QDBusArgument &argument, const GestureInfoNew &
     argument.beginStructure();
     argument << info.id << info.displayName << info.category
              << info.gestureType << info.fingerCount << info.direction
-             << info.triggerType << info.triggerValue << info.localLanguageName;
+             << info.triggerType << info.triggerValue << info.localLanguageName
+             << info.localLanguageCategory << info.isCustom;
     argument.endStructure();
     return argument;
 }
@@ -48,7 +51,8 @@ inline const QDBusArgument &operator>>(const QDBusArgument &argument, GestureInf
     argument.beginStructure();
     argument >> info.id >> info.displayName >> info.category
              >> info.gestureType >> info.fingerCount >> info.direction
-             >> info.triggerType >> info.triggerValue >> info.localLanguageName;
+             >> info.triggerType >> info.triggerValue >> info.localLanguageName
+             >> info.localLanguageCategory >> info.isCustom;
     argument.endStructure();
     return argument;
 }


### PR DESCRIPTION
## Summary
- Wire Wayland Add/Modify/Delete custom shortcut calls through the new shortcut service APIs.
- Fetch custom shortcut commands asynchronously for runtime custom rows.
- Keep dynamic category and custom row updates synchronized in the shortcut model.

## Test plan
- cmake --build build --target keyboard mouse

## Dependency
Stacked on #3320. This branch is based on yixinshark:fix/shortcut-dynamic-categories, so the PR diff may include #3320 until that PR is merged. Please review the top commit: f248ef575 feat(keyboard): wire custom shortcut CRUD on Wayland.