### PR TITLE
fix(accounts): center custom avatar empty state

### DIFF
--- a/src/plugin-accounts/qml/AvatarSettingsDialog.qml
+++ b/src/plugin-accounts/qml/AvatarSettingsDialog.qml
@@ -244,8 +244,9 @@ D.DialogWindow {
             CustomAvatarEmpatyArea {
                 id: customEmptyAvatar
                 visible: needShow()
-                Layout.alignment: Qt.AlignHCenter
-                Layout.rightMargin: 10
+                Layout.fillWidth: true
+                Layout.fillHeight: true
+                Layout.alignment: Qt.AlignHCenter | Qt.AlignVCenter
                 onIconDropped: function (url){
                     let filePath = url.toString()
                     const sourceFile = filePath.replace("file://", "")

--- a/src/plugin-accounts/qml/CustomAvatarEmpatyArea.qml
+++ b/src/plugin-accounts/qml/CustomAvatarEmpatyArea.qml
@@ -9,8 +9,9 @@ import org.deepin.dtk 1.0 as D
 Control {
     id: control
     property real radius: 8
-    width: 430
-    height: 360
+    property bool invalidFileType: false
+    implicitWidth: 460
+    implicitHeight: 360
 
     signal requireFileDialog()
     signal iconDropped(string file)
@@ -57,6 +58,7 @@ Control {
             anchors.fill: parent
             hoverEnabled: true
             onClicked: {
+                control.invalidFileType = false
                 requireFileDialog()
             }
         }
@@ -69,45 +71,48 @@ Control {
                     var filePath = drop.urls[0].toString()
                     var ext = filePath.substring(filePath.lastIndexOf('.') + 1).toLowerCase()
                     if (['png', 'bmp', 'jpg', 'jpeg'].indexOf(ext) === -1) {
-                        errorLabel.visible = true
-                        normalLabel.visible = false
+                        control.invalidFileType = true
                         return
                     }
-                    errorLabel.visible = false
-                    normalLabel.visible = true
+                    control.invalidFileType = false
                     iconDropped(filePath)
                 }
             }
         }
     }
-    D.DciIcon {
-        id: addIcon
-        anchors.centerIn: parent
-        name: "dcc_user_add_icon"
-        sourceSize:  Qt.size(64, 64)
-    }
 
-    D.Label {
-        id: normalLabel
-        width: 360
-        wrapMode: Text.WordWrap
-        font: D.DTK.fontManager.t8
-        anchors.top: addIcon.bottom
-        anchors.topMargin: 20
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        text: qsTr("You haven't uploaded an avatar yet. Click or drag and drop to upload an image.")
-    }
+    Item {
+        id: emptyState
+        width: shape.width - 40
+        height: addIcon.height + 20 + messageLabel.implicitHeight
+        anchors.centerIn: shape
 
-    D.Label {
-        id: errorLabel
-        width: 360
-        wrapMode: Text.WordWrap
-        anchors.top: addIcon.bottom
-        anchors.topMargin: 20
-        horizontalAlignment: Text.AlignHCenter
-        anchors.horizontalCenter: parent.horizontalCenter
-        visible: false
-        text: qsTr("The uploaded file type is incorrect, please upload it again")
+        D.DciIcon {
+            id: addIcon
+            width: 64
+            height: 64
+            anchors.top: parent.top
+            anchors.horizontalCenter: parent.horizontalCenter
+            name: "dcc_user_add_icon"
+            fallbackToQIcon: false
+            palette: D.DTK.makeIconPalette(control.palette)
+            mode: control.D.ColorSelector.controlState
+            theme: control.D.ColorSelector.controlTheme
+            sourceSize: Qt.size(width, height)
+        }
+
+        D.Label {
+            id: messageLabel
+            width: parent.width
+            wrapMode: Text.WordWrap
+            font: D.DTK.fontManager.t8
+            anchors.top: addIcon.bottom
+            anchors.topMargin: 20
+            anchors.horizontalCenter: parent.horizontalCenter
+            horizontalAlignment: Text.AlignHCenter
+            text: control.invalidFileType
+                ? qsTr("The uploaded file type is incorrect, please upload it again")
+                : qsTr("You haven't uploaded an avatar yet. Click or drag and drop to upload an image.")
+        }
     }
 }


### PR DESCRIPTION
## Summary
1. Center the avatar upload placeholder inside the dashed drop area.
2. Resolve dark theme icon lookup to use the bundled DCI asset.

## 概要
1. 将头像上传前的缺省图和提示文案整体居中到虚线拖拽框内。
2. 修复深色主题图标查找逻辑，使用内置 DCI 资源。

## Tracking
PMS: BUG-368683

## Verification
- `cmake --build build -j2 --target accounts accounts_qml/fast dde-control-center`
- Manually verified the custom avatar empty state behavior during local runtime.

## 验证
- 已执行 `cmake --build build -j2 --target accounts accounts_qml/fast dde-control-center`
- 已在本地运行中验证自定义头像空态显示行为。

## Summary by Sourcery

Center the custom avatar upload empty state inside its drop area and improve icon and message handling.

Bug Fixes:
- Show a unified message label that toggles between normal empty-state guidance and invalid file type errors.
- Use the proper DCI icon asset with theme-aware palette and mode for the custom avatar empty state.

Enhancements:
- Center the empty-state icon and message within the dashed drop region and make the avatar area adapt to layout dimensions instead of fixed size.