### PR TITLE
fix: resolve dcc-edit icon blur at 1.25x scale

### DIFF
--- a/src/plugin-accounts/qml/EditActionLabel.qml
+++ b/src/plugin-accounts/qml/EditActionLabel.qml
@@ -3,6 +3,7 @@
 
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import org.deepin.dtk 1.0 as D
 import org.deepin.dtk.style 1.0 as DS
 
@@ -54,40 +55,44 @@ D.LineEdit {
         font: edit.font
     }
 
-    D.ActionButton {
-        id: editButton
-        focusPolicy: Qt.StrongFocus
-        width: 30
-        height: 30
-        icon.name: "dcc-edit"
-        icon.width: DS.Style.edit.actionIconSize
-        icon.height: DS.Style.edit.actionIconSize
-        hoverEnabled: true
-        background: Rectangle {
-            anchors.fill: parent
-            property D.Palette pressedColor: D.Palette {
-                normal: Qt.rgba(0, 0, 0, 0.2)
-                normalDark: Qt.rgba(1, 1, 1, 0.25)
-            }
-            property D.Palette hoveredColor: D.Palette {
-                normal: Qt.rgba(0, 0, 0, 0.1)
-                normalDark: Qt.rgba(1, 1, 1, 0.1)
-            }
-            radius: DS.Style.control.radius
-            color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
-            border {
-                color: parent.palette.highlight
-                width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
-            }
-        }
+    RowLayout {
+        id: actionButtons
         anchors {
             right: edit.right
             verticalCenter: edit.verticalCenter
         }
-        onClicked: {
-            edit.readOnly = false
-            edit.selectAll()
-            edit.forceActiveFocus()
+
+        D.ActionButton {
+            id: editButton
+            focusPolicy: Qt.StrongFocus
+            Layout.preferredWidth: 30
+            Layout.preferredHeight: 30
+            icon.name: "dcc-edit"
+            icon.width: DS.Style.edit.actionIconSize
+            icon.height: DS.Style.edit.actionIconSize
+            hoverEnabled: true
+            background: Rectangle {
+                anchors.fill: parent
+                property D.Palette pressedColor: D.Palette {
+                    normal: Qt.rgba(0, 0, 0, 0.2)
+                    normalDark: Qt.rgba(1, 1, 1, 0.25)
+                }
+                property D.Palette hoveredColor: D.Palette {
+                    normal: Qt.rgba(0, 0, 0, 0.1)
+                    normalDark: Qt.rgba(1, 1, 1, 0.1)
+                }
+                radius: DS.Style.control.radius
+                color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                border {
+                    color: parent.palette.highlight
+                    width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                }
+            }
+            onClicked: {
+                edit.readOnly = false
+                edit.selectAll()
+                edit.forceActiveFocus()
+            }
         }
     }
 }

--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -257,61 +257,71 @@ DccObject {
                             }
                         }
 
-                        D.ActionButton {
-                            id: editButton
-                            visible: hoverHandler.hovered || layout.showActions
-                            implicitWidth: 30
-                            implicitHeight: 30
-                            icon.name: "dcc_edit"
-                            icon.width: DS.Style.edit.actionIconSize
-                            icon.height: DS.Style.edit.actionIconSize
-                            background: Rectangle {
-                                property D.Palette pressedColor: D.Palette {
-                                    normal: Qt.rgba(0, 0, 0, 0.2)
-                                    normalDark: Qt.rgba(1, 1, 1, 0.25)
+                        RowLayout {
+                            id: actionButtons
+                            Layout.preferredWidth: 60
+                            Layout.preferredHeight: 30
+                            Layout.fillWidth: false
+                            Layout.topMargin: 5
+                            Layout.bottomMargin: 5
+                            spacing: 0
+
+                            D.ActionButton {
+                                id: editButton
+                                visible: hoverHandler.hovered || layout.showActions
+                                implicitWidth: 30
+                                implicitHeight: 30
+                                icon.name: "dcc_edit"
+                                icon.width: DS.Style.edit.actionIconSize
+                                icon.height: DS.Style.edit.actionIconSize
+                                background: Rectangle {
+                                    property D.Palette pressedColor: D.Palette {
+                                        normal: Qt.rgba(0, 0, 0, 0.2)
+                                        normalDark: Qt.rgba(1, 1, 1, 0.25)
+                                    }
+                                    property D.Palette hoveredColor: D.Palette {
+                                        normal: Qt.rgba(0, 0, 0, 0.1)
+                                        normalDark: Qt.rgba(1, 1, 1, 0.1)
+                                    }
+                                    radius: DS.Style.control.radius
+                                    color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                                    border {
+                                        color: parent.palette.highlight
+                                        width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                    }
                                 }
-                                property D.Palette hoveredColor: D.Palette {
-                                    normal: Qt.rgba(0, 0, 0, 0.1)
-                                    normalDark: Qt.rgba(1, 1, 1, 0.1)
-                                }
-                                radius: DS.Style.control.radius
-                                color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
-                                border {
-                                    color: parent.palette.highlight
-                                    width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
-                                }
-                            }
-                            onClicked: {
-                                nameEditor.readOnly = false;
-                                nameEditor.forceActiveFocus();
-                            }
-                        }
-                        D.ActionButton {
-                            id: deleteButton
-                            visible: hoverHandler.hovered || layout.showActions
-                            implicitWidth: 30
-                            implicitHeight: 30
-                            icon.name: "dcc_delete"
-                            icon.width: DS.Style.edit.actionIconSize
-                            icon.height: DS.Style.edit.actionIconSize
-                            background: Rectangle {
-                                property D.Palette pressedColor: D.Palette {
-                                    normal: Qt.rgba(0, 0, 0, 0.2)
-                                    normalDark: Qt.rgba(1, 1, 1, 0.25)
-                                }
-                                property D.Palette hoveredColor: D.Palette {
-                                    normal: Qt.rgba(0, 0, 0, 0.1)
-                                    normalDark: Qt.rgba(1, 1, 1, 0.1)
-                                }
-                                radius: DS.Style.control.radius
-                                color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
-                                border {
-                                    color: parent.palette.highlight
-                                    width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                onClicked: {
+                                    nameEditor.readOnly = false;
+                                    nameEditor.forceActiveFocus();
                                 }
                             }
-                            onClicked: {
-                                layout.requestDelete(modelData);
+                            D.ActionButton {
+                                id: deleteButton
+                                visible: hoverHandler.hovered || layout.showActions
+                                implicitWidth: 30
+                                implicitHeight: 30
+                                icon.name: "dcc_delete"
+                                icon.width: DS.Style.edit.actionIconSize
+                                icon.height: DS.Style.edit.actionIconSize
+                                background: Rectangle {
+                                    property D.Palette pressedColor: D.Palette {
+                                        normal: Qt.rgba(0, 0, 0, 0.2)
+                                        normalDark: Qt.rgba(1, 1, 1, 0.25)
+                                    }
+                                    property D.Palette hoveredColor: D.Palette {
+                                        normal: Qt.rgba(0, 0, 0, 0.1)
+                                        normalDark: Qt.rgba(1, 1, 1, 0.1)
+                                    }
+                                    radius: DS.Style.control.radius
+                                    color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                                    border {
+                                        color: parent.palette.highlight
+                                        width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                                    }
+                                }
+                                onClicked: {
+                                    layout.requestDelete(modelData);
+                                }
                             }
                         }
 


### PR DESCRIPTION
1. Wrap action buttons in RowLayout containers in EditActionLabel.qml
2. Wrap edit and delete action buttons in RowLayout in AuthenticationMain.qml
3. Replace direct width/height with Layout.preferredWidth/ preferredHeight
4. Add proper Layout margins and spacing properties
5. Import QtQuick.Layouts module in EditActionLabel.qml
6. Use RowLayout to ensure proper pixel alignment at fractional scale factors

The action buttons were previously positioned using anchors directly, which could result in sub-pixel positioning at fractional scale factors like 1.25x. This caused the dcc-edit and dcc_delete icons to appear blurry. By using RowLayout, the layout system handles pixel alignment more accurately, preventing the blurriness issue.

Log: 修复dcc-edit图标在1.25倍缩放下显示模糊的问题

Influence:
1. Test icon rendering at 1.25x display scale - verify no blurriness
2. Test icon rendering at 1x, 1.5x, and 2x scales for consistency
3. Verify edit button functionality in account settings (EditActionLabel)
4. Verify edit and delete buttons in authentication settings
5. Test button hover and pressed visual states
6. Verify button alignment and positioning within the layout
7. Check that button visibility on hover still works correctly

fix: 解决dcc-edit图标在1.25倍缩放下的模糊问题

1. 在EditActionLabel.qml中将操作按钮包装在RowLayout容器中
2. 在AuthenticationMain.qml中将编辑和删除按钮包装在RowLayout中
3. 将直接的width/height替换为Layout.preferredWidth/preferredHeight
4. 添加适当的Layout边距和间距属性
5. 在EditActionLabel.qml中导入QtQuick.Layouts模块
6. 使用RowLayout确保在小数缩放因子下正确的像素对齐

操作按钮之前直接使用anchors进行定位，在小数缩放因子（如1.25倍）下可
能导致亚像素定位。这导致dcc-edit和dcc_delete图标显示模糊。通过使用
RowLayout，布局系统能更准确地处理像素对齐，从而避免模糊问题。

Log: 修复dcc-edit图标在1.25倍缩放下显示模糊的问题

Influence:
1. 在1.25倍显示缩放下测试图标渲染 - 验证无模糊
2. 在1倍、1.5倍和2倍缩放下测试图标渲染一致性
3. 验证账户设置中编辑按钮功能（EditActionLabel）
4. 验证认证设置中编辑和删除按钮功能
5. 测试按钮悬停和按下视觉状态
6. 验证按钮在布局中的对齐和定位
7. 检查悬停时按钮可见性是否正常工作

PMS: BUG-364883