### PR TITLE
fix(sound): avoid duplicate muted volume feedback

### DIFF
--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -204,7 +204,7 @@ void SoundWorker::setSourceVolume(double volume)
 void SoundWorker::setSinkVolume(double volume)
 {
     qWarning()<<__FUNCTION__<<volume;
-    m_soundDBusInter->SetVolumeSink(volume, true);
+    m_soundDBusInter->SetVolumeSink(volume, !m_soundDBusInter->muteSink());
     qCDebug(DdcSoundWorker) << "set sink volume to " << volume;
 }
 


### PR DESCRIPTION
## Summary
- Avoid requesting volume feedback when output is currently muted.
- Keep normal volume feedback unchanged when output is not muted.

## Issue
PMS: BUG-368463

## Summary by Sourcery

Bug Fixes:
- Avoid triggering sink volume feedback when the sink is muted while preserving normal feedback behavior when unmuted.