### PR TITLE
fix: prevent scroll bounce and focus jump when switching apps in

### DIFF
--- a/src/dde-control-center/plugin/DccRightView.qml
+++ b/src/dde-control-center/plugin/DccRightView.qml
@@ -15,6 +15,14 @@ Flickable {
 
     contentHeight: groupView.height
 
+    // 修复：内容缩小到视口以内时，Qt Flickable C++ 内部可能保留旧的滚动偏移，
+    // 导致切换 app 回来后 contentY 越界使页面滚飞。
+    onContentYChanged: {
+        if (!moving && !dragging && contentHeight <= height && contentY > 0) {
+            cancelFlick()
+            contentY = 0
+        }
+    }
     ScrollBar.vertical: ScrollBar { }
 
     DccGroupView {
@@ -89,6 +97,11 @@ Flickable {
     }
     Connections {
         target: DccApp.mainWindow()
+        function onActiveChanged() {
+            if (!target.active) {
+                skipNextFocusChange = true
+            }
+        }
         function onActiveFocusItemChanged() {
             var focusItem = target.activeFocusItem
             var parentItem = focusItem
@@ -99,12 +112,26 @@ Flickable {
                 return
             }
 
+            // 跳过标记：只在焦点回到 groupView 内部时消耗
+            if (skipNextFocusChange && parentItem === groupView) {
+                skipNextFocusChange = false
+                lastFocusedItem = focusItem
+                return
+            }
+
+            lastFocusedItem = focusItem
             let itemY = focusItem.mapToItem(control, 0, 0).y
             if ((itemY + focusItem.height) > control.height) {
                 control.contentY = itemY + focusItem.height - control.height + control.contentY
             } else if (itemY < 0) {
                 control.contentY = focusItem.mapToItem(groupView, 0, 0).y
             }
+            var maxY = Math.max(0, control.contentHeight - control.height)
+            if (control.contentY > maxY) {
+                control.contentY = maxY
+            }
         }
     }
+    property var lastFocusedItem: null
+    property bool skipNextFocusChange: true
 }


### PR DESCRIPTION
DccRightView

1. Fix contentY exceeding bounds when content fits viewport
   - Add onContentYChanged handler to reset contentY to 0 when contentHeight is less than height
   - Prevents scroll position from being retained incorrectly after app switch

2. Add active window state tracking to skip redundant focus changes
   - Save lastFocusedItem in a property instead of closure
   - When main window becomes inactive, set skipNextFocusChange flag
   - When focus returns to groupView internals, skip the focus scroll adjustment to avoid jump

3. Clamp contentY to max valid value after focus-based scroll to prevent overscroll

Log: Fixed scroll bounce and focus jump issue when switching applications

Influence:
1. Test DccRightView with content smaller than viewport height; switch to another app and back; verify scroll position stays at top
2. Test with content larger than viewport; switch apps; verify no scroll jump or focus change
3. Test focus-based auto-scroll behavior still works correctly for keyboard navigation within the list
4. Verify no regression for focus changes during normal app usage (e.g., clicking items, tab navigation)
5. Test on different locales and layouts to ensure robustness

fix: 阻止 DccRightView 中应用切换时的滚动跳跃与焦点跳转问题

1. 修复内容适配视口时 contentY 越界问题
   - 添加 onContentYChanged 处理器，当 contentHeight 小于 height 时重置 contentY 为 0
   - 避免应用切换后滚动位置被错误保留

2. 添加活动窗口状态跟踪以跳过冗余焦点变化
   - 使用属性保存 lastFocusedItem 而非闭包
   - 当主窗口变为非活动时设置 skipNextFocusChange 标记
   - 当焦点回到 groupView 内部时跳过焦点滚动的调整，避免跳跃

3. 在焦点滚动后钳制 contentY 到最大有效值，防止过度滚动

Log: 修复应用切换时的滚动跳跃与焦点跳转问题

Influence:
1. 测试 DccRightView 内容小于视口高度时切换应用再返回，确认滚动位置保持 在顶部
2. 测试内容大于视口高度时切换应用，确认无滚动跳跃或焦点变化
3. 测试键盘导航在列表内自动滚动行为是否仍正常工作
4. 验证正常应用使用中（如点击项目、Tab 导航）无回归
5. 在不同语言和布局下测试以确保健壮性

PMS: BUG-367961