### PR TITLE
fix: add user timezone existence check in datetime plugin

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -1024,6 +1024,11 @@ void DatetimeModel::removeUserTimeZoneById(const QString &zoneId)
     m_work->removeUserTimeZone(zoneId);
 }
 
+bool DatetimeModel::hasUserTimeZone(const QString &zoneId) const
+{
+    return m_userZoneIds.contains(zoneId);
+}
+
 void DatetimeModel::setSystemTimeZone(const QString &zoneId)
 {
     if (zoneId.isEmpty() || !m_work)

--- a/src/plugin-datetime/operation/datetimemodel.h
+++ b/src/plugin-datetime/operation/datetimemodel.h
@@ -233,6 +233,7 @@ public Q_SLOTS:
     void addUserTimeZoneById(const QString &zoneId);
     void removeUserTimeZoneById(const QString &name);
     void setSystemTimeZone(const QString &zoneId);
+    Q_INVOKABLE bool hasUserTimeZone(const QString &zoneId) const;
     QString timeZoneDescription(const ZoneInfo &zone) const;
     void ensureLangModel();
     void addLang(const QString &lang);

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -535,12 +535,12 @@ DccObject {
                                         timezoneListWindow.setViewIndex(index)
                                     }
                                 }
-                                onCheckedChanged: {
-                                    if (checked) {
-                                        let zoneId = model.zoneId
+                                onClicked: {
+                                    let zoneId = model.zoneId
+                                    if (checked && !dccData.hasUserTimeZone(zoneId)) {
                                         dccData.addUserTimeZoneById(zoneId)
-                                        timezoneListWindow.close()
                                     }
+                                    timezoneListWindow.close()
                                 }
                             }
                         }


### PR DESCRIPTION
1. Add hasUserTimezone() method to DatetimeModel that checks if a zoneId exists in m_userZoneIds
2. Declare method as Q_INVOKABLE for QML access
3. Update QML onCheckedChanged handler to onClicked for more intuitive UX
4. Add check before adding timezone to prevent duplicates
5. Ensure dialog always closes after interaction

Log: Added timezone duplicate check and improved checkbox interaction in datetime settings

Influence:
1. Test adding existing timezone - should not add duplicate
2. Test adding new timezone - should add and close dialog
3. Verify dialog closes on click even if timezone already exists
4. Test with empty zoneId - should return false
5. Verify QML integration with new Q_INVOKABLE method

feat: 在日期时间插件中添加用户时区存在性检查

1. 在 DatetimeModel 中添加 hasUserTimezone() 方法，用于检查 zoneId 是否 存在于 m_userZoneIds
2. 声明方法为 Q_INVOKABLE 以便 QML 访问
3. 将 QML 中的 onCheckedChanged 处理器更新为 onClicked，提供更直观的用户 体验
4. 在添加时区前增加检查，防止重复添加
5. 确保交互后对话框始终关闭

Log: 在日期时间设置中添加时区重复检查并改进复选框交互

Influence:
1. 测试添加已存在的时区 - 不应添加重复项
2. 测试添加新时区 - 应添加并关闭对话框
3. 验证即使时区已存在，点击后对话框也会关闭
4. 测试空 zoneId - 应返回 false
5. 验证与新的 Q_INVOKABLE 方法的 QML 集成

PMS: BUG-368113

## Summary by Sourcery

Add a user timezone existence check to the datetime plugin and wire it into the QML UI to prevent duplicate timezones while keeping the dialog behavior consistent.

New Features:
- Expose a QML-invokable hasUserTimezone(zoneId) API on DatetimeModel to query whether a user timezone already exists.

Bug Fixes:
- Prevent adding duplicate user timezones when interacting with the timezone checkbox in the datetime settings UI.
- Ensure the timezone selection dialog reliably closes after checkbox interaction, regardless of whether a new timezone was added.

Enhancements:
- Adjust the timezone checkbox handler from onCheckedChanged to onClicked for more intuitive interaction in the datetime settings UI.