### PR TITLE
fix(dcc-plugin): adjust MenuEditor switch and arrow alignment

### DIFF
--- a/src/dde-control-center/plugin/DccMenuEditorItem.qml
+++ b/src/dde-control-center/plugin/DccMenuEditorItem.qml
@@ -15,7 +15,7 @@ DccEditorItem {
     bottomPadding: bottomInset
     activeFocusOnTab: false
     rightItem: RowLayout {
-        spacing: 10
+        spacing: 8
         DccLoader {
             active: !editor
             dccObj: model.item


### PR DESCRIPTION
1. Reduce RowLayout spacing from 10px to 8px between switch and arrow icon
2. Remove redundant visible: active from Loader since active already controls
   component lifecycle
3. Ensure switch controls are positioned 30px from the list background
   right edge, consistent with the arrow icon's 10px right padding

Log: Fix MenuEditorItem layout so switch and arrow are properly aligned to 30px from the right edge

1. 将RowLayout间距从10px缩减为8px
2. 移除Loader上多余的visible: active，active已控制组件加载
3. 确保开关控件距列表背景右侧30px，与箭头图标的10px右边距对齐

Log: 修复MenuEditorItem布局，使开关和箭头距列表右边缘30px对齐
PMS: BUG-369103