### PR TITLE
fix: refactor popup width calculation into reusable AutoSizingComboBox

### DIFF
--- a/src/plugin-display/qml/AutoSizingComboBox.qml
+++ b/src/plugin-display/qml/AutoSizingComboBox.qml
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: LGPL-3.0-or-later
+
+import QtQuick
+import org.deepin.dtk 1.0
+import org.deepin.dtk.style 1.0 as DS
+
+
+// AutoSizingComboBox — ComboBox 封装，自动适配下拉面板宽度
+ComboBox {
+    id: control
+
+    property real _popupContentWidth: 0
+
+    TextMetrics {
+        id: _textMetrics
+        font: control.font
+    }
+
+    /**
+     * 文本像素宽度之外的额外填充总和（最坏情况：当前选中项 checked=true 时 indicator 可见）
+     *
+     * T.MenuItem 内容布局（对 checked 项，indicator 显式时）：
+     *   ┌──────────────────────────────────────────────────────────┐
+     *   │ leftPadding(6) │ indicator(14) │ spacing(6) │ contentItem(IconLabel) │ rightPadding(6) │
+     *   └──────────────────────────────────────────────────────────┘
+     *
+     * Style 常量来源（dtkdeclarative/qt6/src/qml/FlowStyle.qml）：
+     *   DS.Style.popup.margin             = 10  Popup contentItem 边距
+     *   DS.Style.control.padding          = 6   MenuItem 外 padding
+     *   DS.Style.control.spacing          = 6   Indicator 与 contentItem 间距
+     *   DS.Style.menu.item.iconSize.width = 14  Indicator（checkmark）宽度
+     *   DS.Style.menu.item.contentPadding = 30  IconLabel 左 padding
+     */
+
+    readonly property real _textExtraPadding: DS.Style.menu.item.contentPadding       // 30
+                                             + DS.Style.control.padding * 2            // 12
+                                             + DS.Style.popup.margin * 2               // 20
+                                             + DS.Style.menu.item.iconSize.width       // 14  (indicator)
+                                             + DS.Style.control.spacing                // 6   (indicator spacing)
+                                                                                       // = 82
+
+    function _updatePopupWidth() {
+        var m = model
+        if (!m) {
+            _popupContentWidth = 0
+            return
+        }
+
+        var count = typeof m.count === 'number' ? m.count
+                  : (typeof m.length === 'number' ? m.length : 0)
+        if (count <= 0) {
+            _popupContentWidth = 0
+            return
+        }
+
+        var usesGet = typeof m.get === 'function'
+
+        var maxWidth = 0
+        for (var i = 0; i < count; ++i) {
+            var item = usesGet ? m.get(i) : m[i]
+            if (!item) {
+                continue
+            }
+
+            var text = textRole ? item[textRole] : item.text
+            if (text === undefined || text === "") {
+                continue
+            }
+
+            _textMetrics.text = String(text)
+            var w = _textMetrics.width + _textExtraPadding
+            if (w > maxWidth) {
+                maxWidth = w
+            }
+        }
+        _popupContentWidth = maxWidth
+    }
+
+    onModelChanged: _updatePopupWidth()
+    onFontChanged: _updatePopupWidth()
+    Component.onCompleted: _updatePopupWidth()
+
+    popup.implicitWidth: Math.max(_popupContentWidth, width)
+}

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -710,15 +710,13 @@ DccObject {
             displayName: qsTr("Resolution") // 分辨率
             weight: 20
             pageType: DccObject.Editor
-            page: ComboBox {
+            page: AutoSizingComboBox {
                 id: resolutionComboBox
                 flat: true
                 enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 model: root.getResolutionModel(screen.resolutionList, screen.bestResolution)
                 textRole: "text"
                 valueRole: "value"
-
-                property real popupContentWidth: 0
 
                 function indexOfSize(model, currentSize) {
                     for (var i = 0; i < model.length; i++) {
@@ -729,28 +727,6 @@ DccObject {
                     }
                     return -1
                 }
-
-                TextMetrics {
-                    id: resolutionTextMetrics
-                    font: resolutionComboBox.font
-                }
-
-                function updatePopupWidth() {
-                    var maxWidth = 0
-                    for (var i = 0; i < model.length; i++) {
-                        resolutionTextMetrics.text = model[i].text
-                        var itemWidth = resolutionTextMetrics.width + 80
-                        if (itemWidth > maxWidth) {
-                            maxWidth = itemWidth
-                        }
-                    }
-                    popupContentWidth = maxWidth
-                }
-
-                Component.onCompleted: updatePopupWidth()
-                onModelChanged: updatePopupWidth()
-
-                popup.width: Math.max(popupContentWidth, width)
 
                 currentIndex: indexOfSize(model, screen.currentResolution)
                 onActivated: {
@@ -856,7 +832,7 @@ DccObject {
             displayName: qsTr("Refresh Rate") // 刷新率
             weight: 40
             pageType: DccObject.Editor
-            page: ComboBox {
+            page: AutoSizingComboBox {
                 flat: true
                 enabled: !(root.isExtendMode && dccData.isConcatScreenMode)
                 textRole: "text"


### PR DESCRIPTION
Extract the duplicated popup width calculation logic from DisplayMain into a reusable QML component, AutoSizingComboBox. This improves code maintainability and ensures consistent behavior across all ComboBoxes that require dynamic popup sizing.

Log: Optimized combobox popup width for display settings

Influence:
1. Verify resolution combobox dropdown width adapts to content
2. Verify refresh rate combobox dropdown width adapts to content
3. Test with various screen resolutions and refresh rate options
4. Ensure no regression in existing combobox functionality
5. Test with long and short text items to verify minimum width handling

feat: 将弹窗宽度计算逻辑重构为可复用的 AutoSizingComboBox 组件

从 DisplayMain 中提取重复的弹窗宽度计算逻辑到可复用的 QML 组件
AutoSizingComboBox 中，提高代码可维护性，确保所有需要动态弹窗大小的
ComboBox 行为一致。

Log: 优化显示设置中的下拉框弹窗宽度

Influence:
1. 验证分辨率下拉框弹窗宽度自适应内容
2. 验证刷新率下拉框弹窗宽度自适应内容
3. 测试不同屏幕分辨率和刷新率选项
4. 确保现有下拉框功能无回归问题
5. 测试长文本和短文本项，验证最小宽度处理

PMS: BUG-366553

## Summary by Sourcery

Refactor display settings comboboxes to use a reusable AutoSizingComboBox that auto-sizes the dropdown popup to fit item content, consolidating duplicated width calculation logic into a single component.

New Features:
- Introduce an AutoSizingComboBox QML component that automatically adjusts its popup width based on item content and styling.

Enhancements:
- Replace custom popup width calculation in resolution and refresh rate comboboxes with the reusable AutoSizingComboBox to ensure consistent behavior and easier maintenance.