### PR TITLE
fix: defer DSysInfo queries in plugins to avoid dlopen deadlock

### DIFF
--- a/src/plugin-commoninfo/operation/utils.h
+++ b/src/plugin-commoninfo/operation/utils.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef UTILS_H
@@ -31,15 +31,47 @@ inline constexpr qint32 ActionIconSize=30;//大图标角标大小
 inline constexpr qint32 ActionListSize=26;//list图标角标大小
 
 
-const DSysInfo::UosType UosType = DSysInfo::uosType();
-const DSysInfo::UosEdition UosEdition = DSysInfo::uosEditionType();
-const bool IsServerSystem = (DSysInfo::UosServer == UosType);//是否是服务器版
-const bool IsCommunitySystem = (DSysInfo::UosCommunity == UosEdition);//是否是社区版
-const bool IsProfessionalSystem = (DSysInfo::UosProfessional == UosEdition);//是否是专业版
-const bool IsHomeSystem = (DSysInfo::UosHome == UosEdition);//是否是个人版
-const bool IsEducationSystem = (DSysInfo::UosEducation == UosEdition); // 是否是教育版
-const bool IsDeepinDesktop = (DSysInfo::DeepinDesktop == DSysInfo::deepinType());//是否是Deepin桌面
-const bool IsNotDeepinUos = !DSysInfo::isDeepin(); // 是否是 Deepin/Uos 以外的发行版
+static inline bool isServerSystem()
+{
+    static const bool serverSystem = DSysInfo::UosServer == DSysInfo::uosType();
+    return serverSystem;
+}
+
+static inline bool isCommunitySystem()
+{
+    static const bool communitySystem = DSysInfo::UosCommunity == DSysInfo::uosEditionType();
+    return communitySystem;
+}
+
+static inline bool isProfessionalSystem()
+{
+    static const bool professionalSystem = DSysInfo::UosProfessional == DSysInfo::uosEditionType();
+    return professionalSystem;
+}
+
+static inline bool isHomeSystem()
+{
+    static const bool homeSystem = DSysInfo::UosHome == DSysInfo::uosEditionType();
+    return homeSystem;
+}
+
+static inline bool isEducationSystem()
+{
+    static const bool educationSystem = DSysInfo::UosEducation == DSysInfo::uosEditionType();
+    return educationSystem;
+}
+
+static inline bool isDeepinDesktop()
+{
+    static const bool deepinDesktop = DSysInfo::DeepinDesktop == DSysInfo::deepinType();
+    return deepinDesktop;
+}
+
+static inline bool isNotDeepinUos()
+{
+    static const bool notDeepinUos = !DSysInfo::isDeepin();
+    return notDeepinUos;
+}
 
 
 template <typename T>

--- a/src/plugin-deepinid/operation/deepinidinterface.cpp
+++ b/src/plugin-deepinid/operation/deepinidinterface.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -16,7 +16,7 @@ DeepinIDInterface::DeepinIDInterface(QObject *parent)
 
 QString DeepinIDInterface::editionName() const
 {
-    if (IsCommunitySystem) {
+    if (isCommunitySystem()) {
         return tr("deepin");
     } else {
         return tr("UOS");

--- a/src/plugin-deepinid/operation/deepinidworker.cpp
+++ b/src/plugin-deepinid/operation/deepinidworker.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -407,7 +407,7 @@ QString DeepinWorker::loadCodeURL()
     };
 
     QString oauthURI = "https://login.uniontech.com";
-    if (IsCommunitySystem) {
+    if (isCommunitySystem()) {
         oauthURI = "https://login.deepin.org";
     }
 
@@ -422,7 +422,7 @@ QString DeepinWorker::loadCodeURL()
 
 void DeepinWorker::getLicenseState()
 {
-    if (IsCommunitySystem) {
+    if (isCommunitySystem()) {
         m_model->setActivation(true);
         return;
     }

--- a/src/plugin-deepinid/operation/utils.cpp
+++ b/src/plugin-deepinid/operation/utils.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -27,9 +27,9 @@ QString getUrlTitle()
 {
     QString url;
     if (qEnvironmentVariableIsEmpty("DEEPIN_PRE")) {
-        url = IsCommunitySystem ? QStringLiteral("https://login.deepin.org") : QStringLiteral("https://login.uniontech.com");
+        url = isCommunitySystem() ? QStringLiteral("https://login.deepin.org") : QStringLiteral("https://login.uniontech.com");
     } else {
-        url = IsCommunitySystem ? QStringLiteral("https://login-pre.deepin.org") : QStringLiteral("https://login-pre.uniontech.com");
+        url = isCommunitySystem() ? QStringLiteral("https://login-pre.deepin.org") : QStringLiteral("https://login-pre.uniontech.com");
     }
     return url;
 }
@@ -196,12 +196,12 @@ QStringList getDeviceInfo()
 
 QString getEditionName()
 {
-    return IsCommunitySystem ? "deepin" : "UOS";
+    return isCommunitySystem() ? "deepin" : "UOS";
 }
 
 QString getIconName()
 {
-    return IsCommunitySystem ? "deepin-id" : "uos-id";
+    return isCommunitySystem() ? "deepin-id" : "uos-id";
 }
 
 }; // namespace utils

--- a/src/plugin-deepinid/operation/utils.h
+++ b/src/plugin-deepinid/operation/utils.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -31,13 +31,35 @@ DCORE_USE_NAMESPACE
 #define DEEPINCLIENT_PATH QStringLiteral("/com/deepin/deepinid/Client")
 #define DEEPINCLIENT_INTERFACE QStringLiteral("com.deepin.deepinid.Client")
 
-const DSysInfo::UosType UosType = DSysInfo::uosType();
-const DSysInfo::UosEdition UosEdition = DSysInfo::uosEditionType();
-const bool IsServerSystem = (DSysInfo::UosServer == UosType);          // 是否是服务器版
-const bool IsCommunitySystem = (DSysInfo::UosCommunity == UosEdition); // 是否是社区版
-const bool IsProfessionalSystem = (DSysInfo::UosProfessional == UosEdition); // 是否是专业版
-const bool IsHomeSystem = (DSysInfo::UosHome == UosEdition);                 // 是否是个人版
-const bool IsDeepinDesktop = (DSysInfo::DeepinDesktop == DSysInfo::deepinType()); // 是否是Deepin桌面
+static inline bool isServerSystem()
+{
+    static const bool serverSystem = DSysInfo::UosServer == DSysInfo::uosType();
+    return serverSystem;
+}
+
+static inline bool isCommunitySystem()
+{
+    static const bool communitySystem = DSysInfo::UosCommunity == DSysInfo::uosEditionType();
+    return communitySystem;
+}
+
+static inline bool isProfessionalSystem()
+{
+    static const bool professionalSystem = DSysInfo::UosProfessional == DSysInfo::uosEditionType();
+    return professionalSystem;
+}
+
+static inline bool isHomeSystem()
+{
+    static const bool homeSystem = DSysInfo::UosHome == DSysInfo::uosEditionType();
+    return homeSystem;
+}
+
+static inline bool isDeepinDesktop()
+{
+    static const bool deepinDesktop = DSysInfo::DeepinDesktop == DSysInfo::deepinType();
+    return deepinDesktop;
+}
 
 enum SyncType {
     Sound,

--- a/src/plugin-power/operation/powermodel.cpp
+++ b/src/plugin-power/operation/powermodel.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "powermodel.h"
@@ -331,7 +331,7 @@ void PowerModel::setBalancePerformanceSupported(bool isBalancePerformanceSupport
 
 void PowerModel::setSuspend(bool suspend)
 {
-    bool enable = !IsServerSystem && suspend;
+    bool enable = !isServerSystem() && suspend;
     if (m_isSuspend != enable) {
         m_isSuspend = enable;
 
@@ -341,7 +341,7 @@ void PowerModel::setSuspend(bool suspend)
 
 void PowerModel::setHibernate(bool hibernate)
 {
-    bool enable = !IsServerSystem && hibernate;
+    bool enable = !isServerSystem() && hibernate;
     if (m_isHibernate != enable) {
         m_isHibernate = enable;
 

--- a/src/plugin-power/operation/utils.h
+++ b/src/plugin-power/operation/utils.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef UTILS_H
@@ -35,9 +35,11 @@ T valueByQSettings(const QStringList& configFiles,
     return failback.value<T>();
 }
 
-inline const static Dtk::Core::DSysInfo::UosType UosType = Dtk::Core::DSysInfo::uosType();
-inline const static bool IsServerSystem =
-        (Dtk::Core::DSysInfo::UosServer == UosType); // 是否是服务器版
+static inline bool isServerSystem()
+{
+    static const bool serverSystem = Dtk::Core::DSysInfo::UosServer == Dtk::Core::DSysInfo::uosType();
+    return serverSystem;
+}
 
 inline static bool isVirtualEnvironment()
 {

--- a/src/plugin-sound/operation/soundmodel.cpp
+++ b/src/plugin-sound/operation/soundmodel.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "soundmodel.h"
@@ -13,8 +13,11 @@
 
 Q_LOGGING_CATEGORY(DdcSoundModel, "dcc-sound-model")
 
-const static Dtk::Core::DSysInfo::UosType UosType = Dtk::Core::DSysInfo::uosType();
-const static bool IsServerSystem = (Dtk::Core::DSysInfo::UosServer == UosType); //是否是服务器版
+static bool isServerSystem()
+{
+    static const bool serverSystem = Dtk::Core::DSysInfo::UosServer == Dtk::Core::DSysInfo::uosType();
+    return serverSystem;
+}
 
 static const QMap<DDesktopServices::SystemSoundEffect, QString> SOUND_EFFECT_MAP{
     { DDesktopServices::SystemSoundEffect::SSE_Notifications, "message" },
@@ -97,7 +100,7 @@ SoundModel::SoundModel(QObject *parent)
         { tr("Error"), DDesktopServices::SSE_Error },
     };
 
-    if (IsServerSystem) {
+    if (isServerSystem()) {
         m_soundEffectMapBattery.removeOne({ tr("Wake up"), DDesktopServices::SSE_WakeUp });
         m_soundEffectMapPower.removeOne({ tr("Wake up"), DDesktopServices::SSE_WakeUp });
     }
@@ -733,4 +736,3 @@ void SoundModel::setShowInputBluetoothMode(bool newShowInputBluetoothMode)
     m_showInputBluetoothMode = newShowInputBluetoothMode;
     emit showInputBluetoothModeChanged();
 }
-


### PR DESCRIPTION
## Summary

- Replace namespace-scope `const` globals (`UosType`, `IsServerSystem`, `IsCommunitySystem`, etc.) in plugin `utils.h` headers with `static inline` lazy-init helper functions that compute the value once on first runtime call, moving `DSysInfo` queries out of the `dlopen` global constructor phase.
- Affected plugins: `sound`, `power`, `commoninfo`, `deepinid`.
- This breaks one side of a deadlock chain observed in the control center: Thread A holds the glibc/ld.so loader lock during plugin `dlopen` -> calls `DSysInfo` -> emits `qWarning` -> enters dtklog and waits for the dtklog write lock; Thread B holds the dtklog write lock -> formats `%{function}` via `QRegularExpression`/pcre2 -> triggers TLS/loader init -> waits for the loader lock.

## Background

On systems where `/etc/os-version` is missing or malformed, `DSysInfo::ensureOsVersion()` emits `qWarning()`, which enters the dtklog appender pipeline. When this happens inside a plugin's global/static initialization (during `QPluginLoader::load()`), the calling thread already holds the dynamic loader lock, creating a lock-order inversion with dtklog.

The companion fixes in `dtkcore` (`DSysInfo::ensureOsVersion` no longer logs while holding `DSysInfoPrivate::mutex`) and `dtklog` (`AbstractStringAppender::qCleanupFuncinfo` no longer uses `QRegularExpression` inside the appender write lock) address the other two links in the chain. This PR addresses the control-center/application side.

## Test plan

- [ ] Build all affected plugins (`sound`, `power`, `commoninfo`, `deepinid`) without errors.
- [ ] Launch `dde-control-center` on a system with valid `/etc/os-version` — verify no regression in edition/type detection (server vs community vs professional, etc.).
- [ ] Launch `dde-control-center` on a system with missing/malformed `/etc/os-version` — verify no startup hang/deadlock.
- [ ] Verify `isServerSystem()` / `isCommunitySystem()` return the same values as the old `IsServerSystem` / `IsCommunitySystem` globals on the same system.

## Summary by Sourcery

Defer system edition/type detection in control center plugins to avoid DSysInfo calls during plugin global initialization and break the loader/dtklog deadlock chain.

Bug Fixes:
- Prevent potential startup deadlocks in dde-control-center when DSysInfo logging is triggered during plugin loading on systems with missing or malformed /etc/os-version.

Enhancements:
- Replace plugin-wide constant globals for UOS/deepin edition and type detection with static inline helper functions that lazily cache DSysInfo query results at first use across sound, power, commoninfo, and deepinid plugins.
- Align SPDX copyright year ranges to include 2026 in affected plugin headers and sources.