### PR TITLE
fix: auto-dismiss alert after duration in name editor

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -142,6 +142,13 @@ DccObject {
                             }
                         }
 
+                        Timer {
+                            id: alertDismissTimer
+                            interval: nameEditPanel.alertDuration
+                            repeat: false
+                            onTriggered: nameEditPanel.showAlert = false
+                        }
+
                         D.LineEdit {
                             id: nameEditor
                             property int maxLength: 15
@@ -170,6 +177,7 @@ DccObject {
                             onTextEdited: {
                                 if (nameEditPanel.showAlert) {
                                     nameEditPanel.showAlert = false
+                                    alertDismissTimer.stop()
                                 }
                                 // 实时检测：过滤非法字符并限制长度
                                 var filteredText = text;
@@ -180,6 +188,7 @@ DccObject {
                                 if (filteredText.length > maxLength) {
                                     nameEditPanel.showAlert = true
                                     nameEditPanel.alertText = qsTr("No more than 15 characters")
+                                    alertDismissTimer.restart()
                                     filteredText = filteredText.slice(0, maxLength);
                                 }
 
@@ -191,10 +200,6 @@ DccObject {
                             onEditingFinished: {
                                 if (readOnly) {
                                     return
-                                }
-
-                                if (nameEditPanel.showAlert) {
-                                    nameEditPanel.showAlert = false
                                 }
 
                                 if (!checkInputInvalid()) {
@@ -253,6 +258,7 @@ DccObject {
                                 } else {
                                     return true;
                                 }
+                                alertDismissTimer.restart()
                                 return false;
                             }
                         }


### PR DESCRIPTION
1. Added a Timer component to automatically hide the character limit alert after the configured duration
2. Fixed alert dismissal logic to stop the timer when alert is manually hidden
3. Consolidated alert state management into the timer restart mechanism
4. Removed redundant alert hiding code that was executed unconditionally during text editing

Log: Optimized name editing alerts to auto-dismiss after set duration

Influence:
1. Test entering text exceeding 15 characters to verify alert appears and auto-dismisses after the configured duration
2. Verify the alert re-appears when typing continues after auto-dismiss
3. Test manual alert dismissal by clearing text when alert is visible
4. Verify alert interaction when quickly editing text multiple times
5. Test alert behavior with different alertDuration configurations

fix: 名称编辑器中提示信息自动消失

1. 添加 Timer 组件，根据配置时长自动隐藏字符限制提示
2. 修复手动隐藏提示时停止定时器的逻辑
3. 将提示状态管理统一为定时器重启机制
4. 移除编辑过程中无条件执行的冗余提示隐藏代码

Log: 优化名称编辑提示自动消失功能

Influence:
1. 测试输入超过15字符，验证提示出现并按照配置时长自动消失
2. 验证自动消失后继续输入，提示重新出现
3. 测试在提示可见时清除文本，手动关闭提示
4. 验证快速多次编辑文本时提示的交互行为
5. 测试不同alertDuration配置下提示的展示行为

PMS: BUG-365811

## Summary by Sourcery

Implement timed auto-dismissal for the name editor character limit alert and simplify its visibility control.

Bug Fixes:
- Ensure the character limit alert stops its dismissal timer when the alert is manually hidden to avoid inconsistent visibility.

Enhancements:
- Add a configurable one-shot timer to automatically hide the name editor character limit alert after the defined duration.
- Centralize alert state management around the timer restart mechanism and remove redundant unconditional alert hiding during text edits.