### PR TITLE
fix: clear stale checkmark in datetime timezone add dialog

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -509,8 +509,6 @@ DccObject {
                                 font: D.DTK.fontManager.t6
                                 highlighted: ListView.isCurrentItem
                                 hoverEnabled: true
-                                checkable: true
-                                autoExclusive: true
 
                                 contentItem: RowLayout {
                                     spacing: 8
@@ -537,7 +535,7 @@ DccObject {
                                 }
                                 onClicked: {
                                     let zoneId = model.zoneId
-                                    if (checked && !dccData.hasUserTimeZone(zoneId)) {
+                                    if (!dccData.hasUserTimeZone(zoneId)) {
                                         dccData.addUserTimeZoneById(zoneId)
                                     }
                                     timezoneListWindow.close()


### PR DESCRIPTION
1. Remove checkable and autoExclusive properties from D.MenuItem delegate in the timezone add popup since the dialog closes on a single click
2. Update onClicked handler to add the timezone based solely on zoneId existence, independent of the checked state
3. Prevent a stale checkmark from persisting when the add dialog is reopened, so the list shows no selection
4. Fix the case where re-clicking the previously selected item fails to add the timezone because checked is toggled to false

Log: Removed persistent checked state in the datetime timezone add dialog so the list shows no checkmark on reopen

Influence:
1. Open the timezone add dialog and select a timezone - it should be added and the dialog closes
2. Reopen the add dialog - no item should display a checkmark
3. Select the previously added timezone again - it should be skipped if already in the user list, without being blocked
4. Verify keyboard navigation and hover highlight still work correctly

fix: 清除日期时间时区添加弹窗中残留的勾选状态

1. 移除时区添加弹窗中 D.MenuItem 代理的 checkable 和 autoExclusive 属性，因为该弹窗为单击即关闭的单选交互
2. 更新 onClicked 处理逻辑，仅依据 zoneId 是否已存在来决定是否添加， 不再依赖 checked 状态
3. 避免再次打开添加弹窗时残留上次的勾选标记，使列表不显示选中项
4. 修复再次点击上次选中项时因 checked 被 toggle 为 false 导致时区 无法添加的问题

Log: 移除日期时间时区添加弹窗中残留的勾选状态，使列表重新打开时不显示勾选项

Influence:
1. 打开时区添加弹窗并选择一个时区 - 应被添加且弹窗关闭
2. 再次打开添加弹窗 - 不应显示任何勾选项
3. 再次选择上一次添加的时区 - 若已在用户时区列表中则跳过，不应被阻止
4. 验证键盘导航与悬停高亮仍正常工作

PMS: BUG-367673

## Summary by Sourcery

Remove persistent selection state from the datetime timezone add dialog to rely solely on existing timezone checks when adding entries.

Bug Fixes:
- Ensure the timezone add dialog does not show a stale checked item when reopened.
- Allow previously selected timezones to be added again when appropriate by decoupling add logic from the menu item's checked state.