### PR TITLE
fix: pass control center help fallback candidates

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -319,11 +319,19 @@ QWindow *DccManager::mainWindow() const
 
 void DccManager::showHelp()
 {
-    QString helpTitle;
-    if (1 < m_currentObjects.count())
-        helpTitle = m_currentObjects.last()->name();
-    if (helpTitle.isEmpty())
-        helpTitle = "controlcenter";
+    QStringList helpTitles;
+    for (auto it = m_currentObjects.crbegin(); it != m_currentObjects.crend(); ++it) {
+        DccObject *object = *it;
+        if (!object || object == m_root)
+            continue;
+
+        if (!(object->pageType() & DccObject::PageType::Menu) || object->displayName().isEmpty())
+            continue;
+
+        helpTitles.append(object->name());
+    }
+
+    const QString helpTitle = helpTitles.isEmpty() ? QStringLiteral("controlcenter") : helpTitles.join(QChar(0x1f));
 
     const QString &dmanInterface = "com.deepin.Manual.Open";
     QDBusMessage message = QDBusMessage::createMethodCall(dmanInterface, "/com/deepin/Manual/Open", dmanInterface, "OpenTitle");


### PR DESCRIPTION
fix: pass control center help fallback candidates

1. Collect the current control center object chain from the active page to parent pages when opening help
2. Skip generic container object names before calling deepin-manual
3. Pass the ordered candidates to deepin-manual so child pages without sections can fall back to a parent topic

Influence:
1. Test help on input method add-ons to fall back to the input method topic
2. Verify shortcut and network child pages still open mapped manual sections
3. Verify the final debug-machine package contains no unrelated desktop file changes

fix: 控制中心帮助跳转传递父级候选链

1. 打开帮助时从当前控制中心页面向父级页面收集对象链
2. 调用 deepin-manual 前过滤通用容器对象名
3. 传递有序候选列表，使没有手册章节的子页面可以回退到父级主题

Influence:
1. 测试输入法附加组件帮助可回退到输入法主题
2. 验证快捷键和网络子页面仍可打开对应手册章节
3. 验证最终调试机包不包含无关 desktop 文件改动

PMS: BUG-368805

