### PR TITLE
fix(accounts): correct ComboBox dropdown arrow position in CreateAccountDialog

### DIFF
--- a/src/plugin-accounts/qml/CreateAccountDialog.qml
+++ b/src/plugin-accounts/qml/CreateAccountDialog.qml
@@ -156,7 +156,6 @@ D.DialogWindow {
             ComboBox {
                 id: userType
                 implicitHeight: 30
-                padding: 0
                 Layout.alignment: Qt.AlignVCenter
                 Layout.fillWidth: true
                 model: dccData.userTypes(true)


### PR DESCRIPTION
1. Remove padding: 0 from the ComboBox in CreateAccountDialog
2. DTK ComboBox default padding is 8, which provides proper spacing for the indicator arrow
3. The explicit padding: 0 was causing the dropdown arrow to sit flush against the right edge

Log: Fix dropdown arrow position in CreateAccountDialog ComboBox

1. 移除 CreateAccountDialog 中 ComboBox 的 padding: 0
2. DTK ComboBox 默认 padding 为 8，可为指示器箭头提供合适的间距
3. 显式的 padding: 0 导致下拉箭头紧贴右边缘

Log: 修复创建账户对话框中 ComboBox 下拉箭头位置偏右的问题
PMS: BUG-369533