### PR TITLE
fix(shortcuts): add spacer item for conflict text layout alignment

### DIFF
--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -308,11 +308,14 @@ DccObject {
                                 id: row
                                 width: parent.width
                                 spacing: 3
+                                Item {
+                                    Layout.fillWidth: true
+                                    Layout.fillHeight: true
+                                }
                                 Label {
                                     id: conflictTextLabel
                                     text: dccData.conflictText + ","
                                     elide: Text.ElideLeft
-                                    Layout.fillWidth: true
                                     horizontalAlignment: Text.AlignRight
                                     HoverHandler { id: conflictHandler }
                                     ToolTip.visible: conflictHandler.hovered


### PR DESCRIPTION
1. Add a flexible spacer Item in the RowLayout to properly align shortcut conflict warning labels
2. Fix right-alignment of conflict text elements (Click, Cancel, or Replace)

Log: Fix shortcut conflict text alignment by adding a proper layout spacer in the RowLayout

fix(shortcuts): 添加快捷键冲突文本布局的弹性占位项

1. 在 RowLayout 中添加弹性占位 Item，使快捷键冲突提示标签正确对齐
2. 修复冲突文本元素（点击、取消、替换）的右对齐问题

Log: 通过添加布局占位项修复快捷键冲突文本对齐问题
PMS: BUG-368147

## Summary by Sourcery

Bug Fixes:
- Correct misaligned shortcut conflict warning labels by introducing a flexible spacer in the row layout.