### PR TITLE
fix(wallpaper): show video previews

### DIFF
--- a/src/plugin-display/CMakeLists.txt
+++ b/src/plugin-display/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.18)
 
-find_package(${QT_NS} REQUIRED COMPONENTS WaylandClient)
+find_package(${QT_NS} REQUIRED COMPONENTS WaylandClient Concurrent)
 find_package(PkgConfig REQUIRED)
 find_package(TreelandProtocols REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
@@ -67,7 +67,9 @@ set(Display_Libraries
     ${QT_NS}::Gui
     ${QT_NS}::DBus
     ${QT_NS}::Quick
+    ${QT_NS}::Concurrent
     ${DTK_NS}::Core
+    dcc-wallpaper-utils
 )
 
 target_link_libraries(${Display_Name} PRIVATE

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -4,6 +4,7 @@
 #include "displayworker.h"
 
 #include "displaymodel.h"
+#include "wallpaperthumbnailutils.h"
 
 #include <Output.h>
 #include <OutputManager.h>
@@ -17,15 +18,30 @@
 #include <QDBusPendingCallWatcher>
 #include <QDebug>
 #include <QFile>
+#include <QFileInfo>
+#include <QDir>
+#include <QJsonArray>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QLoggingCategory>
+#include <QPointer>
 #include <QXmlStreamReader>
+#include <QtConcurrent/QtConcurrent>
 
 Q_LOGGING_CATEGORY(DdcDisplayWorker, "dcc-display-worker")
 
 const QString DisplayInterface("org.deepin.dde.Display1");
 static const QString EyeProtectionConfig = "/usr/share/dde-wloutput-daemon/eyeprotection.xml";
+static const QString SysLiveWallpaperDir = "/usr/share/wallpapers/deepin-livewallpapers";
+
+static const QStringList videoSuffixes = { "mp4", "mov", "avi", "webm", "mkv" };
+
+static bool isVideoFile(const QString &path)
+{
+    return videoSuffixes.contains(QFileInfo(path).suffix().toLower());
+}
+
+static constexpr uint32_t WallpaperSourceTypeVideo = 1;
 
 Q_DECLARE_METATYPE(QList<QDBusObjectPath>)
 using namespace dccV25;
@@ -84,6 +100,17 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
             m_displayInter->Save().waitForFinished();
         });
     }
+
+    connect(this, &DisplayWorker::videoThumbnailReady, this, [this](const QString &videoPath, const QString &thumbnailPath) {
+        const auto monitors = m_videoWallpaperMonitors.take(videoPath);
+        if (thumbnailPath.isEmpty())
+            return;
+
+        for (const auto &monitor : monitors) {
+            if (monitor && monitor->wallpaper() == videoPath)
+                monitor->setWallpaper(thumbnailPath);
+        }
+    });
 }
 
 DisplayWorker::~DisplayWorker()
@@ -347,7 +374,11 @@ void DisplayWorker::updateWallpaper()
 
 void DisplayWorker::updateMonitorWallpaper(Monitor *mon)
 {
-    mon->setWallpaper(m_displayInter->GetCurrentWorkspaceBackgroundForMonitor(mon->name()));
+    QString wallpaper = m_displayInter->GetCurrentWorkspaceBackgroundForMonitor(mon->name());
+    if (isVideoFile(wallpaper)) {
+        wallpaper = resolveVideoThumbnail(wallpaper, mon);
+    }
+    mon->setWallpaper(wallpaper);
 }
 
 void DisplayWorker::updateWallpaperFromWayland()
@@ -376,12 +407,20 @@ void DisplayWorker::onOutputWallpaperReady(WQt::Output *output)
     auto *wp = wpMgr->getWallpaper(output->get());
     if (wp) {
         connect(wp, &WQt::Wallpaper::changed, this, &DisplayWorker::onWallpaperChanged, Qt::UniqueConnection);
+
+        if (wp->sourceType() == WallpaperSourceTypeVideo && !wp->fileSource().isEmpty()) {
+            for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
+                if (it.key()->name() == output->name()) {
+                    it.key()->setWallpaper(resolveVideoThumbnail(wp->fileSource(), it.key()));
+                    break;
+                }
+            }
+        }
     }
 }
 
 void DisplayWorker::onWallpaperChanged(const QString &fileSource, uint32_t sourceType, uint32_t role)
 {
-    Q_UNUSED(sourceType);
     Q_UNUSED(role);
     auto *wp = qobject_cast<WQt::Wallpaper *>(sender());
     if (!wp || !wp->output() || !m_reg)
@@ -400,7 +439,11 @@ void DisplayWorker::onWallpaperChanged(const QString &fileSource, uint32_t sourc
 
     for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
         if (it.key()->name() == outputName) {
-            it.key()->setWallpaper(fileSource);
+            QString wallpaper = fileSource;
+            if (sourceType == WallpaperSourceTypeVideo) {
+                wallpaper = resolveVideoThumbnail(fileSource, it.key());
+            }
+            it.key()->setWallpaper(wallpaper);
             break;
         }
     }
@@ -1398,4 +1441,57 @@ void DisplayWorker::updateConcatScreenMode()
 
     qCDebug(DdcDisplayWorker) << "[ConcatScreen] updateConcatScreenMode via DBus property";
     m_model->setIsConcatScreenMode(m_displayInter->isConcatScreenEnabled());
+}
+
+QString DisplayWorker::resolveVideoThumbnail(const QString &videoPath, Monitor *monitor)
+{
+    QDir liveDir(SysLiveWallpaperDir);
+    if (liveDir.exists()) {
+        QFile metaFile(liveDir.absoluteFilePath("metadata.json"));
+        if (metaFile.open(QIODevice::ReadOnly)) {
+            QJsonParseError parseErr;
+            QJsonDocument doc = QJsonDocument::fromJson(metaFile.readAll(), &parseErr);
+            metaFile.close();
+            if (parseErr.error != QJsonParseError::NoError || !doc.isArray()) {
+                qCWarning(DdcDisplayWorker) << "metadata.json parse error:" << parseErr.errorString();
+            } else {
+                for (const auto &entry : doc.array()) {
+                    QJsonObject obj = entry.toObject();
+                    QString videoAbsPath = liveDir.absoluteFilePath(obj.value("path").toString());
+                    if (videoAbsPath == videoPath) {
+                        QString thumbnailRel = obj.value("thumbnail").toString();
+                        if (!thumbnailRel.isEmpty()) {
+                            QString thumbAbsPath = liveDir.absoluteFilePath(thumbnailRel);
+                            if (QFile::exists(thumbAbsPath)) {
+                                return thumbAbsPath;
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    const QString cachePath = DccWallpaperThumbnail::cachePath(videoPath);
+
+    if (QFile::exists(cachePath)) {
+        return cachePath;
+    }
+
+    if (m_videoWallpaperMonitors.contains(videoPath)) {
+        m_videoWallpaperMonitors[videoPath].append(monitor);
+        return videoPath;
+    }
+
+    m_videoWallpaperMonitors[videoPath] = { monitor };
+
+    QPointer<DisplayWorker> guard(this);
+    (void)QtConcurrent::run([guard, videoPath]() {
+        const QString thumbnailPath = DccWallpaperThumbnail::generate(videoPath);
+        if (guard)
+            Q_EMIT guard->videoThumbnailReady(videoPath, thumbnailPath);
+    });
+
+    return videoPath;
 }

--- a/src/plugin-display/operation/private/displayworker.h
+++ b/src/plugin-display/operation/private/displayworker.h
@@ -11,7 +11,9 @@
 
 #include <dtkcore_global.h>
 
+#include <QMap>
 #include <QObject>
+#include <QPointer>
 #include <QTimer>
 
 #define GAMMA_SUPPORT false
@@ -116,8 +118,11 @@ private:
     // task 264375
     void initCTMData();
 
+    QString resolveVideoThumbnail(const QString &videoPath, Monitor *monitor);
+
 Q_SIGNALS:
     void requestUpdateModeList();
+    void videoThumbnailReady(const QString &videoPath, const QString &thumbnailPath);
 
 private:
     DisplayModel *m_model;
@@ -143,6 +148,7 @@ private:
     int m_tcMaxValue;
     int m_tcMinValue;
     int m_defaultMode;
+    QMap<QString, QList<QPointer<Monitor>>> m_videoWallpaperMonitors;
 };
 }
 

--- a/src/plugin-personalization/CMakeLists.txt
+++ b/src/plugin-personalization/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.18)
 set(LIB_NAME personalization)
 
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(FFMPEGTHUMBNAILER REQUIRED IMPORTED_TARGET libffmpegthumbnailer)
 
-find_package(Qt6 REQUIRED COMPONENTS WaylandClient)
+find_package(Qt6 REQUIRED COMPONENTS WaylandClient Concurrent)
 if(Qt6_VERSION VERSION_GREATER_EQUAL 6.10)
   find_package(Qt6 COMPONENTS WaylandClientPrivate REQUIRED)
 endif()
@@ -44,7 +42,8 @@ set(Personalization_Libraries
     ${QT_NS}::DBus
     ${QT_NS}::Qml
     ${QT_NS}::WaylandClientPrivate
-    PkgConfig::FFMPEGTHUMBNAILER
+    ${QT_NS}::Concurrent
+    dcc-wallpaper-utils
 )
 
 target_include_directories(${LIB_NAME} PUBLIC

--- a/src/plugin-personalization/operation/wallpaperprovider.cpp
+++ b/src/plugin-personalization/operation/wallpaperprovider.cpp
@@ -14,9 +14,6 @@
 #include <QUrl>
 #include <QDir>
 #include <QHash>
-#include <libffmpegthumbnailer/videothumbnailer.h>
-#include <QCryptographicHash>
-#include <QStandardPaths>
 #include <QPointer>
 #include <QtConcurrent/QtConcurrent>
 #include <algorithm>
@@ -26,6 +23,7 @@
 #include "operation/model/wallpapermodel.h"
 #include "operation/personalizationdbusproxy.h"
 #include "utils.hpp"
+#include "wallpaperthumbnailutils.h"
 
 Q_LOGGING_CATEGORY(DdcPersonalizationWallpaperWorker, "dcc-personalization-wallpaper-worker")
 
@@ -439,10 +437,7 @@ void InterfaceWorker::getLiveBackground()
             CHECK_RETURN_RUNNING
             QString videoPath = fileInfo.absoluteFilePath();
             QUrl url = QUrl::fromLocalFile(videoPath);
-            QString cacheDir = thumbnailCacheDir();
-            QDir().mkpath(cacheDir);
-            QString cacheName = QString(QCryptographicHash::hash(videoPath.toUtf8(), QCryptographicHash::Md5).toHex()) + ".png";
-            QString cachePath = cacheDir + "/" + cacheName;
+            QString cachePath = DccWallpaperThumbnail::cachePath(videoPath);
             QString thumbnail = QFile::exists(cachePath) ? cachePath : videoPath;
 
             WallpaperItemPtr ptr(new WallpaperItem{
@@ -452,7 +447,7 @@ void InterfaceWorker::getLiveBackground()
             });
             if (ptr) {
                 if (!QFile::exists(cachePath))
-                    generateVideoThumbnail(videoPath, cachePath, url.toString());
+                    generateVideoThumbnail(videoPath, url.toString());
                 wallpapers.append(ptr);
             }
         }
@@ -475,8 +470,6 @@ void InterfaceWorker::getLiveBackground()
         return;
     }
 
-    QString cacheDir = thumbnailCacheDir();
-    QDir().mkpath(cacheDir);
 
     QJsonArray entries = doc.array();
     for (const auto &entry : entries) {
@@ -508,8 +501,7 @@ void InterfaceWorker::getLiveBackground()
         }
 
         if (needGenerate && videoExists) {
-            QString cacheName = QString(QCryptographicHash::hash(videoAbsPath.toUtf8(), QCryptographicHash::Md5).toHex()) + ".png";
-            QString cachePath = cacheDir + "/" + cacheName;
+            QString cachePath = DccWallpaperThumbnail::cachePath(videoAbsPath);
             if (QFile::exists(cachePath)) {
                 thumbnailPath = cachePath;
                 needGenerate = false;
@@ -531,7 +523,7 @@ void InterfaceWorker::getLiveBackground()
         if (ptr) {
             wallpapers.append(ptr);
             if (needGenerate && videoExists)
-                generateVideoThumbnail(videoAbsPath, thumbnailPath, id);
+                generateVideoThumbnail(videoAbsPath, id);
         }
     }
 
@@ -539,42 +531,17 @@ void InterfaceWorker::getLiveBackground()
     Q_EMIT pushBackground(wallpapers, WallpaperType::Wallpaper_Live);
 }
 
-QString InterfaceWorker::thumbnailCacheDir()
-{
-    return QStandardPaths::writableLocation(QStandardPaths::CacheLocation) + "/live-wallpaper-thumbnails";
-}
 
-void InterfaceWorker::generateVideoThumbnail(const QString &videoPath, const QString &cachePath, const QString &id)
+void InterfaceWorker::generateVideoThumbnail(const QString &videoPath, const QString &id)
 {
     QPointer<InterfaceWorker> guard(this);
-    (void)QtConcurrent::run([guard, videoPath, cachePath, id]() {
-        if (!guard)
+    (void)QtConcurrent::run([guard, videoPath, id]() {
+        if (!guard || !guard->m_running.load(std::memory_order_acquire))
             return;
 
-        if (!guard->m_running.load(std::memory_order_acquire))
-            return;
-
-        ffmpegthumbnailer::VideoThumbnailer thumbnailer(480, false, true, 8, false);
-        thumbnailer.setThumbnailSize(480, -1);
-        thumbnailer.setSeekTime("00:00:01");
-
-        try {
-            thumbnailer.generateThumbnail(videoPath.toStdString(), Png, cachePath.toStdString());
-        } catch (const std::exception &e) {
-            if (!guard)
-                return;
-            qCWarning(DdcPersonalizationWallpaperWorker)
-                << "Failed to generate video thumbnail:" << e.what()
-                << "video:" << videoPath;
-            return;
-        }
-
-        if (!guard)
-            return;
-
-        if (QFile::exists(cachePath)) {
-            Q_EMIT guard->videoThumbnailReady(id, cachePath);
-        }
+        const QString thumbnailPath = DccWallpaperThumbnail::generate(videoPath);
+        if (guard && !thumbnailPath.isEmpty())
+            Q_EMIT guard->videoThumbnailReady(id, thumbnailPath);
     });
 }
 

--- a/src/plugin-personalization/operation/wallpaperprovider.h
+++ b/src/plugin-personalization/operation/wallpaperprovider.h
@@ -29,7 +29,6 @@ public:
     void getSolodBackground();
     void getLiveBackground();
     QStringList fetchWallpaper(const QString &dir);
-    static QString thumbnailCacheDir();
 
 signals:
     void pushBackground(const QList<WallpaperItemPtr> &items, WallpaperType type = WallpaperType::Wallpaper_Sys);
@@ -41,7 +40,7 @@ public slots:
     void startListOne(const QString &path, WallpaperType type = WallpaperType::Wallpaper_all);
 private:
     WallpaperItemPtr createItem(const QString &path, bool del, WallpaperType type);
-    void generateVideoThumbnail(const QString &videoPath, const QString &cachePath, const QString &id);
+    void generateVideoThumbnail(const QString &videoPath, const QString &id);
 private:
     PersonalizationDBusProxy *m_proxy = nullptr;
     std::atomic_bool m_running = false;

--- a/src/shared-utils/CMakeLists.txt
+++ b/src/shared-utils/CMakeLists.txt
@@ -6,6 +6,8 @@ add_library(dcc-shared-utils OBJECT)
 set_target_properties(dcc-shared-utils PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 find_package(ICU COMPONENTS i18n uc)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(FFMPEGTHUMBNAILER REQUIRED IMPORTED_TARGET libffmpegthumbnailer)
 
 set(DCC_SHARED_UTILS_SOURCES
     "dcclocale.h"
@@ -24,6 +26,20 @@ target_link_libraries(dcc-shared-utils PRIVATE
     ICU::i18n
     ICU::uc
     ${QT_NS}::Core
+)
+
+add_library(dcc-wallpaper-utils STATIC
+    wallpaperthumbnailutils.cpp
+)
+set_target_properties(dcc-wallpaper-utils PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(dcc-wallpaper-utils PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+target_link_libraries(dcc-wallpaper-utils
+    PUBLIC
+        ${QT_NS}::Core
+    PRIVATE
+        PkgConfig::FFMPEGTHUMBNAILER
 )
 
 # Treeland input manager (wraps treeland_input_manager_v1 Wayland protocol)

--- a/src/shared-utils/wallpaperthumbnailutils.cpp
+++ b/src/shared-utils/wallpaperthumbnailutils.cpp
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "wallpaperthumbnailutils.h"
+
+#include <QCryptographicHash>
+#include <QDebug>
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QStandardPaths>
+#include <QUuid>
+
+#include <libffmpegthumbnailer/videothumbnailer.h>
+
+namespace DccWallpaperThumbnail {
+
+QString cachePath(const QString &videoPath)
+{
+    const QString cacheLocation = QStandardPaths::writableLocation(QStandardPaths::CacheLocation);
+    if (cacheLocation.isEmpty()) {
+        return {};
+    }
+
+    const QString fileName = QString::fromLatin1(QCryptographicHash::hash(videoPath.toUtf8(), QCryptographicHash::Md5).toHex()) + ".png";
+    return QDir(cacheLocation + "/live-wallpaper-thumbnails").filePath(fileName);
+}
+
+QString generate(const QString &videoPath)
+{
+    const QString outputPath = cachePath(videoPath);
+    if (outputPath.isEmpty()) {
+        return {};
+    }
+
+    if (QFileInfo(outputPath).size() > 0) {
+        return outputPath;
+    }
+
+    if (!QDir().mkpath(QFileInfo(outputPath).absolutePath())) {
+        qWarning() << "Failed to create video thumbnail cache directory:" << outputPath;
+        return {};
+    }
+
+    const QString temporaryPath = outputPath + "." + QUuid::createUuid().toString(QUuid::Id128) + ".tmp";
+    try {
+        ffmpegthumbnailer::VideoThumbnailer thumbnailer(480, false, true, 8, false);
+        thumbnailer.setThumbnailSize(480, -1);
+        thumbnailer.setSeekTime("00:00:01");
+        thumbnailer.generateThumbnail(videoPath.toStdString(), Png, temporaryPath.toStdString());
+    } catch (const std::exception &error) {
+        QFile::remove(temporaryPath);
+        qWarning() << "Failed to generate video thumbnail:" << videoPath << error.what();
+        return {};
+    }
+
+    if (QFileInfo(temporaryPath).size() <= 0) {
+        QFile::remove(temporaryPath);
+        return {};
+    }
+
+    if (QFileInfo(outputPath).size() > 0) {
+        QFile::remove(temporaryPath);
+        return outputPath;
+    }
+
+    if (QFile::rename(temporaryPath, outputPath)) {
+        return outputPath;
+    }
+
+    QFile::remove(temporaryPath);
+    return QFileInfo(outputPath).size() > 0 ? outputPath : QString();
+}
+
+}

--- a/src/shared-utils/wallpaperthumbnailutils.h
+++ b/src/shared-utils/wallpaperthumbnailutils.h
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QString>
+
+namespace DccWallpaperThumbnail {
+
+QString cachePath(const QString &videoPath);
+QString generate(const QString &videoPath);
+
+}


### PR DESCRIPTION
## Summary

- show packaged or cached thumbnails for video wallpapers in display previews
- share thumbnail cache and generation logic with the personalization plugin
- generate cache files atomically and ignore stale asynchronous results

## Verification

- `cmake --build build --target display personalization -j6`
- `./build/bin/dcc-wallpaper-utils-test --gtest_color=no` (2 tests passed)

PMS: BUG-367369