### PR TITLE
fix: improve name validation logic in authentication dialog

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -214,10 +214,14 @@ DccObject {
                             }
 
                             function checkInputInvalid() {
-                                var reg = /^[A-Za-z0-9\u4e00-\u9fa5_]+$/;
-                                var isValid = text.length === 0 || reg.test(nameEditor.text);
-                                var isOverLength = nameEditor.text.length > maxLength;
                                 var isEmpty = nameEditor.text.length === 0;
+                                if (isEmpty) {
+                                    return false
+                                }
+
+                                var reg = /^[A-Za-z0-9\u4e00-\u9fa5_]+$/;
+                                var isValid = reg.test(nameEditor.text);
+                                var isOverLength = nameEditor.text.length > maxLength;
 
                                 var nameList = [];
                                 switch (itemRep.authType) {
@@ -235,10 +239,7 @@ DccObject {
                                 var isDuplicate = nameList.includes(nameEditor.text) &&
                                                   nameEditor.text !== modelData;
 
-                                if (isEmpty) {
-                                    nameEditPanel.showAlert = true
-                                    nameEditPanel.alertText = qsTr("The name cannot be empty")
-                                } else if (!isValid && isOverLength) {
+                                if (!isValid && isOverLength) {
                                     nameEditPanel.showAlert = true
                                     nameEditPanel.alertText = qsTr("Use letters, numbers and underscores only, and no more than 15 characters")
                                 } else if (!isValid) {


### PR DESCRIPTION
1. Reorder validation checks so empty field is checked first before regex validation
2. Remove alert display for empty name field, silently preventing save instead
3. Fix validation logic to return false immediately when field is empty
4. Clean up redundant empty field check in the validation chain

Log: Fixed name validation flow to handle empty input correctly

Influence:
1. Test creating a fingerprint/face/iris record with empty name
2. Verify no alert message shows for empty name field
3. Test creating record with valid names (letters, numbers, underscores, Chinese)
4. Test creating record with names exceeding 15 character limit
5. Test creating record with special characters or symbols
6. Test creating record with duplicate names in the same category
7. Verify editing existing records with empty name field
8. Test name editing with all validation scenarios

fix: 优化认证对话框中的名称验证逻辑

1. 重新排序验证检查，让空字段先于正则验证被检测
2. 移除空名称字段的警告显示，改为静默阻止保存
3. 修复验证逻辑，当字段为空时立即返回 false
4. 清理验证链中的冗余空字段检查

Log: 修复名称验证流程，正确处理空输入情况

Influence:
1. 测试使用空名称创建指纹/人脸/虹膜记录
2. 验证空名称字段不显示警告提示
3. 测试使用有效名称（字母、数字、下划线、中文）创建记录
4. 测试使用超过15个字符的名称创建记录
5. 测试使用特殊字符或符号创建记录
6. 测试在同一类别下使用重复名称创建记录
7. 验证编辑已有记录时使用空名称字段
8. 测试所有验证场景的名称编辑功能

PMS: BUG-365811

## Summary by Sourcery

Adjust authentication dialog name validation to correctly handle empty input and align alert behavior with validation rules.

Bug Fixes:
- Ensure empty name input fails validation early without triggering a save.
- Correct name format validation by removing the implicit allowance of empty names.
- Remove the alert message for empty name input while keeping alerts for invalid or overlength names.