### PR TITLE
refactor: handle undefined aniIconPath in DeviceListView

### DIFF
--- a/src/plugin-commoninfo/qml/DevelopModePage.qml
+++ b/src/plugin-commoninfo/qml/DevelopModePage.qml
@@ -461,12 +461,12 @@ DccObject {
                 }
                 Connections {
                     target: dccData.mode()
-                    onDeveloperModeStateChanged: function(enable) {
+                    function onDeveloperModeStateChanged(enable) {
                         if (enable && developDlg.currentStackIndex === 1) {
                             developDlg.showSuccess = true
                         }
                     }
-                    onIsDeveloperModeChanged: {
+                    function onIsDeveloperModeChanged() {
                         if (dccData.mode().isDeveloperMode && developDlg.currentStackIndex === 1) {
                             developDlg.showSuccess = true
                         }

--- a/src/plugin-sound/qml/DeviceListView.qml
+++ b/src/plugin-sound/qml/DeviceListView.qml
@@ -65,9 +65,11 @@ Rectangle {
                     Layout.alignment: Qt.AlignVCenter
                     spacing: 0
                     AnimatedImage {
-                        source: model.aniIconPath
+                        source: model.aniIconPath || ""
                         Layout.alignment: Qt.AlignLeft
-                        visible: showPlayBtn && model.aniIconPath.length !== 0
+                        visible: showPlayBtn
+                                && model.aniIconPath
+                                && model.aniIconPath.length !== 0
                         sourceSize.width: 24
                         sourceSize.height: 24
                     }

--- a/src/plugin-sound/qml/DeviceListView.qml
+++ b/src/plugin-sound/qml/DeviceListView.qml
@@ -67,9 +67,7 @@ Rectangle {
                     AnimatedImage {
                         source: model.aniIconPath || ""
                         Layout.alignment: Qt.AlignLeft
-                        visible: showPlayBtn
-                                && model.aniIconPath
-                                && model.aniIconPath.length !== 0
+                        visible: showPlayBtn && source.length !== 0
                         sourceSize.width: 24
                         sourceSize.height: 24
                     }


### PR DESCRIPTION
1. Prevent crashes when `model.aniIconPath` is undefined
2. Add explicit check for `undefined` before checking the length
3. Set default empty string to avoid invalid source errors

Influence:
1. Test DeviceListView with audio devices that have no animation icon
2. Verify playback button visibility logic works correctly
3. Check that no console errors appear for missing icon paths

fix: 处理设备列表视图中 aniIconPath 可能为 undefined 的问题

1. 防止当 model.aniIconPath 未定义时导致程序崩溃
2. 在检查字符串长度前增加显式的 undefined 判断
3. 设置默认空字符串以避免无效的 source 错误

Influence:
1. 测试带有无动画图标的音频设备的设备列表视图
2. 验证播放按钮可见性逻辑正常工作
3. 检查无图标路径时是否出现控制台错误

PMS: TASK-392413

## Summary by Sourcery

Handle cases where aniIconPath may be undefined in DeviceListView to prevent crashes and invalid image source errors.

Bug Fixes:
- Prevent DeviceListView from crashing when model.aniIconPath is undefined.
- Ensure playback button visibility logic safely handles missing aniIconPath values.