### PR TITLE
fix: keep wallpaper status row inside viewport

### DIFF
--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -67,6 +67,13 @@ DccObject {
             weight: 200
             pageType: DccObject.Item
             page: RowLayout {
+                // Fixed-size 197x110 preview: never stretch. DccRowView forwards this
+                // to its loader, and Layout.fillWidth defaults to true for layout items.
+                // Filling here starves the sibling status group, whose DccGroupView has
+                // implicitWidth 0, so the row's spare width is distributed in proportion
+                // to preferred width (197 : 0) and the group is left a few pixels wide
+                // against the right edge, clipping its text outside the viewport.
+                Layout.fillWidth: false
                 Item {
                     implicitWidth: 197
                     implicitHeight: 110


### PR DESCRIPTION
## Summary

Prevent the fixed-size wallpaper preview from consuming the RowLayout fill allocation so the sibling status group retains enough width to render inside the viewport.

## Root cause

DccRowView forwards Layout.fillWidth to its loader. The 197x110 preview item inherited fillWidth=true, while the adjacent DccGroupView has an implicit width of zero. The layout therefore assigned nearly all spare width to the preview and clipped the status text at the right edge.

## Testing

- qmlformat parsed WallpaperPage.qml successfully
- git diff --check passed
- the same one-line layout change was built in the 6.1.99 package and visually verified in the live Control Center
- current-master full configure is blocked on this Arch host by the unavailable required dareader development package

This change contains no distribution theme or user-specific customization.

## Summary by Sourcery

Bug Fixes:
- Fix layout allocation in the wallpaper row so the status group retains sufficient width and is no longer clipped at the right edge.