### PR TITLE
Revert "fix(sound): avoid duplicate muted volume feedback"

### DIFF
--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -204,7 +204,7 @@ void SoundWorker::setSourceVolume(double volume)
 void SoundWorker::setSinkVolume(double volume)
 {
     qWarning()<<__FUNCTION__<<volume;
-    m_soundDBusInter->SetVolumeSink(volume, !m_soundDBusInter->muteSink());
+    m_soundDBusInter->SetVolumeSink(volume, true);
     qCDebug(DdcSoundWorker) << "set sink volume to " << volume;
 }
 


### PR DESCRIPTION
This reverts commit b251fd5383b24ccf3a45b51fa9b21acd1e93434f. Fixed in this commit: https://github.com/linuxdeepin/dde-daemon/commit/36cd616507002b19eea8799cfe18d463e1f75bf8

Log: revert

## Summary by Sourcery

Enhancements:
- Restore unconditional sink volume update behavior for sound DBus sink volume calls to align with prior implementation.