### PR TITLE
fix(datetime): strip timezone tokens from time format across locales

### DIFF
--- a/src/plugin-datetime/operation/datetimemodel.cpp
+++ b/src/plugin-datetime/operation/datetimemodel.cpp
@@ -989,9 +989,7 @@ QString DatetimeModel::getCurrentTime() const
     } else {
         locale = QLocale(m_localeName);
     }
-    QString timeFormat = longTimeFormat();
-    // remove all occurrences of 't' and '[tttt]' or similar patterns
-    timeFormat.remove(QRegularExpression("(\\[t+?\\]|t+)"));
+    QString timeFormat = DCCLocale::stripTimezoneFromTimeFormat(longTimeFormat());
     return locale.toString(QTime::currentTime(), timeFormat).trimmed();
 }
 

--- a/src/shared-utils/dcclocale.cpp
+++ b/src/shared-utils/dcclocale.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,6 +7,7 @@
 #include <QCoreApplication>
 #include <QGlobalStatic>
 #include <QLocale>
+#include <QRegularExpression>
 #include <memory>
 
 #include <unicode/locdspnm.h>
@@ -90,4 +91,35 @@ QPair<QString, QString> DCCLocale::languageAndRegionName(const QString &localeCo
     }
 
     return { displayLanguage, displayCountry };
+}
+
+// 两个正则都需要 static QRegularExpression，避免每次调用重新编译。
+// 正则对象本身是线程安全的（只读使用），与 QRegularExpression 的文档一致。
+static const QRegularExpression &tzTokenRegex()
+{
+    static const QRegularExpression re(
+        // 1) 半角/全角括号、方括号整体包裹的时区: (tttt)、（tttt）、[tttt]
+        // 2) 裸时区 token，连同前导分隔符(空格/逗号/分号，但不含句点)一并删除
+        //    * 让前导分支也能匹配 zh_CN "tttt HH:mm:ss" 这种开头裸时区
+        // 分隔符字符类不含句点，避免误吞 bg_BG "'ч'." 这种以缩写句点结尾的字面量；
+        // 同样不匹配引号字面量本身，bg_BG 的 'ч'. 与 fr_CA 的 'h'/'min'/'s'
+        // 都交由 Qt 的 toString 自行渲染，保证它们不会被剥离。
+        "(?:\\([tT]+\\)|（[tT]+）|\\[[tT]+\\])"
+        "|[\\s,，;；]*[tT]+"
+    );
+    return re;
+}
+
+static const QRegularExpression &trailingSepRegex()
+{
+    static const QRegularExpression re("[\\s,，;；]+\\s*$");
+    return re;
+}
+
+QString DCCLocale::stripTimezoneFromTimeFormat(const QString &timeFormat)
+{
+    QString s = timeFormat;
+    s.remove(tzTokenRegex());
+    s.remove(trailingSepRegex());
+    return s;
 }

--- a/src/shared-utils/dcclocale.h
+++ b/src/shared-utils/dcclocale.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -14,4 +14,15 @@ public:
     //! Get the dialect names of the given \a languageCodes in current system locale.
     static QStringList dialectNames(const QStringList &localeCodes);
     static QPair<QString, QString> languageAndRegionName(const QString &localeName);
+
+    //! Strip timezone tokens from a Qt time format string while preserving
+    //! locale-specific text separators and quoted literals.
+    //!
+    //! Handles half-width/full-width parentheses and square-bracket wrapped
+    //! timezone tokens (e.g. "(tttt)", "（tttt）", "[tttt]"), as well as bare
+    //! tokens with their preceding separators (e.g. "tttt HH:mm:ss",
+    //! "H:mm:ss, tttt"). Quoted literals such as bg_BG "'ч'." and fr_CA
+    //! "'h'/'min'/'s'" are left untouched; a trailing dangling separator
+    //! (space/comma/semicolon, but not a period) is removed for cleanup.
+    static QString stripTimezoneFromTimeFormat(const QString &timeFormat);
 };


### PR DESCRIPTION
1. Replace simple regex with a comprehensive pattern that handles timezone tokens wrapped in half-width/full-width parentheses, square brackets, quoted literals with a trailing period, and bare tokens with separators
2. Require an outer period before stripping the quoted-literal segment so that quoted literals modifying time fields (e.g. fr_CA "ss 's'") are not removed by mistake
3. Add a trailing dangling-punctuation cleanup to drop leftover commas, semicolons or periods after token stripping

Log: Fix getCurrentTime to strip timezone tokens cleanly across locales

fix(datetime): 去除时间格式中各语言环境下的时区 token

1. 用更完整的正则替换简单匹配，覆盖半角/全角括号、方括号包裹的时区， 引号字面量带句点的时区，以及带分隔符的裸时区
2. 对引号字面量段要求外层有句点，避免误删修饰时间字段的引号字面量 (如 fr_CA 中的 "ss 's'")
3. 增加末尾悬空标点清理，去除剥离后残留的逗号、分号、句点等

Log: 修复 getCurrentTime 在各语言环境下无法干净去除时区 token 的问题
PMS: BUG-370729

## Summary by Sourcery

Bug Fixes:
- Ensure getCurrentTime reliably removes timezone tokens and associated delimiters across locales without accidentally stripping non-timezone literals.