### PR TITLE
fix(personalization): prevent screen indicator creating extra taskbar entries

### DIFF
--- a/src/plugin-personalization/qml/ScreenIndicator.qml
+++ b/src/plugin-personalization/qml/ScreenIndicator.qml
@@ -20,7 +20,7 @@ Loader {
         screen: root.screen
         color: "#2ca7f8"
 
-        flags: Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint
+        flags: Qt.WindowStaysOnTopHint | Qt.FramelessWindowHint | Qt.X11BypassWindowManagerHint
         DS.DLayerShellWindow.layer: DS.DLayerShellWindow.LayerOverlay
         DS.DLayerShellWindow.exclusionZone: -1
         Component.onCompleted: show()


### PR DESCRIPTION
Add Qt.X11BypassWindowManagerHint to screen indicator window flags, so switching wallpaper screen selection no longer spawns temporary duplicate control center icons in the taskbar.

为屏幕指示器窗口标志添加 Qt.X11BypassWindowManagerHint，
切换壁纸屏幕选择时不再在任务栏中生成临时重复的控制中心图标。

Log: 为屏幕指示器窗口增加 Qt.X11BypassWindowManagerHint 标志，避免任务栏中创建临时图标。 Influence:个性化-壁纸模块的屏幕指示器窗口，在 Treeland 和 X11 环境下验证切换屏幕时任务栏图标无异常。