### PR TITLE
fix: select default screen when current screen is no longer available

### DIFF
--- a/src/plugin-personalization/operation/personalizationmodel.cpp
+++ b/src/plugin-personalization/operation/personalizationmodel.cpp
@@ -195,7 +195,7 @@ void PersonalizationModel::setScreens(const QStringList &screens)
     if (m_screens == screens)
         return;
     m_screens = screens;
-    if (m_currentSelectScreen.isEmpty() && !m_screens.isEmpty())
+    if (!m_screens.isEmpty() && (m_currentSelectScreen.isEmpty() || !m_screens.contains(m_currentSelectScreen)))
         setCurrentSelectScreen(m_screens.first());
     Q_EMIT screensChanged(screens);
 }


### PR DESCRIPTION
Fix screen selection logic to automatically select the first available screen when the currently selected screen is removed from the available screens list. Previously, the selection would only update if the current screen was empty, leaving an invalid selection state.

Log: Fixed screen selection logic to handle screen removal scenarios

Influence:
1. Test with multiple monitors by disconnecting one monitor
2. Verify the active screen selection updates correctly to an available screen
3. Test changing screens on a single monitor setup
4. Verify no crash or invalid state when all screens are disconnected

fix: 当前屏幕不可用时自动选择默认屏幕

修复屏幕选择逻辑，当当前选择的屏幕从可用屏幕列表中移除时，自动选择第一个
可用屏幕。之前只有在当前屏幕为空时才会更新选择，导致出现无效的选择状态。

Log: 修复屏幕移除场景下的选择逻辑

Influence:
1. 测试多显示器场景，断开其中一个显示器
2. 验证当前选择的屏幕正确切换到可用屏幕
3. 测试单显示器场景下的屏幕切换
4. 验证所有显示器断开时不会出现崩溃或无效状态

PMS: BUG-370427