### PR TITLE
fix(display): refine Treeland output configuration

### DIFF
--- a/src/plugin-display/operation/dccscreen.cpp
+++ b/src/plugin-display/operation/dccscreen.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "dccscreen.h"
 
+#include "WayQtUtils.h"
 #include "private/dccscreen_p.h"
 #include "private/displayworker.h"
 
@@ -123,6 +124,12 @@ void DccScreenPrivate::setMonitors(QList<Monitor *> monitors)
     q_ptr->connect(monitor(), &Monitor::currentModeChanged, q_ptr, &DccScreen::currentModeChanged);
     q_ptr->connect(monitor(), &Monitor::enableChanged, q_ptr, &DccScreen::enableChanged);
     q_ptr->connect(monitor(), &Monitor::rotateChanged, q_ptr, &DccScreen::rotateChanged);
+    q_ptr->connect(monitor(), &Monitor::rotateChanged, q_ptr, [this]() {
+        if (WQt::Utils::isTreeland()) {
+            Q_EMIT q_ptr->widthChanged();
+            Q_EMIT q_ptr->heightChanged();
+        }
+    });
     q_ptr->connect(monitor(), &Monitor::scaleChanged, q_ptr, &DccScreen::scaleChanged);
     q_ptr->connect(monitor(), &Monitor::scaleChanged, q_ptr, &DccScreen::widthChanged);
     q_ptr->connect(monitor(), &Monitor::scaleChanged, q_ptr, &DccScreen::heightChanged);
@@ -317,12 +324,24 @@ int DccScreen::y() const
 
 int DccScreen::width() const
 {
-    return d_ptrDccScreen->monitor()->scale() > 0 ? (d_ptrDccScreen->monitor()->w() / d_ptrDccScreen->monitor()->scale()) : d_ptrDccScreen->monitor()->w();
+    const auto *monitor = d_ptrDccScreen->monitor();
+    if (!WQt::Utils::isTreeland()) {
+        return monitor->scale() > 0 ? (monitor->w() / monitor->scale()) : monitor->w();
+    }
+    const bool rotated = monitor->rotate() == Monitor::Rotation90 || monitor->rotate() == Monitor::Rotation270;
+    const int width = rotated ? monitor->h() : monitor->w();
+    return monitor->scale() > 0 ? qRound(width / monitor->scale()) : width;
 }
 
 int DccScreen::height() const
 {
-    return d_ptrDccScreen->monitor()->scale() > 0 ? (d_ptrDccScreen->monitor()->h() / d_ptrDccScreen->monitor()->scale()) : d_ptrDccScreen->monitor()->h();
+    const auto *monitor = d_ptrDccScreen->monitor();
+    if (!WQt::Utils::isTreeland()) {
+        return monitor->scale() > 0 ? (monitor->h() / monitor->scale()) : monitor->h();
+    }
+    const bool rotated = monitor->rotate() == Monitor::Rotation90 || monitor->rotate() == Monitor::Rotation270;
+    const int height = rotated ? monitor->w() : monitor->h();
+    return monitor->scale() > 0 ? qRound(height / monitor->scale()) : height;
 }
 
 QSize DccScreen::bestResolution() const

--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -34,6 +34,27 @@ DisplayModulePrivate::DisplayModulePrivate(DisplayModule *parent)
     qRegisterMetaType<QHash<Monitor *, QPair<int, int>>>("QHash<Monitor *, QPair<int, int>>");
     m_model = new DisplayModel(q_ptr);
     m_worker = new DisplayWorker(m_model, q_ptr);
+    m_scalePositionTimer = new QTimer(q_ptr);
+    m_scalePositionTimer->setSingleShot(true);
+    m_scalePositionTimer->setInterval(300);
+    q_ptr->connect(m_scalePositionTimer, &QTimer::timeout, q_ptr, [this]() {
+        if (m_model->displayMode() != EXTEND_MODE) {
+            m_pendingScalePosition.clear();
+            return;
+        }
+
+        const auto monitors = m_model->monitorList();
+        for (auto *monitor : m_pendingScalePosition.keys()) {
+            if (!monitors.contains(monitor) || !monitor->enable()) {
+                m_pendingScalePosition.clear();
+                return;
+            }
+        }
+
+        const auto monitorPosition = m_pendingScalePosition;
+        m_pendingScalePosition.clear();
+        m_worker->setMonitorPosition(monitorPosition);
+    });
     init();
 }
 
@@ -41,12 +62,20 @@ void DisplayModulePrivate::init()
 {
     m_worker->active();
     q_ptr->connect(m_model, &DisplayModel::monitorListChanged, [this]() {
+        if (WQt::Utils::isTreeland()) {
+            m_scalePositionTimer->stop();
+            m_pendingScalePosition.clear();
+        }
         updateMonitorList();
     });
     q_ptr->connect(m_model, &DisplayModel::primaryScreenChanged, q_ptr, [this]() {
         updatePrimary();
     });
     q_ptr->connect(m_model, &DisplayModel::displayModeChanged, q_ptr, [this]() {
+        if (WQt::Utils::isTreeland()) {
+            m_scalePositionTimer->stop();
+            m_pendingScalePosition.clear();
+        }
         updateVirtualScreens();
         updateDisplayMode();
     });
@@ -411,10 +440,14 @@ void DisplayModulePrivate::updateScale(DccScreen *item)
     auto monitorPosition = buildMonitorPosition(tmpListItems);
     m_worker->updateMonitorPosition(monitorPosition);
     qDeleteAll(tmpListItems);
-    // 设置过快会导致treeland崩溃
-    QTimer::singleShot(300, q_ptr, [this, monitorPosition] {
-        m_worker->setMonitorPosition(monitorPosition);
-    });
+    if (WQt::Utils::isTreeland()) {
+        m_pendingScalePosition = monitorPosition;
+        m_scalePositionTimer->start();
+    } else {
+        QTimer::singleShot(300, q_ptr, [this, monitorPosition] {
+            m_worker->setMonitorPosition(monitorPosition);
+        });
+    }
 }
 
 DisplayModule::DisplayModule(QObject *parent)

--- a/src/plugin-display/operation/private/displaymodule_p.h
+++ b/src/plugin-display/operation/private/displaymodule_p.h
@@ -8,6 +8,10 @@
 #include <QObject>
 #include <QPair>
 
+QT_BEGIN_NAMESPACE
+class QTimer;
+QT_END_NAMESPACE
+
 namespace dccV25 {
 class DisplayWorker;
 class DisplayModel;
@@ -50,6 +54,8 @@ public:
     QString m_displayMode;
     qreal m_maxGlobalScale;
     bool m_screensFormRect;
+    QTimer *m_scalePositionTimer { nullptr };
+    QHash<Monitor *, QPair<int, int>> m_pendingScalePosition;
 
     Q_DECLARE_PUBLIC(DisplayModule)
 };

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -249,7 +249,6 @@ void DisplayWorker::switchMode(const int mode, const QString &name)
                             if (preferMode)
                                 cfgHead->setMode(preferMode);
                         }
-                        cfgHead->setPosition({ 0, 0 });
                     }
                     connect(opCfg, &WQt::OutputConfiguration::succeeded, this, createMergeVirtualOutput);
                     connect(opCfg, &WQt::OutputConfiguration::succeeded, opCfg, &QObject::deleteLater);
@@ -273,7 +272,6 @@ void DisplayWorker::switchMode(const int mode, const QString &name)
                 return;
             }
             m_model->setDisplayMode(mode);
-            int posX = 0;
 
             for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
                 switch (mode) {
@@ -284,8 +282,6 @@ void DisplayWorker::switchMode(const int mode, const QString &name)
                         updateDisplayModeFromCurrentState();
                         return;
                     }
-                    cfgHead->setPosition({ posX, 0 });
-                    posX += it.key()->w();
                     break;
                 }
                 case SINGLE_MODE: {
@@ -304,7 +300,6 @@ void DisplayWorker::switchMode(const int mode, const QString &name)
                         }
                         if (preferMode)
                             cfgHead->setMode(preferMode);
-                        cfgHead->setPosition({ 0, 0 });
                     } else {
                         opCfg->disableHead(it.value());
                     }
@@ -315,6 +310,9 @@ void DisplayWorker::switchMode(const int mode, const QString &name)
                 }
             }
 
+            connect(opCfg, &WQt::OutputConfiguration::succeeded, opCfg, &QObject::deleteLater);
+            connect(opCfg, &WQt::OutputConfiguration::failed, opCfg, &QObject::deleteLater);
+            connect(opCfg, &WQt::OutputConfiguration::canceled, opCfg, &QObject::deleteLater);
             opCfg->apply();
         }
     } else {
@@ -656,13 +654,13 @@ constexpr static int wlRotate2dcc(int wlRotate)
 {
     switch (wlRotate) {
     case WL_OUTPUT_TRANSFORM_NORMAL:
-        return 1;
+        return Monitor::RotationNormal;
     case WL_OUTPUT_TRANSFORM_90:
-        return 2;
+        return Monitor::Rotation90;
     case WL_OUTPUT_TRANSFORM_180:
-        return 4;
+        return Monitor::Rotation180;
     case WL_OUTPUT_TRANSFORM_270:
-        return 8;
+        return Monitor::Rotation270;
     default:
         qWarning("dcc dont support FLIPPED");
         return 0;
@@ -672,13 +670,13 @@ constexpr static int wlRotate2dcc(int wlRotate)
 constexpr static int dccRotate2wl(int dccRotate)
 {
     switch (dccRotate) {
-    case 1:
+    case Monitor::RotationNormal:
         return WL_OUTPUT_TRANSFORM_NORMAL;
-    case 2:
+    case Monitor::Rotation90:
         return WL_OUTPUT_TRANSFORM_90;
-    case 4:
+    case Monitor::Rotation180:
         return WL_OUTPUT_TRANSFORM_180;
-    case 8:
+    case Monitor::Rotation270:
         return WL_OUTPUT_TRANSFORM_270;
     default:
         qWarning("unkone dccRotate, feedback to normal");
@@ -917,6 +915,9 @@ void DisplayWorker::setMonitorPosition(const QHash<Monitor *, QPair<int, int>> m
 {
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();
+        if (!opCfg) {
+            return;
+        }
         for (auto it(monitorPosition.cbegin()); it != monitorPosition.cend(); ++it) {
             auto *head = m_wl_monitors.value(it.key());
             Q_ASSERT(head);
@@ -927,6 +928,9 @@ void DisplayWorker::setMonitorPosition(const QHash<Monitor *, QPair<int, int>> m
             auto *cfgHead = opCfg->enableHead(head);
             cfgHead->setPosition({ it.value().first, it.value().second });
         }
+        connect(opCfg, &WQt::OutputConfiguration::succeeded, opCfg, &QObject::deleteLater);
+        connect(opCfg, &WQt::OutputConfiguration::failed, opCfg, &QObject::deleteLater);
+        connect(opCfg, &WQt::OutputConfiguration::canceled, opCfg, &QObject::deleteLater);
         opCfg->apply();
     } else {
         for (auto it(monitorPosition.cbegin()); it != monitorPosition.cend(); ++it) {
@@ -944,12 +948,12 @@ void DisplayWorker::setUiScale(const double value)
     double rv = value;
     if (rv < 0)
         rv = m_model->uiScale();
-    for (auto &mm : m_model->monitorList()) {
-        mm->setScale(-1);
-    }
 
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();
+        if (!opCfg) {
+            return;
+        }
         for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
             if (!it.key()->enable()) {
                 opCfg->disableHead(it.value());
@@ -958,11 +962,17 @@ void DisplayWorker::setUiScale(const double value)
             auto *cfgHead = opCfg->enableHead(it.value());
             cfgHead->setScale(rv);
         }
-        opCfg->apply();
         connect(opCfg, &WQt::OutputConfiguration::succeeded, this, [this, rv]() {
             m_model->setUIScale(rv);
         });
+        connect(opCfg, &WQt::OutputConfiguration::succeeded, opCfg, &QObject::deleteLater);
+        connect(opCfg, &WQt::OutputConfiguration::failed, opCfg, &QObject::deleteLater);
+        connect(opCfg, &WQt::OutputConfiguration::canceled, opCfg, &QObject::deleteLater);
+        opCfg->apply();
     } else {
+        for (auto &mm : m_model->monitorList()) {
+            mm->setScale(-1);
+        }
         QDBusPendingCall call = m_displayInter->SetScaleFactor(rv);
 
         QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
@@ -976,14 +986,15 @@ void DisplayWorker::setUiScale(const double value)
 
 void DisplayWorker::setIndividualScaling(Monitor *m, const double scaling)
 {
-    if (m && scaling >= 1.0) {
-        m->setScale(scaling);
-    } else {
+    if (!m || scaling < 1.0) {
         return;
     }
 
     if (WQt::Utils::isTreeland()) {
         auto *opCfg = m_reg->outputManager()->createConfiguration();
+        if (!opCfg) {
+            return;
+        }
         for (auto it(m_wl_monitors.cbegin()); it != m_wl_monitors.cend(); ++it) {
             if (!it.key()->enable()) {
                 opCfg->disableHead(it.value());
@@ -994,8 +1005,12 @@ void DisplayWorker::setIndividualScaling(Monitor *m, const double scaling)
                 cfgHead->setScale(scaling);
             }
         }
+        connect(opCfg, &WQt::OutputConfiguration::succeeded, opCfg, &QObject::deleteLater);
+        connect(opCfg, &WQt::OutputConfiguration::failed, opCfg, &QObject::deleteLater);
+        connect(opCfg, &WQt::OutputConfiguration::canceled, opCfg, &QObject::deleteLater);
         opCfg->apply();
     } else {
+        m->setScale(scaling);
         QMap<QString, double> scalemap;
         for (Monitor *m : m_model->monitorList()) {
             scalemap[m->name()] = m_model->monitorScale(m);
@@ -1199,7 +1214,7 @@ void DisplayWorker::wlMonitorAdded(WQt::OutputHead *head)
     mon->setX(head->property(WQt::OutputHead::Position).toPoint().x());
     mon->setY(head->property(WQt::OutputHead::Position).toPoint().y());
 
-    mon->setRotateList({ 1, 2, 4, 8 });
+    mon->setRotateList({ Monitor::RotationNormal, Monitor::Rotation90, Monitor::Rotation180, Monitor::Rotation270 });
     mon->setRotate(wlRotate2dcc(head->property(WQt::OutputHead::Transform).toInt()));
 
     ResolutionList resolutionList;

--- a/src/plugin-display/operation/private/monitor.h
+++ b/src/plugin-display/operation/private/monitor.h
@@ -28,6 +28,14 @@ public:
         Rotate
     };
 
+    enum Rotation : quint16 {
+        RotationNormal = 1,
+        Rotation90 = 2,
+        Rotation180 = 4,
+        Rotation270 = 8,
+    };
+    Q_ENUM(Rotation)
+
 public:
     explicit Monitor(QObject *parent = 0);
 


### PR DESCRIPTION
Let Treeland manage positions during display mode switches, debounce scale-triggered position updates, and handle rotated logical sizes consistently.

PMS: TASK-393105