### PR TITLE
fix: hide DccLabel tooltip during page switch

### DIFF
--- a/src/dde-control-center/plugin/DccLabel.qml
+++ b/src/dde-control-center/plugin/DccLabel.qml
@@ -3,6 +3,7 @@
 import QtQuick 2.15
 import QtQuick.Controls 2.15
 import org.deepin.dtk 1.0
+import org.deepin.dcc 1.0
 
 Label {
     id: control
@@ -10,12 +11,23 @@ Label {
 
     elide: Text.ElideRight
     font: DTK.fontManager.t6
-    ToolTip {
-        visible: control.width < control.implicitWidth && control.hovered
-        text: control.text
-        delay: 500
-        timeout: 3000
-        implicitWidth: Math.min(control.implicitWidth + 10, 400)
+    Loader {
+        active: control.width < control.implicitWidth && control.hovered
+        sourceComponent: Component {
+            ToolTip {
+                visible: true
+                text: control.text
+                delay: 500
+                timeout: 3000
+                implicitWidth: Math.min(control.implicitWidth + 10, 400)
+                Connections {
+                    target: DccApp
+                    function onActiveObjectChanged() {
+                        close()
+                    }
+                }
+            }
+        }
     }
     // 使用Attached方式退出时会崩溃
     // ToolTip.visible: width < implicitWidth && hovered


### PR DESCRIPTION
1. Add Connections inside DccLabel's ToolTip to listen DccApp.activeObjectChanged signal
2. Call tooltip.close() immediately when page changes while tooltip is visible
3. Fixes tooltip remaining visible during page switch animation when navigating via mouse click or keyboard

Log: Tooltip on truncated menu items no longer lingers during page switch

Influence:
1. Hover over a truncated second-level menu item to show tooltip, then click or press Enter to navigate to a third-level page, verify tooltip disappears immediately
2. Use keyboard Up/Down to navigate while hovering over a truncated menu item, verify tooltip closes on navigation

PMS: BUG-370599

fix: 页面切换时隐藏DccLabel的ToolTip

1. 在DccLabel的ToolTip内部添加Connections监听 DccApp.activeObjectChanged信号
2. 页面切换时若ToolTip可见则立即调用tooltip.close()
3. 修复鼠标点击或键盘导航进入新页面时，ToolTip 在页面切换动画期间不消失的问题

Log: 截断菜单项的ToolTip在页面切换时不再残留

Influence:
1. 鼠标悬停在截断的二级菜单项上显示ToolTip后， 点击或按回车进入三级页面，验证ToolTip立即消失
2. 鼠标悬停在截断菜单项上时使用键盘上下导航， 验证ToolTip在导航时关闭

## Summary by Sourcery

Bug Fixes:
- Hide DccLabel tooltips immediately when the active object changes so they do not remain visible during page transitions.