### PR TITLE
feat: migrate shortcut and gesture settings to dde-services

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -9,10 +9,9 @@
 
 #include <PolkitQt1/Authority>
 #include <QFileInfo>
-#include <QGuiApplication>
-#include <QKeySequence>
 #include <QQuickItem>
 #include <QQuickWindow>
+#include <QTimer>
 
 namespace dccV25 {
 DCC_FACTORY_CLASS(KeyboardController)
@@ -32,7 +31,7 @@ KeyboardController::KeyboardController(QObject *parent)
     // WAYLAND_DISPLAY) rather than QGuiApplication::platformName(), so this
     // matches the proxy that decides which D-Bus API to call. On a divergent
     // setup (XWayland / forced -platform xcb) the manager simply won't bind and
-    // captureNext() returns null → beginWaylandKeyCapture reports a visible
+    // captureNext() returns null and reports a visible
     // failure instead of the two halves disagreeing.
     if (m_worker->isWayland()) {
         m_captureManager = new TreelandShortcutCaptureManager(this);
@@ -47,46 +46,99 @@ KeyboardController::KeyboardController(QObject *parent)
     connect(m_model, &KeyboardModel::keyboardEnabledChanged, this, &KeyboardController::keyboardEnabledChanged);
     connect(m_worker, &KeyboardWorker::shortcutCommandReady,
             this, &KeyboardController::shortcutCommandReady);
+    connect(m_worker, &KeyboardWorker::captureRequestFinished, this,
+            [this](quint64 requestId, bool success, const QString &reason) {
+                if (requestId != m_pendingX11RequestId)
+                    return;
 
-    connect(m_shortcutModel, &ShortcutModel::keyEvent, this, [this](bool press, const QString &shortcut){
-        ShortcutInfo *current = m_shortcutModel->currentInfo();
-
-        ShortcutInfo *conflict = m_shortcutModel->getInfo(shortcut);
-
-        if (!press) {
-            if (shortcut.isEmpty()) {
-                Q_EMIT requestRestore();
-                return;
-            }
-
-            if (shortcut == "BackSpace" || shortcut == "Delete") {
-                Q_EMIT requestClear();
-                return;
-            }
-
-            // have conflict
-            if (conflict) {
-                // self conflict
-                if (conflict == current && conflict->accels == current->accels) {
-                    Q_EMIT requestRestore();
+                m_pendingX11RequestId = 0;
+                if (requestId != m_capture.requestId
+                        || m_capture.backend != CaptureBackend::X11) {
+                    if (success)
+                        m_worker->endCapture();
+                    startRequestedX11Capture();
                     return;
                 }
 
-                auto conflictName = QString("<font color=\"red\">%1</font>").arg(conflict->name.toHtmlEscaped());
-                QString text = KeyboardController::tr("This shortcut conflicts with [%1]").arg(conflictName);
-                setConflictText(text);
-                Q_EMIT keyConflicted(current ? current->accels : "", conflict->accels);
-            } else {
-                // save
-                if (current) {
-                    current->accels = shortcut;
+                const QString id = m_capture.id;
+                const int type = m_capture.type;
+                const quint64 generation = m_capture.generation;
+                if (!isCurrentShortcutGeneration(id, type, generation)) {
+                    if (success)
+                        m_worker->endCapture();
+                    m_capture.reset();
+                    return;
                 }
 
-                Q_EMIT keyDone(shortcut);
-            }
-        }
+                if (!success) {
+                    m_capture.reset();
+                    qWarning() << "BeginCapture failed:" << reason;
+                    Q_EMIT keyCaptureFailed(id, type, reason);
+                    return;
+                }
 
-        Q_EMIT keyEvent(shortcut);
+                if (!m_capture.item) {
+                    m_capture.reset();
+                    m_worker->endCapture();
+                    return;
+                }
+
+                m_capture.phase = CapturePhase::Active;
+                Q_EMIT keyCaptureStarted(id, type);
+            });
+    connect(m_worker, &KeyboardWorker::shortcutConflictDetected, this,
+            [this](const QString &id, int type, const QString &shortcut,
+                   const QString &conflictId, const QString &conflictName,
+                   bool replaceable, quint64 generation) {
+                if (!isCurrentShortcutGeneration(id, type, generation))
+                    return;
+
+                ShortcutInfo *current = shortcutInfo(id, type);
+                if (current)
+                    m_shortcutModel->setCurrentInfo(current);
+                if (replaceable) {
+                    m_pendingConflicts.insert(shortcutKey(id, type),
+                                              PendingConflict{conflictId, shortcut, generation});
+                } else {
+                    m_pendingConflicts.remove(shortcutKey(id, type));
+                }
+
+                const QString escapedName = conflictName.toHtmlEscaped();
+                const QString markedName = QStringLiteral("<font color=\"red\">%1</font>").arg(escapedName);
+                const QString message = KeyboardController::tr("This shortcut conflicts with [%1]").arg(markedName);
+                setConflictText(message);
+                Q_EMIT keyConflicted(id, type, current ? current->accels : QString(),
+                                     shortcut, message, replaceable);
+            });
+    connect(m_worker, &KeyboardWorker::shortcutModificationFinished,
+            this, [this](const QString &id, int type, const QString &shortcut,
+                         bool success, quint64 generation) {
+                if (!isCurrentShortcutGeneration(id, type, generation))
+                    return;
+                if (!success)
+                    m_worker->onShortcutChanged(id, type);
+                Q_EMIT shortcutModificationFinished(id, type, shortcut, success);
+            });
+    connect(m_worker, &KeyboardWorker::customShortcutOperationFinished,
+            this, &KeyboardController::customShortcutOperationFinished);
+
+    connect(m_shortcutModel, &ShortcutModel::keyEvent, this, [this](bool press, const QString &shortcut){
+        if (m_capture.backend != CaptureBackend::X11
+                || m_capture.phase != CapturePhase::Active)
+            return;
+
+        const QString id = m_capture.id;
+        const int type = m_capture.type;
+        const quint64 generation = m_capture.generation;
+        if (!isCurrentShortcutGeneration(id, type, generation))
+            return;
+
+        if (press)
+            Q_EMIT keyEvent(id, type, shortcut);
+        else {
+            endKeyCapture();
+            handleCapturedKeystroke(id, type, shortcut, generation);
+        }
     });
 
     QMetaObject::invokeMethod(m_worker, "active", Qt::QueuedConnection);
@@ -245,15 +297,10 @@ QString KeyboardController::customCategoryKey() const
 
 void KeyboardController::updateKey(const QString &id, const int &type)
 {
-    ShortcutInfo *shortcut = nullptr;
-    if (!id.isEmpty()) { // new shortcuts
-        shortcut = m_shortcutModel->findInfoIf([id, type](ShortcutInfo *info){
-            return id == info->id && type == info->type;
-        });
-        if (!shortcut) {
-            qWarning() << "shortcut not found..." << id << type;
-            return;
-        }
+    ShortcutInfo *shortcut = shortcutInfo(id, type);
+    if (!id.isEmpty() && !shortcut) {
+        qWarning() << "shortcut not found..." << id << type;
+        return;
     }
 
     m_worker->updateKey(shortcut);
@@ -264,9 +311,9 @@ QStringList KeyboardController::formatKeys(const QString &shortcuts)
     return ShortcutModel::formatKeys(shortcuts);
 }
 
-QString KeyboardController::keyEventToAccels(int key, int modifiers)
+bool KeyboardController::isWaylandSession() const
 {
-    return QKeySequence(key | modifiers).toString(QKeySequence::PortableText);
+    return m_worker->isWayland();
 }
 
 QString KeyboardController::checkDesktopCmd(const QString &cmd)
@@ -281,56 +328,93 @@ QString KeyboardController::checkDesktopCmd(const QString &cmd)
     return cmd;
 }
 
-void KeyboardController::addCustomShortcut(const QString &name, const QString &cmd, const QString &accels)
+quint64 KeyboardController::addCustomShortcut(const QString &name, const QString &cmd,
+                                              const QString &accels)
 {
-    if (m_worker->isWayland()) {
-        m_worker->addCustomShortcut(name, checkDesktopCmd(cmd), accels);
-        return;
-    }
-
-    // Clear conflicting shortcuts when adding
-    if (auto conflict = m_shortcutModel->getInfo(accels)) {
-        m_worker->onDisableShortcut(conflict);
-    }
-
-    // Check and process desktop commands, add dde-am prefix if needed
-    QString newCmd = checkDesktopCmd(cmd);
-    m_worker->addCustomShortcut(name, newCmd, accels);
+    const quint64 requestId = ++m_customShortcutRequestSerial;
+    m_pendingConflicts.remove(shortcutKey(QString(), ShortcutModel::Custom));
+    m_worker->addCustomShortcut(name, checkDesktopCmd(cmd), accels, requestId);
+    return requestId;
 }
 
-void KeyboardController::modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels)
+quint64 KeyboardController::modifyCustomShortcut(const QString &id, const QString &name,
+                                                 const QString &cmd, const QString &accels)
 {
+    const quint64 requestId = ++m_customShortcutRequestSerial;
     ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id](ShortcutInfo *info){ return id == info->id; });
     if (!shortcut) {
         qWarning() << "shortcut not found..." << id << name;
-        return;
+        QTimer::singleShot(0, this, [this, requestId] {
+            Q_EMIT customShortcutOperationFinished(requestId, false,
+                                                   tr("The shortcut no longer exists."));
+        });
+        return requestId;
     }
 
-    if (m_worker->isWayland()) {
-        ShortcutInfo updated = *shortcut;
-        updated.name = name;
-        updated.command = checkDesktopCmd(cmd);
-        updated.accels = accels;
-        m_worker->modifyCustomShortcut(&updated);
-        return;
-    }
-
-    // Clear conflicting shortcuts when modifying
-    if (auto conflict = m_shortcutModel->getInfo(accels)) {
-        m_worker->onDisableShortcut(conflict);
-    }
-
-    shortcut->name = name;
-    shortcut->command = checkDesktopCmd(cmd);
-    shortcut->accels = accels;
-
-    m_worker->modifyCustomShortcut(shortcut);
+    ShortcutInfo updated = *shortcut;
+    updated.name = name;
+    updated.command = checkDesktopCmd(cmd);
+    updated.accels = accels;
+    m_pendingConflicts.remove(shortcutKey(id, ShortcutModel::Custom));
+    m_worker->modifyCustomShortcut(&updated, requestId);
+    return requestId;
 }
 
-void KeyboardController::requestShortcutCommand(const QString &id)
+quint64 KeyboardController::replaceCustomShortcut(const QString &id, const QString &name,
+                                                  const QString &cmd, const QString &accels)
 {
-    if (m_worker)
-        m_worker->requestShortcutCommand(id);
+    const quint64 requestId = ++m_customShortcutRequestSerial;
+    const int type = ShortcutModel::Custom;
+    if (!id.isEmpty() && !shortcutInfo(id, type)) {
+        qWarning() << "custom shortcut not found..." << id << name;
+        QTimer::singleShot(0, this, [this, requestId] {
+            Q_EMIT customShortcutOperationFinished(requestId, false,
+                                                   tr("The shortcut no longer exists."));
+        });
+        return requestId;
+    }
+
+    const quint64 generation = shortcutGeneration(id, type);
+    if (!isCurrentShortcutGeneration(id, type, generation)) {
+        qWarning() << "ignore custom shortcut replacement outside current capture:" << id;
+        QTimer::singleShot(0, this, [this, requestId] {
+            Q_EMIT customShortcutOperationFinished(requestId, false,
+                                                   tr("The shortcut conflict is no longer current."));
+        });
+        return requestId;
+    }
+
+    const PendingConflict pendingConflict = m_pendingConflicts.take(shortcutKey(id, type));
+    if (pendingConflict.id.isEmpty()
+            || pendingConflict.shortcut != accels
+            || pendingConflict.generation != generation) {
+        qWarning() << "replace custom shortcut requested without a confirmed conflict:" << id;
+        QTimer::singleShot(0, this, [this, requestId] {
+            Q_EMIT customShortcutOperationFinished(requestId, false,
+                                                   tr("Please confirm the shortcut conflict again."));
+        });
+        return requestId;
+    }
+
+    m_worker->replaceCustomShortcut(id, name, checkDesktopCmd(cmd), accels,
+                                    pendingConflict.id, generation, requestId);
+    return requestId;
+}
+
+void KeyboardController::clearPendingConflict(const QString &id, int type)
+{
+    m_pendingConflicts.remove(shortcutKey(id, type));
+}
+
+quint64 KeyboardController::requestShortcutCommand(const QString &id)
+{
+    if (!m_worker)
+        return 0;
+
+    if (++m_shortcutCommandRequestSerial == 0)
+        ++m_shortcutCommandRequestSerial;
+    m_worker->requestShortcutCommand(id, m_shortcutCommandRequestSerial);
+    return m_shortcutCommandRequestSerial;
 }
 
 void KeyboardController::deleteCustomShortcut(const QString &id)
@@ -346,32 +430,47 @@ void KeyboardController::deleteCustomShortcut(const QString &id)
 
 void KeyboardController::modifyShortcut(const QString &id, const QString &accels, const int &type)
 {
-    ShortcutInfo *shortcut = m_shortcutModel->findInfoIf([id, type](ShortcutInfo *info){ return id == info->id && type == info->type; });
+    ShortcutInfo *shortcut = shortcutInfo(id, type);
     if (!shortcut) {
         qWarning() << "shortcut not found..." << id << type;
         return;
     }
 
-    if (shortcut->accels != accels) {
-        // Clear conflicting shortcuts when modifying.
-        // X11 only: onDisableShortcut does a blocking waitForFinished(). On
-        // Wayland that maps to an async Disable + commitAndWait that would
-        // freeze the GUI thread, and it's redundant — the Wayland path in
-        // modifyShortcutEditAux resolves the conflict server-side
-        // (LookupConflictShortcut → Disable → ModifyHotkeys), and dde-services'
-        // ModifyHotkeys already unbinds the conflicting owner atomically.
-        if (auto conflict = m_shortcutModel->getInfo(accels)) {
-            if (!m_worker->isWayland())
-                m_worker->onDisableShortcut(conflict);
-        }
-        // Always update the target's accels so downstream modifyShortcutEditAux
-        // operates on the new value. The previous "only on conflict" placement
-        // left a stale accels when there was no conflict (e.g. Wayland path
-        // where the keyEvent lambda's pre-update doesn't run).
-        shortcut->accels = accels;
+    ShortcutInfo updated = *shortcut;
+    updated.accels = accels;
+    const quint64 generation = shortcutGeneration(id, type);
+    if (!isCurrentShortcutGeneration(id, type, generation)) {
+        qWarning() << "ignore shortcut modification outside current capture:" << id << type;
+        return;
+    }
+    m_pendingConflicts.remove(shortcutKey(id, type));
+    m_worker->modifyShortcutEdit(&updated, generation);
+}
+
+void KeyboardController::replaceShortcut(const QString &id, const QString &accels, const int &type)
+{
+    ShortcutInfo *shortcut = shortcutInfo(id, type);
+    if (!shortcut) {
+        qWarning() << "shortcut not found..." << id << type;
+        return;
     }
 
-    m_worker->modifyShortcutEdit(shortcut);
+    ShortcutInfo updated = *shortcut;
+    updated.accels = accels;
+    const quint64 generation = shortcutGeneration(id, type);
+    if (!isCurrentShortcutGeneration(id, type, generation)) {
+        qWarning() << "ignore shortcut replacement outside current capture:" << id << type;
+        return;
+    }
+
+    const PendingConflict pendingConflict = m_pendingConflicts.take(shortcutKey(id, type));
+    if (pendingConflict.id.isEmpty()
+            || pendingConflict.shortcut != accels
+            || pendingConflict.generation != generation) {
+        qWarning() << "replace shortcut requested without a confirmed conflict:" << id;
+        return;
+    }
+    m_worker->replaceShortcutEdit(&updated, pendingConflict.id, generation);
 }
 
 void KeyboardController::clearShortcut(const QString &id, const int &type)
@@ -521,114 +620,241 @@ static QString qtAccelToXkb(const QString &accel)
     return out;
 }
 
-void KeyboardController::beginWaylandKeyCapture(QQuickItem *item, const QString &id, int type)
+ShortcutInfo *KeyboardController::shortcutInfo(const QString &id, int type) const
 {
-    // Silent no-op on non-Wayland — the X11 path captures via QML Keys.onPressed.
-    // Session-based detection (same source as the proxy / capture manager guard).
-    if (!m_worker->isWayland()) {
+    if (id.isEmpty() || !m_shortcutModel)
+        return nullptr;
+
+    return m_shortcutModel->findInfoIf([&](ShortcutInfo *info) {
+        return info->id == id && static_cast<int>(info->type) == type;
+    });
+}
+
+QString KeyboardController::shortcutKey(const QString &id, int type)
+{
+    return id + QChar(0x1f) + QString::number(type);
+}
+
+quint64 KeyboardController::shortcutGeneration(const QString &id, int type) const
+{
+    return m_shortcutGenerations.value(shortcutKey(id, type));
+}
+
+bool KeyboardController::isCurrentShortcutGeneration(const QString &id, int type,
+                                                      quint64 generation) const
+{
+    const QString key = shortcutKey(id, type);
+    return generation != 0
+            && m_shortcutGenerations.value(key) == generation;
+}
+
+void KeyboardController::beginKeyCapture(QQuickItem *item, const QString &id, int type)
+{
+    endKeyCapture();
+
+    ShortcutInfo *shortcut = shortcutInfo(id, type);
+    if (!id.isEmpty() && !shortcut) {
+        const QString reason = QStringLiteral("shortcut not found");
+        qWarning() << reason << id << type;
+        Q_EMIT keyCaptureFailed(id, type, reason);
         return;
     }
-    if (!item) {
-        Q_EMIT waylandKeyCaptureFailed(id, type, 0);
+    m_worker->updateKey(shortcut);
+
+    const QString key = shortcutKey(id, type);
+    const quint64 generation = ++m_generationSerial;
+    m_shortcutGenerations.insert(key, generation);
+    m_worker->setShortcutGeneration(id, type, generation);
+    m_pendingConflicts.remove(key);
+
+    const quint64 requestId = ++m_captureRequestSerial;
+    m_capture.requestId = requestId;
+    m_capture.generation = generation;
+    m_capture.id = id;
+    m_capture.type = type;
+    m_capture.item = item;
+    m_capture.phase = CapturePhase::Pending;
+    if (item) {
+        connect(item, &QObject::destroyed, this, [this, requestId] {
+            if (requestId == m_capture.requestId)
+                endKeyCapture();
+        });
+    }
+
+    if (m_worker->isWayland()) {
+        m_capture.backend = CaptureBackend::Wayland;
+        startWaylandKeyCapture(item, id, type, requestId, generation);
         return;
     }
-    QQuickWindow *window = item->window();
-    if (!window) {
+
+    m_capture.backend = CaptureBackend::X11;
+    startRequestedX11Capture();
+}
+
+void KeyboardController::startRequestedX11Capture()
+{
+    if (m_capture.backend != CaptureBackend::X11
+            || m_capture.phase != CapturePhase::Pending
+            || m_pendingX11RequestId != 0)
+        return;
+
+    m_pendingX11RequestId = m_capture.requestId;
+    const quint64 requestId = m_capture.requestId;
+    const QString id = m_capture.id;
+    const int type = m_capture.type;
+    const quint64 generation = m_capture.generation;
+    QTimer::singleShot(30000, this, [this, requestId, id, type, generation] {
+        const bool requestPending = requestId == m_pendingX11RequestId;
+        const bool requestActive = requestId == m_capture.requestId
+                && m_capture.backend == CaptureBackend::X11
+                && m_capture.phase == CapturePhase::Active;
+        if ((!requestPending && !requestActive)
+                || !isCurrentShortcutGeneration(id, type, generation)) {
+            return;
+        }
+
+        endKeyCapture();
+        Q_EMIT keyCaptureFailed(id, type, QStringLiteral("shortcut capture timed out"));
+    });
+    m_worker->beginCapture(m_pendingX11RequestId);
+}
+
+void KeyboardController::startWaylandKeyCapture(QQuickItem *item, const QString &id, int type,
+                                                quint64 requestId, quint64 generation)
+{
+    const QString failureReason = QStringLiteral("unable to start compositor shortcut capture");
+    if (!item || !item->window()) {
+        m_capture.reset();
+        Q_EMIT keyCaptureFailed(id, type, failureReason);
         Q_EMIT waylandKeyCaptureFailed(id, type, 0);
         return;
     }
 
-    if (!m_captureManager) {
-        // Cold path: KeyboardController was constructed before the platform
-        // resolved to wayland (shouldn't happen normally). Build lazily.
+    if (!m_captureManager)
         m_captureManager = new TreelandShortcutCaptureManager(this);
-    }
 
-    if (m_activeCapture) {
-        // The user is restarting edit. Disconnect first so any wayland event
-        // still in flight for the old session cannot land in this controller
-        // and modify the wrong row; then schedule the session for delete
-        // (its destructor cancels the wayland capture).
-        disconnect(m_activeCapture, nullptr, this, nullptr);
-        m_activeCapture->deleteLater();
-        m_activeCapture.clear();
-    }
-
-    TreelandShortcutCaptureSession *session = m_captureManager->captureNext(window);
+    TreelandShortcutCaptureSession *session = m_captureManager->captureNext(item->window());
     if (!session) {
+        m_capture.reset();
+        Q_EMIT keyCaptureFailed(id, type, failureReason);
         Q_EMIT waylandKeyCaptureFailed(id, type, 0);
         return;
     }
+
     m_activeCapture = session;
+    m_capture.phase = CapturePhase::Active;
+    if (!isCurrentShortcutGeneration(id, type, generation))
+        return;
+    Q_EMIT keyCaptureStarted(id, type);
 
     connect(session, &TreelandShortcutCaptureSession::captured, this,
-            [this, id, type](const QString &key) {
-                submitWaylandKeystroke(id, type, key);
+            [this, id, type, requestId, generation](const QString &key) {
+                if (requestId != m_capture.requestId
+                        || m_capture.backend != CaptureBackend::Wayland
+                        || m_capture.phase != CapturePhase::Active
+                        || !isCurrentShortcutGeneration(id, type, generation)) {
+                    return;
+                }
                 Q_EMIT waylandKeyCaptureFinished(id, type, key);
+                submitCapturedKeystroke(id, type, key);
             });
     connect(session, &TreelandShortcutCaptureSession::failed, this,
-            [this, id, type](uint32_t reason) {
+            [this, id, type, requestId, generation](uint32_t reason) {
+                if (requestId != m_capture.requestId
+                        || m_capture.backend != CaptureBackend::Wayland
+                        || m_capture.phase != CapturePhase::Active
+                        || !isCurrentShortcutGeneration(id, type, generation)) {
+                    return;
+                }
+                endKeyCapture();
+                const QString message = QStringLiteral("compositor capture failed: %1").arg(reason);
+                Q_EMIT keyCaptureFailed(id, type, message);
                 Q_EMIT waylandKeyCaptureFailed(id, type, static_cast<int>(reason));
             });
 }
 
-void KeyboardController::endWaylandKeyCapture()
+void KeyboardController::stopWaylandKeyCapture()
 {
     if (!m_activeCapture)
         return;
 
-    // Disconnect first so any pending wayland event cannot deliver a
-    // captured() signal after we've already moved on (Replace / Cancel).
     disconnect(m_activeCapture, nullptr, this, nullptr);
     m_activeCapture->deleteLater();
     m_activeCapture.clear();
 }
 
-void KeyboardController::submitWaylandKeystroke(const QString &id, int type, const QString &accels)
+void KeyboardController::endKeyCapture()
 {
+    ++m_captureRequestSerial;
+    const bool x11Capture = m_capture.backend == CaptureBackend::X11;
+    m_capture.reset();
+
+    if (x11Capture || m_pendingX11RequestId != 0)
+        m_worker->endCapture();
+    stopWaylandKeyCapture();
+}
+
+void KeyboardController::submitCapturedKeystroke(const QString &id, int type, const QString &accels)
+{
+    if (m_capture.phase != CapturePhase::Active
+            || id != m_capture.id || type != m_capture.type)
+        return;
+
+    const quint64 generation = m_capture.generation;
+    if (!isCurrentShortcutGeneration(id, type, generation))
+        return;
+
+    endKeyCapture();
+    handleCapturedKeystroke(id, type, accels, generation);
+}
+
+void KeyboardController::handleCapturedKeystroke(const QString &id, int type, const QString &accels,
+                                                 quint64 generation)
+{
+    if (!isCurrentShortcutGeneration(id, type, generation))
+        return;
+
     if (accels.isEmpty()) {
-        Q_EMIT requestRestore();
+        Q_EMIT requestRestore(id, type);
         return;
     }
-    if (accels == QLatin1String("Backspace")
+    if (accels == QLatin1String("Esc") || accels == QLatin1String("Escape")) {
+        Q_EMIT requestRestore(id, type);
+        return;
+    }
+    if (accels == QLatin1String("BackSpace")
+        || accels == QLatin1String("Backspace")
         || accels == QLatin1String("Delete")
         || accels == QLatin1String("Del")) {
-        Q_EMIT requestClear();
+        Q_EMIT requestClear(id, type);
         return;
     }
 
-    ShortcutInfo *current = m_shortcutModel->findInfoIf([&](ShortcutInfo *info) {
-        return info->id == id && info->type == type;
-    });
+    ShortcutInfo *current = shortcutInfo(id, type);
     if (current)
         m_shortcutModel->setCurrentInfo(current);
 
     const QString xkb = qtAccelToXkb(accels);
-
     ShortcutInfo *conflict = m_shortcutModel->getInfo(xkb);
-
     if (conflict) {
-        // Self-conflict (user pressed the same combo already bound to this row)
         if (conflict == current && conflict->accels == xkb) {
-            Q_EMIT requestRestore();
+            Q_EMIT requestRestore(id, type);
             return;
         }
-        auto conflictName = QString("<font color=\"red\">%1</font>").arg(conflict->name.toHtmlEscaped());
-        const QString text = KeyboardController::tr("This shortcut conflicts with [%1]").arg(conflictName);
-        setConflictText(text);
-        Q_EMIT keyConflicted(current ? current->accels : QString(), xkb);
-        // NOTE: deliberately no early return here — fall through to keyEvent
-        // below, mirroring the X11 keyEvent lambda which emits keyEvent
-        // unconditionally after the conflict branch. QML onKeyEvent updates
-        // editItem.keys, so the edit chip shows the combo the user just pressed;
-        // without it the conflict text appears but the chip keeps the old combo.
+
+        const QString conflictName = QStringLiteral("<font color=\"red\">%1</font>")
+                .arg(conflict->name.toHtmlEscaped());
+        m_pendingConflicts.insert(shortcutKey(id, type),
+                                  PendingConflict{conflict->id, xkb, generation});
+        const QString message = KeyboardController::tr("This shortcut conflicts with [%1]").arg(conflictName);
+        setConflictText(message);
+        Q_EMIT keyConflicted(id, type, current ? current->accels : QString(),
+                             xkb, message, true);
     } else {
-        if (current)
-            current->accels = xkb;
-        Q_EMIT keyDone(xkb);
+        Q_EMIT keyDone(id, type, xkb);
     }
 
-    Q_EMIT keyEvent(xkb);
+    Q_EMIT keyEvent(id, type, xkb);
 }
 
 }

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -9,6 +9,7 @@
 #include "keyboardwork.h"
 
 #include <QObject>
+#include <QHash>
 #include <QPointer>
 #include <QSortFilterProxyModel>
 
@@ -76,28 +77,21 @@ public Q_SLOTS:
 
     void updateKey(const QString &id, const int &type);
     QStringList formatKeys(const QString &shortcuts);
-    Q_INVOKABLE QString keyEventToAccels(int key, int modifiers);
-    // Wayland entry point: capture is local (no SelectKeystroke). Performs
-    // the same conflict-check / emit pattern as the X11 KeyEvent lambda,
-    // but queries the server (LookupConflictShortcut) as the source of truth.
-    Q_INVOKABLE void submitWaylandKeystroke(const QString &id, int type, const QString &accels);
+    Q_INVOKABLE bool isWaylandSession() const;
+    Q_INVOKABLE void beginKeyCapture(QQuickItem *item, const QString &id, int type);
+    Q_INVOKABLE void endKeyCapture();
+    Q_INVOKABLE void submitCapturedKeystroke(const QString &id, int type, const QString &accels);
 
-    // Wayland edit entry: ask Treeland to forward the next shortcut input to
-    // this client (bypassing the dispatch-to-action path that swallowed keys
-    // before). On terminal event emits waylandKeyCaptureFinished or
-    // waylandKeyCaptureFailed. Requires the QML item to live in a focused
-    // window — the compositor validates that before starting capture.
-    Q_INVOKABLE void beginWaylandKeyCapture(QQuickItem *item, const QString &id, int type);
-
-    // Cancel an in-progress Wayland capture session.  Safe to call when
-    // no capture is active (no-op).  QML should call this when the user
-    // clicks Replace or Cancel so the compositor stops forwarding keys.
-    Q_INVOKABLE void endWaylandKeyCapture();
-
-    void addCustomShortcut(const QString &name, const QString &cmd, const QString &accels);
-    void modifyCustomShortcut(const QString &id, const QString &name, const QString &cmd, const QString &accels);
-    Q_INVOKABLE void requestShortcutCommand(const QString &id);
+    Q_INVOKABLE quint64 addCustomShortcut(const QString &name, const QString &cmd,
+                                          const QString &accels);
+    Q_INVOKABLE quint64 modifyCustomShortcut(const QString &id, const QString &name,
+                                             const QString &cmd, const QString &accels);
+    Q_INVOKABLE quint64 replaceCustomShortcut(const QString &id, const QString &name,
+                                              const QString &cmd, const QString &accels);
+    Q_INVOKABLE void clearPendingConflict(const QString &id, int type);
+    Q_INVOKABLE quint64 requestShortcutCommand(const QString &id);
     void modifyShortcut(const QString &id, const QString &accels, const int &type);
+    void replaceShortcut(const QString &id, const QString &accels, const int &type);
     void deleteCustomShortcut(const QString &id);
     void clearShortcut(const QString &id, const int &type);
 
@@ -123,20 +117,59 @@ signals:
     void layoutCountChanged();
     void currentLayoutChanged();
 
-    void requestRestore();
-    void requestClear();
-    void keyConflicted(const QString &oldAccels, const QString &newAccels);
-    void keyDone(const QString &accels);
-    void keyEvent(const QString &accels);
+    void requestRestore(const QString &id, int type);
+    void requestClear(const QString &id, int type);
+    void keyConflicted(const QString &id, int type, const QString &oldAccels,
+                       const QString &newAccels, const QString &message, bool replaceable);
+    void keyDone(const QString &id, int type, const QString &accels);
+    void keyEvent(const QString &id, int type, const QString &accels);
+
+    void keyCaptureStarted(const QString &id, int type);
+    void keyCaptureFailed(const QString &id, int type, const QString &reason);
+    void shortcutModificationFinished(const QString &id, int type, const QString &accels, bool success);
+    void customShortcutOperationFinished(quint64 requestId, bool success,
+                                         const QString &errorMessage);
 
     void waylandKeyCaptureFinished(const QString &id, int type, const QString &accels);
     void waylandKeyCaptureFailed(const QString &id, int type, int reason);
-    void shortcutCommandReady(const QString &id, const QString &command, bool available);
+    void shortcutCommandReady(const QString &id, const QString &command, bool available,
+                              quint64 requestSerial);
 
     void conflictTextChanged();
     void keyboardEnabledChanged();
 
 private:
+    struct PendingConflict {
+        QString id;
+        QString shortcut;
+        quint64 generation = 0;
+    };
+
+    enum class CaptureBackend { None, X11, Wayland };
+    enum class CapturePhase { Idle, Pending, Active };
+
+    struct CaptureState {
+        quint64 requestId = 0;
+        quint64 generation = 0;
+        QString id;
+        int type = 0;
+        QPointer<QQuickItem> item;
+        CaptureBackend backend = CaptureBackend::None;
+        CapturePhase phase = CapturePhase::Idle;
+
+        void reset() { *this = {}; }
+    };
+
+    static QString shortcutKey(const QString &id, int type);
+    ShortcutInfo *shortcutInfo(const QString &id, int type) const;
+    quint64 shortcutGeneration(const QString &id, int type) const;
+    bool isCurrentShortcutGeneration(const QString &id, int type, quint64 generation) const;
+    void startRequestedX11Capture();
+    void startWaylandKeyCapture(QQuickItem *item, const QString &id, int type,
+                                quint64 requestId, quint64 generation);
+    void stopWaylandKeyCapture();
+    void handleCapturedKeystroke(const QString &id, int type, const QString &accels,
+                                 quint64 generation);
     // 检查并处理desktop命令，如果desktop文件存在则添加dde-am前缀
     QString checkDesktopCmd(const QString &cmd);
     
@@ -152,6 +185,14 @@ private:
     QString m_conflictText;
     TreelandShortcutCaptureManager *m_captureManager = nullptr;
     QPointer<TreelandShortcutCaptureSession> m_activeCapture;
+    quint64 m_captureRequestSerial = 0;
+    quint64 m_shortcutCommandRequestSerial = 0;
+    quint64 m_customShortcutRequestSerial = 0;
+    quint64 m_generationSerial = 0;
+    quint64 m_pendingX11RequestId = 0;
+    CaptureState m_capture;
+    QHash<QString, quint64> m_shortcutGenerations;
+    QHash<QString, PendingConflict> m_pendingConflicts;
 };
 
 }

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -83,6 +83,7 @@ static QJsonObject shortcutInfoToJsonObject(const ShortcutInfoNew &info)
     // text for direct rendering — dcc no longer translates categories.
     obj["Section"] = info.category;
     obj["SectionName"] = info.localLanguageCategory;
+    obj["Modifiable"] = info.modifiable;
     return obj;
 }
 
@@ -113,16 +114,18 @@ void KeyboardDBusProxy::init()
     // which don't match the legacy Changed/Deleted names auto-wired by
     // QDBusAbstractInterface. Subscribe by full signature so the model
     // refreshes after server-side updates (e.g. Reset).
-    if (m_isWayland) {
-        QDBusConnection::sessionBus().connect(
-            KeybingdingService, KeybingdingPath, KeybingdingInterface,
-            "ShortcutChanged", this,
-            SLOT(onNewShortcutChanged(QString, ShortcutInfoNew)));
-        QDBusConnection::sessionBus().connect(
-            KeybingdingService, KeybingdingPath, KeybingdingInterface,
-            "ShortcutRemoved", this,
-            SLOT(onNewShortcutRemoved(QString)));
-    }
+    QDBusConnection::sessionBus().connect(
+        KeybingdingService, KeybingdingPath, KeybingdingInterface,
+        "ShortcutChanged", this,
+        SLOT(onNewShortcutChanged(QString, ShortcutInfoNew)));
+    QDBusConnection::sessionBus().connect(
+        KeybingdingService, KeybingdingPath, KeybingdingInterface,
+        "ShortcutRemoved", this,
+        SLOT(onNewShortcutRemoved(QString)));
+    QDBusConnection::sessionBus().connect(
+        KeybingdingService, KeybingdingPath, KeybingdingInterface,
+        "KeyEvent", this,
+        SIGNAL(KeyEvent(bool,QString)));
 }
 
 void KeyboardDBusProxy::langSelectorStartServiceProcess()
@@ -305,20 +308,12 @@ void KeyboardDBusProxy::onListAllShortcutsNewFinished(QDBusPendingCallWatcher *w
 QDBusPendingReply<QString> KeyboardDBusProxy::ListAllShortcuts()
 {
     QList<QVariant> argumentList;
-    if (isWayland()) {
-        // New API: ListAllShortcuts() → QList<ShortcutInfoNew>
-        // We fire-and-forget, result arrives in onListAllShortcutsNewFinished
-        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
-            QStringLiteral("ListAllShortcuts"), argumentList);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardDBusProxy::onListAllShortcutsNewFinished);
-        // Return dummy — actual data comes via Added signal
-        return QDBusPendingReply<QString>();
-    }
-    // Old API
-    return QDBusPendingReply<QString>(
-        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ListAllShortcuts"), argumentList));
+    QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+        QStringLiteral("ListAllShortcuts"), argumentList);
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardDBusProxy::onListAllShortcutsNewFinished);
+    return QDBusPendingReply<QString>();
 }
 
 // Wayland: fetch category metadata (key/displayName/order/isCustom) so the
@@ -327,13 +322,11 @@ QDBusPendingReply<QString> KeyboardDBusProxy::ListAllShortcuts()
 QDBusPendingReply<> KeyboardDBusProxy::ListCategories()
 {
     QList<QVariant> argumentList;
-    if (isWayland()) {
-        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
-            QStringLiteral("ListCategories"), argumentList);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardDBusProxy::onListCategoriesFinished);
-    }
+    QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+        QStringLiteral("ListCategories"), argumentList);
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardDBusProxy::onListCategoriesFinished);
     return QDBusPendingReply<>();
 }
 
@@ -386,34 +379,14 @@ QDBusPendingReply<QString> KeyboardDBusProxy::GetShortcut(const QString &in0, in
 {
     Q_UNUSED(in1);
     QList<QVariant> argumentList;
-    if (isWayland()) {
-        // New API: GetShortcut(id) → ShortcutInfoNew
-        argumentList << QVariant::fromValue(in0);
-        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
-            QStringLiteral("GetShortcut"), argumentList);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-        watcher->setProperty("shortcutId", in0);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardDBusProxy::onGetShortcutNewFinished);
-        return QDBusPendingReply<QString>();
-    }
-    // Old API
-    argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
-    return QDBusPendingReply<QString>(
-        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GetShortcut"), argumentList));
-}
-
-QString KeyboardDBusProxy::LookupConflictingShortcut(const QString &in0)
-{
-    QList<QVariant> argumentList;
-    if (isWayland()) {
-        qWarning() << "Wayland LookupConflictingShortcut is asynchronous; use LookupConflictShortcut instead";
-        return QString();
-    }
-    // Old API
     argumentList << QVariant::fromValue(in0);
-    return QDBusPendingReply<QString>(
-        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("LookupConflictingShortcut"), argumentList));
+    QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+        QStringLiteral("GetShortcut"), argumentList);
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    watcher->setProperty("shortcutId", in0);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardDBusProxy::onGetShortcutNewFinished);
+    return QDBusPendingReply<QString>();
 }
 
 QDBusPendingReply<ShortcutInfoNew> KeyboardDBusProxy::LookupConflictShortcut(const QString &in0)
@@ -424,17 +397,12 @@ QDBusPendingReply<ShortcutInfoNew> KeyboardDBusProxy::LookupConflictShortcut(con
         m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("LookupConflictShortcut"), argumentList));
 }
 
-QDBusPendingReply<> KeyboardDBusProxy::ClearShortcutKeystrokes(const QString &in0, int in1)
+QDBusPendingReply<bool> KeyboardDBusProxy::ClearShortcutKeystrokes(const QString &in0, int in1)
 {
+    Q_UNUSED(in1);
     QList<QVariant> argumentList;
-    if (isWayland()) {
-        // New API: Disable(id)
-        argumentList << QVariant::fromValue(in0);
-        return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Disable"), argumentList);
-    }
-    // Old API
-    argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ClearShortcutKeystrokes"), argumentList);
+    argumentList << QVariant::fromValue(in0);
+    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Disable"), argumentList);
 }
 
 QDBusPendingReply<bool> KeyboardDBusProxy::callModifyHotkeys(const QString &id, const QStringList &hotkeys)
@@ -451,19 +419,6 @@ QDBusPendingReply<bool> KeyboardDBusProxy::callReplaceHotkey(const QString &targ
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ReplaceHotkey"), argumentList);
 }
 
-QDBusPendingReply<> KeyboardDBusProxy::AddShortcutKeystroke(const QString &in0, int in1, const QString &in2)
-{
-    QList<QVariant> argumentList;
-    if (isWayland()) {
-        // New API: ModifyHotkeys(id, [keystroke])
-        argumentList << QVariant::fromValue(in0) << QVariant::fromValue(QStringList{in2});
-        return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ModifyHotkeys"), argumentList);
-    }
-    // Old API
-    argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1) << QVariant::fromValue(in2);
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("AddShortcutKeystroke"), argumentList);
-}
-
 QDBusPendingReply<QString> KeyboardDBusProxy::AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2)
 {
     QList<QVariant> argumentList;
@@ -471,11 +426,38 @@ QDBusPendingReply<QString> KeyboardDBusProxy::AddCustomShortcut(const QString &i
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("AddCustomShortcut"), argumentList);
 }
 
+QDBusPendingReply<QString> KeyboardDBusProxy::AddCustomShortcutWithConflict(
+        const QString &name, const QString &command, const QString &accels,
+        const QString &expectedConflictId)
+{
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(name)
+                 << QVariant::fromValue(command)
+                 << QVariant::fromValue(accels)
+                 << QVariant::fromValue(expectedConflictId);
+    return m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("AddCustomShortcutWithConflict"), argumentList);
+}
+
 QDBusPendingReply<bool> KeyboardDBusProxy::ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3)
 {
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1) << QVariant::fromValue(in2) << QVariant::fromValue(in3);
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("ModifyCustomShortcut"), argumentList);
+}
+
+QDBusPendingReply<bool> KeyboardDBusProxy::ModifyCustomShortcutWithConflict(
+        const QString &id, const QString &name, const QString &command,
+        const QString &accels, const QString &expectedConflictId)
+{
+    QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(id)
+                 << QVariant::fromValue(name)
+                 << QVariant::fromValue(command)
+                 << QVariant::fromValue(accels)
+                 << QVariant::fromValue(expectedConflictId);
+    return m_dBusKeybingdingInter->asyncCallWithArgumentList(
+            QStringLiteral("ModifyCustomShortcutWithConflict"), argumentList);
 }
 
 QDBusPendingReply<bool> KeyboardDBusProxy::DeleteCustomShortcut(const QString &in0)
@@ -490,17 +472,6 @@ QDBusPendingReply<QString> KeyboardDBusProxy::GetShortcutCommand(const QString &
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0);
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GetShortcutCommand"), argumentList);
-}
-
-QDBusPendingReply<> KeyboardDBusProxy::GrabScreen()
-{
-    QList<QVariant> argumentList;
-    if (isWayland()) {
-        // Not supported in new API, return empty
-        qWarning() << "Wayland GrabScreen not supported";
-        return QDBusPendingReply<>();
-    }
-    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GrabScreen"), argumentList);
 }
 
 void KeyboardDBusProxy::SetNumLockState(int in0)
@@ -524,51 +495,39 @@ void KeyboardDBusProxy::onSearchShortcutsNewFinished(QDBusPendingCallWatcher *w)
 QDBusPendingReply<QString> KeyboardDBusProxy::SearchShortcuts(const QString &in0)
 {
     QList<QVariant> argumentList;
-    if (isWayland()) {
-        // New API: SearchShortcuts(keyword) → QList<ShortcutInfoNew>
-        argumentList << QVariant::fromValue(in0);
-        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
-            QStringLiteral("SearchShortcuts"), argumentList);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardDBusProxy::onSearchShortcutsNewFinished);
-        return QDBusPendingReply<QString>();
-    }
-    // Old API
     argumentList << QVariant::fromValue(in0);
-    return QDBusPendingReply<QString>(
-        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SearchShortcuts"), argumentList));
+    QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+        QStringLiteral("SearchShortcuts"), argumentList);
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardDBusProxy::onSearchShortcutsNewFinished);
+    return QDBusPendingReply<QString>();
 }
 
 QDBusPendingReply<QString> KeyboardDBusProxy::Query(const QString &in0, int in1)
 {
+    Q_UNUSED(in1);
     QList<QVariant> argumentList;
-    if (isWayland()) {
-        // New API: GetShortcut(id) (Query was same as GetShortcut in old API)
-        argumentList << QVariant::fromValue(in0);
-        QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
-            QStringLiteral("GetShortcut"), argumentList);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-        watcher->setProperty("shortcutId", in0);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardDBusProxy::onGetShortcutNewFinished);
-        return QDBusPendingReply<QString>();
-    }
-    // Old API
-    argumentList << QVariant::fromValue(in0) << QVariant::fromValue(in1);
-    return QDBusPendingReply<QString>(
-        m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("Query"), argumentList));
+    argumentList << QVariant::fromValue(in0);
+    QDBusPendingCall call = m_dBusKeybingdingInter->asyncCallWithArgumentList(
+        QStringLiteral("GetShortcut"), argumentList);
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    watcher->setProperty("shortcutId", in0);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardDBusProxy::onGetShortcutNewFinished);
+    return QDBusPendingReply<QString>();
 }
 
-void KeyboardDBusProxy::SelectKeystroke()
+QDBusPendingReply<bool> KeyboardDBusProxy::BeginCapture(uint timeoutMs)
 {
-    if (isWayland()) {
-        // Not supported — control center handles key capture via Qt keyPressEvent
-        qDebug() << "[Wayland] SelectKeystroke handled by control center natively";
-        return;
-    }
     QList<QVariant> argumentList;
-    m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("SelectKeystroke"), argumentList);
+    argumentList << timeoutMs;
+    return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("BeginCapture"), argumentList);
+}
+
+void KeyboardDBusProxy::EndCapture()
+{
+    m_dBusKeybingdingInter->asyncCall(QStringLiteral("EndCapture"));
 }
 
 //keyBoard

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -76,6 +76,7 @@ struct ShortcutInfoNew {
     QString localLanguageName;
     QString localLanguageCategory;  // Resolved display text for the category
     bool isCustom = false;          // True for runtime-added (service API) shortcuts
+    bool modifiable = false;        // Whether the conflicting shortcut may be replaced
 };
 Q_DECLARE_METATYPE(ShortcutInfoNew)
 Q_DECLARE_METATYPE(QList<ShortcutInfoNew>)
@@ -84,7 +85,7 @@ inline QDBusArgument &operator<<(QDBusArgument &argument, const ShortcutInfoNew 
     argument.beginStructure();
     argument << info.id << info.displayName << info.category
              << info.hotkeys << info.localLanguageName
-             << info.localLanguageCategory << info.isCustom;
+             << info.localLanguageCategory << info.isCustom << info.modifiable;
     argument.endStructure();
     return argument;
 }
@@ -93,7 +94,7 @@ inline const QDBusArgument &operator>>(const QDBusArgument &argument, ShortcutIn
     argument.beginStructure();
     argument >> info.id >> info.displayName >> info.category
              >> info.hotkeys >> info.localLanguageName
-             >> info.localLanguageCategory >> info.isCustom;
+             >> info.localLanguageCategory >> info.isCustom >> info.modifiable;
     argument.endStructure();
     return argument;
 }
@@ -210,10 +211,7 @@ signals:
     void NumLockStateChanged(int  value) const;
     void ShortcutSwitchLayoutChanged(uint  value) const;
     // Keybinding
-    void Added(const QString &in0, int in1);
-    void Changed(const QString &in0, int in1);
-    void Deleted(const QString &in0, int in1);
-    void KeyEvent(bool in0, const QString &in1);
+    void KeyEvent(bool pressed, const QString &keystroke);
     // Wayland new-API bridge: full shortcut list converted to old JSON format.
     void AllShortcutsReady(const QString &json);
     // Wayland: result of a GetShortcut query, already converted to old JSON.
@@ -239,25 +237,32 @@ public slots:
     QDBusPendingReply<QString> ListAllShortcuts();
     // Wayland: fetch category metadata (ordering/display/custom flag).
     QDBusPendingReply<> ListCategories();
-    QString LookupConflictingShortcut(const QString &in0);
     QDBusPendingReply<ShortcutInfoNew> LookupConflictShortcut(const QString &in0);
-    QDBusPendingReply<> ClearShortcutKeystrokes(const QString &in0, int in1);
-    QDBusPendingReply<> AddShortcutKeystroke(const QString &in0, int in1, const QString &in2);
+    QDBusPendingReply<bool> ClearShortcutKeystrokes(const QString &in0, int in1);
     // Wayland: direct ModifyHotkeys (returns bool success), so the caller
     // can detect commit failures and roll back the UI.
     QDBusPendingReply<bool> callModifyHotkeys(const QString &id, const QStringList &hotkeys);
     // Wayland: replace hotkey — remove newHotkey from conflictId, add to targetId.
     QDBusPendingReply<bool> callReplaceHotkey(const QString &targetId, const QString &newHotkey, const QString &conflictId);
     QDBusPendingReply<QString> AddCustomShortcut(const QString &in0, const QString &in1, const QString &in2);
+    QDBusPendingReply<QString> AddCustomShortcutWithConflict(const QString &name,
+                                                             const QString &command,
+                                                             const QString &accels,
+                                                             const QString &expectedConflictId);
     QDBusPendingReply<bool> ModifyCustomShortcut(const QString &in0, const QString &in1, const QString &in2, const QString &in3);
+    QDBusPendingReply<bool> ModifyCustomShortcutWithConflict(const QString &id,
+                                                            const QString &name,
+                                                            const QString &command,
+                                                            const QString &accels,
+                                                            const QString &expectedConflictId);
     QDBusPendingReply<bool> DeleteCustomShortcut(const QString &in0);
     QDBusPendingReply<QString> GetShortcutCommand(const QString &in0);
-    QDBusPendingReply<> GrabScreen();
     void SetNumLockState(int in0);
     QDBusPendingReply<QString> GetShortcut(const QString &in0, int in1);
     QDBusPendingReply<QString> SearchShortcuts(const QString &in0);
     QDBusPendingReply<QString> Query(const QString &in0, int in1);
-    void SelectKeystroke();
+    QDBusPendingReply<bool> BeginCapture(uint timeoutMs = 30000);
+    void EndCapture();
 
     //KeyBoard
     QDBusPendingReply<KeyboardLayoutList> LayoutList();

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -14,19 +14,45 @@
 #include <QCollator>
 #include <QCoreApplication>
 #include <QDBusArgument>
+#include <QDBusError>
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QDBusInterface>
 #include <QDBusPendingCallWatcher>
 #include <QTranslator>
-#include <QDateTime>
 
 using namespace DTK_NAMESPACE::Core;
 using namespace dccV25;
 bool caseInsensitiveLessThan(const MetaData &s1, const MetaData &s2);
 
 Q_LOGGING_CATEGORY(lcKeyboardWorker, "dde.dcc.keyboard.worker")
+
+namespace {
+
+QString customShortcutErrorMessage(const QDBusError &error)
+{
+    switch (error.type()) {
+    case QDBusError::ServiceUnknown:
+    case QDBusError::NoReply:
+    case QDBusError::Timeout:
+    case QDBusError::Disconnected:
+        return QCoreApplication::translate(
+                "KeyboardWorker", "The shortcut service is unavailable. Please try again.");
+    default:
+        return QCoreApplication::translate(
+                "KeyboardWorker", "Failed to save the shortcut. Please try again.");
+    }
+}
+
+QString canonicalShortcut(const QString &shortcut)
+{
+    // Store one logical Delete binding. dde-services expands it to both
+    // Delete and KP_Delete when registering shortcuts in the X11 backend.
+    return QString(shortcut).replace(QStringLiteral("KP_Delete"), QStringLiteral("Delete"));
+}
+
+} // namespace
 
 const QMap<QString, QString> &ModelKeycode = {{"minus", "-"}, {"equal", "="}, {"backslash", "\\"}, {"question", "?/"}, {"exclam", "1"}, {"numbersign", "3"},
     {"semicolon", ";"}, {"apostrophe", "'"}, {"less", ",<"}, {"period", ">."}, {"slash", "?/"}, {"parenleft", "9"}, {"bracketleft", "["},
@@ -71,7 +97,6 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
     }
 
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Added, this, &KeyboardWorker::onAdded);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::AllShortcutsReady, this, &KeyboardWorker::onAllShortcutsReady);
     // Wayland: category metadata (ordering/display/custom flag) from the
     // service's ListCategories(). Feeds the model so it never hardcodes
@@ -101,7 +126,6 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
         if (m_shortcutModel)
             m_shortcutModel->onKeyBindingChanged(json);
     });
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Deleted, this, &KeyboardWorker::removed);
     // Wayland: server-originated removal (ShortcutRemoved) updates the model
     // directly so the row leaves the UI (e.g. on Reset). The X11 Deleted→removed
     // connection above is a dead-end relay, left intact for X11 parity.
@@ -116,7 +140,6 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
         QTimer::singleShot(100, this, &KeyboardWorker::onLangSelectorServiceFinished);
     });
 
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::Changed, this, &KeyboardWorker::onShortcutChanged);
 
     m_model->setLangChangedState(m_keyboardDBusProxy->localeState());
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::LocaleStateChanged, m_model, &KeyboardModel::setLangChangedState);
@@ -155,22 +178,14 @@ void KeyboardWorker::onGetWindowWM(bool)
 void KeyboardWorker::setShortcutModel(ShortcutModel *model)
 {
     m_shortcutModel = model;
-
-    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::KeyEvent, model, &ShortcutModel::keyEvent);
+    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::KeyEvent,
+            model, &ShortcutModel::keyEvent, Qt::UniqueConnection);
 }
 
 void KeyboardWorker::refreshShortcut()
 {
-    if (m_keyboardDBusProxy->isWayland()) {
-        // Wayland: result is delivered asynchronously via AllShortcutsReady signal.
-        m_keyboardDBusProxy->ListAllShortcuts();
-        // Also refresh category metadata (ordering/display/custom flag).
-        m_keyboardDBusProxy->ListCategories();
-        return;
-    }
-    QDBusPendingCallWatcher *result = new QDBusPendingCallWatcher(m_keyboardDBusProxy->ListAllShortcuts(), this);
-    connect(result, SIGNAL(finished(QDBusPendingCallWatcher*)), this,
-            SLOT(onRequestShortcut(QDBusPendingCallWatcher*)));
+    m_keyboardDBusProxy->ListAllShortcuts();
+    m_keyboardDBusProxy->ListCategories();
 }
 
 void KeyboardWorker::refreshLang()
@@ -292,96 +307,72 @@ void KeyboardWorker::onRefreshKBLayout()
 }
 #endif
 
-void KeyboardWorker::modifyShortcutEditAux(ShortcutInfo *info, bool isKPDelete)
+void KeyboardWorker::modifyShortcutEditAux(ShortcutInfo *info, quint64 generation)
 {
-    if (!info)
+    if (!info || !isCurrentShortcutGeneration(info->id, static_cast<int>(info->type), generation))
         return;
 
-    if (info->replace) {
-        onDisableShortcut(info->replace);
-    }
-
-    QString shortcut = info->accels;
-    if (!isKPDelete) {
-        shortcut = shortcut.replace("KP_Delete", "Delete");
-    }
-
-    if (m_keyboardDBusProxy->isWayland()) {
-        QDBusPendingReply<ShortcutInfoNew> reply = m_keyboardDBusProxy->LookupConflictShortcut(shortcut);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
-        watcher->setProperty("id", info->id);
-        watcher->setProperty("type", info->type);
-        watcher->setProperty("shortcut", shortcut);
-        watcher->setProperty("isKPDelete", isKPDelete);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardWorker::onLookupConflictForShortcutFinished);
-        return;
-    }
-
-    const QString &result = m_keyboardDBusProxy->LookupConflictingShortcut(shortcut);
-
-    if (!result.isEmpty()) {
-        const QJsonObject obj = QJsonDocument::fromJson(result.toLatin1()).object();
-        
-        QString targetKey = info->id + "_" + QString::number(info->type);
-        m_replacingShortcuts.insert(targetKey);
-        
-        QDBusPendingCall call = m_keyboardDBusProxy->ClearShortcutKeystrokes(obj["Id"].toString(), obj["Type"].toInt());
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-
-        watcher->setProperty("id", info->id);
-        watcher->setProperty("type", info->type);
-        watcher->setProperty("shortcut", shortcut);
-        watcher->setProperty("clean", !isKPDelete);
-
-        connect(watcher, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onConflictShortcutCleanFinished);
-    } else {
-        if (isKPDelete) {
-            m_keyboardDBusProxy->AddShortcutKeystroke(info->id, static_cast<int>(info->type), shortcut);
-        } else {
-            cleanShortcutSlef(info->id, static_cast<int>(info->type), shortcut);
-        }
-    }
+    const QString shortcut = canonicalShortcut(info->accels);
+    lookupShortcutConflict(info->id, static_cast<int>(info->type), shortcut, generation);
 }
 
-void KeyboardWorker::modifyShortcutEdit(ShortcutInfo *info) {
-    modifyShortcutEditAux(info);
+void KeyboardWorker::modifyShortcutEdit(ShortcutInfo *info, quint64 generation)
+{
+    modifyShortcutEditAux(info, generation);
 }
 
-void KeyboardWorker::addCustomShortcut(const QString &name, const QString &command, const QString &accels)
+void KeyboardWorker::replaceShortcutEdit(ShortcutInfo *info, const QString &expectedConflictId,
+                                         quint64 generation)
 {
-    if (!m_keyboardDBusProxy->isWayland()) {
-        m_keyboardDBusProxy->AddCustomShortcut(name, command, accels);
+    if (!info || expectedConflictId.isEmpty()
+            || !isCurrentShortcutGeneration(info->id, static_cast<int>(info->type), generation)) {
         return;
     }
 
+    const QString shortcut = canonicalShortcut(info->accels);
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->callReplaceHotkey(
+            info->id, shortcut, expectedConflictId);
+    auto *watcher = new QDBusPendingCallWatcher(reply, this);
+    watcher->setProperty("id", info->id);
+    watcher->setProperty("type", static_cast<int>(info->type));
+    watcher->setProperty("shortcut", shortcut);
+    watcher->setProperty("generation", generation);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardWorker::onReplaceHotkeyFinished);
+}
+
+void KeyboardWorker::addCustomShortcut(const QString &name, const QString &command,
+                                       const QString &accels, quint64 requestId)
+{
     QDBusPendingReply<QString> reply = m_keyboardDBusProxy->AddCustomShortcut(name, command, accels);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
+    watcher->setProperty("requestId", QVariant::fromValue(requestId));
     connect(watcher, &QDBusPendingCallWatcher::finished,
             this, &KeyboardWorker::onAddCustomShortcutFinished);
 }
 
 void KeyboardWorker::callModifyCustomShortcut(const QString &id, const QString &name,
                                               const QString &command, const QString &accels,
-                                              int type)
+                                              int type, quint64 requestId)
 {
     QDBusPendingReply<bool> reply = m_keyboardDBusProxy->ModifyCustomShortcut(id, name, command, accels);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
     watcher->setProperty("id", id);
     watcher->setProperty("type", type);
+    watcher->setProperty("requestId", QVariant::fromValue(requestId));
     connect(watcher, &QDBusPendingCallWatcher::finished,
             this, &KeyboardWorker::onModifyCustomShortcutFinished);
 }
 
-void KeyboardWorker::requestShortcutCommand(const QString &id)
+void KeyboardWorker::requestShortcutCommand(const QString &id, quint64 requestSerial)
 {
     ShortcutInfo *shortcut = m_shortcutModel ? m_shortcutModel->findInfoIf([&id](ShortcutInfo *info) {
         return info->id == id;
     }) : nullptr;
     const QString fallbackCommand = shortcut ? shortcut->command : QString();
 
-    if (id.isEmpty() || !m_keyboardDBusProxy->isWayland()) {
-        Q_EMIT shortcutCommandReady(id, fallbackCommand, !id.isEmpty());
+    if (id.isEmpty()) {
+        Q_EMIT shortcutCommandReady(id, fallbackCommand, !id.isEmpty(), requestSerial);
         return;
     }
 
@@ -389,74 +380,54 @@ void KeyboardWorker::requestShortcutCommand(const QString &id)
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
     watcher->setProperty("id", id);
     watcher->setProperty("fallbackCommand", fallbackCommand);
+    watcher->setProperty("requestSerial", QVariant::fromValue(requestSerial));
     connect(watcher, &QDBusPendingCallWatcher::finished,
             this, &KeyboardWorker::onGetShortcutCommandFinished);
 }
 
-void KeyboardWorker::modifyCustomShortcut(ShortcutInfo *info)
+void KeyboardWorker::modifyCustomShortcut(ShortcutInfo *info, quint64 requestId)
 {
-    if (m_keyboardDBusProxy->isWayland()) {
-        callModifyCustomShortcut(info->id, info->name, info->command, info->accels, info->type);
+    callModifyCustomShortcut(info->id, info->name, info->command, info->accels, info->type,
+                             requestId);
+}
+
+void KeyboardWorker::replaceCustomShortcut(const QString &id, const QString &name,
+                                           const QString &command, const QString &accels,
+                                           const QString &expectedConflictId,
+                                           quint64 generation, quint64 requestId)
+{
+    const int type = ShortcutModel::Custom;
+    if (expectedConflictId.isEmpty()
+            || !isCurrentShortcutGeneration(id, type, generation)) {
         return;
     }
 
-    if (info->replace) {
-        onDisableShortcut(info->replace);
+    if (id.isEmpty()) {
+        QDBusPendingReply<QString> reply = m_keyboardDBusProxy->AddCustomShortcutWithConflict(
+                name, command, accels, expectedConflictId);
+        auto *watcher = new QDBusPendingCallWatcher(reply, this);
+        watcher->setProperty("id", id);
+        watcher->setProperty("type", type);
+        watcher->setProperty("generation", generation);
+        watcher->setProperty("requestId", QVariant::fromValue(requestId));
+        connect(watcher, &QDBusPendingCallWatcher::finished,
+                this, &KeyboardWorker::onAddCustomShortcutFinished);
+        return;
     }
 
-    // reset replace shortcut
-    info->replace = nullptr;
-
-    const QString &result = m_keyboardDBusProxy->LookupConflictingShortcut(info->accels);
-
-    if (!result.isEmpty()) {
-        const QJsonObject obj = QJsonDocument::fromJson(result.toUtf8()).object();
-        
-        QString targetKey = info->id + "_" + QString::number(info->type);
-        m_replacingShortcuts.insert(targetKey);
-        
-        QDBusPendingCall call = m_keyboardDBusProxy->ClearShortcutKeystrokes(obj["Id"].toString(), obj["Type"].toInt());
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-
-        watcher->setProperty("id", info->id);
-        watcher->setProperty("name", info->name);
-        watcher->setProperty("command", info->command);
-        watcher->setProperty("shortcut", info->accels);
-
-        connect(watcher, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onCustomConflictCleanFinished);
-    } else {
-        QString targetKey = info->id + "_" + QString::number(info->type);
-        m_replacingShortcuts.insert(targetKey);
-        m_keyboardDBusProxy->ModifyCustomShortcut(info->id, info->name, info->command, info->accels);
-    }
-}
-
-void KeyboardWorker::grabScreen()
-{
-    m_keyboardDBusProxy->GrabScreen();
-}
-
-bool KeyboardWorker::checkAvaliable(const QString &key)
-{
-   const QString &value = m_keyboardDBusProxy->LookupConflictingShortcut(key);
-
-   return value.isEmpty();
-}
-
-QString KeyboardWorker::lookupConflictingShortcut(const QString &key)
-{
-    return m_keyboardDBusProxy->LookupConflictingShortcut(key);
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->ModifyCustomShortcutWithConflict(
+            id, name, command, accels, expectedConflictId);
+    auto *watcher = new QDBusPendingCallWatcher(reply, this);
+    watcher->setProperty("id", id);
+    watcher->setProperty("type", type);
+    watcher->setProperty("generation", generation);
+    watcher->setProperty("requestId", QVariant::fromValue(requestId));
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardWorker::onModifyCustomShortcutFinished);
 }
 
 void KeyboardWorker::delShortcut(ShortcutInfo* info)
 {
-    if (!m_keyboardDBusProxy->isWayland()) {
-        m_keyboardDBusProxy->DeleteCustomShortcut(info->id);
-        if (m_shortcutModel)
-            m_shortcutModel->delInfo(info);
-        return;
-    }
-
     QDBusPendingReply<bool> reply = m_keyboardDBusProxy->DeleteCustomShortcut(info->id);
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
     watcher->setProperty("id", info->id);
@@ -592,20 +563,6 @@ bool caseInsensitiveLessThan(const MetaData &s1, const MetaData &s2)
         return false;
 }
 
-void KeyboardWorker::onRequestShortcut(QDBusPendingCallWatcher *watch)
-{
-    QDBusPendingReply<QString> reply = *watch;
-    if(reply.isError())
-    {
-        qWarning() << "ListAllShortcuts failed:" << reply.error();
-        watch->deleteLater();
-        return;
-    }
-
-    parseShortcutListJson(reply.value());
-    watch->deleteLater();
-}
-
 void KeyboardWorker::onAllShortcutsReady(const QString &info)
 {
     parseShortcutListJson(info);
@@ -656,31 +613,25 @@ void KeyboardWorker::parseShortcutListJson(const QString &info)
 
 void KeyboardWorker::onAdded(const QString &in0, int in1)
 {
-    if (m_keyboardDBusProxy->isWayland()) {
-        m_keyboardDBusProxy->GetShortcut(in0, in1);
-        return;
-    }
-
-    QDBusPendingReply<QString> reply = m_keyboardDBusProxy->GetShortcut(in0, in1);
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onAddedFinished);
+    m_keyboardDBusProxy->GetShortcut(in0, in1);
 }
 
 void KeyboardWorker::onDisableShortcut(ShortcutInfo *info)
 {
-    // disable shortcut need wait!
-    m_keyboardDBusProxy->ClearShortcutKeystrokes(info->id, static_cast<int>(info->type)).waitForFinished();
-    info->accels.clear();
-}
-
-void KeyboardWorker::onAddedFinished(QDBusPendingCallWatcher *watch)
-{
-    QDBusPendingReply<QString> reply = *watch;
-
-    if (m_shortcutModel && !watch->isError())
-        m_shortcutModel->onCustomInfo(reply.value());
-
-    watch->deleteLater();
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->ClearShortcutKeystrokes(
+        info->id, static_cast<int>(info->type));
+    auto *watcher = new QDBusPendingCallWatcher(reply, this);
+    watcher->setProperty("id", info->id);
+    watcher->setProperty("type", static_cast<int>(info->type));
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher] {
+        QDBusPendingReply<bool> result = *watcher;
+        if (result.isError() || !result.value()) {
+            qWarning() << "Disable shortcut failed:" << watcher->property("id").toString()
+                       << (result.isError() ? result.error().message() : QStringLiteral("server returned false"));
+            onShortcutChanged(watcher->property("id").toString(), watcher->property("type").toInt());
+        }
+        watcher->deleteLater();
+    });
 }
 
 void KeyboardWorker::onLayoutListsFinished(QDBusPendingCallWatcher *watch)
@@ -767,14 +718,7 @@ void KeyboardWorker::onCurrentLayout(const QString &value)
 void KeyboardWorker::onSearchShortcuts(const QString &searchKey)
 {
     qDebug() << "onSearchShortcuts: " << searchKey;
-    if (m_keyboardDBusProxy->isWayland()) {
-        m_keyboardDBusProxy->SearchShortcuts(searchKey);
-        return;
-    }
-
-    QDBusPendingReply<QString> reply = m_keyboardDBusProxy->SearchShortcuts(searchKey);
-    QDBusPendingCallWatcher *searchResult = new QDBusPendingCallWatcher(reply, this);
-    connect(searchResult, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onSearchFinished);
+    m_keyboardDBusProxy->SearchShortcuts(searchKey);
 }
 
 void KeyboardWorker::onCurrentLayoutFinished(QDBusPendingCallWatcher *watch)
@@ -783,17 +727,6 @@ void KeyboardWorker::onCurrentLayoutFinished(QDBusPendingCallWatcher *watch)
 
     m_model->setLayout(reply.value());
 
-    watch->deleteLater();
-}
-
-void KeyboardWorker::onSearchFinished(QDBusPendingCallWatcher *watch)
-{
-    QDBusPendingReply<QString> reply = *watch;
-    if (m_shortcutModel && !watch->isError()) {
-        m_shortcutModel->setSearchResult(reply.value());
-    } else {
-        qDebug() << "search finished error." << watch->error();
-    }
     watch->deleteLater();
 }
 
@@ -877,144 +810,88 @@ void KeyboardWorker::onLangSelectorServiceFinished()
 
 void KeyboardWorker::onShortcutChanged(const QString &id, int type)
 {
-    if (m_keyboardDBusProxy->isWayland()) {
-        // NOTE: the Wayland Query reply lands via onGetShortcutNewFinished →
-        // shortcutQueried → onKeyBindingChanged, which carries no per-id query
-        // timestamp and so lacks the X11 stale-response guard below
-        // (m_shortcutQueryTime). This is tolerated because the trigger surface
-        // is tiny: the common server push uses onNewShortcutChanged (full info,
-        // never re-enters Query), and onShortcutChanged is reached on Wayland
-        // only via the single re-query a failed ModifyHotkeys issues — so two
-        // GetShortcut replies for the same id racing out of order is practically
-        // impossible. If that ever changes, stamp+drop in the proxy (per-id
-        // QHash<QString,qint64>) on the Wayland path only.
-        m_keyboardDBusProxy->Query(id, type);
-        return;
-    }
-
-    QString key = makeShortcutKey(id, type);
-    qint64 currentTime = QDateTime::currentMSecsSinceEpoch();
-    m_shortcutQueryTime[key] = currentTime;
-
-    QDBusPendingCallWatcher *result = new QDBusPendingCallWatcher(m_keyboardDBusProxy->Query(id, type));
-    result->setProperty("queryTime", currentTime);
-    result->setProperty("queryKey", key);
-    connect(result, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onGetShortcutFinished);
-}
-
-void KeyboardWorker::onGetShortcutFinished(QDBusPendingCallWatcher *watch)
-{
-    QDBusPendingReply<QString> reply = *watch;
-
-    qint64 queryTime = watch->property("queryTime").toLongLong();
-    QString key = watch->property("queryKey").toString();
-    if (queryTime < m_shortcutQueryTime.value(key, 0)) {
-        watch->deleteLater();
-        return;
-    }
-
-    if (m_shortcutModel && !watch->isError()) {
-        const QJsonObject obj = QJsonDocument::fromJson(reply.value().toStdString().c_str()).object();
-        const QJsonArray accels = obj["Accels"].toArray();
-        
-        // Skip UI update if shortcut is being replaced to prevent flicker
-        // Wait until the new shortcut data is available (non-empty accels)
-        if (m_replacingShortcuts.contains(key)) {
-            if (!accels.isEmpty()) {
-                // New shortcut data has arrived, clear the flag and proceed with update
-                m_replacingShortcuts.remove(key);
-            } else {
-                // Still waiting for new shortcut data, skip this stale response
-                watch->deleteLater();
-                return;
-            }
-        }
-        
-        m_shortcutModel->onKeyBindingChanged(reply.value());
-    } else if (watch->isError()) {
-        if (m_replacingShortcuts.contains(key)) {
-            m_replacingShortcuts.remove(key);
-        }
-    }
-
-    watch->deleteLater();
+    m_keyboardDBusProxy->Query(id, type);
 }
 
 void KeyboardWorker::updateKey(ShortcutInfo *info)
 {
     if (m_shortcutModel)
         m_shortcutModel->setCurrentInfo(info);
-
-    m_keyboardDBusProxy->SelectKeystroke();
 }
 
-void KeyboardWorker::cleanShortcutSlef(const QString &id, const int type, const QString &shortcut)
+QString KeyboardWorker::shortcutKey(const QString &id, int type)
 {
-    QString key = makeShortcutKey(id, type);
-    m_replacingShortcuts.insert(key);
+    return id + QChar(0x1f) + QString::number(type);
+}
 
-    // Wayland: ModifyHotkeys is atomic (unregister + register in one
-    // transaction). Sending a preceding Disable would queue a second commit
-    // before the first finishes, which the compositor's protocol forbids and
-    // makes commitAndWait time out for both. Use callModifyHotkeys
-    // (QDBusPendingReply<bool>) so we can detect server-side failures
-    // (commit timeout, conflict, registerKey failure) and re-query the
-    // current state to keep the UI in sync.
-    if (m_keyboardDBusProxy->isWayland()) {
-        QDBusPendingReply<bool> reply = m_keyboardDBusProxy->callModifyHotkeys(id, QStringList{shortcut});
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
-        watcher->setProperty("id", id);
-        watcher->setProperty("type", type);
-        connect(watcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardWorker::onModifyHotkeysFinished);
+void KeyboardWorker::setShortcutGeneration(const QString &id, int type, quint64 generation)
+{
+    m_shortcutGenerations.insert(shortcutKey(id, type), generation);
+}
+
+bool KeyboardWorker::isCurrentShortcutGeneration(const QString &id, int type,
+                                                  quint64 generation) const
+{
+    return generation != 0
+            && m_shortcutGenerations.value(shortcutKey(id, type)) == generation;
+}
+
+void KeyboardWorker::beginCapture(quint64 requestId)
+{
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->BeginCapture();
+    auto *watcher = new QDBusPendingCallWatcher(reply, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher, requestId] {
+        QDBusPendingReply<bool> result = *watcher;
+        const bool success = !result.isError() && result.value();
+        const QString reason = result.isError()
+                ? result.error().message()
+                : (success ? QString() : QStringLiteral("server returned false"));
+        Q_EMIT captureRequestFinished(requestId, success, reason);
+        watcher->deleteLater();
+    });
+}
+
+void KeyboardWorker::endCapture()
+{
+    m_keyboardDBusProxy->EndCapture();
+}
+
+void KeyboardWorker::cleanShortcutSlef(const QString &id, const int type, const QString &shortcut,
+                                       quint64 generation)
+{
+    if (!isCurrentShortcutGeneration(id, type, generation))
         return;
-    }
 
-    QDBusPendingCall call = m_keyboardDBusProxy->ClearShortcutKeystrokes(id, type);
-
-    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
-
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->callModifyHotkeys(id, QStringList{shortcut});
+    auto *watcher = new QDBusPendingCallWatcher(reply, this);
     watcher->setProperty("id", id);
     watcher->setProperty("type", type);
     watcher->setProperty("shortcut", shortcut);
-
-    connect(watcher, &QDBusPendingCallWatcher::finished, this, &KeyboardWorker::onShortcutCleanFinished);
+    watcher->setProperty("generation", generation);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardWorker::onModifyHotkeysFinished);
 }
 
 void KeyboardWorker::setNewCustomShortcut(const QString &id, const QString &name, const QString &command, const QString &accles)
 {
-    if (m_keyboardDBusProxy->isWayland()) {
-        callModifyCustomShortcut(id, name, command, accles, ShortcutModel::Custom);
-        return;
-    }
-
-    m_keyboardDBusProxy->ModifyCustomShortcut(id, name, command, accles);
+    callModifyCustomShortcut(id, name, command, accles, ShortcutModel::Custom);
 }
 
-void KeyboardWorker::onConflictShortcutCleanFinished(QDBusPendingCallWatcher *watch)
+void KeyboardWorker::lookupShortcutConflict(const QString &id, int type, const QString &shortcut,
+                                            quint64 generation, bool reportFailureIfNoConflict)
 {
-    if (!watch->isError()) {
-        const QString &id = watch->property("id").toString();
-        const int type = watch->property("type").toInt();
-        const QString &shortcut = watch->property("shortcut").toString();
-        const bool clean = watch->property("clean").toBool();
+    if (!isCurrentShortcutGeneration(id, type, generation))
+        return;
 
-        if (clean) {
-            cleanShortcutSlef(id, type, shortcut);
-        } else {
-            m_keyboardDBusProxy->AddShortcutKeystroke(id, type, shortcut);
-        }
-    } else {
-        // X11 path only — onDisableShortcut's blocking waitForFinished
-        // already handled failure inline.  Just clean up the flicker guard.
-        qWarning() << "Disable failed for conflicting shortcut:" << watch->error().message();
-        const QString &id = watch->property("id").toString();
-        const int type = watch->property("type").toInt();
-        QString key = makeShortcutKey(id, type);
-        m_replacingShortcuts.remove(key);
-    }
-
-    watch->deleteLater();
+    QDBusPendingReply<ShortcutInfoNew> reply = m_keyboardDBusProxy->LookupConflictShortcut(shortcut);
+    auto *watcher = new QDBusPendingCallWatcher(reply, this);
+    watcher->setProperty("id", id);
+    watcher->setProperty("type", type);
+    watcher->setProperty("shortcut", shortcut);
+    watcher->setProperty("generation", generation);
+    watcher->setProperty("reportFailureIfNoConflict", reportFailureIfNoConflict);
+    connect(watcher, &QDBusPendingCallWatcher::finished,
+            this, &KeyboardWorker::onLookupConflictForShortcutFinished);
 }
 
 void KeyboardWorker::onLookupConflictForShortcutFinished(QDBusPendingCallWatcher *watch)
@@ -1023,30 +900,31 @@ void KeyboardWorker::onLookupConflictForShortcutFinished(QDBusPendingCallWatcher
     const QString id = watch->property("id").toString();
     const int type = watch->property("type").toInt();
     const QString shortcut = watch->property("shortcut").toString();
-    const bool isKPDelete = watch->property("isKPDelete").toBool();
+    const quint64 generation = watch->property("generation").toULongLong();
+    const bool reportFailureIfNoConflict = watch->property("reportFailureIfNoConflict").toBool();
 
-    const ShortcutInfoNew conflict = reply.isError() ? ShortcutInfoNew() : reply.value();
-    if (!reply.isError() && !conflict.id.isEmpty()) {
-        // Wayland: use ReplaceHotkey to remove the conflicting hotkey from
-        // the conflict shortcut and assign it to the target in one commit.
-        const QString targetKey = makeShortcutKey(id, type);
-        m_replacingShortcuts.insert(targetKey);
+    if (!isCurrentShortcutGeneration(id, type, generation)) {
+        watch->deleteLater();
+        return;
+    }
 
-        QDBusPendingReply<bool> replaceReply = m_keyboardDBusProxy->callReplaceHotkey(id, shortcut, conflict.id);
-        QDBusPendingCallWatcher *replaceWatcher = new QDBusPendingCallWatcher(replaceReply, this);
-        replaceWatcher->setProperty("id", id);
-        replaceWatcher->setProperty("type", type);
-        connect(replaceWatcher, &QDBusPendingCallWatcher::finished,
-                this, &KeyboardWorker::onReplaceHotkeyFinished);
+    if (reply.isError()) {
+        qWarning() << "LookupConflictShortcut failed:" << reply.error();
+        Q_EMIT shortcutModificationFinished(id, type, shortcut, false, generation);
+        watch->deleteLater();
+        return;
+    }
+
+    const ShortcutInfoNew conflict = reply.value();
+    if (!conflict.id.isEmpty() && conflict.id != id) {
+        const QString conflictName = conflict.localLanguageName.isEmpty()
+                ? conflict.displayName : conflict.localLanguageName;
+        Q_EMIT shortcutConflictDetected(id, type, shortcut, conflict.id, conflictName,
+                                        conflict.modifiable, generation);
+    } else if (reportFailureIfNoConflict) {
+        Q_EMIT shortcutModificationFinished(id, type, shortcut, false, generation);
     } else {
-        if (reply.isError()) {
-            qWarning() << "LookupConflictShortcut failed:" << reply.error();
-        }
-        if (isKPDelete) {
-            m_keyboardDBusProxy->AddShortcutKeystroke(id, type, shortcut);
-        } else {
-            cleanShortcutSlef(id, type, shortcut);
-        }
+        cleanShortcutSlef(id, type, shortcut, generation);
     }
 
     watch->deleteLater();
@@ -1057,23 +935,20 @@ void KeyboardWorker::onModifyHotkeysFinished(QDBusPendingCallWatcher *watch)
     QDBusPendingReply<bool> reply = *watch;
     const QString id = watch->property("id").toString();
     const int type = watch->property("type").toInt();
-    const QString key = makeShortcutKey(id, type);
-
-    // This handler is Wayland-only. Clear the flicker guard unconditionally:
-    // on Wayland the model update arrives via ShortcutChanged → shortcutQueried
-    // → onKeyBindingChanged, which — unlike the X11 onGetShortcutFinished —
-    // never touches m_replacingShortcuts. Clearing only on failure (as before)
-    // leaked the entry on every successful edit.
-    m_replacingShortcuts.remove(key);
+    const QString shortcut = watch->property("shortcut").toString();
+    const quint64 generation = watch->property("generation").toULongLong();
+    if (!isCurrentShortcutGeneration(id, type, generation)) {
+        watch->deleteLater();
+        return;
+    }
 
     const bool success = (!reply.isError() && reply.value());
     if (!success) {
         qWarning() << "ModifyHotkeys failed for" << id
                    << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
-        // Re-query the server. On commit-timeout the in-memory state was
-        // rolled back by dde-services, so the response carries the real
-        // (old) hotkeys and onKeyBindingChanged will revert the UI.
-        onShortcutChanged(id, type);
+        lookupShortcutConflict(id, type, shortcut, generation, true);
+    } else {
+        Q_EMIT shortcutModificationFinished(id, type, shortcut, true, generation);
     }
     // On success the server emits ShortcutChanged, which the proxy forwards via
     // shortcutQueried → onKeyBindingChanged to update the model. No extra work here.
@@ -1086,79 +961,55 @@ void KeyboardWorker::onReplaceHotkeyFinished(QDBusPendingCallWatcher *watch)
     QDBusPendingReply<bool> reply = *watch;
     const QString id = watch->property("id").toString();
     const int type = watch->property("type").toInt();
-    const QString key = makeShortcutKey(id, type);
-
-    m_replacingShortcuts.remove(key);
+    const QString shortcut = watch->property("shortcut").toString();
+    const quint64 generation = watch->property("generation").toULongLong();
+    if (!isCurrentShortcutGeneration(id, type, generation)) {
+        watch->deleteLater();
+        return;
+    }
 
     const bool success = (!reply.isError() && reply.value());
     if (!success) {
         qWarning() << "ReplaceHotkey failed for" << id
                    << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
-        // Re-query to restore the UI to the server's actual state.
-        onShortcutChanged(id, type);
     }
+    Q_EMIT shortcutModificationFinished(id, type, shortcut, success, generation);
     // On success the server emits two ShortcutChanged signals (one per
     // shortcut), which the proxy forwards to update both model rows.
 
     watch->deleteLater();
 }
 
-void KeyboardWorker::onShortcutCleanFinished(QDBusPendingCallWatcher *watch)
-{
-    if (!watch->isError()) {
-        const QString &id = watch->property("id").toString();
-        const int type = watch->property("type").toInt();
-        const QString &shortcut = watch->property("shortcut").toString();
-
-        m_keyboardDBusProxy->AddShortcutKeystroke(id, type, shortcut);
-
-        if (shortcut.contains("Delete") && !shortcut.contains("KP_Delete")) {
-            ShortcutInfo si;
-            si.id = id;
-            si.type = static_cast<uint>(type);
-            si.accels = shortcut;
-            si.accels = si.accels.replace("Delete", "KP_Delete");
-            modifyShortcutEditAux(&si, true);
-        }
-    } else {
-        qDebug() << watch->error();
-        const QString &id = watch->property("id").toString();
-        const int type = watch->property("type").toInt();
-        QString key = makeShortcutKey(id, type);
-        m_replacingShortcuts.remove(key);
-    }
-
-    watch->deleteLater();
-}
-
-void KeyboardWorker::onCustomConflictCleanFinished(QDBusPendingCallWatcher *w)
-{
-    if (!w->isError()) {
-        const QString &id = w->property("id").toString();
-        const QString name = w->property("name").toString();
-        const QString &command = w->property("command").toString();
-        const QString &accles = w->property("shortcut").toString();
-
-        setNewCustomShortcut(id, name, command, accles);
-    } else {
-        const QString &id = w->property("id").toString();
-        QString key = id + "_1";
-        m_replacingShortcuts.remove(key);
-    }
-
-    w->deleteLater();
-}
-
 void KeyboardWorker::onAddCustomShortcutFinished(QDBusPendingCallWatcher *watch)
 {
     QDBusPendingReply<QString> reply = *watch;
-    if (reply.isError() || reply.value().isEmpty()) {
+    const quint64 requestId = watch->property("requestId").toULongLong();
+    const quint64 generation = watch->property("generation").toULongLong();
+    if (generation != 0
+            && !isCurrentShortcutGeneration(watch->property("id").toString(),
+                                            watch->property("type").toInt(),
+                                            generation)) {
+        if (requestId != 0) {
+            Q_EMIT customShortcutOperationFinished(
+                    requestId, false, tr("The shortcut conflict is no longer current."));
+        }
+        watch->deleteLater();
+        return;
+    }
+
+    const bool success = !reply.isError() && !reply.value().isEmpty();
+    const QString errorMessage = reply.isError()
+            ? customShortcutErrorMessage(reply.error())
+            : (success ? QString() : tr("Failed to save the shortcut. Please try again."));
+    if (!success) {
         qWarning() << "AddCustomShortcut failed:"
                    << (reply.isError() ? reply.error().message() : QStringLiteral("server returned empty id"));
         refreshShortcut();
     } else {
         onAdded(reply.value(), ShortcutModel::Custom);
     }
+    if (requestId != 0)
+        Q_EMIT customShortcutOperationFinished(requestId, success, errorMessage);
 
     watch->deleteLater();
 }
@@ -1168,7 +1019,21 @@ void KeyboardWorker::onModifyCustomShortcutFinished(QDBusPendingCallWatcher *wat
     QDBusPendingReply<bool> reply = *watch;
     const QString id = watch->property("id").toString();
     const int type = watch->property("type").toInt();
+    const quint64 requestId = watch->property("requestId").toULongLong();
+    const quint64 generation = watch->property("generation").toULongLong();
+    if (generation != 0 && !isCurrentShortcutGeneration(id, type, generation)) {
+        if (requestId != 0) {
+            Q_EMIT customShortcutOperationFinished(
+                    requestId, false, tr("The shortcut conflict is no longer current."));
+        }
+        watch->deleteLater();
+        return;
+    }
+
     const bool success = (!reply.isError() && reply.value());
+    const QString errorMessage = reply.isError()
+            ? customShortcutErrorMessage(reply.error())
+            : (success ? QString() : tr("Failed to save the shortcut. Please try again."));
     if (!success) {
         qWarning() << "ModifyCustomShortcut failed for" << id
                    << (reply.isError() ? reply.error().message() : QStringLiteral("server returned false"));
@@ -1176,6 +1041,8 @@ void KeyboardWorker::onModifyCustomShortcutFinished(QDBusPendingCallWatcher *wat
     } else if (!id.isEmpty()) {
         onShortcutChanged(id, type);
     }
+    if (requestId != 0)
+        Q_EMIT customShortcutOperationFinished(requestId, success, errorMessage);
 
     watch->deleteLater();
 }
@@ -1198,6 +1065,7 @@ void KeyboardWorker::onGetShortcutCommandFinished(QDBusPendingCallWatcher *watch
 {
     QDBusPendingReply<QString> reply = *watch;
     const QString id = watch->property("id").toString();
+    const quint64 requestSerial = watch->property("requestSerial").toULongLong();
     QString command = watch->property("fallbackCommand").toString();
 
     if (reply.isError()) {
@@ -1206,13 +1074,9 @@ void KeyboardWorker::onGetShortcutCommandFinished(QDBusPendingCallWatcher *watch
         command = reply.value();
     }
 
-    Q_EMIT shortcutCommandReady(id, command, !reply.isError() || !command.isEmpty());
+    Q_EMIT shortcutCommandReady(id, command, !reply.isError() || !command.isEmpty(),
+                                requestSerial);
     watch->deleteLater();
-}
-
-QString KeyboardWorker::makeShortcutKey(const QString &id, int type)
-{
-    return id + "_" + QString::number(type);
 }
 
 uint KeyboardWorker::converToDBusDelay(uint value)

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -17,6 +17,7 @@
 
 #include <DConfig>
 
+#include <QHash>
 #include <QObject>
 
 class QDBusPendingCallWatcher;
@@ -45,22 +46,27 @@ public:
     inline QList<MetaData> getDatas() {return m_metaDatas;}
     inline QList<QString> getLetters() {return m_letters;}
 
-    void modifyShortcutEditAux(ShortcutInfo* info, bool isKPDelete = false);
-    void modifyShortcutEdit(ShortcutInfo* info);
-    void addCustomShortcut(const QString& name, const QString& command, const QString& accels);
-    void modifyCustomShortcut(ShortcutInfo *info);
-    void requestShortcutCommand(const QString &id);
+    void modifyShortcutEditAux(ShortcutInfo *info, quint64 generation);
+    void modifyShortcutEdit(ShortcutInfo *info, quint64 generation);
+    void replaceShortcutEdit(ShortcutInfo *info, const QString &expectedConflictId,
+                             quint64 generation);
+    void setShortcutGeneration(const QString &id, int type, quint64 generation);
+    void addCustomShortcut(const QString& name, const QString& command, const QString& accels,
+                           quint64 requestId);
+    void modifyCustomShortcut(ShortcutInfo *info, quint64 requestId);
+    void replaceCustomShortcut(const QString &id, const QString &name,
+                               const QString &command, const QString &accels,
+                               const QString &expectedConflictId, quint64 generation,
+                               quint64 requestId);
+    void requestShortcutCommand(const QString &id, quint64 requestSerial);
     // Fire ModifyCustomShortcut on the Wayland service and wire the reply to
     // onModifyCustomShortcutFinished. Shared by modifyCustomShortcut (Wayland
     // branch) and setNewCustomShortcut so the watcher/id/type setup stays in
     // one place.
     void callModifyCustomShortcut(const QString &id, const QString &name,
                                   const QString &command, const QString &accels,
-                                  int type);
+                                  int type, quint64 requestId = 0);
 
-    void grabScreen();
-    bool checkAvaliable(const QString& key);
-    QString lookupConflictingShortcut(const QString &key);
     void delShortcut(ShortcutInfo *info);
 
     void setRepeatDelay(uint value);
@@ -85,7 +91,6 @@ public:
     bool isWayland() const { return m_keyboardDBusProxy->isWayland(); }
 
 Q_SIGNALS:
-    void KeyEvent(bool in0, const QString &in1);
     void searchChangd(ShortcutInfo* info, const QString& key);
     void removed(const QString &id, int type);
     void requestSetAutoHide(const bool visible);
@@ -93,7 +98,16 @@ Q_SIGNALS:
     void onLettersChanged(QList<QString> letters);
     // 快捷键恢复默认完成
     void onResetFinished();
-    void shortcutCommandReady(const QString &id, const QString &command, bool available);
+    void shortcutCommandReady(const QString &id, const QString &command, bool available,
+                              quint64 requestSerial);
+    void captureRequestFinished(quint64 requestId, bool success, const QString &reason);
+    void shortcutConflictDetected(const QString &id, int type, const QString &shortcut,
+                                  const QString &conflictId, const QString &conflictName,
+                                  bool replaceable, quint64 generation);
+    void shortcutModificationFinished(const QString &id, int type, const QString &shortcut,
+                                      bool success, quint64 generation);
+    void customShortcutOperationFinished(quint64 requestId, bool success,
+                                         const QString &errorMessage);
 
 public Q_SLOTS:
     void setLang(const QString &value);
@@ -102,13 +116,11 @@ public Q_SLOTS:
     void setLayout(const QString& value);
     void addUserLayout(const QString& value);
     void delUserLayout(const QString& value);
-    void onRequestShortcut(QDBusPendingCallWatcher* watch);
     void onAllShortcutsReady(const QString &info);
     void onModifyHotkeysFinished(QDBusPendingCallWatcher *watch);
     void onReplaceHotkeyFinished(QDBusPendingCallWatcher *watch);
     void onAdded(const QString&in0, int in1);
     void onDisableShortcut(ShortcutInfo* info);
-    void onAddedFinished(QDBusPendingCallWatcher *watch);
     void onLocalListsFinished(QDBusPendingCallWatcher *watch);
     void onGetWindowWM(bool value);
     void onLayoutListsFinished(QDBusPendingCallWatcher *watch);
@@ -119,25 +131,26 @@ public Q_SLOTS:
     void onCurrentLayoutFinished(QDBusPendingCallWatcher *watch);
     void onPinyin();
     void onSearchShortcuts(const QString &searchKey);
-    void onSearchFinished(QDBusPendingCallWatcher *watch);
     void append(const MetaData& md);
     void onLangSelectorServiceFinished();
     void onShortcutChanged(const QString &id, int type);
-    void onGetShortcutFinished(QDBusPendingCallWatcher *watch);
     void updateKey(ShortcutInfo *info);
-    void cleanShortcutSlef(const QString &id, const int type, const QString &shortcut);
+    void beginCapture(quint64 requestId);
+    void endCapture();
+    void cleanShortcutSlef(const QString &id, const int type, const QString &shortcut,
+                           quint64 generation);
     void setNewCustomShortcut(const QString &id, const QString &name, const QString &command, const QString &accles);
-    void onConflictShortcutCleanFinished(QDBusPendingCallWatcher *watch);
     void onLookupConflictForShortcutFinished(QDBusPendingCallWatcher *watch);
-    void onShortcutCleanFinished(QDBusPendingCallWatcher *watch);
-    void onCustomConflictCleanFinished(QDBusPendingCallWatcher *w);
     void onAddCustomShortcutFinished(QDBusPendingCallWatcher *watch);
     void onModifyCustomShortcutFinished(QDBusPendingCallWatcher *watch);
     void onDeleteCustomShortcutFinished(QDBusPendingCallWatcher *watch);
     void onGetShortcutCommandFinished(QDBusPendingCallWatcher *watch);
 
 private:
-    static QString makeShortcutKey(const QString &id, int type);
+    static QString shortcutKey(const QString &id, int type);
+    bool isCurrentShortcutGeneration(const QString &id, int type, quint64 generation) const;
+    void lookupShortcutConflict(const QString &id, int type, const QString &shortcut,
+                                quint64 generation, bool reportFailureIfNoConflict = false);
     void initKeyboardEnabledSync();
     void syncKeyboardEnabled();
     uint converToDBusDelay(uint value);
@@ -158,8 +171,7 @@ private:
     QTranslator *m_translatorLanguage;
     Dtk::Core::DConfig *m_inputDevCfg;
     bool m_isResetting = false; // Flag to prevent duplicate reset calls
-    QMap<QString, qint64> m_shortcutQueryTime; // 记录每个快捷键最后一次 Query 的时间戳
-    QSet<QString> m_replacingShortcuts; // 记录正在替换的快捷键，用于屏蔽中间状态的UI更新
+    QHash<QString, quint64> m_shortcutGenerations;
     bool m_isTreelandSession = false;
 #ifdef ENABLE_TREELAND_INPUT_MANAGER
     DCC_NAMESPACE::KeyboardWaylandProxy *m_waylandProxy = nullptr;

--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -23,7 +23,6 @@ Control {
     signal requestKeys
     signal requestEditKeys
     signal requestDeleteKeys
-
     background: Rectangle {
         implicitWidth: DS.Style.keySequenceEdit.width
         implicitHeight: DS.Style.keySequenceEdit.height

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -30,6 +30,24 @@ D.DialogWindow {
     property string saveAccels: ""
     property var saveKeys: [qsTr("None")]
     property bool nameExists: false
+    property var captureRestoreKeys: [qsTr("None")]
+    property string captureRestoreAccels: ""
+    property bool captureRestoreValid: false
+    property bool pendingConflict: false
+    property bool submitting: false
+    property double pendingRequestId: 0
+    signal closeConfirmed()
+
+    onClosing: function(close) {
+        if (ddialog.submitting) {
+            close.accepted = false
+            return
+        }
+        dccData.endKeyCapture()
+        dccData.clearPendingConflict(ddialog.keyId, 1)
+        ddialog.pendingConflict = false
+        ddialog.closeConfirmed()
+    }
 
     ColumnLayout {
         spacing: 10
@@ -137,12 +155,19 @@ D.DialogWindow {
                 else
                     return DS.Style.keySequenceEdit.background;
             }
-            // Wayland: ask Treeland to forward the next combo (capture protocol).
-            // No-op on X11; local Keys.onPressed handles capture there.
             onRequestKeys: {
-                keys = [];
-                dccData.updateKey(ddialog.keyId, 1);
-                dccData.beginWaylandKeyCapture(edit, ddialog.keyId, 1);
+                dccData.clearPendingConflict(ddialog.keyId, 1)
+                ddialog.pendingConflict = false
+                conflictText.text = ""
+                if (!ddialog.captureRestoreValid) {
+                    var restoreKeys = []
+                    for (var index = 0; index < edit.keys.length; ++index)
+                        restoreKeys.push(edit.keys[index])
+                    ddialog.captureRestoreKeys = restoreKeys
+                    ddialog.captureRestoreAccels = edit.accels
+                    ddialog.captureRestoreValid = true
+                }
+                dccData.beginKeyCapture(edit, ddialog.keyId, 1)
             }
         }
 
@@ -166,14 +191,9 @@ D.DialogWindow {
                 font: D.DTK.fontManager.t6
                 Layout.leftMargin: 4
                 text: qsTr("Cancel")
+                enabled: !ddialog.submitting
                 onClicked: {
-                    if (ddialog.keyId.length > 0
-                            && (nameEdit.text !== ddialog.saveKeyName
-                                || commandEdit.text !== ddialog.saveCmdName
-                                || edit.accels !== ddialog.saveAccels)) {
-                        dccData.modifyCustomShortcut(ddialog.keyId, ddialog.saveKeyName, ddialog.saveCmdName, ddialog.saveAccels);
-                    }
-                    ddialog.close();
+                    ddialog.close()
                 }
             }
             Button {
@@ -181,29 +201,50 @@ D.DialogWindow {
                 Layout.fillWidth: true
                 Layout.rightMargin: 24
                 font: D.DTK.fontManager.t6
-                text: ddialog.keyId.length > 0 ? qsTr("Save") : qsTr("Add")
-                enabled: commandEdit.text.length > 0 && nameEdit.text.length > 0 && !ddialog.nameExists
+                text: ddialog.pendingConflict
+                      ? qsTr("Replace")
+                      : (ddialog.keyId.length > 0 ? qsTr("Save") : qsTr("Add"))
+                enabled: !ddialog.submitting && commandEdit.text.length > 0
+                         && nameEdit.text.length > 0 && !ddialog.nameExists
                 onClicked: {
-                    if (edit.keys[0] === qsTr("None")) {
+                    if (edit.keys.length === 0 || edit.keys[0] === qsTr("None")) {
                         edit.showAlertColor = true;
                         return;
                     }
 
-                    if (ddialog.keyId.length > 0)
-                        dccData.modifyCustomShortcut(ddialog.keyId, nameEdit.text, commandEdit.text, edit.accels);
-                    else
-                        dccData.addCustomShortcut(nameEdit.text, commandEdit.text, edit.accels);
-
-                    ddialog.close();
+                    conflictText.text = ""
+                    ddialog.submitting = true
+                    if (ddialog.pendingConflict) {
+                        ddialog.pendingRequestId = dccData.replaceCustomShortcut(
+                                    ddialog.keyId, nameEdit.text, commandEdit.text, edit.accels)
+                    } else if (ddialog.keyId.length > 0) {
+                        ddialog.pendingRequestId = dccData.modifyCustomShortcut(
+                                    ddialog.keyId, nameEdit.text, commandEdit.text, edit.accels)
+                    } else {
+                        ddialog.pendingRequestId = dccData.addCustomShortcut(
+                                    nameEdit.text, commandEdit.text, edit.accels)
+                    }
                 }
             }
         }
 
         Connections {
             target: dccData
-            function onRequestRestore() {
-                edit.keys = ddialog.saveKeys;
-                conflictText.text = "";
+            function onRequestRestore(id, type) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                dccData.endKeyCapture()
+                if (ddialog.captureRestoreValid) {
+                    edit.keys = ddialog.captureRestoreKeys
+                    edit.accels = ddialog.captureRestoreAccels
+                } else {
+                    edit.keys = ddialog.saveKeys
+                    edit.accels = ddialog.saveAccels
+                }
+                ddialog.captureRestoreValid = false
+                dccData.clearPendingConflict(ddialog.keyId, 1)
+                ddialog.pendingConflict = false
+                conflictText.text = ""
                 // 重置名称验证状态
                 if (nameEdit.text.trim().length > 0) {
                     ddialog.nameExists = dccData.isShortcutNameExists(nameEdit.text.trim(), ddialog.keyId);
@@ -211,30 +252,75 @@ D.DialogWindow {
                     ddialog.nameExists = false;
                 }
             }
-            function onRequestClear() {
-                onRequestRestore();
+            function onRequestClear(id, type) {
+                if (id === ddialog.keyId && type === 1)
+                    onRequestRestore(id, type)
             }
-            function onKeyConflicted(oldAccels, newAccels) {
-                edit.accels = newAccels; // 冲突也可以覆盖
-                var actionText = ddialog.keyId.length > 0 ? qsTr("click Save to make this shortcut key effective") : qsTr("click Add to make this shortcut key effective");
-                conflictText.text = dccData.conflictText + ", " + actionText;
+            function onKeyCaptureStarted(id, type) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                ddialog.pendingConflict = false
+                conflictText.text = ""
+                edit.keys = []
             }
-            function onKeyDone(accels) {
+            function onKeyCaptureFailed(id, type, reason) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                edit.keys = ddialog.captureRestoreKeys
+                edit.accels = ddialog.captureRestoreAccels
+                ddialog.captureRestoreValid = false
+                dccData.clearPendingConflict(ddialog.keyId, 1)
+                ddialog.pendingConflict = false
+                conflictText.text = qsTr("Failed to start shortcut capture. Please try again.")
+            }
+            function onKeyConflicted(id, type, oldAccels, newAccels, message, replaceable) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                if (!replaceable) {
+                    edit.keys = ddialog.captureRestoreKeys
+                    edit.accels = ddialog.captureRestoreAccels
+                    ddialog.captureRestoreValid = false
+                    dccData.clearPendingConflict(ddialog.keyId, 1)
+                    ddialog.pendingConflict = false
+                    conflictText.text = message
+                    return
+                }
+                ddialog.captureRestoreValid = false
+                ddialog.pendingConflict = true
+                edit.accels = newAccels;
+                conflictText.text = message + ", "
+                        + qsTr("click Replace to make this shortcut key effective");
+            }
+            function onKeyDone(id, type, accels) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                ddialog.captureRestoreValid = false
+                dccData.clearPendingConflict(ddialog.keyId, 1)
+                ddialog.pendingConflict = false
                 edit.keys = dccData.formatKeys(accels);
                 edit.accels = accels;
                 conflictText.text = "";
             }
-            function onKeyEvent(accels) {
+            function onKeyEvent(id, type, accels) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
                 edit.showAlertColor = false;
                 edit.keys = dccData.formatKeys(accels);
             }
-            function onWaylandKeyCaptureFailed(id, type, reason) {
-                // Restrict to this dialog's own capture — id may be empty
-                // when wrapping a new custom shortcut.
-                if (id !== ddialog.keyId)
-                    return;
-                // Same recovery as a server-side requestRestore.
-                onRequestRestore();
+            function onCustomShortcutOperationFinished(requestId, success, errorMessage) {
+                if (!ddialog.submitting || requestId !== ddialog.pendingRequestId)
+                    return
+
+                ddialog.submitting = false
+                ddialog.pendingRequestId = 0
+                if (success) {
+                    ddialog.close()
+                    return
+                }
+
+                conflictText.text = errorMessage.length > 0
+                        ? errorMessage
+                        : qsTr("Failed to save the shortcut. Please try again.")
             }
         }
     }

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -35,6 +35,8 @@ DccObject {
     Connections {
         target: shortcutSettingsView
         function onDeactive() {
+            dccData.endKeyCapture()
+            shortcutView.restoreShortcutView()
             shortcutSettingsBody.conflictAccels = ""
             shortcutSettingsBody.isEditing = false
         }
@@ -81,9 +83,10 @@ DccObject {
 
             ListView {
                 id: shortcutView
-                property Item editItem
-                property Item conflictText
+                property var editItem
+                property var conflictText
                 property string pendingCommandId
+                property double pendingCommandSerial: 0
                 clip: true
                 interactive: false // 外层有滚动了，listview 就别滚了
                 implicitHeight: contentHeight
@@ -132,11 +135,7 @@ DccObject {
 
                             if (!shortcutView.editItem)
                                 return
-                            shortcutView.editItem.keys = shortcutView.editItem.keySequence
-                            shortcutView.editItem.focus = false
-                            shortcutView.conflictText.visible = false
-                            shortcutView.editItem = null
-                            shortcutView.conflictText = null
+                            shortcutView.editItem.restore()
                         }
                     }
                 }
@@ -161,6 +160,8 @@ DccObject {
                         KeySequenceDisplay {
                             id: edit
                             property string dialogCommand: model.command
+                            property string shortcutId: model.id
+                            property int shortcutType: model.type
                             text: model.display
                             keys: model.keySequence
                             placeholderText: qsTr("please enter a new shortcut key")
@@ -179,32 +180,22 @@ DccObject {
                                 }
                             }
 
-                            // On Wayland the compositor swallows key events
-                            // for already-registered global shortcuts, so we
-                            // ask Treeland (via capture_next_shortcut) to
-                            // forward the next combo here. On X11 the local
-                            // Keys.onPressed in KeySequenceDisplay handles
-                            // capture as before — beginWaylandKeyCapture
-                            // is a no-op there.
                             onRequestKeys: {
                                 if (shortcutView.editItem) {
                                     shortcutView.editItem.restore()
-                                    // return
                                 }
 
-                                edit.keys = ""
-                                dccData.updateKey(model.id, model.type)
                                 shortcutView.editItem = edit
                                 shortcutView.conflictText = conflictText
                                 shortcutSettingsBody.isEditing = false
-                                dccData.beginWaylandKeyCapture(edit, model.id, model.type)
+                                dccData.beginKeyCapture(edit, model.id, model.type)
                             }
                             onRequestEditKeys: {
                                 if (dialogloader.active)
                                     return
 
                                 shortcutView.pendingCommandId = model.id
-                                dccData.requestShortcutCommand(model.id)
+                                shortcutView.pendingCommandSerial = dccData.requestShortcutCommand(model.id)
                             }
                             onRequestDeleteKeys: {
                                 console.log("onRequestDeleteKeys", model.id)
@@ -218,12 +209,54 @@ DccObject {
                                     dccData.modifyShortcut(model.id, accels, model.type)
                             }
 
+                            function replaceShortcut(accels) {
+                                if (accels.length > 0)
+                                    dccData.replaceShortcut(model.id, accels, model.type)
+                            }
+
+                            function matches(id, type) {
+                                return shortcutId === id && shortcutType === type
+                            }
+
+                            function startCapture() {
+                                conflictText.message = ""
+                                conflictText.showActions = true
+                                conflictText.visible = false
+                                keys = []
+                            }
+
+                            function showConflict(accels, message) {
+                                keys = dccData.formatKeys(accels)
+                                conflictText.message = message
+                                conflictText.showActions = true
+                                conflictText.visible = true
+                                shortcutSettingsBody.conflictAccels = accels
+                            }
+
+                            function showFailure(message) {
+                                keys = model.keySequence
+                                conflictText.message = message
+                                conflictText.showActions = false
+                                conflictText.visible = true
+                                shortcutSettingsBody.conflictAccels = ""
+                            }
+
+                            function finishModification(accels) {
+                                keys = dccData.formatKeys(accels)
+                                conflictText.visible = false
+                                conflictText.message = ""
+                                shortcutSettingsBody.conflictAccels = ""
+                                shortcutView.editItem = null
+                                shortcutView.conflictText = null
+                            }
+
                             function clearShortcut() {
+                                dccData.endKeyCapture()
                                 dccData.clearShortcut(model.id, model.type)
 
-                                focus = false
                                 keys = dccData.formatKeys("")
                                 conflictText.visible = false
+                                conflictText.message = ""
 
                                 shortcutSettingsBody.conflictAccels = ""
                                 shortcutView.editItem = null
@@ -231,9 +264,11 @@ DccObject {
                             }
 
                             function restore() {
-                                dccData.endWaylandKeyCapture()
+                                dccData.endKeyCapture()
                                 edit.keys = model.keySequence
                                 conflictText.visible = false
+                                conflictText.message = ""
+                                conflictText.showActions = true
 
                                 shortcutSettingsBody.conflictAccels = ""
                                 shortcutView.editItem = null
@@ -244,8 +279,8 @@ DccObject {
                                 id: dialogloader
                                 active: false
                                 sourceComponent: ShortcutSettingDialog {
-                                    onClosing: {
-                                        dccData.endWaylandKeyCapture()
+                                    onCloseConfirmed: {
+                                        dccData.endKeyCapture()
                                         dialogloader.active = false
                                         shortcutView.pendingCommandId = ""
 
@@ -275,11 +310,14 @@ DccObject {
                             }
                             Connections {
                                 target: dccData
-                                function onShortcutCommandReady(id, command, available) {
-                                    if (shortcutView.pendingCommandId !== id || model.id !== id)
+                                function onShortcutCommandReady(id, command, available, requestSerial) {
+                                    if (shortcutView.pendingCommandId !== id
+                                            || shortcutView.pendingCommandSerial !== requestSerial
+                                            || model.id !== id)
                                         return
 
                                     shortcutView.pendingCommandId = ""
+                                    shortcutView.pendingCommandSerial = 0
                                     if (!available)
                                         return
 
@@ -291,6 +329,8 @@ DccObject {
 
                         Item {
                             id: conflictText
+                            property string message: ""
+                            property bool showActions: true
                             visible: false
                             implicitHeight: 20
                             implicitWidth: row.implicitWidth
@@ -314,22 +354,26 @@ DccObject {
                                 }
                                 Label {
                                     id: conflictTextLabel
-                                    text: dccData.conflictText + ","
+                                    text: conflictText.message + (conflictText.showActions ? "," : "")
                                     elide: Text.ElideLeft
                                     horizontalAlignment: Text.AlignRight
                                     HoverHandler { id: conflictHandler }
                                     ToolTip.visible: conflictHandler.hovered
-                                    ToolTip.text: conflictTextLabel.text + clickLabel.text + " " + cancelLabel.text + " " + orLabel.text + " " + replaceLabel.text
+                                    ToolTip.text: conflictText.showActions
+                                                  ? conflictTextLabel.text + clickLabel.text + " " + cancelLabel.text + " " + orLabel.text + " " + replaceLabel.text
+                                                  : conflictTextLabel.text
                                     ToolTip.delay: 500
                                     ToolTip.timeout: 4000
                                 }
                                 Label {
                                     id: clickLabel
                                     text: qsTr("Click")
+                                    visible: conflictText.showActions
                                 }
                                 Label {
                                     id: cancelLabel
                                     text: qsTr("Cancel")
+                                    visible: conflictText.showActions
                                     color: palette.highlight
                                     MouseArea {
                                         anchors.fill: parent
@@ -341,24 +385,19 @@ DccObject {
                                 Label {
                                     id: orLabel
                                     text: qsTr("or")
+                                    visible: conflictText.showActions
                                 }
                                 Label {
                                     id: replaceLabel
                                     text: qsTr("Replace")
+                                    visible: conflictText.showActions
                                     color: palette.highlight
                                     MouseArea {
                                         anchors.fill: parent
                                         onClicked: {
                                             var newAccels = shortcutSettingsBody.conflictAccels
-                                            dccData.endWaylandKeyCapture()
-                                            edit.modifyShortcut(newAccels)
-                                            shortcutSettingsBody.conflictAccels = ""
-
-                                            // Fix: hide conflict warning and reset edit state after replacing
-                                            edit.keys = dccData.formatKeys(newAccels)
-                                            conflictText.visible = false
-                                            shortcutView.editItem = null
-                                            shortcutView.conflictText = null
+                                            dccData.endKeyCapture()
+                                            edit.replaceShortcut(newAccels)
                                         }
                                     }
                                 }
@@ -385,48 +424,54 @@ DccObject {
                 }
                 Connections {
                     target: dccData
-                    function onRequestRestore() {
+                    function onRequestRestore(id, type) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
                         shortcutView.restoreShortcutView()
                     }
-                    function onRequestClear() {
+                    function onRequestClear(id, type) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
                         shortcutView.editItem.clearShortcut()
                     }
-                    function onKeyConflicted(oldAccels, newAccels) {
-                        if (shortcutView.conflictText)
-                            shortcutView.conflictText.visible = true
-
-                        shortcutSettingsBody.conflictAccels = newAccels
-                    }
-                    function onKeyDone(accels) {
-                        if (!shortcutView.editItem)
+                    function onKeyCaptureStarted(id, type) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
                             return
-                        shortcutView.editItem.focus = false
+                        shortcutView.editItem.startCapture()
+                    }
+                    function onKeyCaptureFailed(id, type, reason) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
+                        shortcutView.editItem.showFailure(qsTr("Failed to start shortcut capture. Please try again."))
+                    }
+                    function onKeyConflicted(id, type, oldAccels, newAccels, message, replaceable) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
+                        if (replaceable)
+                            shortcutView.editItem.showConflict(newAccels, message)
+                        else
+                            shortcutView.editItem.showFailure(message)
+                    }
+                    function onKeyDone(id, type, accels) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
                         shortcutView.editItem.keys = dccData.formatKeys(accels)
                         shortcutView.conflictText.visible = false
-
+                        shortcutView.conflictText.message = ""
                         shortcutView.editItem.modifyShortcut(accels)
-
-                        shortcutView.editItem = null
-                        shortcutView.conflictText = null
-
                     }
-                    function onKeyEvent(accels) {
-                        if (!shortcutView.editItem)
+                    function onKeyEvent(id, type, accels) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
                             return
-
-                        shortcutView.editItem.focus = false
                         shortcutView.editItem.keys = dccData.formatKeys(accels)
                     }
-                    function onWaylandKeyCaptureFailed(id, type, reason) {
-                        // not_active (3) / interrupted (4) / busy (1) / aborted (2).
-                        // Skip if nothing is being edited here — the dialog
-                        // path has its own handler and a stale event from a
-                        // session we've already cancelled (see disconnect in
-                        // beginWaylandKeyCapture) shouldn't tear down a fresh
-                        // edit.
-                        if (!shortcutView.editItem)
+                    function onShortcutModificationFinished(id, type, accels, success) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
                             return
-                        shortcutView.restoreShortcutView()
+                        if (success)
+                            shortcutView.editItem.finishModification(accels)
+                        else
+                            shortcutView.editItem.showFailure(qsTr("Failed to save the shortcut. Please try again."))
                     }
                 }
             }
@@ -523,7 +568,7 @@ DccObject {
                     active: addButton.needShowDialog
                     sourceComponent: ShortcutSettingDialog {
                         id: shortcutSettingDialog
-                        onClosing: {
+                        onCloseConfirmed: {
                             addButton.needShowDialog = false
                             shortcutSettingsBody.conflictAccels = ""
                         }

--- a/src/plugin-mouse/operation/gesturedata.cpp
+++ b/src/plugin-mouse/operation/gesturedata.cpp
@@ -29,6 +29,19 @@ void GestureData::setGestureId(const QString &newGestureId)
     emit gestureIdChanged();
 }
 
+QString GestureData::displayName() const
+{
+    return m_displayName;
+}
+
+void GestureData::setDisplayName(const QString &newDisplayName)
+{
+    if (m_displayName == newDisplayName)
+        return;
+    m_displayName = newDisplayName;
+    emit displayNameChanged();
+}
+
 QString GestureData::direction() const
 {
     return m_direction;
@@ -81,39 +94,14 @@ void GestureData::setSequence(int newSequence)
     emit sequenceChanged();
 }
 
-QStringList GestureData::actionNameList() const
+QList<GestureActionData> GestureData::actions() const
 {
-    return m_actionNameList;
+    return m_actions;
 }
 
-void GestureData::setActionNameList(const QStringList &newActionNameList)
+void GestureData::setActions(const QList<GestureActionData> &actions)
 {
-    m_actionNameList = newActionNameList;
-}
-
-QStringList GestureData::actionDescriptionList() const
-{
-    return m_actionDescriptionList;
-}
-
-void GestureData::setActionDescriptionList(const QStringList &newActionDescriptionList)
-{
-    m_actionDescriptionList = newActionDescriptionList;
-}
-
-QList<QPair<QString, QString> > GestureData::actionMaps() const
-{
-    return m_actionMaps;
-}
-
-void GestureData::setActionMaps(const QList<QPair<QString, QString> > &newActionMaps)
-{
-    m_actionMaps = newActionMaps;
-}
-
-void GestureData::addActiosPair(const QPair<QString, QString> &actionPair)
-{
-    m_actionMaps.append(actionPair);
+    m_actions = actions;
 }
 
 GestureData::GestureData(QObject *parent)

--- a/src/plugin-mouse/operation/gesturedata.h
+++ b/src/plugin-mouse/operation/gesturedata.h
@@ -6,11 +6,20 @@
 
 #include <QObject>
 
+struct GestureActionData
+{
+    QString actionId;
+    QString displayName;
+    bool supported = false;
+    QString unavailableReason;
+};
+
 class GestureData : public QObject
 {
     Q_OBJECT
     Q_PROPERTY(QString actionType READ actionType WRITE setActionType NOTIFY actionTypeChanged FINAL)
     Q_PROPERTY(QString gestureId READ gestureId WRITE setGestureId NOTIFY gestureIdChanged FINAL)
+    Q_PROPERTY(QString displayName READ displayName WRITE setDisplayName NOTIFY displayNameChanged FINAL)
     Q_PROPERTY(QString direction READ direction WRITE setDirection NOTIFY directionChanged FINAL)
     Q_PROPERTY(int fingersNum READ fingersNum WRITE setFingersNum NOTIFY fingersNumChanged FINAL)
     Q_PROPERTY(QString actionName READ actionName WRITE setActionName NOTIFY actionNameChanged FINAL)
@@ -25,6 +34,9 @@ public:
     QString gestureId() const;
     void setGestureId(const QString &newGestureId);
 
+    QString displayName() const;
+    void setDisplayName(const QString &newDisplayName);
+
     QString direction() const;
     void setDirection(const QString &newDirection);
 
@@ -37,24 +49,16 @@ public:
     int sequence() const;
     void setSequence(int newSequence);
 
-    QStringList actionNameList() const;
-    void setActionNameList(const QStringList &newActionNameList);
-
-    QStringList actionDescriptionList() const;
-    void setActionDescriptionList(const QStringList &newActionDescriptionList);
-
-    QList<QPair<QString, QString> > actionMaps() const;
-    void setActionMaps(const QList<QPair<QString, QString> > &newActionMaps);
-
-    void addActiosPair(const QPair<QString, QString> &actionPair);
-
-    QString getActionFromActionDec(QString actionDec);
+    QList<GestureActionData> actions() const;
+    void setActions(const QList<GestureActionData> &actions);
 
 signals:
 
     void actionTypeChanged();
 
     void gestureIdChanged();
+
+    void displayNameChanged();
 
     void directionChanged();
 
@@ -67,16 +71,17 @@ signals:
 private:
     QString m_actionType;
     QString m_gestureId;
+    QString m_displayName;
     QString m_direction;
     int m_fingersNum;
     QString m_actionName;
     int m_sequence = -1;
 
 
-    QList<QPair<QString, QString>> m_actionMaps;
-    QStringList m_actionNameList;
-    QStringList m_actionDescriptionList;
-
+    QList<GestureActionData> m_actions;
 };
+
+Q_DECLARE_METATYPE(GestureActionData)
+Q_DECLARE_METATYPE(QList<GestureActionData>)
 
 #endif // GESTUREDATA_H

--- a/src/plugin-mouse/operation/gesturemodel.cpp
+++ b/src/plugin-mouse/operation/gesturemodel.cpp
@@ -14,12 +14,11 @@ GestureModel::~GestureModel()
     qDeleteAll(m_gestures);
 }
 
-bool GestureModel::containsGestures(QString direction, int fingersNum)
+bool GestureModel::containsGesture(const QString &gestureId) const
 {
-    for (auto data : m_gestures) {
-        if (data->direction() == direction && data->fingersNum() == fingersNum) {
+    for (const GestureData *data : m_gestures) {
+        if (data->gestureId() == gestureId)
             return true;
-        }
     }
     return false;
 }
@@ -27,9 +26,11 @@ bool GestureModel::containsGestures(QString direction, int fingersNum)
 void GestureModel::updateGestureData(const GestureData &data)
 {
     for (int i = 0; i < m_gestures.size(); i++) {
-        if (data.direction() == m_gestures[i]->direction() && data.fingersNum() == m_gestures[i]->fingersNum()) {
+        if (data.gestureId() == m_gestures[i]->gestureId()) {
             m_gestures[i]->setGestureId(data.gestureId());
+            m_gestures[i]->setDisplayName(data.displayName());
             m_gestures[i]->setActionName(data.actionName());
+            m_gestures[i]->setActions(data.actions());
             QModelIndex modelIndex = createIndex(i, 0);
             emit dataChanged(modelIndex, modelIndex, {});
             return;
@@ -62,7 +63,7 @@ QVariant GestureModel::data(const QModelIndex &index, int role) const
         case IconRole:
             return getGesturesIconPath(data);
         case DescriptionRole:
-            return getGesturesDec(data);
+            return data->displayName();
         case ActionsIndexRole:
             return getGestureActionIndex(data);
         case ActionListRole:
@@ -73,42 +74,6 @@ QVariant GestureModel::data(const QModelIndex &index, int role) const
 
     // FIXME: Implement me!
     return QVariant();
-}
-
-QString GestureModel::getGesturesDec(GestureData *data) const
-{
-    QString description;
-    if (data->fingersNum() == 3) {
-        if (data->actionType() == "swipe") {
-            if (data->direction() == "up") {
-                description += tr("Three-finger up");
-            } else if (data->direction() == "down") {
-                description += tr("Three-finger down");
-            } else if (data->direction() == "left") {
-                description += tr("Three-finger left");
-            } else if (data->direction() == "right") {
-                description += tr("Three-finger right");
-            }
-        } else if (data->actionType() == "tap") {
-            description += tr("Three-finger tap");
-        }
-    } else if (data->fingersNum() == 4) {
-        if (data->actionType() == "swipe") {
-            if (data->direction() == "up") {
-                description += tr("Four-finger up");
-            } else if (data->direction() == "down") {
-                description += tr("Four-finger down");
-            } else if (data->direction() == "left") {
-                description += tr("Four-finger left");
-            } else if (data->direction() == "right") {
-                description += tr("Four-finger right");
-            }
-        } else if (data->actionType() == "tap") {
-            description += tr("Four-finger tap");
-        }
-    }
-
-    return description;
 }
 
 QString GestureModel::getGesturesIconPath(GestureData *data) const
@@ -123,10 +88,12 @@ QString GestureModel::getGesturesIconPath(GestureData *data) const
 QVariantList GestureModel::getGestureActionNames(GestureData *data) const
 {
     QVariantList gestureActionNames;
-    for (auto data : data->actionMaps()) {
+    for (const GestureActionData &action : data->actions()) {
         QVariantMap map;
-        map["actionText"] = data.second;
-        map["actionValue"] = data.first;
+        map["actionText"] = action.displayName;
+        map["actionValue"] = action.actionId;
+        map["supported"] = action.supported;
+        map["unavailableReason"] = action.unavailableReason;
         gestureActionNames.append(map);
     }
 
@@ -135,13 +102,13 @@ QVariantList GestureModel::getGestureActionNames(GestureData *data) const
 
 int GestureModel::getGestureActionIndex(GestureData *data) const
 {
-    auto maps = data->actionMaps();
-    for (int i = 0; i < maps.size(); i++) {
-        if (maps[i].first == data->actionName()) {
+    const QList<GestureActionData> actions = data->actions();
+    for (int i = 0; i < actions.size(); i++) {
+        if (actions[i].actionId == data->actionName()) {
             return i;
         }
     }
-    return 0;
+    return -1;
 }
 
 bool GestureModel::insertRows(int row, int count, const QModelIndex &parent)
@@ -191,18 +158,6 @@ void GestureModel::removeGestureData(GestureData *data)
     m_gestures.remove(index);
     endRemoveRows();
     delete data;
-}
-
-void GestureModel::updateGestureData(GestureData *data)
-{
-    for (int index = 0; index < m_gestures.count(); index++) {
-        if (m_gestures[index]->fingersNum() == data->fingersNum()
-            && m_gestures[index]->direction() == data->direction()) {
-            QModelIndex modelIndex = createIndex(index, 0);
-            emit dataChanged(modelIndex, modelIndex, {});
-            break;
-        }
-    }
 }
 
 GestureData *GestureModel::getGestureData(int index) const

--- a/src/plugin-mouse/operation/gesturemodel.h
+++ b/src/plugin-mouse/operation/gesturemodel.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef GESTUREMODEL_H
@@ -23,7 +23,7 @@ public:
     explicit GestureModel(QObject *parent = nullptr);
     ~GestureModel() override;
 
-    bool containsGestures(QString direction, int fingersNum);
+    bool containsGesture(const QString &gestureId) const;
     void updateGestureData(const GestureData &data);
 
     // Basic functionality:
@@ -31,7 +31,6 @@ public:
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
-    QString getGesturesDec(GestureData *data) const;
     QString getGesturesIconPath(GestureData *data) const;
     QVariantList getGestureActionNames(GestureData *data) const;
     int getGestureActionIndex(GestureData *data) const;
@@ -44,8 +43,6 @@ public:
 
     void addGestureData(GestureData *data);
     void removeGestureData(GestureData *data);
-    void updateGestureData(GestureData *data);
-
     GestureData *getGestureData(int index) const;
 
     QHash<int, QByteArray> roleNames() const override

--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -6,7 +6,6 @@
 
 #include <DGuiApplicationHelper>
 
-#include <QCoreApplication>
 #include <QJsonArray>
 #include <QDBusArgument>
 #include <QDBusConnection>
@@ -20,19 +19,42 @@
 
 using namespace DCC_NAMESPACE;
 
-// New API GestureInfo struct (dde-services)
+struct GestureActionInfoNew {
+    QString actionId;
+    QString displayName;
+    bool supported = false;
+    QString unavailableReason;
+};
+Q_DECLARE_METATYPE(GestureActionInfoNew)
+Q_DECLARE_METATYPE(QList<GestureActionInfoNew>)
+
+inline QDBusArgument &operator<<(QDBusArgument &argument, const GestureActionInfoNew &item) {
+    argument.beginStructure();
+    argument << item.actionId << item.displayName << item.supported << item.unavailableReason;
+    argument.endStructure();
+    return argument;
+}
+
+inline const QDBusArgument &operator>>(const QDBusArgument &argument, GestureActionInfoNew &item) {
+    argument.beginStructure();
+    argument >> item.actionId >> item.displayName >> item.supported >> item.unavailableReason;
+    argument.endStructure();
+    return argument;
+}
+
 struct GestureInfoNew {
     QString id;
     QString displayName;
-    QString category;               // Logical category key (mirrors dde-services GestureInfo)
-    int gestureType;                // 1=Swipe, 2=Hold
+    QString category;
+    int gestureType;
     int fingerCount;
-    int direction;                  // 0=None, 1=Down, 2=Left, 3=Up, 4=Right
+    int direction;
     int triggerType;
     QStringList triggerValue;
     QString localLanguageName;
-    QString localLanguageCategory;  // Resolved display text for the category
-    bool isCustom = false;          // True for runtime-added gestures
+    QString localLanguageCategory;
+    bool isCustom = false;
+    QList<GestureActionInfoNew> availableActions;
 };
 Q_DECLARE_METATYPE(GestureInfoNew)
 Q_DECLARE_METATYPE(QList<GestureInfoNew>)
@@ -42,7 +64,7 @@ inline QDBusArgument &operator<<(QDBusArgument &argument, const GestureInfoNew &
     argument << info.id << info.displayName << info.category
              << info.gestureType << info.fingerCount << info.direction
              << info.triggerType << info.triggerValue << info.localLanguageName
-             << info.localLanguageCategory << info.isCustom;
+             << info.localLanguageCategory << info.isCustom << info.availableActions;
     argument.endStructure();
     return argument;
 }
@@ -52,12 +74,11 @@ inline const QDBusArgument &operator>>(const QDBusArgument &argument, GestureInf
     argument >> info.id >> info.displayName >> info.category
              >> info.gestureType >> info.fingerCount >> info.direction
              >> info.triggerType >> info.triggerValue >> info.localLanguageName
-             >> info.localLanguageCategory >> info.isCustom;
+             >> info.localLanguageCategory >> info.isCustom >> info.availableActions;
     argument.endStructure();
     return argument;
 }
 
-// Map new API direction int to old API direction string
 static QString directionIntToString(int dir) {
     switch (dir) {
     case 1: return QStringLiteral("down");
@@ -70,7 +91,6 @@ static QString directionIntToString(int dir) {
     return QStringLiteral("none");
 }
 
-// Map new API gestureType to old API actionType string
 static QString gestureTypeToString(int type) {
     switch (type) {
     case 1: return QStringLiteral("swipe");
@@ -106,7 +126,6 @@ MouseDBusProxy::MouseDBusProxy(QObject *parent)
     , m_dbusTouchPadProperties(nullptr)
     , m_dbusTrackPointProperties(nullptr)
     , m_dbusDevicesProperties(nullptr)
-    , m_dbusGestureProperties(nullptr)
     , m_dbusMouse(nullptr)
     , m_dbusTouchPad(nullptr)
     , m_dbusTrackPoint(nullptr)
@@ -116,17 +135,16 @@ MouseDBusProxy::MouseDBusProxy(QObject *parent)
     , m_isWayland((qgetenv("XDG_SESSION_TYPE").toLower() == QLatin1String("wayland"))
                   || !qgetenv("WAYLAND_DISPLAY").isEmpty())
 {
+    qRegisterMetaType<GestureActionInfoNew>("GestureActionInfoNew");
+    qDBusRegisterMetaType<GestureActionInfoNew>();
+    qRegisterMetaType<QList<GestureActionInfoNew>>("QList<GestureActionInfoNew>");
+    qDBusRegisterMetaType<QList<GestureActionInfoNew>>();
     qRegisterMetaType<GestureInfoNew>("GestureInfoNew");
     qDBusRegisterMetaType<GestureInfoNew>();
     qRegisterMetaType<QList<GestureInfoNew>>("QList<GestureInfoNew>");
     qDBusRegisterMetaType<QList<GestureInfoNew>>();
 
     init();
-}
-
-bool MouseDBusProxy::isWayland() const
-{
-    return m_isWayland;
 }
 
 void MouseDBusProxy::active()
@@ -188,12 +206,7 @@ void MouseDBusProxy::active()
     bool lidIsPresent = getLidIsPresent();
     Q_EMIT lidIsPresentChanged(lidIsPresent);
 
-    if (isWayland()) {
-        refreshGestures();
-    } else {
-        QVariant gestureInfos = m_dbusGestureProperties->call("Get", GestureInterface, "Infos").arguments().at(0).value<QDBusVariant>().variant();
-        parseGesturesData(qvariant_cast<QDBusArgument>(gestureInfos));
-    }
+    refreshGestures();
 
     listCursor();
     auto cursorSize = m_appearance->property("CursorSize").toInt();
@@ -242,28 +255,10 @@ void MouseDBusProxy::init()
 
     QDBusConnection::sessionBus().connect(GestureService,
                                           GesturePath,
-                                          PropertiesInterface,
-                                          "PropertiesChanged",
-                                          "sa{sv}as",
+                                          GestureInterface,
+                                          "GestureInfosChanged",
                                           this,
-                                          SLOT(onGesturePropertiesChanged(QDBusMessage)));
-    if (!isWayland()) {
-        QDBusConnection::sessionBus().connect(GestureService,
-                                              GesturePath,
-                                              PropertiesInterface,
-                                              "PropertiesChanged",
-                                              "sa{sv}as",
-                                              this,
-                                              SLOT(onGesturePropertiesChanged(QDBusMessage)));
-    } else {
-        // Wayland: listen to GestureInfosChanged signal from new API
-        QDBusConnection::sessionBus().connect(GestureService,
-                                              GesturePath,
-                                              GestureInterface,
-                                              "GestureInfosChanged",
-                                              this,
-                                              SLOT(refreshGestures()));
-    }
+                                          SLOT(refreshGestures()));
 
     QDBusConnection::sessionBus().connect(AppearanceService,
                                           AppearancePath,
@@ -299,11 +294,6 @@ void MouseDBusProxy::init()
                                                  InputDevicesPath,
                                                  PropertiesInterface,
                                                  QDBusConnection::sessionBus());
-    m_dbusGestureProperties = new QDBusInterface(GestureService,
-                                                 GesturePath,
-                                                 PropertiesInterface,
-                                                 QDBusConnection::sessionBus());
-                                                
     m_appearance = new QDBusInterface(AppearanceService,
                                       AppearancePath,
                                       AppearanceInterface,
@@ -326,40 +316,6 @@ void MouseDBusProxy::init()
                                        GesturePath,
                                        GestureInterface,
                                        QDBusConnection::sessionBus());
-}
-
-void MouseDBusProxy::parseGesturesData(const QDBusArgument &argument)
-{
-    // 开始解析数组
-    argument.beginArray();
-    int seq = 0;
-    while (!argument.atEnd()) {
-
-        QString actionType, direction, actionName;
-        qint32 fingerNum;
-
-        // 开始解析 Struct of (String,String,Int32,String)
-        argument.beginStructure();
-
-        argument >> actionType;
-        argument >> direction;
-        argument >> fingerNum;
-        argument >> actionName;
-        argument.endStructure();
-
-        QVariantMap data;
-        data.insert("actionType", actionType);
-        data.insert("direction", direction);
-        data.insert("actionName", actionName);
-        data.insert("fingerNum", fingerNum);
-        data.insert("sequence", seq++);
-
-        QDBusPendingReply<QString> reply = m_dbusGesture->asyncCall("GetGestureAvaiableActions", actionType, fingerNum);
-        QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(reply, this);
-        watcher->setProperty("data", QVariant::fromValue(data));
-        connect(watcher, &QDBusPendingCallWatcher::finished, this, &MouseDBusProxy::onGetGestureAvaiableActionsFinished);
-    }
-    argument.endArray();
 }
 
 void MouseDBusProxy::onDefaultReset()
@@ -473,16 +429,18 @@ void MouseDBusProxy::setScrollSpeed(uint speed)
     m_dbusDevicesProperties->call("Set", InputDevicesInterface, "WheelSpeed", speed);
 }
 
-void MouseDBusProxy::setGesture(const QString& name, const QString& direction, int fingers, const QString& action)
+void MouseDBusProxy::setGesture(const QString &gestureId, const QString &actionId)
 {
-    if (isWayland()) {
-        // New API: ModifyGesture(id, action)
-        Q_UNUSED(direction);
-        Q_UNUSED(fingers);
-        m_dbusGesture->asyncCallWithArgumentList("ModifyGesture", { name, QStringList{action} });
-    } else {
-        m_dbusGesture->asyncCallWithArgumentList("SetGesture", { name, direction, fingers, action });
-    }
+    QDBusPendingCall call = m_dbusGesture->asyncCallWithArgumentList(
+        QStringLiteral("ModifyGesture"), {gestureId, QStringList{actionId}});
+    auto *watcher = new QDBusPendingCallWatcher(call, this);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher] {
+        QDBusPendingReply<bool> reply = *watcher;
+        if (reply.isError() || !reply.value())
+            qWarning() << "ModifyGesture failed:" << reply.error();
+        watcher->deleteLater();
+        refreshGestures();
+    });
 }
 
 void MouseDBusProxy::onMousePathPropertiesChanged(QDBusMessage msg)
@@ -602,93 +560,41 @@ void MouseDBusProxy::onInputDevicesPathPropertiesChanged(QDBusMessage msg)
     }
 }
 
-void MouseDBusProxy::onGesturePropertiesChanged(QDBusMessage msg)
-{
-    QList<QVariant> arguments = msg.arguments();
-    if (3 != arguments.count()) {
-        return;
-    }
-    QString interfaceName = msg.arguments().at(0).toString();
-    if (interfaceName == GestureInterface) {
-        QVariantMap changedProps = qdbus_cast<QVariantMap>(arguments.at(1).value<QDBusArgument>());
-        QStringList keys = changedProps.keys();
-        for (int i = 0; i < keys.size(); i++) {
-            if (keys.at(i) == "Infos") {
-                parseGesturesData(qvariant_cast<QDBusArgument>(changedProps.value(keys.at(i))));
-            }
-        }
-    }
-}
-
-namespace {
-struct GestureActionItem {
-    QString value;     // Treeland action enum as string ("11" etc.), or "Disable" sentinel
-    const char *trKey; // Source string for QCoreApplication::translate("MouseDBusProxy", ...)
-};
-
-static const QList<GestureActionItem> kThreeFingerActions = {
-    {"11",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Maximize window")},
-    {"12",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Restore window")},
-    {"10",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Show desktop")},
-    {"20",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Lock screen")},
-    {"16",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Multitasking view")},
-    {"Disable",  QT_TRANSLATE_NOOP("MouseDBusProxy", "Disable")},
-};
-
-static const QList<GestureActionItem> kFourFingerActions = {
-    {"8",        QT_TRANSLATE_NOOP("MouseDBusProxy", "Switch to previous workspace")},
-    {"9",        QT_TRANSLATE_NOOP("MouseDBusProxy", "Switch to next workspace")},
-    {"16",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Multitasking view")},
-    {"17",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Hide multitasking view")},
-    {"18",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Toggle multitasking view")},
-    {"10",       QT_TRANSLATE_NOOP("MouseDBusProxy", "Show desktop")},
-    {"Disable",  QT_TRANSLATE_NOOP("MouseDBusProxy", "Disable")},
-};
-}  // namespace
-
 static void fillGestureData(GestureData *data, const GestureInfoNew &info)
 {
     data->setActionType(gestureTypeToString(info.gestureType));
     data->setGestureId(info.id);
+    data->setDisplayName(info.localLanguageName.isEmpty() ? info.displayName
+                                                          : info.localLanguageName);
     data->setDirection(directionIntToString(info.direction));
     data->setFingersNum(info.fingerCount);
-    // Empty triggerValue (corner case) is treated as Disable so the UI auto-selects it.
-    data->setActionName(info.triggerValue.isEmpty() ? QStringLiteral("Disable") : info.triggerValue.first());
-}
-
-// Translate an action table once into (value, localized-description) pairs.
-// Hoisted out of the per-gesture loop so the ~6 translate() calls per table run
-// once per refresh instead of once per gesture.
-static QList<QPair<QString, QString>> buildTranslatedActions(const QList<GestureActionItem> &table)
-{
-    QList<QPair<QString, QString>> out;
-    out.reserve(table.size());
-    for (const auto &item : table)
-        out.append({ item.value, QCoreApplication::translate("MouseDBusProxy", item.trKey) });
-    return out;
+    data->setActionName(info.triggerValue.isEmpty() ? QStringLiteral("0")
+                                                    : info.triggerValue.first());
 }
 
 void MouseDBusProxy::onListAllGesturesNewFinished(QDBusPendingCallWatcher *w)
 {
     QDBusPendingReply<QList<GestureInfoNew>> reply = *w;
     if (!reply.isError()) {
-        // The server re-emits GestureInfosChanged after every ModifyGesture
-        // (including the UI's own edits), so this handler re-lists the full set
-        // on each change. That full re-list is inherent to the signal design and
-        // left as-is; only the redundant per-gesture re-translation of the two
-        // action tables is hoisted out — build them once and reuse.
-        const QList<QPair<QString, QString>> threeFingerActions = buildTranslatedActions(kThreeFingerActions);
-        const QList<QPair<QString, QString>> fourFingerActions = buildTranslatedActions(kFourFingerActions);
-        for (const auto &info : reply.value()) {
+        int sequence = 0;
+        for (const GestureInfoNew &info : reply.value()) {
+            if (info.isCustom)
+                continue;
             GestureData data;
             fillGestureData(&data, info);
-            const auto &actions = (info.fingerCount == 3) ? threeFingerActions : fourFingerActions;
-            for (const auto &pair : actions)
-                data.addActiosPair(pair);
+            data.setSequence(sequence);
+
+            QList<GestureActionData> actions;
+            for (const GestureActionInfoNew &item : info.availableActions) {
+                actions.append({item.actionId, item.displayName, item.supported,
+                                item.unavailableReason});
+            }
+            data.setActions(actions);
             Q_EMIT gestureDataChanged(data);
+            ++sequence;
         }
     } else {
-        qWarning() << "Wayland ListAllGestures failed:" << reply.error();
+        qWarning() << "ListAllGestures failed:" << reply.error();
     }
     w->deleteLater();
 }
@@ -712,43 +618,6 @@ void MouseDBusProxy::onAppearancePropertiesChanged(QDBusMessage msg)
             }
         }
     }
-}
-
-void MouseDBusProxy::onGetGestureAvaiableActionsFinished(QDBusPendingCallWatcher *w)
-{
-    QVariantMap dbusData = w->property("data").toMap();
-
-    GestureData data;
-    data.setActionType(dbusData.value("actionType").toString());
-    data.setDirection(dbusData.value("direction").toString());
-    data.setActionName(dbusData.value("actionName").toString());
-    data.setFingersNum(dbusData.value("fingerNum").toInt());
-    data.setSequence(dbusData.value("sequence", -1).toInt());
-    QDBusPendingReply<QString> reply = *w;
-    if (!reply.isError()) {
-        QString actions = reply.value();
-        QJsonDocument document = QJsonDocument::fromJson(actions.toUtf8());
-
-        if (document.isArray()) {
-            QJsonArray array = document.array();
-            QStringList actionNameList;
-            QStringList actionDescriptionList;
-            for (int i = 0; i < array.size(); ++i) {
-                QJsonValue value = array.at(i);
-                if (value.isObject()) {
-                    QJsonObject object = value.toObject();
-
-                    QPair<QString, QString> actionPair;
-                    actionPair.first = object.value("Name").toString();
-                    actionPair.second = object.value("Description").toString();
-                    data.addActiosPair(actionPair);
-                }
-            }
-        }
-    }
-
-    Q_EMIT gestureDataChanged(data);
-    w->deleteLater();
 }
 
 void MouseDBusProxy::listCursor()

--- a/src/plugin-mouse/operation/mousedbusproxy.h
+++ b/src/plugin-mouse/operation/mousedbusproxy.h
@@ -22,8 +22,6 @@ public:
     void deactive();
     void init();
 
-    void parseGesturesData(const QDBusArgument &argument);
-
 Q_SIGNALS:
     void mouseExistChanged(bool exist);
     void tpadExistChanged(bool exist);
@@ -82,30 +80,22 @@ public Q_SLOTS:
     void setScrollSpeed(uint speed);
     bool getLidIsPresent();
 
-    void setGesture(const QString& name, const QString& direction, int fingers, const QString& action);
+    void setGesture(const QString &gestureId, const QString &actionId);
 
     void onMousePathPropertiesChanged(QDBusMessage msg);
     void onTouchpadPathPropertiesChanged(QDBusMessage msg);
     void onTrackpointPathPropertiesChanged(QDBusMessage msg);
     void onInputDevicesPathPropertiesChanged(QDBusMessage msg);
-    void onGesturePropertiesChanged(QDBusMessage msg);
     void onAppearancePropertiesChanged(QDBusMessage msg);
 
-    void onGetGestureAvaiableActionsFinished(QDBusPendingCallWatcher *w);
-
-    // New API adapters (Wayland)
     void refreshGestures();
     void onListAllGesturesNewFinished(QDBusPendingCallWatcher *w);
 
 private:
-    bool isWayland() const;
-
     QDBusInterface *m_dbusMouseProperties;
     QDBusInterface *m_dbusTouchPadProperties;
     QDBusInterface *m_dbusTrackPointProperties;
     QDBusInterface *m_dbusDevicesProperties;
-    QDBusInterface *m_dbusGestureProperties;
-
     QDBusInterface *m_dbusMouse;
     QDBusInterface *m_dbusTouchPad;
     QDBusInterface *m_dbusTrackPoint;

--- a/src/plugin-mouse/operation/mousemodel.cpp
+++ b/src/plugin-mouse/operation/mousemodel.cpp
@@ -6,8 +6,36 @@
 #include "mouseworker.h"
 #include "mousedbusproxy.h"
 #include <QFile>
+#include <QHash>
 
 using namespace DCC_NAMESPACE;
+
+namespace {
+
+QString gestureActionIconName(const QString &actionId)
+{
+    static const QHash<QString, QString> iconNames = {
+        {QStringLiteral("11"), QStringLiteral("MaximizeWindow")},
+        {QStringLiteral("12"), QStringLiteral("RestoreWindow")},
+        {QStringLiteral("100"), QStringLiteral("SplitWindowLeft")},
+        {QStringLiteral("101"), QStringLiteral("SplitWindowRight")},
+        {QStringLiteral("16"), QStringLiteral("ShowMultiTask")},
+        {QStringLiteral("17"), QStringLiteral("HideMultitask")},
+        {QStringLiteral("18"), QStringLiteral("ShowMultiTask")},
+        {QStringLiteral("8"), QStringLiteral("SwitchToPreDesktop")},
+        {QStringLiteral("9"), QStringLiteral("SwitchToNextDesktop")},
+        {QStringLiteral("10"), QStringLiteral("ShowDesktop")},
+        {QStringLiteral("102"), QStringLiteral("HideDesktop")},
+        {QStringLiteral("103"), QStringLiteral("ToggleGrandSearch")},
+        {QStringLiteral("104"), QStringLiteral("ToggleLaunchPad")},
+        {QStringLiteral("105"), QStringLiteral("ToggleClipboard")},
+        {QStringLiteral("106"), QStringLiteral("ToggleNotifications")}
+    };
+    return iconNames.value(actionId);
+}
+
+}
+
 MouseModel::MouseModel(QObject *parent)
     : QObject(parent)
     , m_leftHandState(false)
@@ -296,17 +324,18 @@ void MouseModel::updateGesturesData(const GestureData &gestureData)
         return;
     }
 
-    if (gestureModel->containsGestures(gestureData.direction(), gestureData.fingersNum())) {
+    if (gestureModel->containsGesture(gestureData.gestureId())) {
         gestureModel->updateGestureData(gestureData);
     } else {
         GestureData *data = new GestureData(this);
         data->setActionType(gestureData.actionType());
         data->setGestureId(gestureData.gestureId());
+        data->setDisplayName(gestureData.displayName());
         data->setDirection(gestureData.direction());
         data->setActionName(gestureData.actionName());
         data->setFingersNum(gestureData.fingersNum());
         data->setSequence(gestureData.sequence());
-        data->setActionMaps(gestureData.actionMaps());
+        data->setActions(gestureData.actions());
         gestureModel->addGestureData(data);
     }
 }
@@ -339,11 +368,7 @@ void MouseModel::setGestures(int fingerNum, int index, QString actionName)
             return;
 
         updateFigerAniPath(actionName, data);
-        const QString gestureName = data->gestureId().isEmpty() ? data->actionType() : data->gestureId();
-        Q_EMIT m_worker->requestSetGesture(gestureName,
-                                           data->direction(),
-                                           data->fingersNum(),
-                                           actionName);
+        Q_EMIT m_worker->requestSetGesture(data->gestureId(), actionName);
     }
 }
 
@@ -425,7 +450,11 @@ void MouseModel::updateFigerAniPath(QString actionName, GestureData *data)
                                     .arg(themeColor)
                                     .arg(fingerNum)
                                     .arg(gestureDirection));
-    setGestureActionAniPath(QString("qrc:/icons/deepin/builtin/icons/%1/%2.webp").arg(themeColor).arg(actionName));
+    const QString actionIconName = gestureActionIconName(actionName);
+    setGestureActionAniPath(actionIconName.isEmpty()
+                    ? QString()
+                    : QString("qrc:/icons/deepin/builtin/icons/%1/%2.webp")
+                              .arg(themeColor, actionIconName));
 }
 
 void MouseModel::updateFigerAniPath(const Dtk::Gui::DGuiApplicationHelper::ColorType &newThemeType)

--- a/src/plugin-mouse/operation/mouseworker.h
+++ b/src/plugin-mouse/operation/mouseworker.h
@@ -90,7 +90,7 @@ Q_SIGNALS:
     void requestSetTouchpadMotionAcceleration(const double &value);
     void requestSetTrackPointMotionAcceleration(const double &value);
     void requestSetTouchpadEnabled(const bool state);
-    void requestSetGesture(const QString& name, const QString& direction, int fingers, const QString& action);
+    void requestSetGesture(const QString &gestureId, const QString &actionId);
     void requestSetCursorSize(const int cursorSize);
 
 private:

--- a/src/plugin-mouse/qml/GestureGroup.qml
+++ b/src/plugin-mouse/qml/GestureGroup.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
@@ -58,6 +58,21 @@ Rectangle {
                     currentIndex: comboIndex
                     editable: false
                     flat: true
+                    delegate: D.MenuItem {
+                        id: actionItem
+                        useIndicatorPadding: true
+                        width: combo.width
+                        text: modelData.actionText
+                        enabled: modelData.supported
+                        highlighted: combo.isInteractingWithContent
+                                && combo.highlightedIndex === index
+                        hoverEnabled: true
+                        autoExclusive: true
+                        checked: combo.currentIndex === index
+                        implicitHeight: DS.Style.control.implicitHeight(actionItem)
+                        ToolTip.visible: hovered && !modelData.supported && modelData.unavailableReason.length > 0
+                        ToolTip.text: modelData.unavailableReason
+                    }
                     onActivated: {
                         root.comboIndexChanged(itemCtl.delegateIndex, combo.currentValue)
                     }

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -2274,6 +2274,17 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
 </context>
 <context>
+    <name>KeyboardWorker</name>
+    <message>
+        <source>The shortcut service is unavailable. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>LangAndFormat</name>
     <message>
         <source>Language</source>
@@ -3378,6 +3389,22 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Replace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start shortcut capture. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>click Replace to make this shortcut key effective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3454,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to start shortcut capture. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -4353,6 +4388,29 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <name>dccV25::KeyboardController</name>
     <message>
         <source>This shortcut conflicts with [%1]</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The shortcut no longer exists.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>The shortcut conflict is no longer current.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Please confirm the shortcut conflict again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::KeyboardWorker</name>
+    <message>
+        <source>The shortcut conflict is no longer current.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -2205,7 +2205,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Three-finger tap</source>
-        <translation>三指点击</translation>
+        <translation>三指短按</translation>
     </message>
     <message>
         <source>Four-finger up</source>
@@ -2225,7 +2225,7 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Four-finger tap</source>
-        <translation>四指点击</translation>
+        <translation>四指短按</translation>
     </message>
 </context>
 <context>
@@ -2264,6 +2264,28 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Enable all interface and window effects for the best visual experience.</source>
         <translation>启用所有界面和窗口特效，体验最佳视觉效果</translation>
+    </message>
+</context>
+<context>
+    <name>KeyboardWorker</name>
+    <message>
+        <source>The shortcut service is unavailable. Please try again.</source>
+        <translation>快捷键服务不可用，请重试。</translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
+        <translation>保存快捷键失败，请重试。</translation>
+    </message>
+</context>
+<context>
+    <name>dccV25::KeyboardWorker</name>
+    <message>
+        <source>The shortcut conflict is no longer current.</source>
+        <translation>快捷键冲突状态已失效。</translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
+        <translation>保存快捷键失败，请重试。</translation>
     </message>
 </context>
 <context>
@@ -3389,6 +3411,22 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation>点击添加使这个快捷键生效</translation>
     </message>
+    <message>
+        <source>Replace</source>
+        <translation>替换</translation>
+    </message>
+    <message>
+        <source>Failed to start shortcut capture. Please try again.</source>
+        <translation>启动快捷键录入失败，请重试。</translation>
+    </message>
+    <message>
+        <source>click Replace to make this shortcut key effective</source>
+        <translation>点击替换使这个快捷键生效</translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
+        <translation>保存快捷键失败，请重试。</translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3465,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Replace</source>
         <translation>替换</translation>
+    </message>
+    <message>
+        <source>Failed to start shortcut capture. Please try again.</source>
+        <translation>启动快捷键录入失败，请重试。</translation>
+    </message>
+    <message>
+        <source>Failed to save the shortcut. Please try again.</source>
+        <translation>保存快捷键失败，请重试。</translation>
     </message>
     <message>
         <source>Restore default</source>
@@ -4365,6 +4411,18 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>This shortcut conflicts with [%1]</source>
         <translation>此快捷键与[%1]冲突</translation>
+    </message>
+    <message>
+        <source>The shortcut no longer exists.</source>
+        <translation>快捷键已不存在。</translation>
+    </message>
+    <message>
+        <source>The shortcut conflict is no longer current.</source>
+        <translation>快捷键冲突状态已失效。</translation>
+    </message>
+    <message>
+        <source>Please confirm the shortcut conflict again.</source>
+        <translation>请重新确认快捷键冲突。</translation>
     </message>
 </context>
 <context>


### PR DESCRIPTION
## Summary

- Unify X11 and Wayland shortcut management through dde-services, including capture, conflict replacement, and custom shortcut CRUD.
- Load gesture actions and availability information from dde-services.
- Improve asynchronous command loading, save handling, and visible error feedback in QML.

## Test plan

- git diff --check
- cmake --build build --target keyboard keyboard_qml mouse mouse_qml -j2
- cmake --build build --target keyboard_qml_qmllint mouse_qml_qmllint -j2

Pms: TASK-393199