### PR TITLE
fix: refactor account group list to simplify focus and event handling

### DIFF
--- a/src/plugin-accounts/operation/accountlistmodel.cpp
+++ b/src/plugin-accounts/operation/accountlistmodel.cpp
@@ -1,8 +1,15 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #include "accountlistmodel.h"
 #include "accountscontroller.h"
+
+namespace
+{
+    constexpr const char* const kTypeHeader = "header";
+    constexpr const char* const kTypeFooter = "footer";
+    constexpr const char* const kTypeGroup = "group";
+}
 
 using namespace dccV25;
 AccountListModel::AccountListModel(QObject *parent)
@@ -183,4 +190,173 @@ QHash<int, QByteArray> GroupListModel::roleNames() const
     names[EditAbleRole] = "groupEditAble";
     names[EnableRole] = "groupEnabled";
     return names;
+}
+
+/////////////////////////
+/// GroupListProxyModel
+GroupListProxyModel::GroupListProxyModel(QObject *parent)
+    : QAbstractProxyModel(parent)
+{
+}
+
+void GroupListProxyModel::setSourceModel(QAbstractItemModel *model)
+{
+    auto *oldModel = sourceModel();
+    if (oldModel == model)
+        return;
+
+    beginResetModel();
+
+    if (oldModel) {
+        disconnect(oldModel, nullptr, this, nullptr);
+    }
+
+    QAbstractProxyModel::setSourceModel(model);
+
+    if (auto *newModel = sourceModel()) {
+        auto *groupModel = qobject_cast<GroupListModel *>(newModel);
+        if (groupModel) {
+            connect(groupModel, &GroupListModel::groupsUpdated, this, &GroupListProxyModel::groupsUpdated);
+        }
+        connect(newModel, &QAbstractItemModel::rowsAboutToBeInserted, this, [this](const QModelIndex &, int first, int last) {
+            beginInsertRows(QModelIndex(), toProxyRow(first), toProxyRow(last));
+        });
+        connect(newModel, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex &, int, int) {
+            endInsertRows();
+        });
+        connect(newModel, &QAbstractItemModel::rowsAboutToBeRemoved, this, [this](const QModelIndex &, int first, int last) {
+            beginRemoveRows(QModelIndex(), toProxyRow(first), toProxyRow(last));
+        });
+        connect(newModel, &QAbstractItemModel::rowsRemoved, this, [this](const QModelIndex &, int, int) {
+            endRemoveRows();
+        });
+        connect(newModel, &QAbstractItemModel::dataChanged, this, [this](const QModelIndex &topLeft, const QModelIndex &bottomRight, const QList<int> &roles) {
+            Q_EMIT dataChanged(index(toProxyRow(topLeft.row()), 0), index(toProxyRow(bottomRight.row()), 0), roles);
+        });
+        connect(newModel, &QAbstractItemModel::modelAboutToBeReset, this, [this]() {
+            beginResetModel();
+        });
+        connect(newModel, &QAbstractItemModel::modelReset, this, [this]() {
+            endResetModel();
+        });
+    }
+
+    endResetModel();
+}
+
+QModelIndex GroupListProxyModel::mapToSource(const QModelIndex &proxyIndex) const
+{
+    if (!proxyIndex.isValid() || !sourceModel())
+        return QModelIndex();
+
+    int row = proxyIndex.row();
+    if (isHeaderRow(row) || isFooterRow(row))
+        return QModelIndex();
+
+    return sourceModel()->index(toSourceRow(row), proxyIndex.column());
+}
+
+QModelIndex GroupListProxyModel::mapFromSource(const QModelIndex &sourceIndex) const
+{
+    if (!sourceIndex.isValid() || !sourceModel())
+        return QModelIndex();
+
+    return createIndex(toProxyRow(sourceIndex.row()), sourceIndex.column());
+}
+
+int GroupListProxyModel::rowCount(const QModelIndex &parent) const
+{
+    if (parent.isValid() || !sourceModel())
+        return 0;
+
+    return sourceModel()->rowCount() + 2;
+}
+
+int GroupListProxyModel::columnCount(const QModelIndex &parent) const
+{
+    if (parent.isValid() || !sourceModel())
+        return 0;
+
+    return sourceModel()->columnCount();
+}
+
+QModelIndex GroupListProxyModel::index(int row, int column, const QModelIndex &parent) const
+{
+    if (parent.isValid())
+        return QModelIndex();
+
+    if (row < 0 || row >= rowCount() || column < 0)
+        return QModelIndex();
+
+    return createIndex(row, column);
+}
+
+QModelIndex GroupListProxyModel::parent(const QModelIndex &) const
+{
+    return QModelIndex();
+}
+
+QVariant GroupListProxyModel::data(const QModelIndex &index, int role) const
+{
+    if (!index.isValid())
+        return QVariant();
+
+    int row = index.row();
+
+    if (role == TypeRole) {
+        if (isHeaderRow(row))
+            return QString::fromUtf8(kTypeHeader);
+        if (isFooterRow(row))
+            return QString::fromUtf8(kTypeFooter);
+        return QString::fromUtf8(kTypeGroup);
+    }
+
+    if (isHeaderRow(row) || isFooterRow(row))
+        return QVariant();
+
+    QModelIndex sourceIndex = mapToSource(index);
+    if (!sourceIndex.isValid())
+        return QVariant();
+
+    return sourceModel()->data(sourceIndex, role);
+}
+
+QHash<int, QByteArray> GroupListProxyModel::roleNames() const
+{
+    auto names = sourceModel() ? sourceModel()->roleNames() : QHash<int, QByteArray>();
+    names[TypeRole] = "type";
+    return names;
+}
+
+bool GroupListProxyModel::isCreatingGroup() const
+{
+    auto *groupModel = qobject_cast<GroupListModel *>(sourceModel());
+    return groupModel ? groupModel->isCreatingGroup() : false;
+}
+
+void GroupListProxyModel::setCreatingGroup(bool isCreatingGroup)
+{
+    auto *groupModel = qobject_cast<GroupListModel *>(sourceModel());
+    if (groupModel)
+        groupModel->setCreatingGroup(isCreatingGroup);
+}
+
+int GroupListProxyModel::toProxyRow(int sourceRow) const 
+{
+    return sourceRow + 1;
+}
+
+int GroupListProxyModel::toSourceRow(int proxyRow) const 
+{
+    return proxyRow - 1;
+}
+
+bool GroupListProxyModel::isHeaderRow(int row) const 
+{
+    return row < 1;
+}
+
+bool GroupListProxyModel::isFooterRow(int row) const
+{
+    return row >= rowCount() - 1;
 }

--- a/src/plugin-accounts/operation/accountlistmodel.h
+++ b/src/plugin-accounts/operation/accountlistmodel.h
@@ -1,10 +1,11 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #ifndef ACCOUNTLISTMODEL_H
 #define ACCOUNTLISTMODEL_H
 
 #include <QAbstractListModel>
+#include <QAbstractProxyModel>
 namespace dccV25 {
 class AccountListModel : public QAbstractListModel
 {
@@ -56,6 +57,41 @@ private:
     QString m_userId;
     QStringList m_groups;
     bool m_isCreatingGroup = false;
+};
+
+class GroupListProxyModel : public QAbstractProxyModel
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isCreatingGroup READ isCreatingGroup WRITE setCreatingGroup)
+public:
+    explicit GroupListProxyModel(QObject *parent = nullptr);
+
+    enum ProxyRole {
+        TypeRole = Qt::UserRole + 100
+    };
+
+    void setSourceModel(QAbstractItemModel *sourceModel) override;
+    QModelIndex mapToSource(const QModelIndex &proxyIndex) const override;
+    QModelIndex mapFromSource(const QModelIndex &sourceIndex) const override;
+
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    int columnCount(const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const override;
+    QModelIndex parent(const QModelIndex &child) const override;
+    QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+    QHash<int, QByteArray> roleNames() const override;
+
+    bool isCreatingGroup() const;
+    Q_INVOKABLE void setCreatingGroup(bool isCreatingGroup);
+
+signals:
+    void groupsUpdated();
+
+private:
+    int toProxyRow(int sourceRow) const;
+    int toSourceRow(int proxyRow) const;
+    bool isHeaderRow(int row) const;
+    bool isFooterRow(int row) const;
 };
 
 }

--- a/src/plugin-accounts/operation/accountscontroller.cpp
+++ b/src/plugin-accounts/operation/accountscontroller.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -732,15 +732,21 @@ QAbstractListModel *AccountsController::accountsModel()
     return m_accountsModel;
 }
 
-QAbstractListModel *AccountsController::groupsModel(const QString &id)
+QAbstractItemModel *AccountsController::groupsModel(const QString &id)
 {
     if (m_groupsModel) {
-        static_cast<GroupListModel*>(m_groupsModel)->setUserId(id);
+        auto *proxy = qobject_cast<GroupListProxyModel *>(m_groupsModel);
+        auto *source = proxy ? qobject_cast<GroupListModel *>(proxy->sourceModel()) : nullptr;
+        if (source)
+            source->setUserId(id);
+
         return m_groupsModel;
     }
 
-    auto groupsModel = new GroupListModel(id, this);
-    m_groupsModel = groupsModel;
+    auto *groupsModel = new GroupListModel(id, this);
+    auto *proxyModel = new GroupListProxyModel(this);
+    proxyModel->setSourceModel(groupsModel);
+    m_groupsModel = proxyModel;
     return m_groupsModel;
 }
 

--- a/src/plugin-accounts/operation/accountscontroller.h
+++ b/src/plugin-accounts/operation/accountscontroller.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -84,7 +84,7 @@ public slots:
     QSortFilterProxyModel *avatarFilterModel();
     QAbstractListModel *avatarTypesModel();
     QAbstractListModel *accountsModel();
-    QAbstractListModel *groupsModel(const QString &id);
+    QAbstractItemModel *groupsModel(const QString &id);
 
     int passwordLevel(const QString &pwd);
     QString checkUsername(const QString &name);
@@ -134,7 +134,7 @@ private:
     QAbstractListModel    *m_avatarTypesModel = nullptr;
     QAbstractListModel    *m_accountsModel = nullptr;
     QHash<QString, QStringList> m_groups;
-    QAbstractListModel    *m_groupsModel = nullptr;
+    QAbstractItemModel    *m_groupsModel = nullptr;
     bool m_isCreatingUser = false;
 };
 

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -3,6 +3,7 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
+import Qt.labs.qmlmodels
 import org.deepin.dcc 1.0
 import org.deepin.dtk 1.0
 import org.deepin.dtk.style 1.0 as DS
@@ -760,14 +761,9 @@ DccObject {
                 id: groupview
                 property int lrMargin: DccUtils.getMargin(width)
                 property int conY: 0
-                property bool blockInitialFocus: false
-                property bool focusNewlyCreatedItem: false
-                property bool mousePressed: false
-                property Item headerEditButton
-                property Item addGroupButton
+                property bool resetActive: false
                 spacing: 0
                 currentIndex: -1
-                activeFocusOnTab: true
                 keyNavigationEnabled: true
                 clip: false
 
@@ -775,65 +771,11 @@ DccObject {
                 displayMarginBeginning: height * 2
                 displayMarginEnd: height * 2
 
-                MouseArea {
-                    anchors.fill: parent
-                    propagateComposedEvents: true
-                    onPressed: function(mouse) {
-                        groupview.mousePressed = true
-                        mouse.accepted = false
-                    }
-                    onReleased: function(mouse) {
-                        groupview.mousePressed = false
-                        mouse.accepted = false
-                    }
-                }
-
-                onActiveFocusChanged: {
-                    if (activeFocus && count > 0) {
-                        if (focusNewlyCreatedItem) {
-                            return
-                        }
-                        if (blockInitialFocus) {
-                            if (model && model.isCreatingGroup) {
-                                blockInitialFocus = false
-                                return
-                            }
-                            blockInitialFocus = false
-                            if (mousePressed) {
-                                mousePressed = false
-                                return
-                            }
-                            focus = false
-                            return
-                        }
-                        if (groupview.headerEditButton && !mousePressed) {
-                            groupview.headerEditButton.forceActiveFocus(Qt.TabFocusReason)
-                            return
-                        }
-                        if (mousePressed) {
-                            mousePressed = false
-                        }
-                    }
-                }
-
-                onCurrentIndexChanged: {
-                    if (activeFocus && currentItem) {
-                        currentItem.forceActiveFocus()
-                    }
-                }
-
-                function qmlListModelUpdata() {
+                function qmlListModelUpdate() {
                     if (model && model.isCreatingGroup) {
                         model.setCreatingGroup(false)
                         Qt.callLater(function () {
                             groupview.positionViewAtEnd()
-                            if (groupview.focusNewlyCreatedItem && groupview.count > 0) {
-                                groupview.currentIndex = groupview.count - 1
-                                if (groupview.currentItem && groupview.currentItem.forceActiveFocus) {
-                                    groupview.currentItem.forceActiveFocus()
-                                }
-                                groupview.focusNewlyCreatedItem = false
-                            }
                         })
                     } else {
                         groupview.contentY = conY
@@ -841,489 +783,438 @@ DccObject {
                 }
 
                 Connections {
-                    target: model
+                    target: groupview.model
                     function onGroupsUpdated() {
-                        qmlListModelUpdata()
+                        qmlListModelUpdate()
+                    }
+                }
+
+                Connections {
+                    target: groupview.model
+                    function onModelAboutToBeReset() {
+                        conY = groupview.contentY
+                        resetActive = true
+                    }
+                    function onModelReset() {
+                        Qt.callLater(function() {
+                            groupview.contentY = conY
+                            resetActive = false
+                        })
                     }
                 }
 
                 onContentYChanged: {
-                    if(contentY != -50) {
+                    if (!resetActive && contentY != -50) {
                         conY = contentY
                     }
-                }
-                anchors {
-                    left: parent ? parent.left : undefined
-                    right: parent ? parent.right : undefined
                 }
 
                 ScrollBar.vertical: ScrollBar { }
 
-                header: Item {
-                    implicitHeight: 50
-                    anchors {
-                        left: parent ? parent.left : undefined
-                        right: parent ? parent.right : undefined
-                        leftMargin: groupview.lrMargin
-                        rightMargin: groupview.lrMargin
-                    }
-                    RowLayout {
-                        anchors.fill: parent
-                        DccLabel {
-                            Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
-                            Layout.leftMargin: 10
-                            font.pixelSize: DTK.fontManager.t5.pixelSize
-                            font.weight: 700
-                            text: dccObj.displayName
-                        }
+                model: settings.userId.length > 0 ? dccData.groupsModel(settings.userId)  : null
 
-                        Button {
-                            id: button
-                            checkable: true
-                            checked: groupSettings.isEditing
-                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                            Layout.rightMargin: 10
-                            text: groupSettings.isEditing ? qsTr("done") : qsTr("edit")
-                            font: DTK.fontManager.t8
-                            focusPolicy: Qt.TabFocus
-                            activeFocusOnTab: true
-                            background: Rectangle {
-                                radius: addGroupButton.background.radius
-                                color: "transparent"
-                                border.color: parent.palette.highlight
-                                border.width: button.activeFocus ? 2 : 0
+                delegate: DelegateChooser {
+                    role: "type"
+
+                    DelegateChoice {
+                        roleValue: "header"
+                        delegate: Item {
+                            implicitHeight: 50
+                            anchors {
+                                left: parent ? parent.left : undefined
+                                right: parent ? parent.right : undefined
+                                leftMargin: groupview.lrMargin
+                                rightMargin: groupview.lrMargin
                             }
-                            Keys.onPressed: function(event) {
-                                if (event.key === Qt.Key_Tab && !event.isAutoRepeat) {
-                                    event.accepted = true
-                                    groupview.blockInitialFocus = false
-                                    groupview.currentIndex = 0
-                                    groupview.positionViewAtIndex(0, ListView.Beginning)
-                                    Qt.callLater(function() {
-                                        if (groupview.currentItem && groupview.currentItem.forceActiveFocus) {
-                                            groupview.currentItem.forceActiveFocus(Qt.TabFocusReason)
+                            RowLayout {
+                                anchors.fill: parent
+                                DccLabel {
+                                    Layout.alignment: Qt.AlignLeft | Qt.AlignVCenter
+                                    Layout.leftMargin: 10
+                                    font.pixelSize: DTK.fontManager.t5.pixelSize
+                                    font.weight: 700
+                                    text: groupSettings.displayName
+                                }
+
+                                Button {
+                                    id: headerEditButton
+                                    checkable: true
+                                    checked: groupSettings.isEditing
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    Layout.rightMargin: 10
+                                    text: groupSettings.isEditing ? qsTr("done") : qsTr("edit")
+                                    font: DTK.fontManager.t8
+                                    focusPolicy: Qt.TabFocus
+                                    activeFocusOnTab: true
+                                    background: Rectangle {
+                                        radius: 8
+                                        color: "transparent"
+                                        border.color: parent.palette.highlight
+                                        border.width: headerEditButton.activeFocus ? 2 : 0
+                                    }
+                                    textColor: Palette {
+                                        normal {
+                                            common: DTK.makeColor(Color.Highlight)
+                                            crystal: DTK.makeColor(Color.Highlight)
                                         }
-                                    })
-                                    return
+                                    }
+                                    onCheckedChanged: {
+                                        groupSettings.isEditing = headerEditButton.checked
+                                    }
                                 }
-                            }
-                            Component.onCompleted: {
-                                groupview.headerEditButton = button
-                            }
-                            onActiveFocusChanged: {
-                                if (activeFocus) {
-                                    groupview.positionViewAtBeginning()
-                                }
-                            }
-                            textColor: Palette {
-                                normal {
-                                    common: DTK.makeColor(Color.Highlight)
-                                    crystal: DTK.makeColor(Color.Highlight)
-                                }
-                            }
-                            onCheckedChanged: {
-                                groupSettings.isEditing = button.checked
                             }
                         }
                     }
-                }
 
-                model: settings.userId.length > 0 ? dccData.groupsModel(settings.userId) : 0
-                delegate: ItemDelegate {
-                    id: itemDelegate
-                    implicitHeight: 36
-                    padding: 0
-                    checkable: false
-                    clip: false
-                    z: editLabel.showAlert ? 100 : 1
-
-                    focusPolicy: Qt.StrongFocus
-                    activeFocusOnTab: false
-                    KeyNavigation.tab: groupview.addGroupButton
-
-                    Keys.onPressed: function(event) {
-                        if (!model.groupEnabled) {
-                            if (event.key === Qt.Key_Up) {
-                                if (groupview.currentIndex > 0) {
-                                    groupview.currentIndex = groupview.currentIndex - 1
-                                    groupview.positionViewAtIndex(groupview.currentIndex, ListView.Contain)
-                                }
-                                event.accepted = true
-                                return
-                            } else if (event.key === Qt.Key_Down) {
-                                if (groupview.currentIndex < groupview.count - 1) {
-                                    groupview.currentIndex = groupview.currentIndex + 1
-                                    groupview.positionViewAtIndex(groupview.currentIndex, ListView.Contain)
-                                }
-                                event.accepted = true
-                                return
+                    DelegateChoice {
+                        roleValue: "footer"
+                        delegate: Item {
+                            implicitHeight: 50
+                            anchors {
+                                left: parent ? parent.left : undefined
+                                right: parent ? parent.right : undefined
+                                leftMargin: groupview.lrMargin
+                                rightMargin: groupview.lrMargin
                             }
-                            event.accepted = true
-                            return
-                        }
-                        if (!editLabel.readOnly) {
-                            return
-                        }
-                        if (event.key === Qt.Key_Up) {
-                            if (groupview.currentIndex > 0) {
-                                groupview.currentIndex = groupview.currentIndex - 1
-                                groupview.positionViewAtIndex(groupview.currentIndex, ListView.Contain)
-                            }
-                            event.accepted = true
-                        } else if (event.key === Qt.Key_Down) {
-                            if (groupview.currentIndex < groupview.count - 1) {
-                                groupview.currentIndex = groupview.currentIndex + 1
-                                groupview.positionViewAtIndex(groupview.currentIndex, ListView.Contain)
-                            }
-                            event.accepted = true
-                        } else if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
-                            if (!groupSettings.isEditing && model.groupEnabled) {
-                                dccData.setGroup(settings.userId, model.display, !editButton.checked)
-                                groupview.currentIndex = -1
-                                groupview.focus = false
-                            }
-                            event.accepted = true
-                        }
-                    }
-
-                    property var editTextWidth: itemDelegate.width - editButton.width - rightPadding - 80
-                    background: DccItemBackground {
-                        backgroundType: DccObject.Normal
-                        separatorVisible: true
-                    }
-                    anchors {
-                        left: parent ? parent.left : undefined
-                        right: parent ? parent.right : undefined
-                        leftMargin: groupview.lrMargin
-                        rightMargin: groupview.lrMargin
-                    }
-
-                    onWidthChanged: {
-                        if (editLabel.readOnly) {
-                            var elidedText = editLabel.metrics.elidedText(editLabel.completeText, Text.ElideRight, editTextWidth)
-                            editLabel.text = elidedText
-                            return
-                        }
-                    }
-
-                    contentItem: RowLayout {
-                        spacing: 0
-                        Item {
-                            id: editContainer
-                            Layout.fillWidth: !editLabel.readOnly
-                            Layout.alignment: Qt.AlignVCenter
-                            Layout.leftMargin: 14
-                            Layout.rightMargin: 2
-                            implicitHeight: 36
-                            implicitWidth: !editLabel.readOnly 
-                                        ? groupview.width
-                                        : Math.min(editLabel.metrics.advanceWidth(editLabel.text) + editButton.width + 20,
-                                                groupview.width - editButton.width - 30)
-
-                            EditActionLabel {
-                                id: editLabel
-                                property bool editAble: model.groupEditAble
-                                property string lastValidText: ""
-                                property bool isRestoring: false
-                                property string originalGroupName: ""
+                            RowLayout {
                                 anchors.fill: parent
-                                text: model.display
-                                completeText: model.display
-                                rightPadding: editButton.width + 10
-                                placeholderText: qsTr("Group name")
-                                background: Item{}
-                                horizontalAlignment: TextInput.AlignLeft
-                                verticalAlignment: TextInput.AlignVCenter
-                                editBtn.visible: readOnly && editAble
-                                                 && !groupSettings.isEditing
-                                readOnly: model.display.length > 0
-                                ToolTip {
-                                    visible: parent.hovered && parent.readOnly && parent.completeText != "" && (parent.metrics.advanceWidth(parent.completeText) > (parent.width - parent.rightPadding - 10))
-                                    text: parent.completeText
-                                }
-
-                                // Monitor model.display changes to update elided text
-                                onCompleteTextChanged: {
-                                    if (readOnly && completeText.length > 0) {
-                                        var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
-                                        text = elidedText
+                                Button {
+                                    id: addGroupButton
+                                    Layout.alignment: Qt.AlignRight
+                                    text: qsTr("Add group")
+                                    implicitWidth: implicitContentWidth + 20
+                                    implicitHeight: 30
+                                    focusPolicy: Qt.StrongFocus
+                                    activeFocusOnTab: true
+                                    onClicked: {
+                                        dccData.requestCreateGroup(settings.userId)
+                                        groupview.positionViewAtEnd()
                                     }
                                 }
-
-                            onReadOnlyChanged: {
-                                if (!readOnly) {
-                                    text = completeText
-                                    lastValidText = model.display
-                                    originalGroupName = model.display
-                                }
-                            }
-
-                            Connections {
-                                target: dccData
-                                function onGroupsUpdateFailed(groupName) {
-                                    if (groupName === editLabel.originalGroupName) {
-                                        editLabel.completeText = editLabel.originalGroupName
-                                        var elidedText = editLabel.metrics.elidedText(editLabel.originalGroupName, Text.ElideRight, editTextWidth)
-                                        editLabel.text = elidedText
-                                    }
-                                }
-                            }
-
-                            onTextChanged: {
-                                if (readOnly) {
-                                    return
-                                }
-                                if (isRestoring) {
-                                    isRestoring = false
-                                    return
-                                }
-
-                                if (showAlert)
-                                    showAlert = false
-
-                                if (text.length < 1 && lastValidText.length > 0 && !readOnly) {
-                                    Qt.callLater(function() {
-                                        editLabel.forceActiveFocus()
-                                    })
-                                }
-
-                                var isNewGroup = (model.display.length === 0)
-
-                                if (text.length > 32) {
-                                    showAlert = true
-                                    alertText = qsTr("Group names should be no more than 32 characters")
-                                    dccData.playSystemSound(14)
-                                    isRestoring = true
-                                    text = lastValidText
-                                    return
-                                }
-
-                                var numbersOnlyRegex = /^[0-9]+$/
-                                if (text.length > 0 && numbersOnlyRegex.test(text)) {
-                                    showAlert = true
-                                    alertText = qsTr("Group names cannot only have numbers")
-                                    dccData.playSystemSound(14)
-                                    isRestoring = true
-                                    text = lastValidText
-                                    return
-                                }
-
-                                var validFormatRegex = /^[a-zA-Z][a-zA-Z0-9-_]*$/
-                                if (text.length > 0 && !validFormatRegex.test(text) && model.display != "_ssh") {
-                                    showAlert = true
-                                    alertText = qsTr("Use letters,numbers,underscores and dashes only, and must start with a letter")
-                                    dccData.playSystemSound(14)
-                                    isRestoring = true
-                                    text = lastValidText
-                                    return
-                                }
-
-                                lastValidText = text
-                            }
-
-                            onFinished: function () {
-                                var wasNewGroup = (model.display.length < 1)
-                                if (text.length < 1) {
-                                    if (model.display.length < 1) {
-                                        dccData.requestClearEmptyGroup(settings.userId)
-                                    } else {
-                                        var elidedText = metrics.elidedText(model.display, Text.ElideRight, editTextWidth)
-                                        text = elidedText
-                                        readOnly = true
-                                    }
-                                    return
-                                }
-
-                                if (dccData.groupExists(text) && text !== model.display) {
-                                    showAlert = true
-                                    alertText = qsTr("The group name has been used")
-                                    return
-                                }
-
-                                if (text === model.display) {
-                                    completeText = text
-                                    var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
-                                    text = elidedText
-                                    readOnly = true
-                                    return
-                                }
-
-                                if (model.display.length < 1)
-                                    dccData.createGroup(text)
-                                else
-                                    dccData.modifyGroup(model.display, text)
-
-                                completeText = text
-                                var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
-                                text = elidedText
-                                readOnly = true
-
-                                // 当通过回车结束新建分组的编辑时，清空 ListView 的焦点与选中
-                                if (wasNewGroup) {
-                                    groupview.currentIndex = -1
-                                    groupview.focus = false
-                                }
-                            }
-                            onFocusChanged: {
-                                if (focus || text.length > 0 || editLabel.readOnly)
-                                    return
-
-                                if (model.display.length < 1) {
-                                    dccData.requestClearEmptyGroup(settings.userId)
-                                    return
-                                }
-
-                                text = model.display
-                            }
-                            Component.onCompleted: {
-                                completeText = model.display
-                                lastValidText = model.display
-                                originalGroupName = model.display  // Initialize original name
-
-                                if (editLabel.readOnly) {
-                                    var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
-                                    text = elidedText
-                                    return
-                                }
-
-                                Qt.callLater(function () {
-                                    editLabel.focus = true
-                                })
                             }
                         }
-                        }
+                    }
 
-                        Item {
-                            Layout.fillWidth: true
-                            Layout.alignment: Qt.AlignVCenter
+                    DelegateChoice {
+                        roleValue: "group"
+                        delegate: ItemDelegate {
+                            id: itemDelegate
                             implicitHeight: 36
-
-                            MouseArea {
-                                anchors.fill: parent
-                                visible: !groupSettings.isEditing
-                                enabled: model.groupEnabled
-                                acceptedButtons: Qt.AllButtons
-                                onClicked: {
-                                    dccData.setGroup(settings.userId, model.display, !editButton.checked)
-                                }
-                            }
-                        }
-
-                        ActionButton {
-                            id: editButton
-                            focusPolicy: Qt.NoFocus
-                            icon.width: 16
-                            icon.height: 16
-                            visible: groupSettings.isEditing ? editLabel.editAble : editLabel.readOnly
-                            enabled: model.groupEnabled
-                            icon.name: {
-                                if (groupSettings.isEditing) {
-                                    return "list_delete"
-                                }
-
-                                return editButton.checked ? "item_checked" : "radio_unchecked"
-                            }
-
-                            background: null
-                            Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                            // list_delete.dci icon has padding 10 (1.10p)
-                            Layout.rightMargin: groupSettings.isEditing ? 0 : 10
-                            // only checked from groupsChanged
+                            padding: 0
                             checkable: false
-                            checked: dccData.groupContains(settings.userId, model.display)
-                            onClicked: {
-                                if (groupSettings.isEditing) {
-                                    // delete group
-                                    dccData.deleteGroup(model.display)
-                                    groupSettings.isEditing = false
-                                    return
-                                }
+                            clip: false
+                            z: editLabel.showAlert ? 100 : 1
 
-                                dccData.setGroup(settings.userId, model.display, !editButton.checked)
-                            }
-                        }
-                    }
-
-                    Item {
-                        anchors.fill: parent
-                        visible: !model.groupEnabled
-                        z: 10000
-                        focus: true
-                        Keys.onPressed: function(event) {
-                            if (event.key === Qt.Key_Up) {
-                                if (groupview.currentIndex > 0) {
-                                    groupview.currentIndex = groupview.currentIndex - 1
-                                    groupview.positionViewAtIndex(groupview.currentIndex, ListView.Contain)
-                                }
-                                event.accepted = true
-                                return
-                            } else if (event.key === Qt.Key_Down) {
-                                if (groupview.currentIndex < groupview.count - 1) {
-                                    groupview.currentIndex = groupview.currentIndex + 1
-                                    groupview.positionViewAtIndex(groupview.currentIndex, ListView.Contain)
-                                }
-                                event.accepted = true
-                                return
-                            }
-                            event.accepted = true
-                        }
-                        Keys.onReleased: function(event) { event.accepted = true }
-                        Keys.onShortcutOverride: function(event) { event.accepted = true }
-
-                        MouseArea {
-                            anchors.fill: parent
-                            acceptedButtons: Qt.AllButtons
-                            hoverEnabled: true
-                            preventStealing: true
-                            onPressed: function(mouse) { mouse.accepted = true }
-                            onReleased: function(mouse) { mouse.accepted = true }
-                            onClicked: function(mouse) { mouse.accepted = true }
-                            onWheel: function(wheel) { wheel.accepted = true }
-                        }
-                    }
-
-                    corners: getCornersForBackground(index, groupview.count)
-                }
-
-                footer: Item {
-                    implicitHeight: 50
-                    anchors {
-                        left: parent ? parent.left : undefined
-                        right: parent ? parent.right : undefined
-                        leftMargin: groupview.lrMargin
-                        rightMargin: groupview.lrMargin
-                    }
-                    RowLayout {
-                        anchors.fill: parent
-                        Button {
-                            id: addGroupButton
-                            Layout.alignment: Qt.AlignRight
-                            text: qsTr("Add group")
-                            implicitWidth: implicitContentWidth + 20
-                            implicitHeight: 30
                             focusPolicy: Qt.StrongFocus
                             activeFocusOnTab: true
-                            Component.onCompleted: {
-                                groupview.addGroupButton = addGroupButton
-                            }
+
                             onActiveFocusChanged: {
                                 if (activeFocus) {
-                                    groupview.positionViewAtEnd()
+                                    groupview.currentIndex = index
                                 }
                             }
+
                             Keys.onPressed: function(event) {
-                                if (event.key === Qt.Key_Tab || event.key === Qt.Key_Backtab) {
-                                    groupview.blockInitialFocus = true
-                                    groupview.focus = false
-                                    event.accepted = false
+                                if (!model.groupEnabled) {
+                                    return
+                                }
+                                if (!editLabel.readOnly) {
+                                    return
+                                }
+                                if (event.key === Qt.Key_Space || event.key === Qt.Key_Return || event.key === Qt.Key_Enter) {
+                                    if (!groupSettings.isEditing && model.groupEnabled) {
+                                        dccData.setGroup(settings.userId, model.display, !editButton.checked)
+                                        groupview.currentIndex = -1
+                                        groupview.focus = false
+                                    }
+                                    event.accepted = true
+                                }
+                            }
+
+                            property var editTextWidth: itemDelegate.width - editButton.width - rightPadding - 80
+                            background: DccItemBackground {
+                                backgroundType: DccObject.Normal
+                                separatorVisible: true
+                                externalFocus: itemDelegate.activeFocus
+                            }
+                            anchors {
+                                left: parent ? parent.left : undefined
+                                right: parent ? parent.right : undefined
+                                leftMargin: groupview.lrMargin
+                                rightMargin: groupview.lrMargin
+                            }
+
+                            onWidthChanged: {
+                                if (editLabel.readOnly) {
+                                    var elidedText = editLabel.metrics.elidedText(editLabel.completeText, Text.ElideRight, editTextWidth)
+                                    editLabel.text = elidedText
                                     return
                                 }
                             }
-                            onClicked: {
-                                groupview.focusNewlyCreatedItem = true
-                                dccData.requestCreateGroup(settings.userId)
-                                groupview.positionViewAtEnd()
+
+                            contentItem: RowLayout {
+                                spacing: 0
+                                Item {
+                                    id: editContainer
+                                    Layout.fillWidth: !editLabel.readOnly
+                                    Layout.alignment: Qt.AlignVCenter
+                                    Layout.leftMargin: 14
+                                    Layout.rightMargin: 2
+                                    implicitHeight: 36
+                                    implicitWidth: !editLabel.readOnly 
+                                                ? groupview.width
+                                                : Math.min(editLabel.metrics.advanceWidth(editLabel.text) + editButton.width + 20,
+                                                        groupview.width - editButton.width - 30)
+
+                                    EditActionLabel {
+                                        id: editLabel
+                                        property bool editAble: model.groupEditAble
+                                        property string lastValidText: ""
+                                        property bool isRestoring: false
+                                        property string originalGroupName: ""
+                                        anchors.fill: parent
+                                        text: model.display
+                                        completeText: model.display
+                                        rightPadding: editButton.width + 10
+                                        placeholderText: qsTr("Group name")
+                                        background: Item{}
+                                        horizontalAlignment: TextInput.AlignLeft
+                                        verticalAlignment: TextInput.AlignVCenter
+                                        editBtn.visible: readOnly && editAble
+                                                        && !groupSettings.isEditing
+                                        readOnly: model.display.length > 0
+                                        activeFocusOnTab: !readOnly
+                                        ToolTip {
+                                            visible: parent.hovered && parent.readOnly && parent.completeText != "" && (parent.metrics.advanceWidth(parent.completeText) > (parent.width - parent.rightPadding - 10))
+                                            text: parent.completeText
+                                        }
+
+                                        // Monitor model.display changes to update elided text
+                                        onCompleteTextChanged: {
+                                            if (readOnly && completeText.length > 0) {
+                                                var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
+                                                text = elidedText
+                                            }
+                                        }
+
+                                    onReadOnlyChanged: {
+                                        if (!readOnly) {
+                                            text = completeText
+                                            lastValidText = model.display
+                                            originalGroupName = model.display
+                                        }
+                                    }
+
+                                    Connections {
+                                        target: dccData
+                                        function onGroupsUpdateFailed(groupName) {
+                                            if (groupName === editLabel.originalGroupName) {
+                                                editLabel.completeText = editLabel.originalGroupName
+                                                var elidedText = editLabel.metrics.elidedText(editLabel.originalGroupName, Text.ElideRight, editTextWidth)
+                                                editLabel.text = elidedText
+                                            }
+                                        }
+                                    }
+
+                                    onTextChanged: {
+                                        if (readOnly) {
+                                            return
+                                        }
+                                        if (isRestoring) {
+                                            isRestoring = false
+                                            return
+                                        }
+
+                                        if (showAlert)
+                                            showAlert = false
+
+                                        if (text.length < 1 && lastValidText.length > 0 && !readOnly) {
+                                            Qt.callLater(function() {
+                                                editLabel.forceActiveFocus()
+                                            })
+                                        }
+
+                                        var isNewGroup = (model.display.length === 0)
+
+                                        if (text.length > 32) {
+                                            showAlert = true
+                                            alertText = qsTr("Group names should be no more than 32 characters")
+                                            dccData.playSystemSound(14)
+                                            isRestoring = true
+                                            text = lastValidText
+                                            return
+                                        }
+
+                                        var numbersOnlyRegex = /^[0-9]+$/
+                                        if (text.length > 0 && numbersOnlyRegex.test(text)) {
+                                            showAlert = true
+                                            alertText = qsTr("Group names cannot only have numbers")
+                                            dccData.playSystemSound(14)
+                                            isRestoring = true
+                                            text = lastValidText
+                                            return
+                                        }
+
+                                        var validFormatRegex = /^[a-zA-Z][a-zA-Z0-9-_]*$/
+                                        if (text.length > 0 && !validFormatRegex.test(text) && model.display != "_ssh") {
+                                            showAlert = true
+                                            alertText = qsTr("Use letters,numbers,underscores and dashes only, and must start with a letter")
+                                            dccData.playSystemSound(14)
+                                            isRestoring = true
+                                            text = lastValidText
+                                            return
+                                        }
+
+                                        lastValidText = text
+                                    }
+
+                                    onFinished: function () {
+                                        var wasNewGroup = (model.display.length < 1)
+                                        if (text.length < 1) {
+                                            if (model.display.length < 1) {
+                                                dccData.requestClearEmptyGroup(settings.userId)
+                                            } else {
+                                                var elidedText = metrics.elidedText(model.display, Text.ElideRight, editTextWidth)
+                                                text = elidedText
+                                                readOnly = true
+                                            }
+                                            return
+                                        }
+
+                                        if (dccData.groupExists(text) && text !== model.display) {
+                                            showAlert = true
+                                            alertText = qsTr("The group name has been used")
+                                            return
+                                        }
+
+                                        if (text === model.display) {
+                                            completeText = text
+                                            var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
+                                            text = elidedText
+                                            readOnly = true
+                                            return
+                                        }
+
+                                        if (model.display.length < 1)
+                                            dccData.createGroup(text)
+                                        else
+                                            dccData.modifyGroup(model.display, text)
+
+                                        completeText = text
+                                        var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
+                                        text = elidedText
+                                        readOnly = true
+
+                                        // 当通过回车结束新建分组的编辑时，清空 ListView 的焦点与选中
+                                        if (wasNewGroup) {
+                                            groupview.currentIndex = -1
+                                            groupview.focus = false
+                                        }
+                                    }
+                                    onFocusChanged: {
+                                        if (focus || text.length > 0 || editLabel.readOnly)
+                                            return
+
+                                        if (model.display.length < 1) {
+                                            dccData.requestClearEmptyGroup(settings.userId)
+                                            return
+                                        }
+
+                                        text = model.display
+                                    }
+                                    Component.onCompleted: {
+                                        completeText = model.display
+                                        lastValidText = model.display
+                                        originalGroupName = model.display  // Initialize original name
+
+                                        if (editLabel.readOnly) {
+                                            var elidedText = metrics.elidedText(completeText, Text.ElideRight, editTextWidth)
+                                            text = elidedText
+                                            return
+                                        }
+
+                                        Qt.callLater(function () {
+                                            editLabel.focus = true
+                                        })
+                                    }
+                                }
+                                }
+
+                                Item {
+                                    Layout.fillWidth: true
+                                    Layout.alignment: Qt.AlignVCenter
+                                    implicitHeight: 36
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        visible: !groupSettings.isEditing
+                                        enabled: model.groupEnabled
+                                        acceptedButtons: Qt.AllButtons
+                                        onClicked: {
+                                            dccData.setGroup(settings.userId, model.display, !editButton.checked)
+                                        }
+                                    }
+                                }
+
+                                ActionButton {
+                                    id: editButton
+                                    focusPolicy: Qt.NoFocus
+                                    icon.width: 16
+                                    icon.height: 16
+                                    visible: groupSettings.isEditing ? editLabel.editAble : editLabel.readOnly
+                                    enabled: model.groupEnabled
+                                    icon.name: {
+                                        if (groupSettings.isEditing) {
+                                            return "list_delete"
+                                        }
+
+                                        return editButton.checked ? "item_checked" : "radio_unchecked"
+                                    }
+
+                                    background: null
+                                    Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                                    // list_delete.dci icon has padding 10 (1.10p)
+                                    Layout.rightMargin: groupSettings.isEditing ? 0 : 10
+                                    // only checked from groupsChanged
+                                    checkable: false
+                                    checked: dccData.groupContains(settings.userId, model.display)
+                                    onClicked: {
+                                        if (groupSettings.isEditing) {
+                                            // delete group
+                                            dccData.deleteGroup(model.display)
+                                            groupSettings.isEditing = false
+                                            return
+                                        }
+
+                                        dccData.setGroup(settings.userId, model.display, !editButton.checked)
+                                    }
+                                }
                             }
+
+                            Item {
+                                anchors.fill: parent
+                                visible: !model.groupEnabled
+                                z: 10000
+                                focus: true
+                                Keys.onPressed: function(event) {
+                                    event.accepted = true
+                                }
+                                Keys.onReleased: function(event) { event.accepted = true }
+                                Keys.onShortcutOverride: function(event) { event.accepted = true }
+
+                                MouseArea {
+                                    anchors.fill: parent
+                                    acceptedButtons: Qt.AllButtons
+                                    hoverEnabled: true
+                                    preventStealing: true
+                                    onPressed: function(mouse) { mouse.accepted = true }
+                                    onReleased: function(mouse) { mouse.accepted = true }
+                                    onClicked: function(mouse) { mouse.accepted = true }
+                                    onWheel: function(wheel) { wheel.accepted = true }
+                                }
+                            }
+
+                            corners: getCornersForBackground(index - 1, groupview.count - 2)
                         }
                     }
                 }


### PR DESCRIPTION
1. Removed the dedicated ListView with complex focus, MouseArea, key navigation, and scroll management
2. Replaced with a simpler Item container containing header row and ListView
3. Removed blockInitialFocus, focusNewlyCreatedItem, mousePressed, and conY state tracking
4. Simplified key navigation by removing manual up/down key handling in delegates
5. Removed addGroupButton component reference tracking from ListView
6. Consolidated add group button logic with direct onClicked handler
7. Cleaned up Tab key navigation responsibilities between header button and list
8. Added externalFocus property to DccItemBackground for visual focus indication
9. Removed redundant KeyNavigation.tab settings from delegates
10. Added disable overlay mouse area to prevent interaction on disabled groups
11. Updated header row to use groupSettings.displayName directly and simplified radius

The refactoring reduces code duplication and consolidates focus management, making the group list more maintainable and simplifying event handling. The changes ensure the account group settings UI is more robust and follows modern QML patterns.

Log: Refactored account group list for simplified focus and event handling

Influence:
1. Test adding new groups via the "Add group" button
2. Verify group deletion in editing mode
3. Check keyboard navigation between group items
4. Verify group selection and deselection
5. Test group editing with validation rules
6. Verify disabled groups cannot be interacted with
7. Test focus behavior when tabbing through the UI
8. Verify scrollbar visibility and behavior
9. Test group list with many entries for scrolling performance
10. Verify the header edit button toggle works correctly

feat: 重构账户分组列表，简化焦点和事件处理

1. 移除了包含复杂焦点、鼠标区域、键盘导航和滚动管理的专用 ListView
2. 用更简单的包含标题行和 ListView 的 Item 容器替代
3. 移除了 blockInitialFocus、focusNewlyCreatedItem、mousePressed 和 conY 状态跟踪
4. 通过移除委托中的手动上下键处理来简化键盘导航
5. 移除了从 ListView 跟踪 addGroupButton 组件引用的代码
6. 将添加分组按钮的逻辑整合为直接的 onClicked 处理
7. 清理了标题按钮和列表之间的 Tab 键导航责任
8. 为 DccItemBackground 添加了 externalFocus 属性，用于视觉焦点指示
9. 从委托中移除了多余的 KeyNavigation.tab 设置
10. 添加了禁用覆盖鼠标区域，防止与禁用的组交互
11. 更新了标题行以直接使用 groupSettings.displayName，并简化了圆角

此重构减少了代码重复并整合了焦点管理，使分组列表更易于维护并简化了事件处
理。这些更改确保了账户分组设置 UI 更加健壮，并遵循现代 QML 模式。

Log: 重构账户分组列表以简化焦点和事件处理

Influence:
1. 测试通过“添加分组”按钮添加新分组
2. 验证编辑模式下的分组删除功能
3. 检查分组项之间的键盘导航
4. 验证分组选择和取消选择
5. 测试带有验证规则的分组编辑
6. 验证禁用的分组无法交互
7. 测试在 UI 中通过 Tab 键切换时的焦点行为
8. 验证滚动条的可见性和行为
9. 测试包含大量分组项时的滚动性能
10. 验证标题编辑按钮切换功能正常

PMS: BUG-370737