### PR TITLE
fix(datetime): scroll to highlighted item on popup reopen

### DIFF
--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -42,6 +42,27 @@ Popup {
         highlightedIndex = viewIndex
     }
 
+    function scrollToHighlighted() {
+        if (!view) return
+
+        var foundChecked = false
+        for (var i = 0; i < view.count; i++) {
+            var item = view.itemAtIndex(i)
+            if (item && item.checked === true) {
+                setViewIndex(i)
+                view.positionViewAtIndex(i, ListView.Center)
+                foundChecked = true
+                break
+            }
+        }
+
+        if (!foundChecked && highlightedIndex >= 0) {
+            setViewIndex(highlightedIndex)
+            view.positionViewAtIndex(highlightedIndex, ListView.Center)
+        }
+    }
+
+
     function show() {
         if (anchorItem) {
             positionWindow()
@@ -75,6 +96,12 @@ Popup {
     onClosed: {
         searchEdit.clear()
     }
+    
+    onOpened: {
+        scrollToHighlighted()
+        if (view) view.forceActiveFocus()
+    }
+
 
     TextMetrics {
         id: textMetrics
@@ -215,23 +242,7 @@ Popup {
                     Component.onCompleted: {
                         control.view = listView
                         control.viewWidth = listView.width
-
-                        var foundChecked = false
-                        for (var i = 0; i < count; i++) {
-                            var item = itemAtIndex(i)
-                            if (item && item.checked === true) {
-                                control.setViewIndex(i)
-                                positionViewAtIndex(i, ListView.Center)
-                                foundChecked = true
-                                break
-                            }
-                        }
-
-                        if (!foundChecked && control.highlightedIndex >= 0) {
-                            control.setViewIndex(control.highlightedIndex)
-                            positionViewAtIndex(control.highlightedIndex, ListView.Center)
-                        }
-
+                        control.scrollToHighlighted()
                         forceActiveFocus()
                     }
 


### PR DESCRIPTION
1. Extract scroll-to-highlighted logic into a reusable function
2. Add onOpened handler to scroll and focus when popup reopens
3. Remove duplicated scroll logic from internal ListView onCompleted

Log: Fix popup losing scroll position to the selected item on reopen
Influence: Popup scrolls to selected item on reopen

fix(datetime): 弹窗重新打开时滚动到选中项

1. 将滚动到选中项的逻辑提取为可复用函数
2. 添加 onOpened 处理，弹窗重新打开时滚动并聚焦
3. 移除内部 ListView onCompleted 中的重复滚动代码

Log: 修复弹窗重新打开时丢失选中项滚动位置的问题
PMS: BUG-370379
Influence: 弹窗重新打开时自动滚动到选中项