### PR TITLE
fix(authentication): remove hardcoded LineEdit height to fix face nam…

### DIFF
--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -152,6 +152,9 @@ DccObject {
                             Layout.topMargin: 5
                             Layout.bottomMargin: 5
                             horizontalAlignment: TextInput.AlignLeft
+                            verticalAlignment: TextInput.AlignVCenter
+                            topPadding: 0
+                            bottomPadding: 0
                             text: modelData
                             readOnly: true
                             clearButton.active: false


### PR DESCRIPTION
…e truncation at large font

1. Remove implicitHeight: 30 on D.LineEdit in AuthenticationMain.qml
2. Let TextField calculate natural implicitHeight based on font size
3. Fixes vertical text clipping of biometric names (e.g. "面纹1") when system font size is set to 20

Log: Face/Fingerprint/Iris name display no longer truncated at large font sizes
Influence: Biometric authentication page name display adapts to font size changes correctly

fix(authentication): 移除硬编码的LineEdit高度以修复大字体下面纹名称截断

1. 移除AuthenticationMain.qml中D.LineEdit的implicitHeight: 30
2. 让TextField根据字体大小自动计算自然高度
3. 修复系统字体调至20时生物认证名称(如"面纹1")垂直截断的问题

Log: 大字体下人脸/指纹/虹膜名称不再截断
Influence: 生物认证页面名称显示随字体自适应

PMS: BUG-370735

## Summary by Sourcery

Bug Fixes:
- Prevent biometric authentication name text from being vertically clipped when using large system font sizes.