### PR TITLE
refactor: resolve boot page image source empty path issue

### DIFF
--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -70,7 +70,7 @@ DccObject {
 
             Image {
                 id: image
-                source: "file://" + dccData.mode().grubThemePath + "?timestamp=" + Date.now()
+                source: dccData.mode().grubThemePath ? "file://" + dccData.mode().grubThemePath + "?timestamp=" + Date.now() : ""
                 asynchronous: true
                 anchors.fill: parent
                 width: parent.width


### PR DESCRIPTION
The change adds a check to ensure the image source is only set when the grub theme path is not empty. Previously, an empty path would still trigger a file:// URI request, potentially causing warnings or errors in the loading process.

Log: Fix boot page image loading with empty path

Influence:
1. Test boot page display with valid grub theme path
2. Verify boot page display without grub theme (empty path)
3. Ensure no error messages when theme path is empty

fix: 修复启动页图像空路径问题

该更改添加了一个检查，确保仅在grub主题路径非空时才设置图像源。之前，空路
径仍会触发file:// URI请求，可能导致加载过程中的警告或错误。

Log: 修复空路径下启动页图像加载问题

Influence:
1. 测试有效grub主题路径下的启动页显示
2. 验证无grub主题（空路径）时的启动页显示
3. 确保主题路径为空时没有错误信息

PMS: TASK-392413

## Summary by Sourcery

Bug Fixes:
- Prevent boot page image source from being set when the grub theme path is empty, avoiding spurious file:// URI loads and related warnings.