### PR TITLE
fix(personalization): apply greeter background in global theme

### DIFF
--- a/src/plugin-personalization/operation/treelandworker.cpp
+++ b/src/plugin-personalization/operation/treelandworker.cpp
@@ -548,11 +548,13 @@ void TreeLandWorker::applyGlobalTheme(KeyFile &theme, const QString &themeName, 
 
 void TreeLandWorker::doSetByType(const QString &type, const QString &value)
 {
-    if (type == TYPEWALLPAPER) {
+    if (type == TYPEWALLPAPER || type == TYPEGREETERBACKGROUND) {
+        WallpaperContext::wallpaper_role wallpaperRole = type == TYPEWALLPAPER ? 
+            WallpaperContext::wallpaper_role_desktop : WallpaperContext::wallpaper_role_lockscreen;
         auto screens = qApp->screens();
         for (const auto screen : screens) {
-            // FIXME(mhduiy): only set image, only set to desktop
-            setWallpaper(screen->name(), value, WallpaperContext::wallpaper_role_desktop, WallpaperContext::wallpaper_source_type_image);
+            // FIXME(mhduiy): only set image
+            setWallpaper(screen->name(), value, wallpaperRole, WallpaperContext::wallpaper_source_type_image);
         }
     } else if(type == TYPEICON) {
         setIconTheme(value);


### PR DESCRIPTION
## Summary
Apply lockscreen wallpaper (`TYPEGREETERBACKGROUND`) when applying global theme.

## Change
- Extend `applyGlobalTheme` to handle `TYPEGREETERBACKGROUND` (lockscreen)
- Select correct `wallpaper_role` based on wallpaper type
- Remove outdated FIXME comment

## Bug
BUG-370731