### PR TITLE
fix: show the complete NTP server list

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -130,6 +130,7 @@ DccObject {
                     anchors.fill: parent
                     hoverEnabled: true
                     model: serverList
+                    popup.popupType: Popup.Window
                     // 不设置默认的话可能无法滚动（不显示上下箭头按钮）。。。
                     maxVisibleItems: serverList.length - 1
                     currentIndex:  {


### PR DESCRIPTION
## Summary

- Use `Popup.Window` for the NTP server ComboBox so the server list is not clipped by the control center window.
- Keep the change scoped to the time and date page.

## Dependency

- Depends on linuxdeepin/dtkdeclarative#656 for correct ComboBox focus transfer when the popup window is activated.

## Verification

- Rebased onto the latest `upstreams/master`.
- Built `datetime_qml` from a clean archive of the final commit; QML AOT compilation completed successfully (57/57).
- Verified on Treeland that the full list remains open, is scrollable to the last item, and closes when pressing the parent window.

## Bug

BUG-371355

## Summary by Sourcery

Ensure the NTP server selection dropdown displays its full list within the time and date settings page.

Bug Fixes:
- Prevent the NTP server ComboBox list from being clipped by the control center window by using a popup window type.

Enhancements:
- Scope the popup behavior change specifically to the time and date page’s NTP server ComboBox.