### PR TITLE
fix: skip control center loading page under Treeland

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -68,6 +68,8 @@ DccManager::DccManager(QObject *parent)
     , m_showTimer(nullptr)
     , m_showFallbackTimer(nullptr)
     , m_showPagePending(false)
+    , m_showLoadPage(!isTreeland())
+    , m_needShow(false)
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -472,15 +474,19 @@ void DccManager::cacheImage(const QString &id, const QSize &thumbnailSize)
 
 void DccManager::show()
 {
+    m_needShow = true;
     QWindow *w = DccManager::mainWindow();
     if (!w) {
         return;
     }
-
+    if (!m_showLoadPage && !m_activeObject) {
+        return;
+    }
     if (w->windowStates() == Qt::WindowMinimized || !w->isVisible()) {
         w->showNormal();
     }
     w->requestActivate();
+    m_needShow = false;
 }
 
 void DccManager::toggle()
@@ -1009,6 +1015,9 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
         Q_EMIT triggeredObjectsChanged(m_triggeredObjects);
 
     m_showFallbackTimer->stop();
+    if (m_needShow) {
+        show();
+    }
 }
 
 QSet<QString> findAddItems(QSet<QString> *oldSet, QSet<QString> *newSet)

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -152,6 +152,8 @@ private:
     QString m_showUrl;
     QDBusMessage m_showMessage;
     bool m_showPagePending;
+    bool m_showLoadPage;
+    bool m_needShow;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
 


### PR DESCRIPTION
1. Add m_showLoadPage flag, initialized to false under Treeland since the compositor already provides a loading screen
2. Add m_needShow flag to defer window show() when page is not yet ready (e.g. DBus-triggered open before plugin loads)
3. In show(), return early without activating window when m_showLoadPage is false and no active page exists
4. In doShowPage(), check m_needShow to show window after page content is fully loaded

PMS: BUG-366597

fix: Treeland 下不显示控制中心启动界面

1. 新增 m_showLoadPage 标志位，Treeland 下初始化为 false， 因为合成器已提供启动画面
2. 新增 m_needShow 标志位，在页面未就绪时延迟 show() （如 DBus 触发打开时插件尚未加载完成）
3. show() 中当 m_showLoadPage 为 false 且无活动页面时 提前返回，不激活窗口
4. doShowPage() 末尾检查 m_needShow，页面加载完成后 再显示窗口

PMS: BUG-366597

## Summary by Sourcery

Adjust control center window show behavior so Treeland skips the loading screen and only activates the window after a page is ready.

Bug Fixes:
- Prevent the control center from showing an empty loading page under Treeland where the compositor already provides a splash screen.
- Ensure DBus-triggered opens defer window activation until the target page content has finished loading.