### PR TITLE
fix: limit custom shortcut names to 128 characters

### DIFF
--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -30,6 +30,8 @@ D.DialogWindow {
     property string saveAccels: ""
     property var saveKeys: [qsTr("None")]
     property bool nameExists: false
+    property bool nameLengthExceeded: false
+    property string lastAcceptedName: ""
     property var captureRestoreKeys: [qsTr("None")]
     property string captureRestoreAccels: ""
     property bool captureRestoreValid: false
@@ -84,16 +86,33 @@ D.DialogWindow {
             Layout.rightMargin: 20
             Layout.preferredWidth: parent.width
             font: D.DTK.fontManager.t6
+            maximumLength: 129
             placeholderText: qsTr("Required")
-            showAlert: ddialog.nameExists
-            alertText: qsTr("The shortcut name is already in use. Choose a different name.")
+            showAlert: ddialog.nameLengthExceeded || ddialog.nameExists
+            alertText: ddialog.nameLengthExceeded
+                       ? qsTr("The name cannot exceed 128 characters.")
+                       : qsTr("The shortcut name is already in use. Choose a different name.")
             onTextChanged: {
+                if (text.length > 128) {
+                    text = ddialog.lastAcceptedName.length === 128
+                           ? ddialog.lastAcceptedName
+                           : text.substr(0, 128)
+                    ddialog.nameLengthExceeded = true
+                    nameLengthAlertTimer.restart()
+                }
+                ddialog.lastAcceptedName = text
                 // 检查名称是否已存在（包括系统和自定义快捷键）
                 if (text.trim().length > 0) {
                     ddialog.nameExists = dccData.isShortcutNameExists(text.trim(), ddialog.keyId);
                 } else {
                     ddialog.nameExists = false;
                 }
+            }
+            Timer {
+                id: nameLengthAlertTimer
+                interval: 2000
+                repeat: false
+                onTriggered: ddialog.nameLengthExceeded = false
             }
         }
 

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -3370,6 +3370,10 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>The name cannot exceed 128 characters.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Change custom shortcut</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
## Summary

- Limit custom shortcut names to 128 characters
- Preserve the existing name when users continue typing after reaching the limit
- Show the standard control center line edit alert when input exceeds the limit
- Add the Transifex source entry for the length-limit message

## Verification

- Clean-built the `keyboard_qml` target
- Verified with an offscreen Qt probe that middle insertion at 128 characters preserves the original text and overlong paste stops at 128
- Compiled and round-trip verified `zh_CN`, `zh_HK`, and `zh_TW` QM files
- Pushed `zh_CN`, `zh_HK`, and `zh_TW` translations to Transifex
- Validated the 128-character limit and DTK alert style on the debug machine before the final text-preservation refinement

PMS: BUG-372255
