### PR TITLE
fix: use uint for NumLock DBus calls

### DIFF
--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -263,7 +263,11 @@ int KeyboardDBusProxy::numLockState() const
 
 void KeyboardDBusProxy::setNumLockState(int value)
 {
-    SetNumLockState(value != 0);
+    // The dde-services Keybinding1 API exposes SetNumLockState with an
+    // unsigned DBus argument (signature "u"). Keep the device-proxy API as
+    // int for the Wayland implementation, but use the service's exact type at
+    // the X11 DBus boundary.
+    SetNumLockState(value != 0 ? 1U : 0U);
 }
 
 uint KeyboardDBusProxy::shortcutSwitchLayout()
@@ -474,7 +478,7 @@ QDBusPendingReply<QString> KeyboardDBusProxy::GetShortcutCommand(const QString &
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("GetShortcutCommand"), argumentList);
 }
 
-void KeyboardDBusProxy::SetNumLockState(int in0)
+void KeyboardDBusProxy::SetNumLockState(uint in0)
 {
     QList<QVariant> argumentList;
     argumentList << QVariant::fromValue(in0);

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -257,7 +257,7 @@ public slots:
                                                             const QString &expectedConflictId);
     QDBusPendingReply<bool> DeleteCustomShortcut(const QString &in0);
     QDBusPendingReply<QString> GetShortcutCommand(const QString &in0);
-    void SetNumLockState(int in0);
+    void SetNumLockState(uint in0);
     QDBusPendingReply<QString> GetShortcut(const QString &in0, int in1);
     QDBusPendingReply<QString> SearchShortcuts(const QString &in0);
     QDBusPendingReply<QString> Query(const QString &in0, int in1);


### PR DESCRIPTION
PMS: BUG-372041

The dde-services Keybinding1 interface defines SetNumLockState with a uint argument, while the hand-written X11 keyboard proxy sent int (DBus signature i). The call was rejected, so NumLock did not change and no OSD appeared.

This keeps the internal keyboard-device interface unchanged for Wayland and uses uint only at the dde-services DBus boundary.

Validation:
- cmake --build /tmp/dcc-numlock-build --target keyboard -j2
- Verified remote DBus introspection: SetNumLockState accepts uint; prior control-center call used int.

## Summary by Sourcery

Bug Fixes:
- Correct NumLock DBus proxy to send an unsigned value matching the dde-services Keybinding1 SetNumLockState signature.