### PR TITLE
fix: clarify custom shortcut conflict guidance

### DIFF
--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -308,7 +308,9 @@ D.DialogWindow {
                 ddialog.pendingConflict = true
                 edit.accels = newAccels;
                 conflictText.text = message + ", "
-                        + qsTr("click Replace to make this shortcut key effective");
+                        + (ddialog.keyId.length > 0
+                           ? qsTr("click Save to make this shortcut key effective")
+                           : qsTr("click Add to make this shortcut key effective"));
             }
             function onKeyDone(id, type, accels) {
                 if (id !== ddialog.keyId || type !== 1)


### PR DESCRIPTION
## Summary
- show Save in conflict guidance when modifying a custom shortcut
- show Add in conflict guidance when creating a custom shortcut

## Test plan
- Verify conflict guidance uses Save in the edit dialog
- Verify conflict guidance uses Add in the add dialog

## Summary by Sourcery

Enhancements:
- Update conflict guidance to reference the Save button when editing an existing custom shortcut and the Add button when creating a new custom shortcut.