### PR TITLE
fix: synchronize NumLock state from DBus

### DIFF
--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -258,7 +258,12 @@ QStringList KeyboardDBusProxy::locales()
 //Keybinding
 int KeyboardDBusProxy::numLockState() const
 {
-    return qvariant_cast<int>(m_dBusKeybingdingInter->property("NumLockState"));
+    return static_cast<int>(dbusNumLockState());
+}
+
+uint KeyboardDBusProxy::dbusNumLockState() const
+{
+    return qvariant_cast<uint>(m_dBusKeybingdingInter->property("NumLockState"));
 }
 
 void KeyboardDBusProxy::setNumLockState(int value)

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -179,7 +179,8 @@ public:
     QStringList locales();
 
     //Keybinding
-    Q_PROPERTY(int NumLockState READ numLockState NOTIFY NumLockStateChanged)
+    Q_PROPERTY(uint NumLockState READ dbusNumLockState NOTIFY NumLockStateChanged)
+    uint dbusNumLockState() const;
     int numLockState() const override;
     void setNumLockState(int value) override;
 
@@ -208,7 +209,7 @@ signals:
     void LocalesChanged(const QStringList & value) const;
 
     // Keybinding property
-    void NumLockStateChanged(int  value) const;
+    void NumLockStateChanged(uint value) const;
     void ShortcutSwitchLayoutChanged(uint  value) const;
     // Keybinding
     void KeyEvent(bool pressed, const QString &keystroke);

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -90,7 +90,8 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
 #endif
     {
         m_inputDevCfg = DConfig::create("org.deepin.dde.daemon", "org.deepin.dde.daemon.inputdevices", QString(), this);
-        connect(m_keyboardDBusProxy, &KeyboardDBusProxy::NumLockStateChanged, m_model, &KeyboardModel::setNumLock);
+        connect(m_keyboardDBusProxy, &KeyboardDBusProxy::NumLockStateChanged,
+                m_model, [this](uint value) { m_model->setNumLock(value != 0); });
         connect(m_keyboardDBusProxy, &KeyboardDBusProxy::RepeatDelayChanged, this, &KeyboardWorker::setModelRepeatDelay);
         connect(m_keyboardDBusProxy, &KeyboardDBusProxy::RepeatIntervalChanged, this, &KeyboardWorker::setModelRepeatInterval);
         m_deviceProxy = m_keyboardDBusProxy;


### PR DESCRIPTION
PMS: BUG-372041

## Summary
- match the NumLockState property and change signal to the uint type exposed by dde-services
- convert the DBus value explicitly to the internal boolean model
- keep the NumLock switch state correct after reopening the keyboard page

## Test plan
- Build the keyboard plugin with `cmake --build /tmp/dcc-numlock-build --target keyboard -j2`
- Toggle NumLock and verify the OSD appears
- Leave and reopen the keyboard page and verify the switch matches the actual NumLock state

## Summary by Sourcery

Synchronize the keyboard plugin's NumLock state handling with the uint-valued DBus property and keep the UI switch in sync with the actual NumLock state.

Bug Fixes:
- Fix NumLock state desynchronization by matching the DBus NumLockState property type and converting it to the internal boolean model.
- Ensure the NumLock switch reflects the correct state after reopening the keyboard settings page.

Enhancements:
- Expose a dedicated uint-typed accessor for the DBus NumLockState property and update the related signal signature to use uint.