### PR TITLE
fix: align custom shortcut conflict actions

### DIFF
--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -220,9 +220,7 @@ D.DialogWindow {
                 Layout.fillWidth: true
                 Layout.rightMargin: 24
                 font: D.DTK.fontManager.t6
-                text: ddialog.pendingConflict
-                      ? qsTr("Replace")
-                      : (ddialog.keyId.length > 0 ? qsTr("Save") : qsTr("Add"))
+                text: ddialog.keyId.length > 0 ? qsTr("Save") : qsTr("Add")
                 enabled: !ddialog.submitting && commandEdit.text.length > 0
                          && nameEdit.text.length > 0 && !ddialog.nameExists
                 onClicked: {


### PR DESCRIPTION
## Summary

BUG-372091
- show **Save** for conflict handling when editing a custom shortcut
- show **Add** for conflict handling when creating a custom shortcut
- keep the existing shortcut replacement behavior unchanged

## Test plan

- `git diff --check`
- `/usr/lib/qt6/bin/qmllint src/plugin-keyboard/qml/ShortcutSettingDialog.qml` (passes; environment reports existing missing-QML-type warnings)

## Summary by Sourcery

Align custom shortcut conflict handling text with the existing Save/Add actions in the shortcut dialog.

Enhancements:
- Always label the primary shortcut dialog action as Save for edits and Add for creations, regardless of conflicts.
- Update conflict helper text to reference Save or Add depending on whether the user is editing or creating a shortcut.