### PR TITLE
fix(time-range): apply manually entered time on edit finish

### DIFF
--- a/src/dde-control-center/plugin/DccTimeRange.qml
+++ b/src/dde-control-center/plugin/DccTimeRange.qml
@@ -149,6 +149,13 @@ D.SpinBox {
                     event.accepted = false
                 }
             }
+            onEditingFinished: {
+                if (text !== "") {
+                    var h = parseInt(text, 10)
+                    var m = control.value % 60
+                    control.value = h * 60 + m
+                }
+            }
         }
         Label {
             Layout.preferredWidth: 10
@@ -195,6 +202,13 @@ D.SpinBox {
                     event.accepted = true
                 } else {
                     event.accepted = false
+                }
+            }
+            onEditingFinished: {
+                if (text !== "") {
+                    var m = parseInt(text, 10)
+                    var h = Math.floor(control.value / 60)
+                    control.value = h * 60 + m
                 }
             }
         }


### PR DESCRIPTION
1. Sync hour field edits into the total value on editing finished
2. Sync minute field edits into the total value on editing finished
3. Skip empty text so clearing the field does not corrupt the value

Log: Typed hour/minute values now take effect when editing finishes
Influence: Manual time entry takes effect immediately

fix(time-range): 手动输入的时间在编辑完成后生效

1. 小时输入框编辑完成后同步到总时长值
2. 分钟输入框编辑完成后同步到总时长值
3. 文本为空时跳过处理，避免清空输入破坏当前值

Log: 手动输入的小时/分钟在编辑完成后立即生效
PMS: BUG-371785
Influence: 手动输入的时间现在会立即生效

## Summary by Sourcery

Ensure manually entered hours and minutes in the time range spin boxes are applied to the underlying total value when editing finishes, while ignoring empty input to avoid corrupting the current value.

Bug Fixes:
- Apply hour field edits to the total time value when the hour input editing is finished.
- Apply minute field edits to the total time value when the minute input editing is finished.
- Ignore empty text on editing finish so clearing the input does not alter the existing time value.