### PR TITLE
fix: place language and region after time and date

### DIFF
--- a/src/plugin-defaultapp/qml/Defaultapp.qml
+++ b/src/plugin-defaultapp/qml/Defaultapp.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import org.deepin.dcc 1.0
 
@@ -8,5 +8,5 @@ DccObject {
     displayName: qsTr("Default App")
     description: qsTr("Set the default application for opening various types of files")
     icon: "default_program"
-    weight: 40
+    weight: 50
 }


### PR DESCRIPTION
1|fix: place language and region after time and date
2|
3|1. Adjust the Default App navigation weight so Language and region follows Time and date
4|2. Update the copyright year to 2026
5|
6|Influence:
7|1. Verify the order of entries in System common settings
8|2. Verify the Default App entry remains available
9|
10|fix: 将语言和区域放到时间和日期之后
11|
12|1. 调整默认程序导航权重，使语言和区域紧随时间和日期
13|2. 将版权年份更新为2026年
14|
15|Influence:
16|1. 验证系统常用设置入口顺序
17|2. 验证默认程序入口仍可正常使用
18|
19|PMS: BUG-372465
20|