### PR TITLE
fix: avoid shortcut pinyin expansion stalls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,5 +246,6 @@ if(BUILD_EXAMPLES)
 endif()
 
 if(UNITTEST)
+    enable_testing()
     add_subdirectory(tests)
 endif()

--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -266,7 +266,7 @@ QSortFilterProxyModel *KeyboardController::shortcutSearchModel()
     if (m_shortcutSearchModel)
         return m_shortcutSearchModel;
 
-    m_shortcutSearchModel = new QSortFilterProxyModel(this);
+    m_shortcutSearchModel = new ShortcutFilterModel(this);
 
     auto sourceModel = new ShortcutListModel(this);
     sourceModel->setSouceModel(m_shortcutModel);

--- a/src/plugin-keyboard/operation/pinyinsearch.cpp
+++ b/src/plugin-keyboard/operation/pinyinsearch.cpp
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pinyinsearch.h"
+
+#include <DPinyin>
+
+#include <QSet>
+
+#include <utility>
+
+namespace dccV25 {
+namespace {
+
+QStringList orderedUnique(const QStringList &values)
+{
+    QSet<QString> seen;
+    QStringList result;
+    seen.reserve(values.size());
+    result.reserve(values.size());
+
+    for (const QString &value : values) {
+        if (seen.contains(value))
+            continue;
+
+        seen.insert(value);
+        result.append(value);
+    }
+
+    return result;
+}
+
+bool matchesReadings(const QList<QStringList> &readings, const PinyinSearchQuery &query)
+{
+    if (query.pattern.isEmpty())
+        return true;
+
+    QList<bool> states(query.pattern.size(), false);
+    states[0] = true;
+
+    for (const QStringList &choices : readings) {
+        QList<bool> nextStates(query.pattern.size(), false);
+        for (qsizetype state = 0; state < states.size(); ++state) {
+            if (!states.at(state))
+                continue;
+
+            for (const QString &choice : choices) {
+                qsizetype matched = state;
+                for (const QChar character : choice.toCaseFolded()) {
+                    while (matched > 0 && character != query.pattern.at(matched))
+                        matched = query.prefixTable.at(matched - 1);
+                    if (character == query.pattern.at(matched))
+                        ++matched;
+                    if (matched == query.pattern.size())
+                        return true;
+                }
+                nextStates[matched] = true;
+            }
+        }
+        states = std::move(nextStates);
+    }
+
+    return false;
+}
+
+}
+
+PinyinSearchIndex buildPinyinSearchIndex(const QString &text)
+{
+    DCORE_USE_NAMESPACE
+
+    QList<QStringList> spellings;
+    QList<QStringList> initials;
+    spellings.reserve(text.size());
+    initials.reserve(text.size());
+
+    for (const QChar character : text) {
+        QStringList choices = orderedUnique(pinyin(QString(character), TS_NoneTone));
+        if (choices.isEmpty())
+            choices.append(character);
+        spellings.append(choices);
+
+        for (QString &choice : choices)
+            choice = choice.left(1);
+        initials.append(orderedUnique(choices));
+    }
+
+    return {spellings, initials};
+}
+
+PinyinSearchQuery buildPinyinSearchQuery(const QString &query)
+{
+    const QString pattern = query.toCaseFolded();
+    QList<int> table(pattern.size(), 0);
+    for (qsizetype i = 1, matched = 0; i < pattern.size(); ++i) {
+        while (matched > 0 && pattern.at(i) != pattern.at(matched))
+            matched = table.at(matched - 1);
+        if (pattern.at(i) == pattern.at(matched))
+            ++matched;
+        table[i] = matched;
+    }
+
+    return {pattern, table};
+}
+
+bool matchesPinyin(const PinyinSearchIndex &index, const PinyinSearchQuery &query)
+{
+    return matchesReadings(index.syllables, query);
+}
+
+bool matchesPinyinInitials(const PinyinSearchIndex &index, const PinyinSearchQuery &query)
+{
+    return matchesReadings(index.initials, query);
+}
+
+bool matchesPinyinSearch(const PinyinSearchIndex &index, const PinyinSearchQuery &query)
+{
+    return matchesPinyin(index, query) || matchesPinyinInitials(index, query);
+}
+
+}

--- a/src/plugin-keyboard/operation/pinyinsearch.h
+++ b/src/plugin-keyboard/operation/pinyinsearch.h
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef PINYINSEARCH_H
+#define PINYINSEARCH_H
+
+#include <QList>
+#include <QStringList>
+
+namespace dccV25 {
+
+struct PinyinSearchIndex
+{
+    QList<QStringList> syllables;
+    QList<QStringList> initials;
+};
+
+struct PinyinSearchQuery
+{
+    QString pattern;
+    QList<int> prefixTable;
+};
+
+PinyinSearchIndex buildPinyinSearchIndex(const QString &text);
+PinyinSearchQuery buildPinyinSearchQuery(const QString &query);
+bool matchesPinyin(const PinyinSearchIndex &index, const PinyinSearchQuery &query);
+bool matchesPinyinInitials(const PinyinSearchIndex &index, const PinyinSearchQuery &query);
+bool matchesPinyinSearch(const PinyinSearchIndex &index, const PinyinSearchQuery &query);
+
+}
+
+#endif // PINYINSEARCH_H

--- a/src/plugin-keyboard/operation/shortcutmodel.cpp
+++ b/src/plugin-keyboard/operation/shortcutmodel.cpp
@@ -3,6 +3,7 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "shortcutmodel.h"
+#include "pinyinsearch.h"
 
 #include <DSysInfo>
 #include <QDBusInterface>
@@ -13,7 +14,6 @@
 #include <QJsonValue>
 #include <QThreadPool>
 #include <QGuiApplication>
-#include <DPinyin>
 
 QStringList systemFilter = {"terminal",
                             "terminalQuake",
@@ -89,12 +89,6 @@ static const QMap<QString, QString> &DisplaykeyMap = { {"exclam", "!"}, {"at", "
     {"Super_L", "Super"}, {"Super_R", "Super"}
 };
 
-static QString toPinyin(const QString &name)
-{
-    DCORE_USE_NAMESPACE
-    return pinyin(name, TS_NoneTone).join(FieldSeparator) + FieldSeparator + firstLetters(name).join(FieldSeparator);
-}
-
 static void fillShortcutInfoFromJson(dccV25::ShortcutInfo *info, const QJsonObject &obj)
 {
     if (!info)
@@ -104,7 +98,7 @@ static void fillShortcutInfoFromJson(dccV25::ShortcutInfo *info, const QJsonObje
     const QJsonArray accels = obj["Accels"].toArray();
     info->accels = accels.isEmpty() ? QString() : accels.first().toString();
     info->name = obj["Name"].toString();
-    info->pinyin = toPinyin(info->name);
+    info->pinyinIndex = dccV25::buildPinyinSearchIndex(info->name);
     info->id = obj["Id"].toString();
     info->command = obj["Exec"].toString();
 
@@ -330,7 +324,7 @@ void ShortcutModel::onParseInfo(const QString &info)
         if (systemShortKeys.contains(info->id)) {
             info->name    = info->name.trimmed();
         }
-        info->pinyin  =  toPinyin(info->name);
+        info->pinyinIndex = buildPinyinSearchIndex(info->name);
         info->command = obj["Exec"].toString();
 
         m_infos << info;
@@ -461,7 +455,7 @@ void ShortcutModel::onCustomInfo(const QString &json)
     info->accels = accels;
 
     info->name    = obj["Name"].toString();
-    info->pinyin = toPinyin(info->name);
+    info->pinyinIndex = buildPinyinSearchIndex(info->name);
     info->id      = obj["Id"].toString();
     info->command = obj["Exec"].toString();
     info->sectionName = tr("Custom");
@@ -773,6 +767,7 @@ void ShortcutModel::setSearchResult(const QString &searchResult)
         info->type         = type;
         info->accels       = obj["Accels"].toArray().first().toString();
         info->name    = obj["Name"].toString();
+        info->pinyinIndex = buildPinyinSearchIndex(info->name);
         info->id      = obj["Id"].toString();
         info->command = obj["Exec"].toString();
 
@@ -918,6 +913,11 @@ ShortcutModel *ShortcutListModel::souceModel()
     return m_model;
 }
 
+const ShortcutInfo *ShortcutListModel::shortcutAt(int row) const
+{
+    return m_model ? m_model->shortcutAt(row) : nullptr;
+}
+
 void ShortcutListModel::reset()
 {
     beginResetModel();
@@ -969,7 +969,7 @@ QVariant ShortcutListModel::data(const QModelIndex &index, int role) const
     case Qt::DisplayRole:
         return info->name;
     case SearchedTextRole:
-        return info->name + info->pinyin + FieldSeparator + displayKeys.join(FieldSeparator);
+        return info->name + FieldSeparator + displayKeys.join(FieldSeparator);
     case IdRole:
         return info->id;
     case TypeRole:
@@ -1010,4 +1010,32 @@ QHash<int, QByteArray> ShortcutListModel::roleNames() const
     names[IsCustomRole] = "isCustom";
 
     return names;
+}
+
+ShortcutFilterModel::ShortcutFilterModel(QObject *parent)
+    : QSortFilterProxyModel(parent)
+{
+}
+
+const PinyinSearchQuery &ShortcutFilterModel::cachedPinyinQuery(const QString &pattern) const
+{
+    if (pattern != m_cachedPinyinPattern) {
+        m_cachedPinyinPattern = pattern;
+        m_cachedPinyinQuery = buildPinyinSearchQuery(pattern);
+    }
+    return m_cachedPinyinQuery;
+}
+
+bool ShortcutFilterModel::filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const
+{
+    if (QSortFilterProxyModel::filterAcceptsRow(sourceRow, sourceParent))
+        return true;
+
+    const auto *model = qobject_cast<const ShortcutListModel *>(sourceModel());
+    const ShortcutInfo *info = model ? model->shortcutAt(sourceRow) : nullptr;
+    if (!info)
+        return false;
+
+    const QString pattern = filterRegularExpression().pattern();
+    return matchesPinyinSearch(info->pinyinIndex, cachedPinyinQuery(pattern));
 }

--- a/src/plugin-keyboard/operation/shortcutmodel.h
+++ b/src/plugin-keyboard/operation/shortcutmodel.h
@@ -5,6 +5,8 @@
 #ifndef SHORTCUTMODEL_H
 #define SHORTCUTMODEL_H
 
+#include "pinyinsearch.h"
+
 #define MEDIAKEY 2
 
 #include <QAbstractListModel>
@@ -27,7 +29,7 @@ struct ShortcutInfo
     ShortcutItem *item = nullptr;
     QString sectionKey;            // Stable logical category key (never translated)
     QString sectionName;           // Resolved translated display text for section
-    QString pinyin;
+    PinyinSearchIndex pinyinIndex;
     int index = 0;
 
     ShortcutInfo()
@@ -197,6 +199,7 @@ public:
 
     void setSouceModel(ShortcutModel *model);
     ShortcutModel *souceModel();
+    const ShortcutInfo *shortcutAt(int row) const;
 
     int rowCount(const QModelIndex &parent) const override;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
@@ -208,6 +211,22 @@ public Q_SLOTS:
 
 private:
     ShortcutModel *m_model = nullptr;
+};
+
+class ShortcutFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+public:
+    explicit ShortcutFilterModel(QObject *parent = nullptr);
+
+protected:
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+
+private:
+    const PinyinSearchQuery &cachedPinyinQuery(const QString &pattern) const;
+
+    mutable QString m_cachedPinyinPattern;
+    mutable PinyinSearchQuery m_cachedPinyinQuery;
 };
 
 } // namespace dccV25

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,1 +1,19 @@
 set(BIN_NAME unit-test)
+
+add_executable(${BIN_NAME}
+    ut_pinyinsearch.cpp
+    ${PROJECT_SOURCE_DIR}/src/plugin-keyboard/operation/pinyinsearch.cpp
+)
+
+target_include_directories(${BIN_NAME} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/plugin-keyboard/operation
+)
+
+target_link_libraries(${BIN_NAME} PRIVATE
+    GTest::gtest_main
+    ${DTK_NS}::Core
+    ${QT_NS}::Core
+)
+
+include(GoogleTest)
+gtest_discover_tests(${BIN_NAME})

--- a/tests/ut_pinyinsearch.cpp
+++ b/tests/ut_pinyinsearch.cpp
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "pinyinsearch.h"
+
+#include <gtest/gtest.h>
+
+namespace {
+
+using dccV25::buildPinyinSearchQuery;
+
+TEST(PinyinSearch, matchesMultipleAlternativeReadings)
+{
+    const dccV25::PinyinSearchIndex index =
+            dccV25::buildPinyinSearchIndex(QStringLiteral("度重"));
+
+    EXPECT_TRUE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(QStringLiteral("duochong"))));
+    EXPECT_FALSE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(QStringLiteral("duoxiang"))));
+
+    dccV25::PinyinSearchIndex syntheticIndex;
+    syntheticIndex.syllables = {{QStringLiteral("a"), QStringLiteral("x")},
+                                {QStringLiteral("b"), QStringLiteral("y")},
+                                {QStringLiteral("c"), QStringLiteral("z")}};
+    EXPECT_TRUE(dccV25::matchesPinyin(syntheticIndex, buildPinyinSearchQuery(QStringLiteral("xyz"))));
+}
+
+TEST(PinyinSearch, preservesLaterPolyphonicReadings)
+{
+    const dccV25::PinyinSearchIndex index =
+            dccV25::buildPinyinSearchIndex(QStringLiteral("度度度度度度重"));
+    const QString allAlternatives = QStringLiteral("duo").repeated(6) + QStringLiteral("chong");
+
+    EXPECT_TRUE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(allAlternatives)));
+    EXPECT_TRUE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(QStringLiteral("chong"))));
+}
+
+TEST(PinyinSearch, matchesMultipleAlternativeInitials)
+{
+    dccV25::PinyinSearchIndex index;
+    index.initials = {{QStringLiteral("a"), QStringLiteral("x")},
+                      {QStringLiteral("b"), QStringLiteral("y")},
+                      {QStringLiteral("c"), QStringLiteral("z")}};
+
+    EXPECT_TRUE(dccV25::matchesPinyinInitials(index, buildPinyinSearchQuery(QStringLiteral("xyz"))));
+    EXPECT_TRUE(dccV25::matchesPinyinInitials(index, buildPinyinSearchQuery(QStringLiteral("xy"))));
+    EXPECT_FALSE(dccV25::matchesPinyinInitials(index, buildPinyinSearchQuery(QStringLiteral("xya"))));
+}
+
+TEST(PinyinSearch, matchesSubstringAcrossSyllables)
+{
+    dccV25::PinyinSearchIndex index;
+    index.syllables = {{QStringLiteral("duo")}, {QStringLiteral("chong")}};
+
+    EXPECT_TRUE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(QStringLiteral("och"))));
+    EXPECT_TRUE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(QStringLiteral("CHONG"))));
+}
+
+TEST(PinyinSearch, compilesQueryOnceForFullAndInitialMatches)
+{
+    dccV25::PinyinSearchIndex index;
+    index.syllables = {{QStringLiteral("shen")}, {QStringLiteral("du"), QStringLiteral("duo")}};
+    index.initials = {{QStringLiteral("s")}, {QStringLiteral("d")}};
+    const dccV25::PinyinSearchQuery fullQuery = buildPinyinSearchQuery(QStringLiteral("SHENDUO"));
+    const dccV25::PinyinSearchQuery initialsQuery = buildPinyinSearchQuery(QStringLiteral("SD"));
+
+    EXPECT_EQ(fullQuery.pattern, QStringLiteral("shenduo"));
+    EXPECT_EQ(fullQuery.prefixTable.size(), fullQuery.pattern.size());
+    EXPECT_TRUE(dccV25::matchesPinyinSearch(index, fullQuery));
+    EXPECT_TRUE(dccV25::matchesPinyinSearch(index, initialsQuery));
+}
+
+TEST(PinyinSearch, storesLongPolyphonicTextLinearly)
+{
+    const QString text = QStringLiteral("深度影院").repeated(24);
+    const QString alternativePinyin = QStringLiteral("shenduoyingyuan").repeated(24);
+    const dccV25::PinyinSearchIndex index = dccV25::buildPinyinSearchIndex(text);
+
+    qsizetype spellingCount = 0;
+    qsizetype initialCount = 0;
+    for (const QStringList &choices : index.syllables)
+        spellingCount += choices.size();
+    for (const QStringList &choices : index.initials)
+        initialCount += choices.size();
+
+    EXPECT_EQ(index.syllables.size(), text.size());
+    EXPECT_EQ(index.initials.size(), text.size());
+    EXPECT_LE(spellingCount, text.size() * 5);
+    EXPECT_LE(initialCount, text.size() * 5);
+    EXPECT_TRUE(dccV25::matchesPinyin(index, buildPinyinSearchQuery(alternativePinyin)));
+    EXPECT_TRUE(dccV25::matchesPinyinInitials(
+            index, buildPinyinSearchQuery(QStringLiteral("sdyy").repeated(24))));
+}
+
+}


### PR DESCRIPTION
## Summary

- replace whole-name polyphonic expansion with a linear per-character pinyin index
- preserve full-pinyin, initials, alternative-pronunciation, and substring search through bounded state matching
- add regression coverage for a 96-character custom shortcut name

## Test plan

- `cmake --build build-pinyin-search --target unit-test keyboard -j4`
- `ctest --test-dir build-pinyin-search --output-on-failure`
- verify `PinyinSearch.storesLongPolyphonicTextLinearly` completes without DTK combination-limit warnings

PMS: BUG-372249

## Summary by Sourcery

Switch shortcut pinyin handling to a new linear per-character search index and integrate it into shortcut filtering to improve performance and correctness for polyphonic and long shortcut names, with corresponding unit tests and test harness updates.

New Features:
- Introduce a dedicated pinyin search index and matching helpers for shortcut names, supporting full pinyin, initials, and substring queries via bounded-state matching.

Bug Fixes:
- Prevent pinyin shortcut search stalls for long or highly polyphonic shortcut names by replacing whole-name expansion with a per-character linear index.

Enhancements:
- Refactor shortcut list filtering to use a custom proxy model that delegates to the new pinyin search matcher instead of embedding pinyin in the search text role.

Build:
- Enable CTest-based unit testing and wire up a new unit-test binary covering the pinyin search implementation.

Tests:
- Add unit tests validating polyphonic pinyin handling, substring matching, and bounded growth of pinyin indices for long shortcut names.