### PR TITLE
fix(bluetooth): adjust device icon left padding in other devices list

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,14 @@
+dde-control-center (6.1.103) unstable; urgency=medium
+
+  * fix(time-range): apply manually entered time on edit finish
+  * fix: place language and region after time and date
+  * i18n: Updates for project Deepin Desktop Environment (#3384)
+  * fix: avoid shortcut pinyin expansion stalls
+  * fix: skip control center loading page under Treeland
+  * i18n: Updates for project Deepin Desktop Environment (#3387)
+
+ -- zhangkun <zhangkun2@uniontech.com>  Thu, 06 Aug 2026 15:53:12 +0800
+
 dde-control-center (6.1.102) unstable; urgency=medium
 
   * fix(authentication): set fixed height and vertical center alignment

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -477,9 +477,11 @@ void DccManager::show()
     m_needShow = true;
     QWindow *w = DccManager::mainWindow();
     if (!w) {
+        m_needShow = false;
         return;
     }
     if (!m_showLoadPage && !m_activeObject) {
+        m_needShow = false;
         return;
     }
     if (w->windowStates() == Qt::WindowMinimized || !w->isVisible()) {

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -68,6 +68,8 @@ DccManager::DccManager(QObject *parent)
     , m_showTimer(nullptr)
     , m_showFallbackTimer(nullptr)
     , m_showPagePending(false)
+    , m_showLoadPage(!isTreeland())
+    , m_needShow(false)
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -472,15 +474,19 @@ void DccManager::cacheImage(const QString &id, const QSize &thumbnailSize)
 
 void DccManager::show()
 {
+    m_needShow = true;
     QWindow *w = DccManager::mainWindow();
     if (!w) {
         return;
     }
-
+    if (!m_showLoadPage && !m_activeObject) {
+        return;
+    }
     if (w->windowStates() == Qt::WindowMinimized || !w->isVisible()) {
         w->showNormal();
     }
     w->requestActivate();
+    m_needShow = false;
 }
 
 void DccManager::toggle()
@@ -1009,6 +1015,9 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
         Q_EMIT triggeredObjectsChanged(m_triggeredObjects);
 
     m_showFallbackTimer->stop();
+    if (m_needShow) {
+        show();
+    }
 }
 
 QSet<QString> findAddItems(QSet<QString> *oldSet, QSet<QString> *newSet)

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -152,6 +152,8 @@ private:
     QString m_showUrl;
     QDBusMessage m_showMessage;
     bool m_showPagePending;
+    bool m_showLoadPage;
+    bool m_needShow;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
 

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -53,10 +53,8 @@ public:
         if (m_manager->isDeleting()) {
             return;
         }
+        // createData和moveThread需要完整，都执行或都不执行
         m_loader->createData();
-        if (m_manager->isDeleting()) {
-            return;
-        }
         m_loader->moveThread();
         m_loader->setLog("create data finished. elapsed time :" + QString::number(timer.elapsed()));
         m_loader->transitionStatus(DccPluginLoader::DataEnd);

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -55,6 +55,9 @@ public:
         }
         // createData和moveThread需要完整，都执行或都不执行
         m_loader->createData();
+        if (m_manager->isDeleting()) {
+            return;
+        }
         m_loader->moveThread();
         m_loader->setLog("create data finished. elapsed time :" + QString::number(timer.elapsed()));
         m_loader->transitionStatus(DccPluginLoader::DataEnd);

--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -37,6 +37,7 @@ Rectangle {
                 Layout.fillHeight: true
 
                 topPadding: 0
+                leftPadding: 14
                 bottomPadding: 0
 
                 cascadeSelected: true

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -3385,7 +3385,7 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     </message>
     <message>
         <source>The name cannot exceed 128 characters.</source>
-        <translation type="unfinished"/>
+        <translation>El nom no pot superar els 128 caràcters.</translation>
     </message>
     <message>
         <source>Change custom shortcut</source>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -3385,7 +3385,7 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
     </message>
     <message>
         <source>The name cannot exceed 128 characters.</source>
-        <translation type="unfinished"/>
+        <translation>Nazwa nie może przekraczać 128 znaków.</translation>
     </message>
     <message>
         <source>Change custom shortcut</source>


### PR DESCRIPTION
## Summary

fix(bluetooth): adjust device icon left padding in other devices list

1. Add leftPadding: 14 to ItemDelegate so the device icon is 14px from the left edge of the list background

Log: Fix device icon too close to left edge in bluetooth other devices list
Influence: Improves spacing between device icon and list left edge

fix(bluetooth): 调整蓝牙其他设备列表中设备图标的左边距

1. 为 ItemDelegate 添加 leftPadding: 14，使设备图标距离列表背景左边缘 14px

Log: 修复蓝牙其他设备列表中设备图标距左边缘过近的问题
PMS: BUG-372857
Influence: 改善设备图标与列表左边缘的间距

## Test
- 打开蓝牙页面，查看其他设备列表中设备图标与左边缘的间距是否符合预期（14px）
- 图标与设备名称间距保持不变（10px）

## Summary by Sourcery

Bug Fixes:
- Increase left padding for Bluetooth 'other devices' list items so device icons are no longer too close to the left edge.