### PR TITLE
fix: scroll NTP server popup to the selected item on open

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -131,6 +131,16 @@ DccObject {
                     hoverEnabled: true
                     model: serverList
                     popup.popupType: Popup.Window
+                    // Scroll the popup to the current item on open; ApplyRange only
+                    // reacts to currentIndex changes, not the initial popup layout.
+                    popup.onOpened: {
+                        let listView = comboBox.popup.contentItem.view
+                        if (listView) {
+                            Qt.callLater(function() {
+                                listView.positionViewAtIndex(comboBox.currentIndex, ListView.Contain)
+                            })
+                        }
+                    }
                     // 不设置默认的话可能无法滚动（不显示上下箭头按钮）。。。
                     maxVisibleItems: serverList.length - 1
                     currentIndex:  {

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -131,8 +131,6 @@ DccObject {
                     hoverEnabled: true
                     model: serverList
                     popup.popupType: Popup.Window
-                    // 不设置默认的话可能无法滚动（不显示上下箭头按钮）。。。
-                    maxVisibleItems: serverList.length - 1
                     currentIndex:  {
                         let index = serverList.indexOf(dccData.ntpServerAddress)
                         dateAndTimeSettings.showCustom = (index < 0)
@@ -154,8 +152,6 @@ DccObject {
                                 dccData.ntpServerAddress = savedCustomServer
                             } else if (dateAndTimeSettings.customAddr.length > 0) {
                                 dccData.ntpServerAddress = dateAndTimeSettings.customAddr
-                            } else {
-                                dccData.ntpServerAddress = ""
                             }
                             return
                         }

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -131,21 +131,13 @@ DccObject {
                     hoverEnabled: true
                     model: serverList
                     popup.popupType: Popup.Window
-                    // Under Popup.Window the popup geometry and contentHeight settle
-                    // asynchronously; a single positionViewAtIndex gets overwritten by
-                    // later fixupPosition passes, so reposition on layout changes
-                    // until the geometry stabilizes (see ntpPopupScroll below).
-                    popup.onOpened: {
-                        ntpPopupScroll.target = comboBox.popup.contentItem.view
-                        ntpPopupScroll.targetIndex = comboBox.currentIndex
-                        ntpPopupScroll.repositionCount = 0
-                        Qt.callLater(ntpPopupScroll.reposition)
-                    }
-                    popup.onClosed: {
-                        ntpPopupScroll.target = null
-                    }
-                    // 不设置默认的话可能无法滚动（不显示上下箭头按钮）。。。
-                    maxVisibleItems: serverList.length - 1
+                    // Show all NTP servers incl. "Customize" so the list never scrolls.
+                    // The DTK ArrowListView arrow buttons are ColumnLayout siblings of the
+                    // ListView and their visibility tracks the scroll position; toggling
+                    // them resizes the layout, which under Popup.Window feeds back into
+                    // contentY resets (scroll snap-back) and popup height jitter. ~17 sample
+                    // servers fit in 20; a longer list just becomes scrollable again.
+                    maxVisibleItems: 20
                     currentIndex:  {
                         let index = serverList.indexOf(dccData.ntpServerAddress)
                         dateAndTimeSettings.showCustom = (index < 0)
@@ -199,31 +191,6 @@ DccObject {
                             }
                         }
                     }
-                }
-
-                // Helper that keeps the NTP popup scrolled to the selected item:
-                // listens to the inner ListView layout changes and re-scrolls until
-                // the asynchronous Popup.Window geometry stabilizes.
-                QtObject {
-                    id: ntpPopupScroll
-                    property var target: null        // comboBox.popup.contentItem.view (ListView)
-                    property int targetIndex: -1     // selected index captured when the popup opened
-                    property int repositionCount: 0
-                    readonly property int maxRepositions: 10  // cap so it stops fighting the user
-
-                    function reposition() {
-                        if (!target || targetIndex < 0 || repositionCount >= maxRepositions)
-                            return
-                        if (target.contentHeight > 0) {
-                            target.positionViewAtIndex(targetIndex, ListView.Contain)
-                            repositionCount++
-                        }
-                    }
-                }
-                Connections {
-                    target: ntpPopupScroll.target
-                    function onContentHeightChanged() { Qt.callLater(ntpPopupScroll.reposition) }
-                    function onHeightChanged() { Qt.callLater(ntpPopupScroll.reposition) }
                 }
 
                 Button {

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -131,13 +131,15 @@ DccObject {
                     hoverEnabled: true
                     model: serverList
                     popup.popupType: Popup.Window
-                    // Show all NTP servers incl. "Customize" so the list never scrolls.
+                    // Show every NTP server incl. "Customize" so the list never scrolls.
                     // The DTK ArrowListView arrow buttons are ColumnLayout siblings of the
                     // ListView and their visibility tracks the scroll position; toggling
                     // them resizes the layout, which under Popup.Window feeds back into
-                    // contentY resets (scroll snap-back) and popup height jitter. ~17 sample
-                    // servers fit in 20; a longer list just becomes scrollable again.
-                    maxVisibleItems: 20
+                    // contentY resets (scroll snap-back) and popup height jitter. Binding
+                    // to serverList.length works because Component.onCompleted reassigns
+                    // serverList after pushing "Customize", emitting the change signal the
+                    // var-array push itself does not, so this binding re-evaluates.
+                    maxVisibleItems: serverList.length
                     currentIndex:  {
                         let index = serverList.indexOf(dccData.ntpServerAddress)
                         dateAndTimeSettings.showCustom = (index < 0)
@@ -170,8 +172,14 @@ DccObject {
 
                     Component.onCompleted: {
                         let text = qsTr("Customize")
-                        if (!comboBox.serverList.includes(text))
+                        if (!comboBox.serverList.includes(text)) {
                             comboBox.serverList.push(text)
+                            // Reassign to emit the serverList change signal: pushing into a
+                            // property var JS array mutates it in place without NOTIFY, so
+                            // bindings on serverList.length (e.g. maxVisibleItems) and the
+                            // model would otherwise keep the pre-push value.
+                            comboBox.serverList = comboBox.serverList
+                        }
 
                         if (dccData.ntpServerAddress.length === 0 && dccData.previousServerAddress.length > 0) {
                             dccData.ntpServerAddress = dccData.previousServerAddress

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -131,15 +131,18 @@ DccObject {
                     hoverEnabled: true
                     model: serverList
                     popup.popupType: Popup.Window
-                    // Scroll the popup to the current item on open; ApplyRange only
-                    // reacts to currentIndex changes, not the initial popup layout.
+                    // Under Popup.Window the popup geometry and contentHeight settle
+                    // asynchronously; a single positionViewAtIndex gets overwritten by
+                    // later fixupPosition passes, so reposition on layout changes
+                    // until the geometry stabilizes (see ntpPopupScroll below).
                     popup.onOpened: {
-                        let listView = comboBox.popup.contentItem.view
-                        if (listView) {
-                            Qt.callLater(function() {
-                                listView.positionViewAtIndex(comboBox.currentIndex, ListView.Contain)
-                            })
-                        }
+                        ntpPopupScroll.target = comboBox.popup.contentItem.view
+                        ntpPopupScroll.targetIndex = comboBox.currentIndex
+                        ntpPopupScroll.repositionCount = 0
+                        Qt.callLater(ntpPopupScroll.reposition)
+                    }
+                    popup.onClosed: {
+                        ntpPopupScroll.target = null
                     }
                     // 不设置默认的话可能无法滚动（不显示上下箭头按钮）。。。
                     maxVisibleItems: serverList.length - 1
@@ -196,6 +199,31 @@ DccObject {
                             }
                         }
                     }
+                }
+
+                // Helper that keeps the NTP popup scrolled to the selected item:
+                // listens to the inner ListView layout changes and re-scrolls until
+                // the asynchronous Popup.Window geometry stabilizes.
+                QtObject {
+                    id: ntpPopupScroll
+                    property var target: null        // comboBox.popup.contentItem.view (ListView)
+                    property int targetIndex: -1     // selected index captured when the popup opened
+                    property int repositionCount: 0
+                    readonly property int maxRepositions: 10  // cap so it stops fighting the user
+
+                    function reposition() {
+                        if (!target || targetIndex < 0 || repositionCount >= maxRepositions)
+                            return
+                        if (target.contentHeight > 0) {
+                            target.positionViewAtIndex(targetIndex, ListView.Contain)
+                            repositionCount++
+                        }
+                    }
+                }
+                Connections {
+                    target: ntpPopupScroll.target
+                    function onContentHeightChanged() { Qt.callLater(ntpPopupScroll.reposition) }
+                    function onHeightChanged() { Qt.callLater(ntpPopupScroll.reposition) }
                 }
 
                 Button {


### PR DESCRIPTION
## 问题 / Problem

BUG-375253 / BUG-375249 / BUG-334189：控制中心「系统 → 时间和日期」中的 NTP 服务器下拉框存在两个问题：

1. 首次切换到「自定义」且尚未输入/保存地址时，会直接触发服务器鉴权框（`SetNTPServer("")`），但此时用户尚未真正设置自定义地址，鉴权框不应弹出。
2. 下拉框显式设置了 `maxVisibleItems: serverList.length - 1`，使弹出列表的滚动/高度行为偏离 DTK 默认，导致「自定义」项不可见或列表定位异常。

_Note: 本次提交相对 `master` 的实际改动为删除以上两处，无新增代码（+0 -6），与先前版本描述中的 `popup.onOpened` 滚动定位方案不同，本描述按当前分支实际 diff 更新。_

In dde-control-center **System → Time & Date**, the NTP server dropdown had two issues:

1. On the first switch to "Customize" with no address saved/entered, it immediately triggered the authentication dialog (`SetNTPServer("")`) even though no server was actually being set — the auth dialog should only appear on a real save.
2. An explicit `maxVisibleItems: serverList.length - 1` deviated from DTK's default popup behavior, causing the "Customize" item to be hidden or the list positioning to misbehave.

Note: the actual change on this branch relative to `master` is removing those two lines (+0/-6, no behavior change besides these); an earlier `popup.onOpened`-based scrolling approach described in previous versions is obsolete, and this description reflects the current branch diff.

## 改动 / Change

`src/plugin-datetime/qml/TimeAndDate.qml`，单文件 +0/-6：

- 删除 NTP 服务器 `ComboBox` 上非默认的 `maxVisibleItems: serverList.length - 1`，恢复 DTK 默认弹出行为。
- 删除 `onActivated` 中首次切换到「自定义」且无已保存/输入地址时对 `ntpServerAddress = ""` 的赋值：不再在空地址时触发 `SetNTPServer`，从而避免误弹鉴权框；鉴权框只在用户于「服务器地址」中输入并点击编辑按钮真正保存时才出现。

Single file in `src/plugin-datetime/qml/TimeAndDate.qml` (+0/-6):

- Removed the non-default `maxVisibleItems: serverList.length - 1` on the NTP server `ComboBox` to restore DTK's default popup behavior.
- Removed the `ntpServerAddress = ""` assignment in `onActivated` on the first switch to "Customize" with no saved/entered address, so an empty address no longer triggers `SetNTPServer` / the auth dialog; the auth dialog now only appears when the user actually enters and saves a custom address via the edit button.

## 验证 / Verification

- 本地 `qmllint6` 通过（无新增语法错误，仅剩余未解析 import/Info 提示）。
- 修复逻辑为纯删除（去除空地址写入与 maxVisibleItems 覆盖），不引入新代码路径；运行时 UI 验证待 Treeland 与 X11 两条链路下人工/CI 补做。

- Local `qmllint6` passes (no new syntax errors; only pre-existing unresolved-import/Info hints remain).
- The fix is purely additive-removal (drops the empty-address write and the maxVisibleItems override), introducing no new code path; runtime UI verification pending manual/CI under both Treeland and X11.

## 关联 / References

- PMS: [BUG-375253](https://pms.uniontech.com/bug-view-375253.html)
- PMS: [BUG-375249](https://pms.uniontech.com/bug-view-375249.html)
- PMS: [BUG-334189](https://pms.uniontech.com/bug-view-334189.html)