### PR TITLE
fix: remember control center maximized state across restarts

### DIFF
--- a/misc/configs/org.deepin.dde.control-center.json
+++ b/misc/configs/org.deepin.dde.control-center.json
@@ -24,6 +24,17 @@
             "permissions": "readwrite",
             "visibility": "public"
         },
+        "maximized": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "maximized",
+            "name[zh_CN]": "最大化",
+            "description": "config dde-control-center maximized state",
+            "description[zh_CN]": "控制中心最大化状态配置",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
         "sidebarWidth": {
             "value": -1,
             "serial": 0,

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -45,6 +45,7 @@ namespace dccV25 {
 
 const QString WidthConfig = QStringLiteral("width");
 const QString HeightConfig = QStringLiteral("height");
+const QString MaximizedConfig = QStringLiteral("maximized");
 const QString HideConfig = QStringLiteral("hideModule");
 const QString DisableConfig = QStringLiteral("disableModule");
 const QString ControlCenterIcon = QStringLiteral("preferences-system");
@@ -150,6 +151,9 @@ void DccManager::setMainWindow(QWindow *window)
     connect(m_window, &QWindow::widthChanged, this, &DccManager::saveSize);
     connect(m_window, &QWindow::heightChanged, this, &DccManager::saveSize);
     connect(m_window, &QWindow::windowStateChanged, this, &DccManager::saveSize);
+    // Persist the maximized flag on the authoritative state-change event only,
+    // not on the high-frequency widthChanged/heightChanged resize signals.
+    connect(m_window, &QWindow::windowStateChanged, this, &DccManager::onWindowStateChanged);
     connect(qGuiApp, &QGuiApplication::screenAdded, this, &DccManager::handleScreenAdded);
     m_window->installEventFilter(this);
 }
@@ -483,7 +487,10 @@ void DccManager::show()
         return;
     }
     if (w->windowStates() == Qt::WindowMinimized || !w->isVisible()) {
-        w->showNormal();
+        if (m_dconfig->value(MaximizedConfig, false).toBool())
+            w->showMaximized();
+        else
+            w->showNormal();
     }
     w->requestActivate();
     m_needShow = false;
@@ -745,6 +752,21 @@ void DccManager::saveSize()
 
     m_dconfig->setValue(WidthConfig, m_window->width());
     m_dconfig->setValue(HeightConfig, m_window->height());
+}
+
+void DccManager::onWindowStateChanged()
+{
+    if (!m_window)
+        return;
+    if (!m_dconfig->isValid())
+        return;
+
+    // Persist the maximized/fullscreen flag only on the state-change event so
+    // the last window state can be restored on the next launch. Writing it here
+    // (rather than inside saveSize) avoids touching DConfig on every resize.
+    m_dconfig->setValue(MaximizedConfig,
+        m_window->windowStates().testFlag(Qt::WindowMaximized)
+            || m_window->windowStates().testFlag(Qt::WindowFullScreen));
 }
 
 void DccManager::handleScreenAdded(QScreen *screen)

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -107,6 +107,7 @@ private:
 
 private Q_SLOTS:
     void saveSize();
+    void onWindowStateChanged();
     void handleScreenAdded(QScreen *screen);
     void waitShowPage(const QString &url, const QDBusMessage message);
     void clearShowParam();


### PR DESCRIPTION
## fix: remember control center maximized state across restarts

### Background
控制中心（dde-control-center）最大化后关闭窗口，再重新打开时未记住上次的窗口大小/最大化状态，展示默认初始小窗口而非上次最大化的窗口。

### Root Cause
`DccManager` 只持久化了窗口 `width`/`height`（normal 尺寸），从未持久化 maximized 状态；`show()` 在窗口不可见时恒走 `showNormal()`，导致最大化状态丢失，用户看到的是 normal 尺寸的小窗口。

### Change
- `misc/configs/org.deepin.dde.control-center.json`: 新增 `maximized` 键（`value: false`、`permissions: readwrite`、`visibility: public`），格式参照现有 `width`/`height`；CMake 用 `file(GLOB misc/configs/*.json)` 自动安装，无需改 CMake。
- `src/dde-control-center/dccmanager.cpp`:
  - 新增常量 `const QString MaximizedConfig = QStringLiteral("maximized");`
  - `setMainWindow()` 新增 `windowStateChanged → onWindowStateChanged` 连接（保留原有 `windowStateChanged → saveSize` 连接，未回退 `965e1e5c9`）
  - 新增私有 slot `onWindowStateChanged()`：仅在状态变更事件时写 `maximized` 标志（`WindowMaximized || WindowFullScreen`），避免在 resize 过程中随 `widthChanged/heightChanged` 高频写 DConfig
  - `show()`：`!isVisible() || WindowMinimized` 分支按标志分流——`maximized` 为 true 时 `showMaximized()`，否则 `showNormal()`（`value(MaximizedConfig, false)` 兜底）
- `src/dde-control-center/dccmanager.h`: `private Q_SLOTS:` 新增 `void onWindowStateChanged();` 声明

### Notes
- 保留 `965e1e5c9` 的 normal 尺寸保存逻辑与 `handleScreenAdded()` HDMI 热插拔逻辑，未回退。
- 首次启动/键缺失时 `maximized` 默认 `false`，行为与现状一致，不引入"全新装就最大化"回归。
- QML（`DccWindow.qml`）未改动：`Component.onCompleted` 仍按 `DccApp.width/height` 设置 normal 尺寸并居中，随后 `show()` 决定是否 maximize。

### Verification
- 研发自测：cmake Debug 编译 0 error、DConfig schema 校验/安装通过（`dconfig2cpp` 正确导出 `maximized`）、6/6 既有单测不回归。
- 代码审核：96/100，风险 Low，安全漏洞 0，2 项非阻塞风格建议（可选采纳，不影响合入）。
- 建议 AT/手动回归场景：①最大化→关闭→重开应最大化 ②最大化→还原→关闭→重开为上次 normal 尺寸 ③minimize 后从 dock 唤起按上次状态恢复 ④HDMI 热插拔回退 normal。

### References
- Multica Issue: [DDE-57](mention://issue/b71d2fe2-7419-478f-9da8-09e9f5c73856)
- PMS: [#353601](https://pms.uniontech.com/bug-view-353601.html)

## Summary by Sourcery

Remember the control center window's maximized state across sessions and restore it on reopen.

Bug Fixes:
- Fix control center always reopening in normal size instead of the last maximized state.
- Ensure minimized or hidden control center windows are restored according to the last saved maximized state on activation.

Enhancements:
- Persist the window's maximized/fullscreen flag via a dedicated handler to avoid excessive config writes during resize operations.