### PR TITLE
fix: refresh shortcuts and gestures after service restart

### DIFF
--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -6,9 +6,12 @@
 
 #include <QMetaObject>
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusInterface>
 #include <QDBusPendingReply>
 #include <QDBusPendingCallWatcher>
+#include <QDBusReply>
+#include <QDBusServiceWatcher>
 #include <QDBusMetaType>
 #include <QDebug>
 #include <QJsonArray>
@@ -126,6 +129,39 @@ void KeyboardDBusProxy::init()
         KeybingdingService, KeybingdingPath, KeybingdingInterface,
         "KeyEvent", this,
         SIGNAL(KeyEvent(bool,QString)));
+
+    auto *keybindingWatcher = new QDBusServiceWatcher(
+        KeybingdingService,
+        QDBusConnection::sessionBus(),
+        QDBusServiceWatcher::WatchForRegistration,
+        this);
+    connect(keybindingWatcher, &QDBusServiceWatcher::serviceRegistered,
+            this, [this](const QString &service) {
+        if (service != KeybingdingService)
+            return;
+
+        auto *oldKeybindingInterface = m_dBusKeybingdingInter;
+        m_dBusKeybingdingInter = new DDBusInterface(KeybingdingService,
+                                                    KeybingdingPath,
+                                                    KeybingdingInterface,
+                                                    QDBusConnection::sessionBus(),
+                                                    this);
+        if (oldKeybindingInterface)
+            oldKeybindingInterface->deleteLater();
+        Q_EMIT keybindingServiceRegistered();
+    });
+}
+
+bool KeyboardDBusProxy::keybindingServiceAvailable() const
+{
+    auto *busInterface = QDBusConnection::sessionBus().interface();
+    if (!busInterface)
+        return false;
+
+    QDBusReply<bool> reply = busInterface->isServiceRegistered(KeybingdingService);
+    return reply.isValid() && reply.value()
+            && m_dBusKeybingdingInter
+            && m_dBusKeybingdingInter->isValid();
 }
 
 void KeyboardDBusProxy::langSelectorStartServiceProcess()

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -190,6 +190,7 @@ public:
 
     bool langSelectorIsValid();
     void langSelectorStartServiceProcess();
+    bool keybindingServiceAvailable() const;
 
 signals:
     // Keyboard property
@@ -226,6 +227,8 @@ signals:
     // Wayland: category metadata from ListCategories() — drives grouping,
     // ordering, display names, and custom-group identity in the model.
     void categoriesReady(const QList<CategoryInfoNew> &categories);
+    // Emitted when the shortcut service appears after control center startup.
+    void keybindingServiceRegistered();
 
     //wm
     void compositingEnabledChanged(bool enabled);

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -99,6 +99,10 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
 
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::AllShortcutsReady, this, &KeyboardWorker::onAllShortcutsReady);
+    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::keybindingServiceRegistered, this, [this] {
+        qCInfo(lcKeyboardWorker) << "Keybinding service registered, refresh shortcuts";
+        refreshShortcut();
+    });
     // Wayland: category metadata (ordering/display/custom flag) from the
     // service's ListCategories(). Feeds the model so it never hardcodes
     // category strings for grouping or Custom detection.
@@ -185,6 +189,9 @@ void KeyboardWorker::setShortcutModel(ShortcutModel *model)
 
 void KeyboardWorker::refreshShortcut()
 {
+    if (!m_keyboardDBusProxy->keybindingServiceAvailable())
+        return;
+
     m_keyboardDBusProxy->ListAllShortcuts();
     m_keyboardDBusProxy->ListCategories();
 }

--- a/src/plugin-mouse/operation/mousedbusproxy.cpp
+++ b/src/plugin-mouse/operation/mousedbusproxy.cpp
@@ -9,10 +9,12 @@
 #include <QJsonArray>
 #include <QDBusArgument>
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusInterface>
 #include <QDBusPendingCall>
 #include <QDBusPendingCallWatcher>
 #include <QDBusReply>
+#include <QDBusServiceWatcher>
 #include <QDBusMetaType>
 #include <QJsonDocument>
 #include <QJsonObject>
@@ -215,6 +217,15 @@ void MouseDBusProxy::active()
 
 void MouseDBusProxy::refreshGestures()
 {
+    auto *busInterface = QDBusConnection::sessionBus().interface();
+    if (!busInterface)
+        return;
+
+    const QDBusReply<bool> registered = busInterface->isServiceRegistered(GestureService);
+    if (!registered.isValid() || !registered.value()
+            || !m_dbusGesture || !m_dbusGesture->isValid())
+        return;
+
     QDBusPendingCall call = m_dbusGesture->asyncCall(QStringLiteral("ListAllGestures"));
     QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(call, this);
     connect(watcher, &QDBusPendingCallWatcher::finished,
@@ -259,6 +270,27 @@ void MouseDBusProxy::init()
                                           "GestureInfosChanged",
                                           this,
                                           SLOT(refreshGestures()));
+
+    auto *gestureWatcher = new QDBusServiceWatcher(
+        GestureService,
+        QDBusConnection::sessionBus(),
+        QDBusServiceWatcher::WatchForRegistration,
+        this);
+    connect(gestureWatcher, &QDBusServiceWatcher::serviceRegistered,
+            this, [this](const QString &service) {
+        if (service != GestureService)
+            return;
+
+        auto *oldGestureInterface = m_dbusGesture;
+        m_dbusGesture = new QDBusInterface(GestureService,
+                                           GesturePath,
+                                           GestureInterface,
+                                           QDBusConnection::sessionBus(),
+                                           this);
+        if (oldGestureInterface)
+            oldGestureInterface->deleteLater();
+        refreshGestures();
+    });
 
     QDBusConnection::sessionBus().connect(AppearanceService,
                                           AppearancePath,
@@ -315,7 +347,8 @@ void MouseDBusProxy::init()
     m_dbusGesture = new QDBusInterface(GestureService,
                                        GesturePath,
                                        GestureInterface,
-                                       QDBusConnection::sessionBus());
+                                       QDBusConnection::sessionBus(),
+                                       this);
 }
 
 void MouseDBusProxy::onDefaultReset()


### PR DESCRIPTION
## Summary

- watch the keybinding and gesture D-Bus services for registration
- recreate stale D-Bus proxies after service restart
- refresh shortcut and gesture data only when the service is available

## Test plan

- `cmake --build build --target keyboard mouse --clean-first -j2`
- D-Bus service restart integration was not exercised in this environment

## Summary by Sourcery

Handle D-Bus service restarts for keyboard shortcuts and mouse gestures to keep data and proxies in sync.

New Features:
- Emit a signal when the keybinding D-Bus service registers so keyboard shortcuts can be refreshed automatically.
- Watch the gesture D-Bus service for registration and recreate its proxy on service availability.

Bug Fixes:
- Avoid refreshing keyboard shortcuts and mouse gestures when their respective D-Bus services or proxies are unavailable, preventing calls to stale connections.

Enhancements:
- Recreate keyboard keybinding and mouse gesture D-Bus proxies on service re-registration to recover cleanly after service restarts.