### PR TITLE
fix(personalization): scale theme thumbnail sourceSize by DPR for 4K/200% clarity

### DIFF
--- a/src/plugin-personalization/qml/ThemeSelectView.qml
+++ b/src/plugin-personalization/qml/ThemeSelectView.qml
@@ -191,7 +191,8 @@ FocusScope {
                                     anchors.margins: 4
                                     mipmap: true
                                     source: model.pic
-                                    sourceSize: Qt.size(width, height)
+                                    sourceSize: Qt.size(width * Screen.devicePixelRatio,
+                                                        height * Screen.devicePixelRatio)
                                     asynchronous: true
                                 }
                             }
@@ -270,6 +271,8 @@ FocusScope {
                                         mipmap: true
                                         source: D.DTK.themeType === D.ApplicationHelper.LightType ?
                                             "qrc:/icons/download_more_light.png" : "qrc:/icons/download_more_dark.png"
+                                        sourceSize: Qt.size(width * Screen.devicePixelRatio,
+                                                            height * Screen.devicePixelRatio)
                                     }
                                 }
                             }


### PR DESCRIPTION
## 问题 / Problem

控制中心「个性化」页面主题缩略图在 4K 屏 200% 缩放下显示不清晰（PMS BUG-359771）。

Theme thumbnails in the personalization module of `dde-control-center` appear blurry under 4K / 200% scaling (PMS BUG-359771).

## 根因 / Root Cause

`src/plugin-personalization/qml/ThemeSelectView.qml` 中主题缩略图 `Image` 的 `sourceSize` 绑定为逻辑像素 `Qt.size(width, height)`。在 4K / 200% 缩放下，解码目标尺寸被限制在逻辑像素级，再经 `mipmap` 缩放后丢失细节，导致模糊。壁纸缩略图因走 `DccImageProvider` 高分辨率解码链路而不受影响。

`Image.sourceSize` for theme thumbnails was bound to logical pixels `Qt.size(width, height)`. Under 4K / 200% scaling the decode target is capped at logical size and then mipmapped down, losing detail. Wallpaper thumbnails are unaffected because they go through the high-resolution `DccImageProvider` path.

## 方案 / Fix

将两处 `Image` 的 `sourceSize` 按 `Screen.devicePixelRatio` 放大，使图像先解码到设备像素分辨率再交 `mipmap` 显示：

Scale `sourceSize` by `Screen.devicePixelRatio` for both `Image` instances, so the image decodes to full device resolution before mipmap display:

- 主题缩略图 Image（约 194 行 / ~L194）：`sourceSize: Qt.size(width * Screen.devicePixelRatio, height * Screen.devicePixelRatio)`
- 「更多壁纸」占位图 Image（约 274 行 / ~L274）：新增同样的 DPR 放大 `sourceSize` 绑定以保持一致

`import QtQuick.Window 2.15` 已存在于文件顶部，`Screen.devicePixelRatio` 可直接使用。使用 `Screen.devicePixelRatio` 而非硬编码 2，兼容 1.25 / 1.5 / 1.75 等缩放档位，并在多屏 DPR 变化时自动刷新。

`import QtQuick.Window 2.15` already exists at the top of the file, so `Screen.devicePixelRatio` is available directly. Using `Screen.devicePixelRatio` instead of a hardcoded 2 keeps 1.25 / 1.5 / 1.75 scaling tiers correct and auto-refreshes when the window crosses screens with a different DPR.

## 改动范围 / Scope

仅改动 `src/plugin-personalization/qml/ThemeSelectView.qml` 一个文件（4 增 1 删），不涉及布局、交互与数据链路；未改动 `ScreenSaverPage.qml`、`dde-appearance`、`DccImageProvider` 等。

Only one file, `src/plugin-personalization/qml/ThemeSelectView.qml` (4 insertions / 1 deletion). Layout, interaction and data wiring are untouched; `ScreenSaverPage.qml`, `dde-appearance` and `DccImageProvider` are not in scope.

```diff
@@ ThemeSelectView.qml (theme thumbnail Image, ~L194) @@
                                     mipmap: true
                                     source: model.pic
-                                    sourceSize: Qt.size(width, height)
+                                    sourceSize: Qt.size(width * Screen.devicePixelRatio,
+                                                        height * Screen.devicePixelRatio)
                                     asynchronous: true

@@ ThemeSelectView.qml ('More Wallpapers' placeholder Image, ~L274) @@
                                         mipmap: true
                                         source: D.DTK.themeType === D.ApplicationHelper.LightType ?
                                             "qrc:/icons/download_more_light.png" : "qrc:/icons/download_more_dark.png"
+                                        sourceSize: Qt.size(width * Screen.devicePixelRatio,
+                                                            height * Screen.devicePixelRatio)
```

## 验证 / Verification

- 代码审核：通过（98 分 / 优秀，风险等级 Low）
- 本地编译打包：通过（`dde-control-center` 6.1.103，deb 产物生成成功，无编译错误，无新增 lintian 告警）
- 建议安装后在 1080p / 100% 与 4K / 200% 两档下做视觉回归：主题 / 图标 / 光标三类缩略图清晰度，翻页 / 选中边框 / 键盘焦点框等交互不受影响

- Code review: PASS (98 / Excellent, risk Low)
- Local build & packaging: PASS (`dde-control-center` 6.1.103, deb artifacts generated, no compile errors, no new lintian warnings)
- Recommended visual regression on 1080p / 100% and 4K / 200%: clarity of theme / icon / cursor thumbnails; paging / selection border / keyboard focus frame unaffected

## 关联 / Links

- PMS: https://pms.uniontech.com/bug-view-359771.html (BUG-359771)
- Multica issue: DDE-60 【控制中心】【个性化】4K屏主题缩略图显示不够清晰

## Summary by Sourcery

Improve clarity of personalization theme thumbnails by scaling QML image source sizes according to the screen device pixel ratio.

Bug Fixes:
- Fix blurry theme thumbnails on high-DPI displays by decoding images at device pixel resolution.

Enhancements:
- Align 'More Wallpapers' placeholder image scaling with theme thumbnails for consistent high-DPI rendering.