### PR TITLE
fix: remove redundant isDeleting guard in LoadDataTask

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -53,10 +53,8 @@ public:
         if (m_manager->isDeleting()) {
             return;
         }
+        // createData和moveThread需要完整，都执行或都不执行
         m_loader->createData();
-        if (m_manager->isDeleting()) {
-            return;
-        }
         m_loader->moveThread();
         m_loader->setLog("create data finished. elapsed time :" + QString::number(timer.elapsed()));
         m_loader->transitionStatus(DccPluginLoader::DataEnd);


### PR DESCRIPTION
1. Remove the second isDeleting() check in LoadDataTask::run() before createData()
2. The guard at method entry (line 45) and the caller loadPlugin() already cover this case
3. Reduces risk of use-after-free during DccPluginLoader teardown when plugins are still running

PMS: BUG-372823

fix: 移除 LoadDataTask 中冗余的 isDeleting 检查

1. 移除 LoadDataTask::run() 中 createData() 调用前的 第二次 isDeleting() 检查
2. 方法入口（第45行）和调用方 loadPlugin() 已覆盖 此情况
3. 降低插件仍在运行时 DccPluginLoader 拆解过程中 use-after-free 的风险

PMS: BUG-372823

Influence:
1. 桌面右击菜单点击显示设置/设置壁纸，验证控制中心正常打开
2. 控制中心启动后立即关闭，验证无崩溃

## Summary by Sourcery

Bug Fixes:
- Eliminate an unnecessary isDeleting() guard in LoadDataTask::run() to avoid conflicting lifecycle checks that could contribute to use-after-free risks when plugins are torn down while still running.