### PR TITLE
fix(bluetooth): use DccTitleObject for section titles

### DIFF
--- a/src/plugin-bluetooth/qml/MyDevice.qml
+++ b/src/plugin-bluetooth/qml/MyDevice.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
@@ -8,20 +8,12 @@ import QtQuick.Layouts 1.15
 import org.deepin.dtk 1.0
 
 DccObject{
-    DccObject {
+    DccTitleObject {
         name: "myDeviceTitle"
         parentName: "myDevice" + model.id
         displayName: qsTr("My Devices")
         weight: 10
-        pageType: DccObject.Item
         visible: model.myDeviceVisiable
-        page: Label {
-            leftPadding: 10
-            font.bold: true
-            font.pixelSize: DTK.fontManager.t5.pixelSize
-            text: dccObj.displayName
-        }
-
     }
 
     DccObject {

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
 
 import org.deepin.dcc 1.0
 import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0
+import org.deepin.dtk 1.0 as D
 
 DccObject{
     property bool refreshEnable: true
@@ -68,21 +68,12 @@ DccObject{
         }
     }
 
-    DccObject {
+    DccTitleObject {
         name: "OtherDeviceTitle"
         parentName: "otherDevice" + model.id
         displayName: qsTr("Other Devices")
         weight: 10
         visible: model.powered
-        pageType: DccObject.Item
-        page: ColumnLayout {
-            Label {
-                Layout.leftMargin: 10
-                font.bold: true
-                font.pixelSize: DTK.fontManager.t5.pixelSize
-                text: dccObj.displayName
-            }
-        }
     }
 
     DccObject {
@@ -93,7 +84,7 @@ DccObject{
         visible: model.powered && !hideWhenUserClosing
 
         page: RowLayout {
-            CheckBox {
+            D.CheckBox {
                 Layout.leftMargin: 10
                 Layout.alignment: Qt.AlignLeft
                 checked: dccData.model().displaySwitch
@@ -103,7 +94,7 @@ DccObject{
                 }
             }
 
-            IconButton {
+            D.IconButton {
                 id: redobtn
                 Layout.alignment: Qt.AlignRight
                 flat: true
@@ -115,7 +106,7 @@ DccObject{
                 }
             }
 
-            BusyIndicator {
+            D.BusyIndicator {
                 id: scanAnimation
                 Layout.alignment: Qt.AlignRight
                 running: model.discovering


### PR DESCRIPTION
fix(bluetooth): use DccTitleObject for section titles

1. Replace custom Label with DccTitleObject for My Devices title
2. Replace custom Label with DccTitleObject for Other Devices title
3. Add D. prefix to CheckBox, IconButton and BusyIndicator in OtherDevice.qml

Log: Use framework DccTitleObject for bluetooth section titles
Influence: Section titles match the framework unified styling

fix(bluetooth): 使用 DccTitleObject 实现分区标题

1. 将"我的设备"标题从自定义 Label 替换为 DccTitleObject
2. 将"其他设备"标题从自定义 Label 替换为 DccTitleObject
3. 为 OtherDevice.qml 中的 CheckBox、IconButton、BusyIndicator 添加 D. 前缀

Log: 使用框架 DccTitleObject 实现蓝牙分区标题
PMS: BUG-373143
Influence: 分区标题与框架统一样式保持一致