### PR TITLE
fix: use shortcut-owned lock key configuration

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,6 +54,7 @@ Depends:
  libdtk6declarative(>> 6.7.40),
  netselect,
  dde-daemon (>> 6.1.99),
+ dde-services (>> 1.0.38),
  deepin-security-loader,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -26,6 +26,10 @@ const static QString KeyboardService = "org.deepin.dde.InputDevices1";
 const static QString KeyboardPath = "/org/deepin/dde/InputDevice1/Keyboard";
 const static QString KeyboardInterface = "org.deepin.dde.InputDevice1.Keyboard";
 
+const static QString ShortcutKeyboardConfigAppId = "org.deepin.dde.keybinding";
+const static QString ShortcutKeyboardConfigName = "org.deepin.dde.keybinding.keyboard";
+const static QString CapsLockToggleConfigKey = "capslockToggle";
+
 const static QString KeybingdingService = "org.deepin.dde.Keybinding1";
 const static QString KeybingdingPath = "/org/deepin/dde/Keybinding1";
 const static QString KeybingdingInterface = "org.deepin.dde.Keybinding1";
@@ -36,6 +40,9 @@ const static QString WMInterface = "com.deepin.wm";
 
 KeyboardDBusProxy::KeyboardDBusProxy(QObject *parent)
     : QObject(parent)
+    , m_shortcutKeyboardConfig(DConfig::create(ShortcutKeyboardConfigAppId,
+                                                ShortcutKeyboardConfigName,
+                                                QString(), this))
     , m_isWayland((qgetenv("XDG_SESSION_TYPE").toLower() == QLatin1String("wayland"))
                   || !qgetenv("WAYLAND_DISPLAY").isEmpty())
 {
@@ -150,6 +157,18 @@ void KeyboardDBusProxy::init()
             oldKeybindingInterface->deleteLater();
         Q_EMIT keybindingServiceRegistered();
     });
+
+    if (!m_shortcutKeyboardConfig || !m_shortcutKeyboardConfig->isValid()) {
+        qWarning() << "Shortcut keyboard config is unavailable";
+    } else {
+        connect(m_shortcutKeyboardConfig, &DConfig::valueChanged,
+                this, [this](const QString &key) {
+            if (key == CapsLockToggleConfigKey) {
+                Q_EMIT CapslockToggleChanged(
+                        m_shortcutKeyboardConfig->value(key).toBool());
+            }
+        });
+    }
 }
 
 bool KeyboardDBusProxy::keybindingServiceAvailable() const
@@ -192,12 +211,18 @@ void KeyboardDBusProxy::onLangSelectorStartServiceProcessFinished(QDBusPendingCa
 //Keyboard
 bool KeyboardDBusProxy::capslockToggle()
 {
-    return qvariant_cast<bool>(m_dBusKeyboardInter->property("CapslockToggle"));
+    if (!m_shortcutKeyboardConfig || !m_shortcutKeyboardConfig->isValid())
+        return true;
+    return m_shortcutKeyboardConfig->value(CapsLockToggleConfigKey).toBool();
 }
 
 void KeyboardDBusProxy::setCapslockToggle(bool value)
 {
-    m_dBusKeyboardInter->setProperty("CapslockToggle", QVariant::fromValue(value));
+    if (!m_shortcutKeyboardConfig || !m_shortcutKeyboardConfig->isValid()) {
+        qWarning() << "Cannot update CapsLock OSD setting: shortcut keyboard config is unavailable";
+        return;
+    }
+    m_shortcutKeyboardConfig->setValue(CapsLockToggleConfigKey, value);
 }
 
 QString KeyboardDBusProxy::currentLayout()

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -8,6 +8,7 @@
 #include "ikeyboarddeviceproxy.h"
 
 #include <DDBusInterface>
+#include <DConfig>
 
 #include <QObject>
 #include <QDBusPendingReply>
@@ -16,6 +17,7 @@ class QDBusInterface;
 class QDBusMessage;
 
 using Dtk::Core::DDBusInterface;
+using Dtk::Core::DConfig;
 
 typedef QMap<QString, QString> KeyboardLayoutList;
 
@@ -308,6 +310,7 @@ private:
     DDBusInterface *m_dBusKeyboardInter;
     DDBusInterface *m_dBusKeybingdingInter;
     DDBusInterface *m_dBusWMInter;
+    DConfig *m_shortcutKeyboardConfig;
     const bool m_isWayland;
 };
 


### PR DESCRIPTION
## Summary
- read and write the CapsLock OSD preference through the keyboard DConfig installed by dde-services
- observe configuration changes so the control-center switch remains synchronized
- require a dde-services version newer than 1.0.38 that provides the new configuration

Depends on: https://github.com/linuxdeepin/dde-services/pull/137

## Test plan
- `cmake --build build-pinyin-search --target keyboard -j2`
- toggle the CapsLock OSD option and verify `org.deepin.dde.keybinding.keyboard/capslockToggle` changes
- verify external DConfig changes update the control-center switch

## Summary by Sourcery

Use shortcut-owned DConfig for CapsLock OSD preference and keep the control-center toggle synchronized with external configuration changes.

Bug Fixes:
- Ensure CapsLock OSD preference is stored and read from the keyboard shortcut configuration instead of the keyboard DBus property to align with dde-services behavior.

Enhancements:
- Observe CapsLock shortcut configuration changes via DConfig and propagate them through CapslockToggleChanged so the control-center switch stays in sync.