### PR TITLE
fix: improve shortcut capture failure feedback

### DIFF
--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -16,6 +16,10 @@
 namespace dccV25 {
 DCC_FACTORY_CLASS(KeyboardController)
 
+namespace {
+constexpr int ShortcutCaptureTimeoutMs = 30000;
+}
+
 KeyboardController::KeyboardController(QObject *parent)
     : QObject(parent)
 {
@@ -681,6 +685,19 @@ void KeyboardController::beginKeyCapture(QQuickItem *item, const QString &id, in
         });
     }
 
+    QTimer::singleShot(ShortcutCaptureTimeoutMs, this,
+                       [this, requestId, id, type, generation] {
+        if (requestId != m_capture.requestId
+                || m_capture.phase == CapturePhase::Idle
+                || !isCurrentShortcutGeneration(id, type, generation)) {
+            return;
+        }
+
+        qWarning() << "Shortcut capture timed out:" << id << type;
+        endKeyCapture();
+        Q_EMIT keyCaptureTimedOut(id, type);
+    });
+
     if (m_worker->isWayland()) {
         m_capture.backend = CaptureBackend::Wayland;
         startWaylandKeyCapture(item, id, type, requestId, generation);
@@ -699,23 +716,6 @@ void KeyboardController::startRequestedX11Capture()
         return;
 
     m_pendingX11RequestId = m_capture.requestId;
-    const quint64 requestId = m_capture.requestId;
-    const QString id = m_capture.id;
-    const int type = m_capture.type;
-    const quint64 generation = m_capture.generation;
-    QTimer::singleShot(30000, this, [this, requestId, id, type, generation] {
-        const bool requestPending = requestId == m_pendingX11RequestId;
-        const bool requestActive = requestId == m_capture.requestId
-                && m_capture.backend == CaptureBackend::X11
-                && m_capture.phase == CapturePhase::Active;
-        if ((!requestPending && !requestActive)
-                || !isCurrentShortcutGeneration(id, type, generation)) {
-            return;
-        }
-
-        endKeyCapture();
-        Q_EMIT keyCaptureFailed(id, type, QStringLiteral("shortcut capture timed out"));
-    });
     m_worker->beginCapture(m_pendingX11RequestId);
 }
 
@@ -725,6 +725,7 @@ void KeyboardController::startWaylandKeyCapture(QQuickItem *item, const QString 
     const QString failureReason = QStringLiteral("unable to start compositor shortcut capture");
     if (!item || !item->window()) {
         m_capture.reset();
+        qWarning() << failureReason << id << type;
         Q_EMIT keyCaptureFailed(id, type, failureReason);
         Q_EMIT waylandKeyCaptureFailed(id, type, 0);
         return;
@@ -736,6 +737,7 @@ void KeyboardController::startWaylandKeyCapture(QQuickItem *item, const QString 
     TreelandShortcutCaptureSession *session = m_captureManager->captureNext(item->window());
     if (!session) {
         m_capture.reset();
+        qWarning() << failureReason << id << type;
         Q_EMIT keyCaptureFailed(id, type, failureReason);
         Q_EMIT waylandKeyCaptureFailed(id, type, 0);
         return;
@@ -768,7 +770,13 @@ void KeyboardController::startWaylandKeyCapture(QQuickItem *item, const QString 
                 }
                 endKeyCapture();
                 const QString message = QStringLiteral("compositor capture failed: %1").arg(reason);
-                Q_EMIT keyCaptureFailed(id, type, message);
+                qWarning() << message << id << type;
+                using Capture = QtWayland::treeland_shortcut_capture_v1;
+                const auto failedReason = static_cast<Capture::failed_reason>(reason);
+                if (failedReason == Capture::failed_reason_interrupted)
+                    Q_EMIT invalidShortcutCaptured(id, type);
+                else
+                    Q_EMIT keyCaptureFailed(id, type, message);
                 Q_EMIT waylandKeyCaptureFailed(id, type, static_cast<int>(reason));
             });
 }
@@ -815,7 +823,7 @@ void KeyboardController::handleCapturedKeystroke(const QString &id, int type, co
         return;
 
     if (accels.isEmpty()) {
-        Q_EMIT requestRestore(id, type);
+        Q_EMIT invalidShortcutCaptured(id, type);
         return;
     }
     if (accels == QLatin1String("Esc") || accels == QLatin1String("Escape")) {

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -126,6 +126,8 @@ signals:
 
     void keyCaptureStarted(const QString &id, int type);
     void keyCaptureFailed(const QString &id, int type, const QString &reason);
+    void keyCaptureTimedOut(const QString &id, int type);
+    void invalidShortcutCaptured(const QString &id, int type);
     void shortcutModificationFinished(const QString &id, int type, const QString &accels, bool success);
     void customShortcutOperationFinished(quint64 requestId, bool success,
                                          const QString &errorMessage);

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -280,15 +280,28 @@ D.DialogWindow {
                 conflictText.text = ""
                 edit.keys = []
             }
-            function onKeyCaptureFailed(id, type, reason) {
-                if (id !== ddialog.keyId || type !== 1)
-                    return
+            function showCaptureFailure(message) {
                 edit.keys = ddialog.captureRestoreKeys
                 edit.accels = ddialog.captureRestoreAccels
                 ddialog.captureRestoreValid = false
                 dccData.clearPendingConflict(ddialog.keyId, 1)
                 ddialog.pendingConflict = false
-                conflictText.text = qsTr("Failed to start shortcut capture. Please try again.")
+                conflictText.text = message
+            }
+            function onKeyCaptureFailed(id, type, reason) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                showCaptureFailure(qsTr("Failed to start shortcut capture. Please try again."))
+            }
+            function onKeyCaptureTimedOut(id, type) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                showCaptureFailure(qsTr("Shortcut input timed out. Try again."))
+            }
+            function onInvalidShortcutCaptured(id, type) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                showCaptureFailure(qsTr("Invalid keyboard shortcut. Set a new one."))
             }
             function onKeyConflicted(id, type, oldAccels, newAccels, message, replaceable) {
                 if (id !== ddialog.keyId || type !== 1)

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -444,6 +444,16 @@ DccObject {
                             return
                         shortcutView.editItem.showFailure(qsTr("Failed to start shortcut capture. Please try again."))
                     }
+                    function onKeyCaptureTimedOut(id, type) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
+                        shortcutView.editItem.showFailure(qsTr("Shortcut input timed out. Try again."))
+                    }
+                    function onInvalidShortcutCaptured(id, type) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
+                        shortcutView.editItem.showFailure(qsTr("Invalid keyboard shortcut. Set a new one."))
+                    }
                     function onKeyConflicted(id, type, oldAccels, newAccels, message, replaceable) {
                         if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
                             return

--- a/translations/dde-control-center_ady.ts
+++ b/translations/dde-control-center_ady.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_af.ts
+++ b/translations/dde-control-center_af.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_af_ZA.ts
+++ b/translations/dde-control-center_af_ZA.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ak.ts
+++ b/translations/dde-control-center_ak.ts
@@ -2543,6 +2543,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -2597,6 +2605,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_am.ts
+++ b/translations/dde-control-center_am.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_am_ET.ts
+++ b/translations/dde-control-center_am_ET.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ar.ts
+++ b/translations/dde-control-center_ar.ts
@@ -3410,6 +3410,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3471,6 +3479,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_ar_EG.ts
+++ b/translations/dde-control-center_ar_EG.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ast.ts
+++ b/translations/dde-control-center_ast.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_az.ts
+++ b/translations/dde-control-center_az.ts
@@ -3410,6 +3410,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3471,6 +3479,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_bg.ts
+++ b/translations/dde-control-center_bg.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_bn.ts
+++ b/translations/dde-control-center_bn.ts
@@ -3429,6 +3429,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3490,6 +3498,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_bo.ts
+++ b/translations/dde-control-center_bo.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_bqi.ts
+++ b/translations/dde-control-center_bqi.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_br.ts
+++ b/translations/dde-control-center_br.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ca.ts
+++ b/translations/dde-control-center_ca.ts
@@ -3416,6 +3416,14 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
         <translation>Ha fallat iniciar la captura de dreceres. Si us plau, torneu-ho a provar.</translation>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation>Feu clic a Reemplaça per activar aquesta drecera de teclat.</translation>
     </message>
@@ -3477,6 +3485,14 @@ Inicieu la sessió a l&apos;ID d&apos;%1 per obtenir funcions i serveis personal
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation>Ha fallat iniciar la captura de dreceres. Si us plau, torneu-ho a provar.</translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_cgg.ts
+++ b/translations/dde-control-center_cgg.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_cs.ts
+++ b/translations/dde-control-center_cs.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_da.ts
+++ b/translations/dde-control-center_da.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_de.ts
+++ b/translations/dde-control-center_de.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation>auf Ersetzen klicken, um diese Tastenkombination einzurichten</translation>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_el.ts
+++ b/translations/dde-control-center_el.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_el_GR.ts
+++ b/translations/dde-control-center_el_GR.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en.ts
+++ b/translations/dde-control-center_en.ts
@@ -3402,6 +3402,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3462,6 +3470,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/dde-control-center_en_AU.ts
+++ b/translations/dde-control-center_en_AU.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_en_GB.ts
+++ b/translations/dde-control-center_en_GB.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_NO.ts
+++ b/translations/dde-control-center_en_NO.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_en_US.ts
+++ b/translations/dde-control-center_en_US.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_eo.ts
+++ b/translations/dde-control-center_eo.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_es.ts
+++ b/translations/dde-control-center_es.ts
@@ -3418,6 +3418,14 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3479,6 +3487,14 @@ Inicie sesión en Deepin ID para obtener funciones y servicios personalizados de
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_et.ts
+++ b/translations/dde-control-center_et.ts
@@ -3405,6 +3405,14 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3466,6 +3474,14 @@ Logige sisse %1 identiteedis, et saada brauseri, aadressipoodi ja muude funktsio
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_eu.ts
+++ b/translations/dde-control-center_eu.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fa.ts
+++ b/translations/dde-control-center_fa.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fi.ts
+++ b/translations/dde-control-center_fi.ts
@@ -3409,6 +3409,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3470,6 +3478,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_fil.ts
+++ b/translations/dde-control-center_fil.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_fr.ts
+++ b/translations/dde-control-center_fr.ts
@@ -3418,6 +3418,14 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3479,6 +3487,14 @@ Connectez-vous à votre identifiant %1 pour accéder aux fonctionnalités et ser
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_gl.ts
+++ b/translations/dde-control-center_gl.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_gl_ES.ts
+++ b/translations/dde-control-center_gl_ES.ts
@@ -3429,6 +3429,14 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3490,6 +3498,14 @@ Regístrate no teu %1 ID para obter características e servicios personalizados 
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_he.ts
+++ b/translations/dde-control-center_he.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_hi_IN.ts
+++ b/translations/dde-control-center_hi_IN.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hr.ts
+++ b/translations/dde-control-center_hr.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_hu.ts
+++ b/translations/dde-control-center_hu.ts
@@ -3424,6 +3424,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3485,6 +3493,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_hy.ts
+++ b/translations/dde-control-center_hy.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_id.ts
+++ b/translations/dde-control-center_id.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_id_ID.ts
+++ b/translations/dde-control-center_id_ID.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_it.ts
+++ b/translations/dde-control-center_it.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_ja.ts
+++ b/translations/dde-control-center_ja.ts
@@ -3413,6 +3413,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3474,6 +3482,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_ka.ts
+++ b/translations/dde-control-center_ka.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_kab.ts
+++ b/translations/dde-control-center_kab.ts
@@ -3404,6 +3404,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3465,6 +3473,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_kk.ts
+++ b/translations/dde-control-center_kk.ts
@@ -3401,6 +3401,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3462,6 +3470,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_km_KH.ts
+++ b/translations/dde-control-center_km_KH.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_kn_IN.ts
+++ b/translations/dde-control-center_kn_IN.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ko.ts
+++ b/translations/dde-control-center_ko.ts
@@ -3428,6 +3428,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3489,6 +3497,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_krl.ts
+++ b/translations/dde-control-center_krl.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ku.ts
+++ b/translations/dde-control-center_ku.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ku_IQ.ts
+++ b/translations/dde-control-center_ku_IQ.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ky.ts
+++ b/translations/dde-control-center_ky.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ky@Arab.ts
+++ b/translations/dde-control-center_ky@Arab.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_la.ts
+++ b/translations/dde-control-center_la.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_lo.ts
+++ b/translations/dde-control-center_lo.ts
@@ -3404,6 +3404,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3465,6 +3473,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_lt.ts
+++ b/translations/dde-control-center_lt.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_lv.ts
+++ b/translations/dde-control-center_lv.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ml.ts
+++ b/translations/dde-control-center_ml.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_mn.ts
+++ b/translations/dde-control-center_mn.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_mr.ts
+++ b/translations/dde-control-center_mr.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ms.ts
+++ b/translations/dde-control-center_ms.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nb.ts
+++ b/translations/dde-control-center_nb.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_nb_NO.ts
+++ b/translations/dde-control-center_nb_NO.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ne.ts
+++ b/translations/dde-control-center_ne.ts
@@ -3405,6 +3405,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3466,6 +3474,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_nl.ts
+++ b/translations/dde-control-center_nl.ts
@@ -3403,6 +3403,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3464,6 +3472,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_pa.ts
+++ b/translations/dde-control-center_pa.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pam.ts
+++ b/translations/dde-control-center_pam.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_pl.ts
+++ b/translations/dde-control-center_pl.ts
@@ -3416,6 +3416,14 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
         <translation>Nie udało się przechwycić skrótu klawiszowego. Spróbuj ponownie.</translation>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation>Kliknij Zamień, aby aktywować skrót klawiszowy.</translation>
     </message>
@@ -3477,6 +3485,14 @@ Zaloguj się do %1 ID, aby uzyskać dodatkowe funkcje Przeglądarki, sklepu App 
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation>Nie udało się przechwycić skrótu klawiszowego. Spróbuj ponownie.</translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_ps.ts
+++ b/translations/dde-control-center_ps.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_pt.ts
+++ b/translations/dde-control-center_pt.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_pt_BR.ts
+++ b/translations/dde-control-center_pt_BR.ts
@@ -3411,6 +3411,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>Falha ao iniciar a captura de atalho. Tente novamente.</translation>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation>Clique em Substituir para ativar esta tecla de atalho</translation>
     </message>
@@ -3472,6 +3480,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation>Não foi possível iniciar a captura do atalho. Tente novamente.</translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_qu.ts
+++ b/translations/dde-control-center_qu.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_ro.ts
+++ b/translations/dde-control-center_ro.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ru.ts
+++ b/translations/dde-control-center_ru.ts
@@ -3412,6 +3412,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3473,6 +3481,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_ru_UA.ts
+++ b/translations/dde-control-center_ru_UA.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sc.ts
+++ b/translations/dde-control-center_sc.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_si.ts
+++ b/translations/dde-control-center_si.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sk.ts
+++ b/translations/dde-control-center_sk.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sl.ts
+++ b/translations/dde-control-center_sl.ts
@@ -3404,6 +3404,14 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3465,6 +3473,14 @@ Prijava na %1 ID vam omogoči osebne funkcije in storitve, kot so prehodnik in T
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_sq.ts
+++ b/translations/dde-control-center_sq.ts
@@ -3416,6 +3416,14 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3477,6 +3485,14 @@ Bëni hyrjen te %1 ID, që të merrni veçori dhe shërbime të personalizuara S
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_sr.ts
+++ b/translations/dde-control-center_sr.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_sv.ts
+++ b/translations/dde-control-center_sv.ts
@@ -3404,6 +3404,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3465,6 +3473,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_sv_SE.ts
+++ b/translations/dde-control-center_sv_SE.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_sw.ts
+++ b/translations/dde-control-center_sw.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ta.ts
+++ b/translations/dde-control-center_ta.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_te.ts
+++ b/translations/dde-control-center_te.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_th.ts
+++ b/translations/dde-control-center_th.ts
@@ -3403,6 +3403,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3464,6 +3472,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_tr.ts
+++ b/translations/dde-control-center_tr.ts
@@ -3415,6 +3415,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3476,6 +3484,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_tzm.ts
+++ b/translations/dde-control-center_tzm.ts
@@ -2543,6 +2543,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -2597,6 +2605,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_ug.ts
+++ b/translations/dde-control-center_ug.ts
@@ -3400,6 +3400,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3461,6 +3469,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_uk.ts
+++ b/translations/dde-control-center_uk.ts
@@ -3410,6 +3410,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3471,6 +3479,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_ur.ts
+++ b/translations/dde-control-center_ur.ts
@@ -3376,6 +3376,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3426,6 +3434,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>please enter a new shortcut key</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>

--- a/translations/dde-control-center_uz.ts
+++ b/translations/dde-control-center_uz.ts
@@ -3378,6 +3378,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <source>click Add to make this shortcut key effective</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>Shortcuts</name>
@@ -3427,6 +3435,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     </message>
     <message>
         <source>please enter a new shortcut key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
         <translation type="unfinished"></translation>
     </message>
 </context>

--- a/translations/dde-control-center_vi.ts
+++ b/translations/dde-control-center_vi.ts
@@ -3407,6 +3407,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3468,6 +3476,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_zh_CN.ts
+++ b/translations/dde-control-center_zh_CN.ts
@@ -3413,6 +3413,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation>启动快捷键录入失败，请重试。</translation>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation>点击替换使这个快捷键生效</translation>
     </message>
@@ -3474,6 +3482,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation>启动快捷键录入失败，请重试。</translation>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_zh_HK.ts
+++ b/translations/dde-control-center_zh_HK.ts
@@ -3410,6 +3410,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3471,6 +3479,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>

--- a/translations/dde-control-center_zh_TW.ts
+++ b/translations/dde-control-center_zh_TW.ts
@@ -3410,6 +3410,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
         <translation type="unfinished"/>
     </message>
     <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>click Replace to make this shortcut key effective</source>
         <translation type="unfinished"/>
     </message>
@@ -3471,6 +3479,14 @@ Sign in to %1 ID to get personalized features and services of Browser, App Store
     <message>
         <source>Failed to start shortcut capture. Please try again.</source>
         <translation type="unfinished"/>
+    </message>
+    <message>
+        <source>Shortcut input timed out. Try again.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <source>Invalid keyboard shortcut. Set a new one.</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <source>Failed to save the shortcut. Please try again.</source>


### PR DESCRIPTION
## Summary

- distinguish 30-second shortcut capture timeouts from generic startup failures on X11 and Wayland
- show dedicated invalid-shortcut feedback for rejected X11 input and Treeland interrupted captures
- update English and Simplified Chinese shortcut feedback translations

Pms: BUG-373165

## Test plan

- `cmake --build build-pinyin-search --target keyboard keyboard_qml -j2`
- `cmake --build build-pinyin-search --target keyboard_qml_qmllint -j2` (passes with existing DTK import/type warnings)
- `cmake --build build-pinyin-search --target dde-control-center_lrelease -j2`
- `ctest --test-dir build-pinyin-search --output-on-failure`
- Runtime compositor interaction was not exercised

## Summary by Sourcery

Improve keyboard shortcut capture feedback and error handling for X11 and Wayland, including clearer user messages for timeouts and invalid shortcuts.

New Features:
- Introduce dedicated timeout handling for shortcut capture sessions with a specific timeout signal.
- Add explicit invalid-shortcut signaling when empty or interrupted shortcut captures are detected on X11/Wayland.

Bug Fixes:
- Distinguish compositor startup failures from shortcut capture timeouts to provide accurate feedback to users.
- Handle Treeland shortcut capture interruption as an invalid shortcut instead of a generic failure.

Enhancements:
- Unify and simplify shortcut capture failure handling in QML by centralizing failure display logic.
- Log compositor and capture startup failures to aid debugging of shortcut capture issues.