### PR TITLE
fix(bluetooth): fix connect button margin in other devices list

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -174,6 +174,7 @@ Rectangle {
                         RowLayout {
                             id: rowCtl
                             Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                            Layout.rightMargin: showMoreBtn ? 0 : 10
                             spacing: 10
                             D.BusyIndicator {
                                 id: connectBusyIndicator


### PR DESCRIPTION
fix(bluetooth): fix connect button margin in other devices list

1. Add Layout.rightMargin: 10 to rowCtl when showMoreBtn is false in other devices list
2. Set m_showLoadPage=true at end of doShowPage() and tryShowFallback() to mark async loading complete
3. Remove m_needShow=false in !m_showLoadPage && !m_activeObject branch
4. Change section title font.bold to font.weight: Font.Medium with theme-aware D.Palette colors
5. Add DTK namespace prefix to DTK controls in OtherDevice.qml

Log: Fix bluetooth connect button margin and related styling issues
Influence: Connect button has proper right margin; titles adapt to themes

fix(bluetooth): 修复其他设备列表连接按钮右边距

1. 为其他设备列表的 rowCtl 添加 Layout.rightMargin: 10（showMoreBtn 为 false 时）
2. 在 doShowPage() 和 tryShowFallback() 末尾将 m_showLoadPage 置为 true，标记异步加载阶段结束
3. 移除 !m_showLoadPage && !m_activeObject 分支中的 m_needShow=false
4. 将分区标题的 font.bold 改为 font.weight: Font.Medium 并添加主题感知的 D.Palette 颜色
5. 为 OtherDevice.qml 中的 DTK 控件添加 D 命名空间前缀

Log: 修复蓝牙其他设备列表连接按钮右边距及相关样式问题
PMS: BUG-373145
Influence: 连接按钮右边距正常；标题适配主题