### PR TITLE
fix(bluetooth): correct hover and press style of refresh button in other devices

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -37,6 +37,7 @@ Rectangle {
                 Layout.fillHeight: true
 
                 topPadding: 0
+                leftPadding: 14
                 bottomPadding: 0
 
                 cascadeSelected: true

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
@@ -6,6 +6,7 @@ import QtQuick.Controls 2.0
 import org.deepin.dcc 1.0
 import QtQuick.Layouts 1.15
 import org.deepin.dtk 1.0 as D
+import org.deepin.dtk.style 1.0 as DS
 
 DccObject{
     property bool refreshEnable: true
@@ -94,13 +95,35 @@ DccObject{
                 }
             }
 
-            D.IconButton {
+            D.ActionButton {
                 id: redobtn
                 Layout.alignment: Qt.AlignRight
-                flat: true
                 visible: !model.discovering
-
+                palette.windowText: D.ColorSelector.textColor
                 icon.name: "redo"
+                icon.width: 16
+                icon.height: 16
+                implicitHeight: 30
+                implicitWidth: 30
+                flat: !hovered
+
+                background: Rectangle {
+                    property D.Palette pressedColor: D.Palette {
+                        normal: Qt.rgba(0, 0, 0, 0.2)
+                        normalDark: Qt.rgba(1, 1, 1, 0.25)
+                    }
+                    property D.Palette hoveredColor: D.Palette {
+                        normal: Qt.rgba(0, 0, 0, 0.1)
+                        normalDark: Qt.rgba(1, 1, 1, 0.1)
+                    }
+                    radius: DS.Style.control.radius
+                    color: parent.pressed ? D.ColorSelector.pressedColor : (parent.hovered ? D.ColorSelector.hoveredColor : "transparent")
+                    border {
+                        color: parent.palette.highlight
+                        width: parent.visualFocus ? DS.Style.control.focusBorderWidth : 0
+                    }
+                }
+
                 onClicked: {
                     dccData.work().setAdapterDiscoverable(model.id)
                 }


### PR DESCRIPTION
1. Replace D.IconButton with D.ActionButton for the refresh button in OtherDevice.qml
2. Add custom background with hover/press color states matching the more button style in BlueToothDeviceListView.qml
3. Add org.deepin.dtk.style import for consistent radius and focus border width

Log: 刷新按钮悬浮和按压样式与我的设备列表中的更多按钮不一致
Influence: 修复其他设备列表刷新按钮的悬浮和按压视觉反馈

1. 将 OtherDevice.qml 中的刷新按钮从 D.IconButton 替换为 D.ActionButton
2. 添加与更多按钮一致的自定义悬浮/按压背景色
3. 新增 org.deepin.dtk.style 导入以使用统一的圆角和焦点边框宽度

PMS: BUG-373149

## Summary by Sourcery

Align Bluetooth other-device refresh button behavior and control center window show logic, while updating related UI consistency and translations.

Bug Fixes:
- Unify the hover and press visual states of the Bluetooth other-device refresh button with the existing more button style.
- Ensure the control center window only shows after pages are loaded on Treeland by gating show() with asynchronous load state and a pending flag.
- Fix missing localized messages for the name length validation in Catalan and Polish translations.

Enhancements:
- Align Bluetooth device section headers and controls with DTK styling, including typography, palette usage, and consistent padding.
- Use DTK-prefixed controls (checkbox, busy indicator, action button) and shared style imports for consistent radius and focus borders across Bluetooth device lists.
- Document plugin data loading behavior in PluginManager with an inline comment to clarify createData and moveThread coupling.