### PR TITLE
fix(bluetooth): reduce gap between device icon and name

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -79,7 +79,7 @@ Rectangle {
                             Layout.fillHeight: true
                             Layout.fillWidth: true
                             spacing: 0
-                            Layout.leftMargin: 10
+                            Layout.leftMargin: 5
                             implicitHeight: Math.max(myDeviceName.implicitHeight, loader.implicitHeight) + 10
                             Label {
                                 id: myDeviceName


### PR DESCRIPTION
1. Change Layout.leftMargin of the status ColumnLayout from 10 to 5
   in BlueToothDeviceListView.qml
2. The DTK ItemDelegate contentItem RowLayout already adds 5px spacing
   between the icon and the content Loader
3. Combined spacing is now 10px instead of the previous 15px
4. Device icon left padding remains 14px from the background left edge

Log: Fix device icon and name spacing too wide in bluetooth my devices
Influence: Improves spacing between device icon and name in bluetooth list

fix(bluetooth): 缩小蓝牙设备图标与设备名称之间的间距

1. 将 BlueToothDeviceListView.qml 中状态 ColumnLayout 的
   Layout.leftMargin 从 10 改为 5
2. DTK ItemDelegate 的 contentItem RowLayout 已在图标与内容 Loader
   之间添加 5px 间距
3. 合并后间距为 10px，而非之前的 15px
4. 设备图标距背景左边缘仍保持 14px

Log: 修复蓝牙我的设备中设备图标与设备名称间距过宽的问题
PMS: BUG-373151
Influence: 改善蓝牙列表中设备图标与名称的间距

## Summary by Sourcery

Adjust Bluetooth device list UI spacing and align control center behavior with asynchronous page loading on Treeland while updating some UI components and translations.

Enhancements:
- Refine Bluetooth device list item layout by reducing spacing between device icon and device name and setting explicit left padding for the icon column.
- Align Bluetooth section labels and controls with DTK components and theming, including updated typography and action button styling.
- Ensure control center window only shows after pages are loaded on Treeland by tracking load state and deferring show() calls via new flags.
- Clarify plugin loading behavior with an added comment about atomic execution of data creation and thread movement.

Documentation:
- Add completed Catalan and Polish translations for the name length validation message.