### PR TITLE
fix(bluetooth): adjust section spacing in bluetooth module

### DIFF
--- a/src/plugin-bluetooth/qml/BlueToothMain.qml
+++ b/src/plugin-bluetooth/qml/BlueToothMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
@@ -27,7 +27,7 @@ DccObject{
             pageType: DccObject.Item
 
             page: DccGroupView {
-                spacing: 0
+                spacing: 10
                 isGroup: false
             }
 

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -144,26 +144,34 @@ DccObject{
         visible: model.powered
         backgroundType: DccObject.Normal
         pageType: DccObject.Item
-        page: BlueToothDeviceListView {
-            id: deviceListView
-            showMoreBtn: false
-            showConnectStatus: false
-            showPowerStatus: false
+        page: ColumnLayout {
+            spacing: 0
+            Item {
+                Layout.fillWidth: true
+                Layout.preferredHeight: 2
+            }
+            BlueToothDeviceListView {
+                id: deviceListView
+                Layout.fillWidth: true
+                showMoreBtn: false
+                showConnectStatus: false
+                showPowerStatus: false
 
-            Timer {
-                interval: 300
-                repeat: false
-                running: true
-                onTriggered: {
-                    deviceListView.deviceModel = model.otherDevice
+                Timer {
+                    interval: 300
+                    repeat: false
+                    running: true
+                    onTriggered: {
+                        deviceListView.deviceModel = model.otherDevice
+                    }
                 }
-            }
 
-            onClicked: function (index, checked) {
-            }
+                onClicked: function (index, checked) {
+                }
 
-            onVisibleChanged: {
-                refreshEnable = visible
+                onVisibleChanged: {
+                    refreshEnable = visible
+                }
             }
         }
     }


### PR DESCRIPTION
1. Set spacing to 10 in blueToothAdapters DccGroupView to increase gap between My Devices and Other Devices sections to 16px
2. Wrap otherDeviceList page in ColumnLayout with a 2px top spacer to set the gap between description text and device list to 8px
3. Keep the gap between Other Devices title and description text at 6px by leaving the otherDevice DccGroupView spacing at 0

Log: Adjust bluetooth section spacing to meet design specifications
Influence: Improves visual layout consistency of the bluetooth settings page

1. 将 blueToothAdapters DccGroupView 的 spacing 设为 10，使我的设备与其他设备区块间距增至 16px
2. 为 otherDeviceList 页面包裹 ColumnLayout 并添加 2px 顶部占位，使说明文字与设备列表间距设为 8px
3. 保持其他设备 DccGroupView 的 spacing 为 0，使标题与说明文字间距保持 6px

Log: 调整蓝牙各区块间距以满足设计规范
PMS: BUG-373153
Influence: 提升蓝牙设置页面的视觉布局一致性

## Summary by Sourcery

Adjust Bluetooth settings page layout to match specified spacing between sections and lists.

Enhancements:
- Increase spacing between Bluetooth device groups by updating the main group view spacing configuration.
- Wrap the other devices list in a layout container with a small top spacer to fine-tune the gap between descriptive text and the device list.