### PR TITLE
fix(mouse): adjust spacing in mouse and touchpad page

### DIFF
--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -18,7 +18,7 @@ DccObject {
         weight: 10
         onParentItemChanged: {
             if (parentItem) {
-                parentItem.bottomInset = 10
+                parentItem.bottomInset = 5
             }
         }
     }
@@ -211,8 +211,8 @@ DccObject {
         }
         onParentItemChanged: {
             if (parentItem) {
-                parentItem.topInset = 6
-                parentItem.bottomInset = 15
+                parentItem.topInset = 3
+                parentItem.bottomInset = 14
             }
         }
     }

--- a/src/plugin-mouse/qml/Mouse.qml
+++ b/src/plugin-mouse/qml/Mouse.qml
@@ -13,6 +13,6 @@ DccObject {
     weight: 30
 
     page: DccRightView {
-        spacing: -4
+        spacing: 0
     }
 }

--- a/src/plugin-mouse/qml/MouseMain.qml
+++ b/src/plugin-mouse/qml/MouseMain.qml
@@ -26,7 +26,7 @@ DccObject {
         weight: 10
         pageType: DccObject.Item
         page: DccGroupView {
-            spacing: -5
+            spacing: 0
             isGroup: false
         }
         Common {}


### PR DESCRIPTION
1. Set spacing to 0 in parent DccRightView and Common DccGroupView to remove negative spacing that caused incorrect gaps
2. Adjust Common title bottomInset from 10 to 5 to keep the gap between title and scrolling speed unchanged
3. Adjust LeftHandMode topInset from 6 to 3 and bottomInset from 15 to 14 to achieve correct spacing between sections

Log: Adjust mouse and touchpad page spacing to meet design specifications
Influence: Improves visual layout consistency of the mouse and touchpad settings page

1. 将父级 DccRightView 和 Common DccGroupView 的 spacing 设为 0，消除导致间距不正确的负间距
2. 将通用标题 bottomInset 从 10 调整为 5，保持标题与滚动速度模块间距不变
3. 将左手模式 topInset 从 6 调整为 3、bottomInset 从 15 调整为 14，使各模块间距符合设计规范

Log: 调整鼠标与触控板页面间距以满足设计规范
PMS: BUG-373177
Influence: 提升鼠标与触控板设置页面的视觉布局一致性

## Summary by Sourcery

Adjust spacing and insets in mouse settings views and Bluetooth device lists to align UI layout with design specifications.

Bug Fixes:
- Correct visual spacing issues on the mouse and touchpad settings page by removing negative spacing and fine-tuning section insets.
- Fix minor layout offset in the Bluetooth other devices list by adding a small top padding within a column layout.

Enhancements:
- Standardize group view spacing in the Bluetooth main page for more consistent device list presentation.