### PR TITLE
fix: force C locale for grub pbkdf2 hash parse

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -14,6 +14,7 @@
 #include <QDebug>
 #include <QDateTime>
 #include <QProcess>
+#include <QProcessEnvironment>
 #include <QRegularExpression>
 #include <QSettings>
 #include <QLoggingCategory>
@@ -769,6 +770,13 @@ QString CommonInfoWork::passwdEncrypt(const QString &password)
     pbkdf2.setProgram("grub-mkpasswd-pbkdf2");
     pbkdf2.setProcessChannelMode(QProcess::SeparateChannels);
 
+    // 强制使用 C locale，避免 grub-mkpasswd-pbkdf2 的输出被本地化，
+    // 导致按固定字段下标提取哈希时取到错误值（如英文 locale 下取到 "your"）。
+    QProcessEnvironment env = QProcessEnvironment::systemEnvironment();
+    env.insert("LANG", "C");
+    env.insert("LANGUAGE", "C");
+    pbkdf2.setProcessEnvironment(env);
+
     pbkdf2.start();
     if (!pbkdf2.waitForStarted()) {
         qCWarning(DccCommonInfoWork) << "Failed to start grub-mkpasswd-pbkdf2:" << pbkdf2.errorString();
@@ -792,15 +800,18 @@ QString CommonInfoWork::passwdEncrypt(const QString &password)
         return QString();
     }
 
-    // 解析输出：grep PBKDF2 并提取第4个字段
+    // 使用正则提取 PBKDF2 哈希，避免依赖 grub-mkpasswd-pbkdf2 输出的 locale。
+    // 哈希格式：grub.pbkdf2.sha512.<iterations>.<salt>.<hash>
+    static const QRegularExpression pbkdf2HashRe(
+        QStringLiteral("grub\\.pbkdf2\\.sha\\d+\\.\\d+\\.[0-9A-Fa-f]+\\.[0-9A-Fa-f]+"));
     QString output = QString::fromUtf8(pbkdf2.readAllStandardOutput());
     QStringList lines = output.split('\n', Qt::SkipEmptyParts);
 
     for (const QString &line : lines) {
         if (line.contains("PBKDF2")) {
-            QStringList fields = line.split(QRegularExpression("\\s+"), Qt::SkipEmptyParts);
-            if (fields.size() >= 4) {
-                return fields.at(3);  // 返回第4个字段（下标3）
+            QRegularExpressionMatch match = pbkdf2HashRe.match(line);
+            if (match.hasMatch()) {
+                return match.captured(0);
             }
         }
     }


### PR DESCRIPTION
## 修复 grub 启动菜单编辑认证在非中文 locale 下失效

### 问题
在非中文 locale（如 sw64 的 2500 基础镜像缺少中文翻译）下，`grub-mkpasswd-pbkdf2` 输出英文格式，`passwdEncrypt()` 按固定字段下标 `fields.at(3)` 提取到 `"your"` 而非哈希，导致 grub 编辑认证被静默绕过——开关显示已开启但实际无密码保护。

### 改动
- 为 `grub-mkpasswd-pbkdf2` 子进程经 `QProcessEnvironment` 强制注入 `LANG=C`/`LANGUAGE=C`，固定输出为英文格式，消除对系统 locale 的依赖。
- 哈希提取改用正则 `grub\.pbkdf2\.sha\d+\.\d+\.[0-9A-Fa-f]+\.[0-9A-Fa-f]+`（`captured(0)`），替代固定下标 `fields.at(3)`，无论哈希落在第 4 字段（zh_CN）还是第 7 字段（C/en_US）都能正确提取，且自带格式校验。
- 新增 `#include <QProcessEnvironment>`。

### 关联
- Multica issue: https://agent-dev.uniontech.com/dde/issues/afa07fcb-a545-4913-b0d2-71dc1c5d27c3
- PMS: BUG-371591 (https://pms.uniontech.com/bug-view-371591.html)

### 审核 / 编译状态
- 代码审核：已通过（95 分 / 优秀）
- amd64 编译验证：已通过

## Summary by Sourcery

Ensure grub PBKDF2 password hashing works reliably across locales by making hash extraction locale-independent.

Bug Fixes:
- Fix grub menu edit authentication being silently bypassed when grub-mkpasswd-pbkdf2 output is localized and the hash field is misparsed.

Enhancements:
- Make grub-mkpasswd-pbkdf2 subprocess run under a forced C locale to produce predictable, non-localized output.
- Extract the PBKDF2 hash from grub-mkpasswd-pbkdf2 output using a validated regular expression matching the expected hash format instead of relying on a fixed field position.