### PR TITLE
fix(display): correct eye-comfort list spacing

### DIFF
--- a/src/dde-control-center/frame/plugin/DccEditorItem.qml
+++ b/src/dde-control-center/frame/plugin/DccEditorItem.qml
@@ -14,7 +14,7 @@ D.ItemDelegate {
     property var rightItem: null
     property real iconRadius: model.item.iconRadius ? model.item.iconRadius : 0
     property real iconSize: model.item.iconSize ? model.item.iconSize : 0
-    property real leftPaddingSize: model.item.leftPaddingSize ? model.item.leftPaddingSize : 10
+    property real leftPaddingSize: model.item.leftPaddingSize ? model.item.leftPaddingSize : 14
     property real rightItemTopMargin: 5
     property real rightItemBottomMargin: 5
 

--- a/src/dde-control-center/frame/plugin/DccTitleObject.qml
+++ b/src/dde-control-center/frame/plugin/DccTitleObject.qml
@@ -30,7 +30,7 @@ DccObject {
     }
     onParentItemChanged: {
         if (parentItem) {
-            parentItem.leftPadding = 10
+            parentItem.leftPadding = 14
         }
     }
 }

--- a/src/plugin-display/qml/displayMain.qml
+++ b/src/plugin-display/qml/displayMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
 import QtQuick.Controls 2.0
@@ -822,6 +822,7 @@ DccObject {
         parentName: "display"
         displayName: qsTr("Eye Comfort")
         weight: 90
+        onParentItemChanged: item => { if (item) { item.leftPadding = 14 } }
     }
     DccObject {
         name: "eyeComfort"
@@ -835,6 +836,7 @@ DccObject {
             checked: dccData.colorTemperatureEnabled
             onClicked: dccData.colorTemperatureEnabled = checked
         }
+        onParentItemChanged: item => { if (item) { item.topInset = 0; item.bottomInset = 0; item.rightItemTopMargin = 6; item.rightItemBottomMargin = 6 } }
     }
     DccObject {
         name: "eyeComfortGroup"
@@ -843,6 +845,7 @@ DccObject {
         visible: dccData.colorTemperatureEnabled
         pageType: DccObject.Item
         page: DccGroupView {}
+        onParentItemChanged: item => { if (item) item.topInset = 6 }
         DccObject {
             name: "time"
             parentName: "display/eyeComfortGroup"


### PR DESCRIPTION
## 修复内容

护眼模式间距列表高度不对（[PMS bug-308813](https://pms.uniontech.com/bug-view-308813.html)）。

在 `release/deepin25.0.10` 分支上回填护眼模式间距修复，共 3 个 QML 文件：

1. `src/dde-control-center/frame/plugin/DccEditorItem.qml` — 默认 `leftPaddingSize` 10→14（全局左侧间距）
2. `src/dde-control-center/frame/plugin/DccTitleObject.qml` — `parentItem.leftPadding` 10→14（标题左间距）
3. `src/plugin-display/qml/displayMain.qml` — 护眼段落：
   - `displayColorTemperature` 补 `leftPadding = 14`
   - `eyeComfort` 补 `topInset=0; bottomInset=0; rightItemTopMargin=6; rightItemBottomMargin=6`
   - `eyeComfortGroup` 补 `topInset = 6`

## 5 条 UI 要求覆盖

1. 标题距左 14px ✅
2. 开关设置项高度 48px ✅（eyeComfort 基高 48 + inset 0）
3. 文字距上 6px、说明文字距下 6px ✅（rightItemTopMargin/BottomMargin=6）
4. 开关项与下方设置项间距 6px ✅（eyeComfort bottomInset 0 + eyeComfortGroup topInset 6）
5. 色温调节列表高度 40px ✅（colorTemperature 无 description 命中 40px）

## 说明

- 纯前端 QML 数值/属性调整，无 C++/DBus/DConfig 变更。
- `DccEditorItem.qml` 左间距 10→14 为全局默认值（与 master 一致），personalization/sound/power 等共用模块需回归间距。
- 已通过代码审核（97/100）与本地编译打包验证（deb 已交付，3 个 QML 改动已从 deb 内验证）。
- personalization 插件编译失败为预存的 treeland-protocols 适配问题，与本次 QML 改动无关，作为独立问题处理。

## 关联

- Multica issue: [DDE-78](https://agent-dev.uniontech.com/dde/issues/65aa6a7b-6175-4a22-86e4-4971fb00e726)
- PMS: https://pms.uniontech.com/bug-view-308813.html

## Summary by Sourcery

Align eye comfort display settings spacing with updated design specifications across control center and display QML components.

Enhancements:
- Increase default left padding for editor items and titles to 14px for consistent global alignment.
- Adjust eye comfort toggle and group layout in the display plugin to meet specified spacing and inset requirements.