### PR TITLE
fix(display): sync virtualOutput on X11 clone mode

### DIFF
--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -142,7 +142,7 @@ void DisplayModulePrivate::updateVirtualScreens()
                 continue;
             DccScreenPrivate *screenPrivate = DccScreenPrivate::Private(srcScreen);
             QRect rect(QPoint(srcScreen->x(), srcScreen->y()), srcScreen->currentResolution());
-            QString key = QStringLiteral("%1,%2,%3,%4").arg(rect.x()).arg(rect.y()).arg(rect.width()).arg(rect.height());
+            QString key = srcScreen->name();
             if (addScreenMap.contains(key)) {
                 addScreenMap[key].append(screenPrivate->monitors());
             } else {

--- a/src/plugin-display/operation/private/displaymodel.cpp
+++ b/src/plugin-display/operation/private/displaymodel.cpp
@@ -3,6 +3,7 @@
 //SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "displaymodel.h"
+#include "WayQtUtils.h"
 
 using namespace dccV25;
 const double DoubleZero = 0.000001;
@@ -64,6 +65,17 @@ void DisplayModel::setDisplayMode(const int mode)
 {
     if (m_mode != mode && mode >= 0 && mode < 5) {
         m_mode = mode;
+        if (!WQt::Utils::isTreeland()) {
+            QMap<QString, QStringList> voMap;
+            if (mode == MERGE_MODE) {
+                QStringList outputNames;
+                for (auto &&monitor : monitorList()) {
+                    outputNames.append(monitor->name());
+                }
+                voMap.insert(outputNames.join("="), outputNames);
+            }
+            setVirtualOutput(voMap);
+        }
         Q_EMIT displayModeChanged(m_mode);
     }
 }


### PR DESCRIPTION
1. DisplayModel::setDisplayMode now populates virtualOutput from monitorList when under X11, matching the Treeland behavior so updateVirtualScreens() correctly creates a merged DccScreen in clone mode
2. Use unique screen name as dedup key in updateVirtualScreens EXTEND branch instead of position+resolution string, which could mismatch during mode transitions

Log: Clone mode screen list displays correctly on X11

Influence:
1. Switch between clone/extend/single mode with multiple monitors on X11, verify screen list and mode options
2. Connect two monitors with different resolutions, switch to clone mode, verify merged screen resolution and name

PMS: BUG-372313

fix(display): X11 复制模式同步 virtualOutput

1. DisplayModel::setDisplayMode 在 X11 下从 monitorList 填充 virtualOutput，与 Treeland 路径保持一致，使 updateVirtualScreens() 在复制模式下能正确创建合并屏幕
2. updateVirtualScreens 扩展模式分支使用唯一的屏幕名称作为 去重 key，替代原来基于位置+分辨率的字符串，避免模式 切换过程中因位置未同步导致 key 不匹配

Log: X11 下切换到复制模式后控制中心能正确显示合并屏幕

Influence:
1. X11 多显示器下切换复制/扩展/仅主屏模式，验证屏幕列表和 模式选项是否正确
2. 连接两个不同分辨率的显示器，切换复制模式后验证合并屏幕 的分辨率和名称显示是否正常

## Summary by Sourcery

Align virtual output handling and screen deduplication on X11 to ensure correct merged screen representation in clone mode.

Bug Fixes:
- Ensure virtualOutput is populated from monitorList on X11 so merged screens are correctly created in clone mode.
- Use unique screen names instead of geometry-based keys when deduplicating screens in extend mode to avoid mismatches during mode transitions.