### PR TITLE
fix: grub preview flicker on theme toggle

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfomodel.cpp
+++ b/src/plugin-commoninfo/operation/commoninfomodel.cpp
@@ -229,8 +229,28 @@ QString CommonInfoModel::grubThemePath() const
 
 void CommonInfoModel::setGrubThemePath(const QString &newGrubThemePath)
 {
+    // Guard against redundant emits: the grub background path is a fixed
+    // location whose content is overwritten in place, so BackgroundChanged
+    // frequently reports the same string. Emitting on identical values
+    // made the QML Image reload twice (real change + delayed duplicate)
+    // and flicker; cache-busting for genuine same-path content changes
+    // is handled by grubBackgroundRevision instead.
+    if (m_grubThemePath == newGrubThemePath)
+        return;
+
     m_grubThemePath = newGrubThemePath;
     emit grubThemePathChanged();
+}
+
+int CommonInfoModel::grubBackgroundRevision() const
+{
+    return m_grubBackgroundRevision;
+}
+
+void CommonInfoModel::bumpGrubBackgroundRevision()
+{
+    ++m_grubBackgroundRevision;
+    emit grubBackgroundRevisionChanged();
 }
 
 int CommonInfoModel::debugLogCurrentIndex() const

--- a/src/plugin-commoninfo/operation/commoninfomodel.h
+++ b/src/plugin-commoninfo/operation/commoninfomodel.h
@@ -25,6 +25,7 @@ class CommonInfoModel : public QObject
     Q_PROPERTY(bool isLogin READ isLogin NOTIFY isLoginChenged FINAL)
     Q_PROPERTY(bool isActivate READ isActivate NOTIFY LicenseStateChanged FINAL)
     Q_PROPERTY(QString grubThemePath READ grubThemePath NOTIFY grubThemePathChanged FINAL)
+    Q_PROPERTY(int grubBackgroundRevision READ grubBackgroundRevision NOTIFY grubBackgroundRevisionChanged FINAL)
     Q_PROPERTY(bool needShowModalDialog READ needShowModalDialog NOTIFY needShowModalDialogChanged FINAL)
     Q_PROPERTY(bool isDeveloperMode READ isDeveloperMode NOTIFY isDeveloperModeChanged FINAL)
     Q_PROPERTY(bool readOnlyProtectionEnabled READ readOnlyProtectionEnabled NOTIFY readOnlyProtectionEnabledChanged FINAL)
@@ -63,6 +64,9 @@ public:
     QString grubThemePath() const;
     void setGrubThemePath(const QString &newGrubThemePath);
 
+    int grubBackgroundRevision() const;
+    void bumpGrubBackgroundRevision();
+
     bool needShowModalDialog() const;
     void setNeedShowModalDialog(bool newNeedShowModalDialog);
 
@@ -96,6 +100,7 @@ Q_SIGNALS:
     void debugLogCurrentIndexChanged();
 
     void grubThemePathChanged();
+    void grubBackgroundRevisionChanged();
 
     void needShowModalDialogChanged();
 
@@ -136,6 +141,7 @@ private:
     int m_plymouthscale;
     QString m_plymouththeme;
     QString m_grubThemePath;
+    int m_grubBackgroundRevision{0};
 
     GrubAnimationModel* m_GrubAnimationModel;
     GrubMenuListModel* m_GrubMenuListModel;

--- a/src/plugin-commoninfo/operation/commoninfowork.cpp
+++ b/src/plugin-commoninfo/operation/commoninfowork.cpp
@@ -198,10 +198,21 @@ CommonInfoWork::CommonInfoWork(CommonInfoModel *model, QObject *parent)
     });
     connect(m_commonInfoProxy, &CommonInfoProxy::UpdatingChanged, m_commomModel, &CommonInfoModel::setUpdating);
     connect(m_commonInfoProxy, &CommonInfoProxy::BackgroundChanged, m_commomModel, [this] () {
-        if (!m_commomModel->themeEnabled()) {
+        // Only a background change we initiated (user dragged an image)
+        // should refresh the preview and, when the theme was off, turn it
+        // back on. A BackgroundChanged we did not request -- e.g. the
+        // delayed signal that follows a theme toggle -- must neither bump
+        // the cache-busting revision nor fight the user's explicit
+        // theme-off choice, otherwise the preview reloads a second time
+        // and flickers, and the theme switch bounces back on by itself.
+        const bool pending = m_pendingBackgroundRefresh;
+        m_pendingBackgroundRefresh = false;
+
+        if (pending && !m_commomModel->themeEnabled()) {
             setEnableTheme(true);
             m_commomModel->setThemeEnabled(true);
         }
+
         QString backgroundPath = m_commonInfoProxy->Background();
         QPixmap pix = QPixmap(backgroundPath);
         m_commomModel->setGrubThemePath(backgroundPath);
@@ -210,6 +221,14 @@ CommonInfoWork::CommonInfoWork(CommonInfoModel *model, QObject *parent)
         QDir dir(kTmpGrubBgDir);
         if (dir.exists()) {
             dir.removeRecursively();
+        }
+
+        // Bump the revision only for a content change we requested so the
+        // QML Image reloads once for same-path new content (BUG-281399)
+        // while the duplicate BackgroundChanged after a theme toggle is
+        // a no-op thanks to the setGrubThemePath same-value guard.
+        if (pending) {
+            m_commomModel->bumpGrubBackgroundRevision();
         }
     });
     connect(m_commonInfoProxy, &CommonInfoProxy::EnabledUsersChanged, m_commomModel, [this] (const QStringList &users) {
@@ -623,6 +642,11 @@ void CommonInfoWork::setBackground(const QString &path)
         }
         qCDebug(DccCommonInfoWork) << "Resolved symlink" << path << "to" << realPath;
     }
+
+    // Mark this as a self-initiated background change so the delayed
+    // BackgroundChanged handler refreshes the preview (and re-enables
+    // the theme if it was off) instead of treating the signal as noise.
+    m_pendingBackgroundRefresh = true;
 
     QString suffix = QFileInfo(realPath).suffix();
     if (suffix.isEmpty()) {

--- a/src/plugin-commoninfo/operation/commoninfowork.h
+++ b/src/plugin-commoninfo/operation/commoninfowork.h
@@ -90,6 +90,7 @@ private:
     QDBusInterface *m_debugConfigInter;
     QDBusInterface *m_inter;
     QString m_tmpBackgroundPath;
+    bool m_pendingBackgroundRefresh{false};
     QString m_immutableWritableStatus;
     Dtk::Core::DConfig *m_dtkConfig = nullptr;
 };

--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -70,7 +70,7 @@ DccObject {
 
             Image {
                 id: image
-                source: dccData.mode().grubThemePath ? "file://" + dccData.mode().grubThemePath + "?timestamp=" + Date.now() : ""
+                source: dccData.mode().grubThemePath ? "file://" + dccData.mode().grubThemePath + "?v=" + dccData.mode().grubBackgroundRevision : ""
                 asynchronous: true
                 anchors.fill: parent
                 width: parent.width


### PR DESCRIPTION
1. Add same-value guard to setGrubThemePath to stop redundant emits
2. Add grubBackgroundRevision counter for cache-busting same-path content
3. Add pending flag to distinguish self-initiated background changes
4. Replace Date.now() with grubBackgroundRevision in BootPage.qml

Log: Fixed background preview flicker when toggling boot menu theme or changing background image

Influence:
1. Test theme off→on: preview refreshes once, no later flicker
2. Test theme on→off: preview clears with no bounce-back
3. Test dragging new background with theme on (BUG-281399 not regressed)
4. Test dragging background with theme off (auto-enable theme preserved)
5. Test deleting/restoring default background and first page entry

fix: 修复启动菜单主题切换后背景预览闪烁

1. 为 setGrubThemePath 增加同值守卫，避免冗余 emit
2. 新增 grubBackgroundRevision 计数器，用于同路径内容变更的缓存失效
3. 新增 pending 标志，区分主动发起的背景变更
4. BootPage.qml 中用 grubBackgroundRevision 替换 Date.now()

Log: 修复启动菜单主题切换或更换背景图后背景预览区闪烁问题

Influence:
1. 测试主题关→开：背景预览只刷新一次，稍后不再闪
2. 测试主题开→关：预览清空，无回跳
3. 测试主题开启态拖拽换背景（验证 BUG-281399 未回归）
4. 测试主题关闭态拖拽背景（验证自动开主题原行为保留）
5. 测试删除/恢复默认背景及首次进入页面

PMS: BUG-371485

## Summary by Sourcery

Prevent boot menu background preview flicker when toggling the GRUB theme or changing the background image.

Bug Fixes:
- Ensure theme toggle and background changes no longer cause duplicate preview reloads or unintended re-enabling of the boot menu theme.

Enhancements:
- Introduce a grub background revision counter exposed to QML for cache-busting same-path background updates without relying on timestamps.
- Add a guard on grub theme path updates to avoid redundant change notifications and unnecessary image reloads.
- Track self-initiated background changes with a pending flag so only user-driven updates refresh the preview and adjust theme state.