### PR TITLE
fix(dcc-plugin): drop unused MenuEditor editor loader

### DIFF
--- a/src/dde-control-center/plugin/DccEditorItem.qml
+++ b/src/dde-control-center/plugin/DccEditorItem.qml
@@ -105,6 +105,7 @@ D.ItemDelegate {
             enabled: model.item.enabledToApp
             opacity: enabled ? 1 : 0.4
             active: !rightItem
+            visible: active
             dccObj: model.item
             dccObjItem: control
         }
@@ -115,6 +116,7 @@ D.ItemDelegate {
             enabled: model.item.enabledToApp
             opacity: enabled ? 1 : 0.4
             active: rightItem
+            visible: active
             sourceComponent: rightItem
         }
     }

--- a/src/dde-control-center/plugin/DccMenuEditorItem.qml
+++ b/src/dde-control-center/plugin/DccMenuEditorItem.qml
@@ -8,7 +8,6 @@ import org.deepin.dtk 1.0 as D
 
 DccEditorItem {
     id: control
-    property Component editor: null
     leftPadding: 14
     rightPadding: 10
     topPadding: topInset
@@ -17,13 +16,8 @@ DccEditorItem {
     rightItem: RowLayout {
         spacing: 8
         DccLoader {
-            active: !editor
             dccObj: model.item
             dccObjItem: control
-        }
-        Loader {
-            active: editor
-            sourceComponent: editor
         }
         D.IconLabel {
             icon {


### PR DESCRIPTION
1. Remove unused editor property and its Loader from DccMenuEditorItem
2. Never assigned by any caller, the custom editor path was dead code
3. Keep DccLoader active as the sole right-side editor via dccObj.page

Log: Remove dead editor property/loader from MenuEditor item
Influence: No functional change for existing MenuEditor items

fix(dcc-plugin): 移除 MenuEditor 未使用的 editor 加载器

1. 删除 DccMenuEditorItem 中未使用的 editor 属性及对应 Loader
2. 该属性从未被任何调用方赋值，属冗余代码
3. 右侧控件仅保留 DccLoader，由 dccObj.page 驱动

Log: 移除 MenuEditor 项中无用的 editor 属性与加载器
PMS: BUG-359785
Influence: 对现有 MenuEditor 项无功能影响

## Summary by Sourcery

Enhancements:
- Simplify DccMenuEditorItem by always using DccLoader driven by dccObj.page and dropping the unused editor hook.