### PR TITLE
fix: improve shortcut capture outcome handling

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -54,7 +54,7 @@ Depends:
  libdtk6declarative(>> 6.7.40),
  netselect,
  dde-daemon (>> 6.1.99),
- dde-services (>> 1.0.38),
+ dde-services (>> 1.0.39),
  deepin-security-loader,
 Recommends: uos-license-content,
 Conflicts: dde-control-center-dock

--- a/src/plugin-keyboard/operation/keyboardcontroller.cpp
+++ b/src/plugin-keyboard/operation/keyboardcontroller.cpp
@@ -18,6 +18,12 @@ DCC_FACTORY_CLASS(KeyboardController)
 
 namespace {
 constexpr int ShortcutCaptureTimeoutMs = 30000;
+enum CaptureResult : uint {
+    CaptureSuccess = 0,
+    CaptureInvalid = 1,
+    CaptureCanceled = 2,
+    CaptureTimedOut = 3,
+};
 }
 
 KeyboardController::KeyboardController(QObject *parent)
@@ -126,6 +132,41 @@ KeyboardController::KeyboardController(QObject *parent)
     connect(m_worker, &KeyboardWorker::customShortcutOperationFinished,
             this, &KeyboardController::customShortcutOperationFinished);
 
+    connect(m_worker, &KeyboardWorker::captureFinished, this,
+            [this](quint64 captureId, uint result, const QString &keystroke) {
+                if (m_capture.backend != CaptureBackend::X11
+                        || m_capture.phase != CapturePhase::Active
+                        || captureId != m_capture.requestId) {
+                    return;
+                }
+
+                const QString id = m_capture.id;
+                const int type = m_capture.type;
+                const quint64 generation = m_capture.generation;
+                ++m_captureRequestSerial;
+                m_capture.reset();
+
+                switch (result) {
+                case CaptureSuccess:
+                    handleCapturedKeystroke(id, type, keystroke, generation);
+                    break;
+                case CaptureInvalid:
+                    Q_EMIT invalidShortcutCaptured(id, type);
+                    break;
+                case CaptureCanceled:
+                    Q_EMIT keyCaptureCanceled(id, type);
+                    break;
+                case CaptureTimedOut:
+                    Q_EMIT keyCaptureTimedOut(id, type);
+                    break;
+                default:
+                    qWarning() << "Unknown shortcut capture result:" << result;
+                    Q_EMIT keyCaptureFailed(id, type,
+                                            QStringLiteral("unknown capture result"));
+                    break;
+                }
+            });
+
     connect(m_shortcutModel, &ShortcutModel::keyEvent, this, [this](bool press, const QString &shortcut){
         if (m_capture.backend != CaptureBackend::X11
                 || m_capture.phase != CapturePhase::Active)
@@ -139,10 +180,6 @@ KeyboardController::KeyboardController(QObject *parent)
 
         if (press)
             Q_EMIT keyEvent(id, type, shortcut);
-        else {
-            endKeyCapture();
-            handleCapturedKeystroke(id, type, shortcut, generation);
-        }
     });
 
     QMetaObject::invokeMethod(m_worker, "active", Qt::QueuedConnection);
@@ -652,7 +689,8 @@ bool KeyboardController::isCurrentShortcutGeneration(const QString &id, int type
             && m_shortcutGenerations.value(key) == generation;
 }
 
-void KeyboardController::beginKeyCapture(QQuickItem *item, const QString &id, int type)
+void KeyboardController::beginKeyCapture(QQuickItem *item, const QString &id, int type,
+                                         bool timeoutEnabled)
 {
     endKeyCapture();
 
@@ -685,18 +723,20 @@ void KeyboardController::beginKeyCapture(QQuickItem *item, const QString &id, in
         });
     }
 
-    QTimer::singleShot(ShortcutCaptureTimeoutMs, this,
-                       [this, requestId, id, type, generation] {
-        if (requestId != m_capture.requestId
-                || m_capture.phase == CapturePhase::Idle
-                || !isCurrentShortcutGeneration(id, type, generation)) {
-            return;
-        }
+    if (timeoutEnabled) {
+        QTimer::singleShot(ShortcutCaptureTimeoutMs, this,
+                           [this, requestId, id, type, generation] {
+            if (requestId != m_capture.requestId
+                    || m_capture.phase == CapturePhase::Idle
+                    || !isCurrentShortcutGeneration(id, type, generation)) {
+                return;
+            }
 
-        qWarning() << "Shortcut capture timed out:" << id << type;
-        endKeyCapture();
-        Q_EMIT keyCaptureTimedOut(id, type);
-    });
+            qWarning() << "Shortcut capture timed out:" << id << type;
+            endKeyCapture();
+            Q_EMIT keyCaptureTimedOut(id, type);
+        });
+    }
 
     if (m_worker->isWayland()) {
         m_capture.backend = CaptureBackend::Wayland;
@@ -773,8 +813,12 @@ void KeyboardController::startWaylandKeyCapture(QQuickItem *item, const QString 
                 qWarning() << message << id << type;
                 using Capture = QtWayland::treeland_shortcut_capture_v1;
                 const auto failedReason = static_cast<Capture::failed_reason>(reason);
+                // The protocol groups pointer clicks, Escape and unmodified
+                // alphanumeric keys under "interrupted" without exposing the
+                // triggering input. Treat it as cancellation so clicking away
+                // never produces a misleading invalid-shortcut error.
                 if (failedReason == Capture::failed_reason_interrupted)
-                    Q_EMIT invalidShortcutCaptured(id, type);
+                    Q_EMIT keyCaptureCanceled(id, type);
                 else
                     Q_EMIT keyCaptureFailed(id, type, message);
                 Q_EMIT waylandKeyCaptureFailed(id, type, static_cast<int>(reason));
@@ -822,12 +866,15 @@ void KeyboardController::handleCapturedKeystroke(const QString &id, int type, co
     if (!isCurrentShortcutGeneration(id, type, generation))
         return;
 
-    if (accels.isEmpty()) {
-        Q_EMIT invalidShortcutCaptured(id, type);
-        return;
+    QString capturedKey = accels.trimmed();
+    if (capturedKey.startsWith(QLatin1Char('<'))
+            && capturedKey.endsWith(QLatin1Char('>'))) {
+        capturedKey = capturedKey.mid(1, capturedKey.size() - 2);
     }
-    if (accels == QLatin1String("Esc") || accels == QLatin1String("Escape")) {
-        Q_EMIT requestRestore(id, type);
+    if (capturedKey.isEmpty()
+            || capturedKey.compare(QLatin1String("Esc"), Qt::CaseInsensitive) == 0
+            || capturedKey.compare(QLatin1String("Escape"), Qt::CaseInsensitive) == 0) {
+        Q_EMIT keyCaptureCanceled(id, type);
         return;
     }
     if (accels == QLatin1String("BackSpace")

--- a/src/plugin-keyboard/operation/keyboardcontroller.h
+++ b/src/plugin-keyboard/operation/keyboardcontroller.h
@@ -78,7 +78,8 @@ public Q_SLOTS:
     void updateKey(const QString &id, const int &type);
     QStringList formatKeys(const QString &shortcuts);
     Q_INVOKABLE bool isWaylandSession() const;
-    Q_INVOKABLE void beginKeyCapture(QQuickItem *item, const QString &id, int type);
+    Q_INVOKABLE void beginKeyCapture(QQuickItem *item, const QString &id, int type,
+                                     bool timeoutEnabled = true);
     Q_INVOKABLE void endKeyCapture();
     Q_INVOKABLE void submitCapturedKeystroke(const QString &id, int type, const QString &accels);
 
@@ -127,6 +128,7 @@ signals:
     void keyCaptureStarted(const QString &id, int type);
     void keyCaptureFailed(const QString &id, int type, const QString &reason);
     void keyCaptureTimedOut(const QString &id, int type);
+    void keyCaptureCanceled(const QString &id, int type);
     void invalidShortcutCaptured(const QString &id, int type);
     void shortcutModificationFinished(const QString &id, int type, const QString &accels, bool success);
     void customShortcutOperationFinished(quint64 requestId, bool success,

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.cpp
@@ -136,6 +136,10 @@ void KeyboardDBusProxy::init()
         KeybingdingService, KeybingdingPath, KeybingdingInterface,
         "KeyEvent", this,
         SIGNAL(KeyEvent(bool,QString)));
+    QDBusConnection::sessionBus().connect(
+        KeybingdingService, KeybingdingPath, KeybingdingInterface,
+        "CaptureFinished", this,
+        SIGNAL(CaptureFinished(qulonglong,uint,QString)));
 
     auto *keybindingWatcher = new QDBusServiceWatcher(
         KeybingdingService,
@@ -588,9 +592,10 @@ QDBusPendingReply<QString> KeyboardDBusProxy::Query(const QString &in0, int in1)
     return QDBusPendingReply<QString>();
 }
 
-QDBusPendingReply<bool> KeyboardDBusProxy::BeginCapture(uint timeoutMs)
+QDBusPendingReply<bool> KeyboardDBusProxy::BeginCapture(quint64 captureId, uint timeoutMs)
 {
     QList<QVariant> argumentList;
+    argumentList << QVariant::fromValue(captureId);
     argumentList << timeoutMs;
     return m_dBusKeybingdingInter->asyncCallWithArgumentList(QStringLiteral("BeginCapture"), argumentList);
 }

--- a/src/plugin-keyboard/operation/keyboarddbusproxy.h
+++ b/src/plugin-keyboard/operation/keyboarddbusproxy.h
@@ -216,6 +216,9 @@ signals:
     void ShortcutSwitchLayoutChanged(uint  value) const;
     // Keybinding
     void KeyEvent(bool pressed, const QString &keystroke);
+    // Explicit terminal result from the new shortcut capture protocol:
+    // 0=success, 1=invalid, 2=canceled, 3=timed out.
+    void CaptureFinished(quint64 captureId, uint result, const QString &keystroke);
     // Wayland new-API bridge: full shortcut list converted to old JSON format.
     void AllShortcutsReady(const QString &json);
     // Wayland: result of a GetShortcut query, already converted to old JSON.
@@ -267,7 +270,7 @@ public slots:
     QDBusPendingReply<QString> GetShortcut(const QString &in0, int in1);
     QDBusPendingReply<QString> SearchShortcuts(const QString &in0);
     QDBusPendingReply<QString> Query(const QString &in0, int in1);
-    QDBusPendingReply<bool> BeginCapture(uint timeoutMs = 30000);
+    QDBusPendingReply<bool> BeginCapture(quint64 captureId, uint timeoutMs = 30000);
     void EndCapture();
 
     //KeyBoard

--- a/src/plugin-keyboard/operation/keyboardwork.cpp
+++ b/src/plugin-keyboard/operation/keyboardwork.cpp
@@ -99,6 +99,8 @@ KeyboardWorker::KeyboardWorker(KeyboardModel *model, QObject *parent)
 
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::compositingEnabledChanged, this, &KeyboardWorker::onGetWindowWM);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::AllShortcutsReady, this, &KeyboardWorker::onAllShortcutsReady);
+    connect(m_keyboardDBusProxy, &KeyboardDBusProxy::CaptureFinished,
+            this, &KeyboardWorker::captureFinished);
     connect(m_keyboardDBusProxy, &KeyboardDBusProxy::keybindingServiceRegistered, this, [this] {
         qCInfo(lcKeyboardWorker) << "Keybinding service registered, refresh shortcuts";
         refreshShortcut();
@@ -846,7 +848,7 @@ bool KeyboardWorker::isCurrentShortcutGeneration(const QString &id, int type,
 
 void KeyboardWorker::beginCapture(quint64 requestId)
 {
-    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->BeginCapture();
+    QDBusPendingReply<bool> reply = m_keyboardDBusProxy->BeginCapture(requestId);
     auto *watcher = new QDBusPendingCallWatcher(reply, this);
     connect(watcher, &QDBusPendingCallWatcher::finished, this, [this, watcher, requestId] {
         QDBusPendingReply<bool> result = *watcher;

--- a/src/plugin-keyboard/operation/keyboardwork.h
+++ b/src/plugin-keyboard/operation/keyboardwork.h
@@ -101,6 +101,7 @@ Q_SIGNALS:
     void shortcutCommandReady(const QString &id, const QString &command, bool available,
                               quint64 requestSerial);
     void captureRequestFinished(quint64 requestId, bool success, const QString &reason);
+    void captureFinished(quint64 captureId, uint result, const QString &keystroke);
     void shortcutConflictDetected(const QString &id, int type, const QString &shortcut,
                                   const QString &conflictId, const QString &conflictName,
                                   bool replaceable, quint64 generation);

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -175,6 +175,7 @@ D.DialogWindow {
                     return DS.Style.keySequenceEdit.background;
             }
             onRequestKeys: {
+                captureFailureTimer.stop()
                 dccData.clearPendingConflict(ddialog.keyId, 1)
                 ddialog.pendingConflict = false
                 conflictText.text = ""
@@ -186,7 +187,7 @@ D.DialogWindow {
                     ddialog.captureRestoreAccels = edit.accels
                     ddialog.captureRestoreValid = true
                 }
-                dccData.beginKeyCapture(edit, ddialog.keyId, 1)
+                dccData.beginKeyCapture(edit, ddialog.keyId, 1, true)
             }
         }
 
@@ -250,6 +251,7 @@ D.DialogWindow {
             function onRequestRestore(id, type) {
                 if (id !== ddialog.keyId || type !== 1)
                     return
+                captureFailureTimer.stop()
                 dccData.endKeyCapture()
                 if (ddialog.captureRestoreValid) {
                     edit.keys = ddialog.captureRestoreKeys
@@ -281,6 +283,7 @@ D.DialogWindow {
                 edit.keys = []
             }
             function showCaptureFailure(message) {
+                captureFailureTimer.restart()
                 edit.keys = ddialog.captureRestoreKeys
                 edit.accels = ddialog.captureRestoreAccels
                 ddialog.captureRestoreValid = false
@@ -298,6 +301,11 @@ D.DialogWindow {
                     return
                 showCaptureFailure(qsTr("Shortcut input timed out. Try again."))
             }
+            function onKeyCaptureCanceled(id, type) {
+                if (id !== ddialog.keyId || type !== 1)
+                    return
+                onRequestRestore(id, type)
+            }
             function onInvalidShortcutCaptured(id, type) {
                 if (id !== ddialog.keyId || type !== 1)
                     return
@@ -306,13 +314,9 @@ D.DialogWindow {
             function onKeyConflicted(id, type, oldAccels, newAccels, message, replaceable) {
                 if (id !== ddialog.keyId || type !== 1)
                     return
+                captureFailureTimer.stop()
                 if (!replaceable) {
-                    edit.keys = ddialog.captureRestoreKeys
-                    edit.accels = ddialog.captureRestoreAccels
-                    ddialog.captureRestoreValid = false
-                    dccData.clearPendingConflict(ddialog.keyId, 1)
-                    ddialog.pendingConflict = false
-                    conflictText.text = message
+                    showCaptureFailure(message)
                     return
                 }
                 ddialog.captureRestoreValid = false
@@ -326,6 +330,7 @@ D.DialogWindow {
             function onKeyDone(id, type, accels) {
                 if (id !== ddialog.keyId || type !== 1)
                     return
+                captureFailureTimer.stop()
                 ddialog.captureRestoreValid = false
                 dccData.clearPendingConflict(ddialog.keyId, 1)
                 ddialog.pendingConflict = false
@@ -350,9 +355,30 @@ D.DialogWindow {
                     return
                 }
 
+                edit.keys = ddialog.saveKeys
+                edit.accels = ddialog.saveAccels
+                ddialog.captureRestoreValid = false
+                dccData.clearPendingConflict(ddialog.keyId, 1)
+                ddialog.pendingConflict = false
                 conflictText.text = errorMessage.length > 0
                         ? errorMessage
                         : qsTr("Failed to save the shortcut. Please try again.")
+                captureFailureTimer.restart()
+            }
+        }
+
+        Timer {
+            id: captureFailureTimer
+            interval: 20000
+            repeat: false
+            onTriggered: {
+                // The failure handler has already restored the shortcut. Only
+                // clear the temporary alert and any stale capture state here.
+                dccData.endKeyCapture()
+                ddialog.captureRestoreValid = false
+                dccData.clearPendingConflict(ddialog.keyId, 1)
+                ddialog.pendingConflict = false
+                conflictText.text = ""
             }
         }
     }

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -188,7 +188,7 @@ DccObject {
                                 shortcutView.editItem = edit
                                 shortcutView.conflictText = conflictText
                                 shortcutSettingsBody.isEditing = false
-                                dccData.beginKeyCapture(edit, model.id, model.type)
+                                dccData.beginKeyCapture(edit, model.id, model.type, true)
                             }
                             onRequestEditKeys: {
                                 if (dialogloader.active)
@@ -219,6 +219,7 @@ DccObject {
                             }
 
                             function startCapture() {
+                                captureFailureTimer.stop()
                                 conflictText.message = ""
                                 conflictText.showActions = true
                                 conflictText.visible = false
@@ -239,9 +240,11 @@ DccObject {
                                 conflictText.showActions = false
                                 conflictText.visible = true
                                 shortcutSettingsBody.conflictAccels = ""
+                                captureFailureTimer.restart()
                             }
 
                             function finishModification(accels) {
+                                captureFailureTimer.stop()
                                 keys = dccData.formatKeys(accels)
                                 conflictText.visible = false
                                 conflictText.message = ""
@@ -251,6 +254,7 @@ DccObject {
                             }
 
                             function clearShortcut() {
+                                captureFailureTimer.stop()
                                 dccData.endKeyCapture()
                                 dccData.clearShortcut(model.id, model.type)
 
@@ -264,6 +268,7 @@ DccObject {
                             }
 
                             function restore() {
+                                captureFailureTimer.stop()
                                 dccData.endKeyCapture()
                                 edit.keys = model.keySequence
                                 conflictText.visible = false
@@ -273,6 +278,15 @@ DccObject {
                                 shortcutSettingsBody.conflictAccels = ""
                                 shortcutView.editItem = null
                                 shortcutView.conflictText = null
+                            }
+
+                            // Keep capture errors visible long enough to be read, then
+                            // return the row to its normal state when the user is idle.
+                            Timer {
+                                id: captureFailureTimer
+                                interval: 20000
+                                repeat: false
+                                onTriggered: edit.restore()
                             }
 
                             Loader {
@@ -448,6 +462,11 @@ DccObject {
                         if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
                             return
                         shortcutView.editItem.showFailure(qsTr("Shortcut input timed out. Try again."))
+                    }
+                    function onKeyCaptureCanceled(id, type) {
+                        if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))
+                            return
+                        shortcutView.restoreShortcutView()
                     }
                     function onInvalidShortcutCaptured(id, type) {
                         if (!shortcutView.editItem || !shortcutView.editItem.matches(id, type))


### PR DESCRIPTION
## Summary
- consume correlated shortcut capture results from dde-services
- distinguish invalid input, cancellation, timeout, conflict, and save failure feedback
- auto-dismiss temporary messages after 20 seconds and require the new service ABI

## Test plan
- build `keyboard` and `keyboard_qml`
- run `ctest --test-dir build-pinyin-search --output-on-failure`
- verify X11 Shift reports invalid, Escape/pointer click cancel silently, and timeout feedback clears after 20 seconds

Pms: BUG-373653

## Summary by Sourcery

Integrate explicit shortcut capture results from the keybinding service and refine keyboard shortcut capture UX, including clearer differentiation of invalid input, cancellation, timeout, and save failures.

New Features:
- Consume the keybinding service's CaptureFinished signal to handle explicit shortcut capture outcomes in the keyboard plugin.

Bug Fixes:
- Treat Escape and related inputs as capture cancellation rather than invalid shortcuts to avoid misleading error feedback.
- Ensure capture failures and conflicts restore prior shortcut state consistently and clear stale capture state.
- Stop using key-release on X11 to implicitly complete captures, relying instead on the service-provided result to avoid incorrect completions.

Enhancements:
- Add dedicated handling for canceled, timed-out, invalid, and failed shortcut captures across X11 and Wayland backends.
- Introduce 20-second timers in shortcut QML views to auto-dismiss temporary failure messages and revert UI to a normal state.
- Extend beginKeyCapture to support configurable timeout behavior aligned with the new capture protocol.