### PR TITLE
chore(qml): 去除 QML import 版本号（Qt6）& 统一 SPDX 版权年份至 2026

### DIFF
--- a/examples/plugin-example/qml/Example.qml
+++ b/examples/plugin-example/qml/Example.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 // 该文件中不能使用dccData,根对象为DccObject
 DccObject {

--- a/examples/plugin-example/qml/ExampleMain.qml
+++ b/examples/plugin-example/qml/ExampleMain.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 // 该文件中可以使用dccData,根对象为DccObject
 DccObject {

--- a/examples/plugin-example/qml/ExamplePage1.qml
+++ b/examples/plugin-example/qml/ExamplePage1.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/examples/plugin-example/qml/ExamplePage2.qml
+++ b/examples/plugin-example/qml/ExamplePage2.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/examples/plugin-example/qml/ExamplePage3.qml
+++ b/examples/plugin-example/qml/ExamplePage3.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccSettingsObject {
     id: root

--- a/src/dde-control-center/plugin/Crumb.qml
+++ b/src/dde-control-center/plugin/Crumb.qml
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Controls 2.3
+import QtQuick.Controls
 import QtQml.Models //Delegatechoice for Qt >= 6.9
 import Qt.labs.qmlmodels //DelegateChooser
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 FocusScope {
     id: root

--- a/src/dde-control-center/plugin/DccCheckIcon.qml
+++ b/src/dde-control-center/plugin/DccCheckIcon.qml
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
 import QtQuick.Controls
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 D.ActionButton {
     property real size: 16

--- a/src/dde-control-center/plugin/DccEditorItem.qml
+++ b/src/dde-control-center/plugin/DccEditorItem.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 D.ItemDelegate {
     id: control

--- a/src/dde-control-center/plugin/DccGroupView.qml
+++ b/src/dde-control-center/plugin/DccGroupView.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
 import QtQml.Models //Delegatechoice for Qt >= 6.9
 import Qt.labs.qmlmodels //DelegateChooser
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 Rectangle {
     id: control

--- a/src/dde-control-center/plugin/DccItem.qml
+++ b/src/dde-control-center/plugin/DccItem.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 D.ItemDelegate {
     id: control

--- a/src/dde-control-center/plugin/DccItemBackground.qml
+++ b/src/dde-control-center/plugin/DccItemBackground.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 Item {
     id: bgItem

--- a/src/dde-control-center/plugin/DccLabel.qml
+++ b/src/dde-control-center/plugin/DccLabel.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import org.deepin.dtk
+import org.deepin.dcc
 
 Label {
     id: control

--- a/src/dde-control-center/plugin/DccMenuEditorItem.qml
+++ b/src/dde-control-center/plugin/DccMenuEditorItem.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 DccEditorItem {
     id: control

--- a/src/dde-control-center/plugin/DccMenuItem.qml
+++ b/src/dde-control-center/plugin/DccMenuItem.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 DccEditorItem {
     topInset: 5

--- a/src/dde-control-center/plugin/DccRightView.qml
+++ b/src/dde-control-center/plugin/DccRightView.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import Qt.labs.qmlmodels 1.2
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.qmlmodels
+import QtQuick.Layouts
 import "DccUtils.js" as DccUtils
 
 Flickable {

--- a/src/dde-control-center/plugin/DccRowView.qml
+++ b/src/dde-control-center/plugin/DccRowView.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
-import Qt.labs.qmlmodels 1.2
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
+import Qt.labs.qmlmodels
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 RowLayout {
     objectName: "noPadding"

--- a/src/dde-control-center/plugin/DccSettingsObject.qml
+++ b/src/dde-control-center/plugin/DccSettingsObject.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
+import QtQuick
 
 DccObject {
     id: root

--- a/src/dde-control-center/plugin/DccSettingsView.qml
+++ b/src/dde-control-center/plugin/DccSettingsView.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import Qt.labs.qmlmodels 1.2
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import Qt.labs.qmlmodels
+import QtQuick.Layouts
 import "DccUtils.js" as DccUtils
 
 Flickable {

--- a/src/dde-control-center/plugin/DccTimeRange.qml
+++ b/src/dde-control-center/plugin/DccTimeRange.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 D.SpinBox {
     id: control

--- a/src/dde-control-center/plugin/DccTitleObject.qml
+++ b/src/dde-control-center/plugin/DccTitleObject.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
 import "DccUtils.js" as DccUtils
 
 DccObject {

--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 D.ApplicationWindow {
     id: mainWindow

--- a/src/dde-control-center/plugin/HomePage.qml
+++ b/src/dde-control-center/plugin/HomePage.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 Control {
     id: root

--- a/src/dde-control-center/plugin/SearchBar.qml
+++ b/src/dde-control-center/plugin/SearchBar.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import org.deepin.dtk 1.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import org.deepin.dtk
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 Rectangle {
     id: control

--- a/src/dde-control-center/plugin/SecondPage.qml
+++ b/src/dde-control-center/plugin/SecondPage.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 Item {
     id: root

--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -4,9 +4,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Qt.labs.qmlmodels
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
 
 DccObject {
     id: settings

--- a/src/plugin-accounts/qml/Accounts.qml
+++ b/src/plugin-accounts/qml/Accounts.qml
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "accounts"

--- a/src/plugin-accounts/qml/AccountsMain.qml
+++ b/src/plugin-accounts/qml/AccountsMain.qml
@@ -4,9 +4,9 @@ import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 DccObject {
     AccountSettings {

--- a/src/plugin-accounts/qml/AutoLoginWarningDialog.qml
+++ b/src/plugin-accounts/qml/AutoLoginWarningDialog.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-accounts/qml/AvatarGridView.qml
+++ b/src/plugin-accounts/qml/AvatarGridView.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
 import QtQuick.Effects
 
 GridView {

--- a/src/plugin-accounts/qml/AvatarSettingsDialog.qml
+++ b/src/plugin-accounts/qml/AvatarSettingsDialog.qml
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Window
 import QtQml.Models
-import QtQuick.Layouts 1.15
+import QtQuick.Layouts
 import Qt.labs.qmlmodels
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import Qt.labs.platform 1.1
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import Qt.labs.platform
+import org.deepin.dcc
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-accounts/qml/ComfirmDeleteDialog.qml
+++ b/src/plugin-accounts/qml/ComfirmDeleteDialog.qml
@@ -4,8 +4,8 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-accounts/qml/ComfirmSafePage.qml
+++ b/src/plugin-accounts/qml/ComfirmSafePage.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-accounts/qml/CreateAccountDialog.qml
+++ b/src/plugin-accounts/qml/CreateAccountDialog.qml
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Window
 import QtQml.Models
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
-import AccountsController 1.0
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
+import AccountsController
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-accounts/qml/CustomAvatarCropper.qml
+++ b/src/plugin-accounts/qml/CustomAvatarCropper.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dtk 1.0 as D
-import Qt.labs.platform 1.1
+import org.deepin.dtk as D
+import Qt.labs.platform
 
 Control {
     id: control

--- a/src/plugin-accounts/qml/CustomAvatarEmpatyArea.qml
+++ b/src/plugin-accounts/qml/CustomAvatarEmpatyArea.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Shapes
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 Control {
     id: control

--- a/src/plugin-accounts/qml/CustomLocalAvatarsRow.qml
+++ b/src/plugin-accounts/qml/CustomLocalAvatarsRow.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 Item {
     id: root

--- a/src/plugin-accounts/qml/EditActionLabel.qml
+++ b/src/plugin-accounts/qml/EditActionLabel.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 D.LineEdit {
     id: edit

--- a/src/plugin-accounts/qml/LoginMethod.qml
+++ b/src/plugin-accounts/qml/LoginMethod.qml
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 DccTitleObject {
     id: loginMethodTitle

--- a/src/plugin-accounts/qml/PasswordLayout.qml
+++ b/src/plugin-accounts/qml/PasswordLayout.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 ColumnLayout {
     id: pwdLayout

--- a/src/plugin-accounts/qml/PasswordModifyDialog.qml
+++ b/src/plugin-accounts/qml/PasswordModifyDialog.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Window
 import QtQml.Models
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-authentication/qml/AddFaceinfoDialog.qml
+++ b/src/plugin-authentication/qml/AddFaceinfoDialog.qml
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Window
-import QtQml.Models 2.1
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
-import org.deepin.dcc.account.biometric 1.0
+import QtQml.Models
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
+import org.deepin.dcc.account.biometric
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-authentication/qml/AddFingerDialog.qml
+++ b/src/plugin-authentication/qml/AddFingerDialog.qml
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Window
-import QtQml.Models 2.1
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
-import org.deepin.dcc.account.biometric 1.0
+import QtQml.Models
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
+import org.deepin.dcc.account.biometric
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-authentication/qml/AddIrisDialog.qml
+++ b/src/plugin-authentication/qml/AddIrisDialog.qml
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Dialogs
 import QtQuick.Window
-import QtQml.Models 2.1
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
-import org.deepin.dcc.account.biometric 1.0
+import QtQml.Models
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
+import org.deepin.dcc.account.biometric
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-authentication/qml/Authentication.qml
+++ b/src/plugin-authentication/qml/Authentication.qml
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import org.deepin.dcc 1.0
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import org.deepin.dcc
+import QtQuick
+import QtQuick.Controls
 
 DccObject {
     id: authentication

--- a/src/plugin-authentication/qml/AuthenticationMain.qml
+++ b/src/plugin-authentication/qml/AuthenticationMain.qml
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc.account.biometric 1.0
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc.account.biometric
 
 DccObject {
     id: root

--- a/src/plugin-authentication/qml/DisclaimerControl.qml
+++ b/src/plugin-authentication/qml/DisclaimerControl.qml
@@ -4,8 +4,8 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 ColumnLayout {  
     id: control

--- a/src/plugin-bluetooth/qml/Adapters.qml
+++ b/src/plugin-bluetooth/qml/Adapters.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
+import org.deepin.dcc
+import QtQuick.Layouts
 
 DccObject{
     property bool isUserClosingBluetooth: false  // 跟踪用户是否正在关闭蓝牙

--- a/src/plugin-bluetooth/qml/BlueTooth.qml
+++ b/src/plugin-bluetooth/qml/BlueTooth.qml
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
+++ b/src/plugin-bluetooth/qml/BlueToothDeviceListView.qml
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
-import org.deepin.dtk.style 1.0 as DS
-import QtQuick.Window 2.15
+import org.deepin.dtk as D
+import org.deepin.dcc
+import org.deepin.dtk.style as DS
+import QtQuick.Window
 import Qt.labs.platform
 
 Rectangle {

--- a/src/plugin-bluetooth/qml/BlueToothMain.qml
+++ b/src/plugin-bluetooth/qml/BlueToothMain.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
-import Qt.labs.qmlmodels 1.2
+import org.deepin.dcc
+import QtQuick.Layouts
+import Qt.labs.platform
+import Qt.labs.qmlmodels
 
 DccObject{
     name: "bluetoothSetting"

--- a/src/plugin-bluetooth/qml/BluetoothCtl.qml
+++ b/src/plugin-bluetooth/qml/BluetoothCtl.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import QtQuick.Layouts
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
 
 DccObject{
     signal userClickedClose()

--- a/src/plugin-bluetooth/qml/MyDevice.qml
+++ b/src/plugin-bluetooth/qml/MyDevice.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0
+import org.deepin.dcc
+import QtQuick.Layouts
+import org.deepin.dtk
 
 DccObject{
     DccTitleObject {

--- a/src/plugin-bluetooth/qml/OtherDevice.qml
+++ b/src/plugin-bluetooth/qml/OtherDevice.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import QtQuick.Layouts
+import org.deepin.dtk as D
 
 DccObject{
     property bool refreshEnable: true

--- a/src/plugin-commoninfo/qml/BootPage.qml
+++ b/src/plugin-commoninfo/qml/BootPage.qml
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.11
-import QtQuick.Controls 2.4
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 import QtQuick.Effects
-import org.deepin.dtk 1.0
+import org.deepin.dtk
 
 import Qt5Compat.GraphicalEffects
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
 

--- a/src/plugin-commoninfo/qml/CommonInfoMain.qml
+++ b/src/plugin-commoninfo/qml/CommonInfoMain.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
+import org.deepin.dcc
+import QtQuick.Layouts
 
 DccObject {
     DccObject {

--- a/src/plugin-commoninfo/qml/DevelopModePage.qml
+++ b/src/plugin-commoninfo/qml/DevelopModePage.qml
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import org.deepin.dtk 1.0 as D
+import QtQuick
+import QtQuick.Controls
+import org.deepin.dtk as D
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
-import Qt.labs.platform 1.1
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import QtQuick.Layouts
+import QtQuick.Window
+import Qt.labs.platform
+import org.deepin.dtk.style as DS
 
 DccObject {
     DccObject {

--- a/src/plugin-datetime/qml/ComboLabel.qml
+++ b/src/plugin-datetime/qml/ComboLabel.qml
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick.Controls
+import QtQuick.Layouts
 
 Item {
     id: item

--- a/src/plugin-datetime/qml/DateTimeSettingDialog.qml
+++ b/src/plugin-datetime/qml/DateTimeSettingDialog.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Window
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
         
 D.DialogWindow {
     id: ddialog

--- a/src/plugin-datetime/qml/Datetime.qml
+++ b/src/plugin-datetime/qml/Datetime.qml
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "datetime"

--- a/src/plugin-datetime/qml/DatetimeMain.qml
+++ b/src/plugin-datetime/qml/DatetimeMain.qml
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 // import QtQuick 2.15
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 TimeAndDate {
     DccObject {

--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dcc
+import org.deepin.dtk
 import QtQml.Models
 
 // 语言和区域

--- a/src/plugin-datetime/qml/LangsChooserDialog.qml
+++ b/src/plugin-datetime/qml/LangsChooserDialog.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Window
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import QtQuick.Layouts
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
 
 Loader {
     id: langDialogLoader

--- a/src/plugin-datetime/qml/RegionFormatDialog.qml
+++ b/src/plugin-datetime/qml/RegionFormatDialog.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Controls 2.0
+import QtQuick.Controls
 import QtQuick.Window
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 import QtQml.Models
 import QtQuick.Effects
 

--- a/src/plugin-datetime/qml/RegionsChooserWindow.qml
+++ b/src/plugin-datetime/qml/RegionsChooserWindow.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Lt
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Window
 import QtQuick.Layouts
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
 
 Popup {
     id: control

--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Lt
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Window
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dtk.private 1.0 as P
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
+import org.deepin.dtk.private as P
 
 Popup {
     id: control

--- a/src/plugin-datetime/qml/SpinboxEx.qml
+++ b/src/plugin-datetime/qml/SpinboxEx.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import org.deepin.dtk 1.0 as D
+import QtQuick
+import QtQuick.Controls
+import org.deepin.dtk as D
 
 SpinBox {
     id: sp

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQml.Models 2.11
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.private 1.0 as P
-import org.deepin.dtk.style 1.0 as DS
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQml.Models
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.private as P
+import org.deepin.dtk.style as DS
 
-import ZoneInfoModel 1.0
+import ZoneInfoModel
 
 // 时间和日期
 DccObject {

--- a/src/plugin-datetime/qml/TimezoneDialog.qml
+++ b/src/plugin-datetime/qml/TimezoneDialog.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.15
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Window
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0 as Dcc
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dcc as Dcc
 
 D.DialogWindow {
     id: timezoneDialog

--- a/src/plugin-deepinid/qml/ConFirmDialog.qml
+++ b/src/plugin-deepinid/qml/ConFirmDialog.qml
@@ -5,8 +5,8 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-deepinid/qml/ConfirmManager.qml
+++ b/src/plugin-deepinid/qml/ConfirmManager.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 Item {
     id: root

--- a/src/plugin-deepinid/qml/DeepinIDAccountSecurity.qml
+++ b/src/plugin-deepinid/qml/DeepinIDAccountSecurity.qml
@@ -1,14 +1,14 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 DccObject {
     DccObject {

--- a/src/plugin-deepinid/qml/DeepinIDLogin.qml
+++ b/src/plugin-deepinid/qml/DeepinIDLogin.qml
@@ -2,13 +2,13 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     id: root

--- a/src/plugin-deepinid/qml/DeepinIDSyncService.qml
+++ b/src/plugin-deepinid/qml/DeepinIDSyncService.qml
@@ -1,14 +1,14 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 DccObject {
     name: "syncService"

--- a/src/plugin-deepinid/qml/DeepinIDUserInfo.qml
+++ b/src/plugin-deepinid/qml/DeepinIDUserInfo.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -7,9 +7,9 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import QtQuick.Effects
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-deepinid/qml/Deepinid.qml
+++ b/src/plugin-deepinid/qml/Deepinid.qml
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.3
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-deepinid/qml/DeepinidMain.qml
+++ b/src/plugin-deepinid/qml/DeepinidMain.qml
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     DeepinIDLogin {

--- a/src/plugin-deepinid/qml/RegisterDialog.qml
+++ b/src/plugin-deepinid/qml/RegisterDialog.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-deepinid/qml/VerifyDialog.qml
+++ b/src/plugin-deepinid/qml/VerifyDialog.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-defaultapp/qml/Defaultapp.qml
+++ b/src/plugin-defaultapp/qml/Defaultapp.qml
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2024-2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "defaultapp"

--- a/src/plugin-defaultapp/qml/DefaultappMain.qml
+++ b/src/plugin-defaultapp/qml/DefaultappMain.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import org.deepin.dcc.defApp 1.0
+import org.deepin.dcc
+import org.deepin.dcc.defApp
 
 DccObject {
     DetailItem {

--- a/src/plugin-defaultapp/qml/DetailItem.qml
+++ b/src/plugin-defaultapp/qml/DetailItem.qml
@@ -1,15 +1,15 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import Qt.labs.platform 1.1
-import Qt.labs.qmlmodels 1.2
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Qt.labs.platform
+import Qt.labs.qmlmodels
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
-import org.deepin.dcc.defApp 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
+import org.deepin.dcc.defApp
 
 DccObject {
     id: root

--- a/src/plugin-device/qml/Device.qml
+++ b/src/plugin-device/qml/Device.qml
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "device"

--- a/src/plugin-display/qml/AutoSizingComboBox.qml
+++ b/src/plugin-display/qml/AutoSizingComboBox.qml
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 import QtQuick
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
 
 
 // AutoSizingComboBox — ComboBox 封装，自动适配下拉面板宽度

--- a/src/plugin-display/qml/Display.qml
+++ b/src/plugin-display/qml/Display.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "display"

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-display/qml/ScreenIndicator.qml
+++ b/src/plugin-display/qml/ScreenIndicator.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
+import QtQuick
 
-import org.deepin.ds 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.ds as DS
+import org.deepin.dcc
 
 Loader {
     id: root

--- a/src/plugin-display/qml/ScreenItem.qml
+++ b/src/plugin-display/qml/ScreenItem.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 import QtQuick.Effects
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 Item {
     id: root

--- a/src/plugin-display/qml/ScreenRecognize.qml
+++ b/src/plugin-display/qml/ScreenRecognize.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.ds 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import org.deepin.dtk as D
+import org.deepin.ds as DS
+import org.deepin.dcc
 
 Window {
     id: root

--- a/src/plugin-display/qml/ScreenTab.qml
+++ b/src/plugin-display/qml/ScreenTab.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 Item {
     id: root

--- a/src/plugin-display/qml/TimeoutDialog.qml
+++ b/src/plugin-display/qml/TimeoutDialog.qml
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Layouts 1.15
-import QtQuick.Controls 2.5
+import QtQuick
+import QtQuick.Layouts
+import QtQuick.Controls
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 D.DialogWindow {
     id: root

--- a/src/plugin-dock/qml/CustomComBobox.qml
+++ b/src/plugin-dock/qml/CustomComBobox.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 D.ComboBox {
     id: control

--- a/src/plugin-dock/qml/Dock.qml
+++ b/src/plugin-dock/qml/Dock.qml
@@ -1,14 +1,14 @@
-//SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     name: "dock"

--- a/src/plugin-dock/qml/DockMain.qml
+++ b/src/plugin-dock/qml/DockMain.qml
@@ -2,13 +2,13 @@
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     readonly property int modeDelegateWidth: 144

--- a/src/plugin-dock/qml/PluginArea.qml
+++ b/src/plugin-dock/qml/PluginArea.qml
@@ -2,13 +2,13 @@
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     Connections {

--- a/src/plugin-keyboard/qml/Common.qml
+++ b/src/plugin-keyboard/qml/Common.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-keyboard/qml/KeySequenceDisplay.qml
+++ b/src/plugin-keyboard/qml/KeySequenceDisplay.qml
@@ -5,10 +5,10 @@
 import QtQuick
 import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dtk.private 1.0 as P
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dtk.private as P
+import org.deepin.dcc
 
 Control {
     id: control

--- a/src/plugin-keyboard/qml/Keyboard.qml
+++ b/src/plugin-keyboard/qml/Keyboard.qml
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: keyboard

--- a/src/plugin-keyboard/qml/KeyboardMain.qml
+++ b/src/plugin-keyboard/qml/KeyboardMain.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.3
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     Connections {

--- a/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
+++ b/src/plugin-keyboard/qml/ShortcutSettingDialog.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
+import QtQuick
 import QtQuick.Controls
 import QtQuick.Window
 import QtQuick.Dialogs
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 D.DialogWindow {
     id: ddialog

--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Controls 2.3
+import QtQuick.Controls
 import QtQuick.Layouts
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 DccObject {
     id: shortcutSettingsView

--- a/src/plugin-mouse/qml/ClickTest.qml
+++ b/src/plugin-mouse/qml/ClickTest.qml
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
 Item {
     id: root

--- a/src/plugin-mouse/qml/Common.qml
+++ b/src/plugin-mouse/qml/Common.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-mouse/qml/GestureGroup.qml
+++ b/src/plugin-mouse/qml/GestureGroup.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 Rectangle {
     id: root

--- a/src/plugin-mouse/qml/Mouse.qml
+++ b/src/plugin-mouse/qml/Mouse.qml
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: mouse

--- a/src/plugin-mouse/qml/MouseMain.qml
+++ b/src/plugin-mouse/qml/MouseMain.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     Connections {

--- a/src/plugin-mouse/qml/MousePage.qml
+++ b/src/plugin-mouse/qml/MousePage.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-mouse/qml/Touchpad.qml
+++ b/src/plugin-mouse/qml/Touchpad.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 DccObject {
     id: touchpad

--- a/src/plugin-notification/qml/ImageCheckBox.qml
+++ b/src/plugin-notification/qml/ImageCheckBox.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.11
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Layouts
 import QtQuick.Templates as T
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 T.Control {
     id: control

--- a/src/plugin-notification/qml/Notification.qml
+++ b/src/plugin-notification/qml/Notification.qml
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "notification"

--- a/src/plugin-notification/qml/NotificationMain.qml
+++ b/src/plugin-notification/qml/NotificationMain.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-notification/qml/TimeRange.qml
+++ b/src/plugin-notification/qml/TimeRange.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 RowLayout {
     property var sysItemModel: dccData.sysItemModel

--- a/src/plugin-personalization/qml/ColorAndIcons.qml
+++ b/src/plugin-personalization/qml/ColorAndIcons.qml
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Dialogs
 import Qt5Compat.GraphicalEffects
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-personalization/qml/CustomComboBox.qml
+++ b/src/plugin-personalization/qml/CustomComboBox.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 D.ComboBox {
     id: control
     flat: true

--- a/src/plugin-personalization/qml/DccColorDialog.qml
+++ b/src/plugin-personalization/qml/DccColorDialog.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
@@ -10,9 +10,9 @@ import QtQuick.Layouts
 import QtQuick.Templates as T
 
 import org.deepin.dtk as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc.personalization 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk.style as DS
+import org.deepin.dcc.personalization
+import org.deepin.dcc
 
 ColorDialogImpl {
     id: control

--- a/src/plugin-personalization/qml/DownloadIndicator.qml
+++ b/src/plugin-personalization/qml/DownloadIndicator.qml
@@ -6,7 +6,7 @@ import QtQuick.Controls
 import QtQuick.Layouts
 import Qt5Compat.GraphicalEffects
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
 Canvas {
     property real progress: 0

--- a/src/plugin-personalization/qml/FontCombobox.qml
+++ b/src/plugin-personalization/qml/FontCombobox.qml
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 D.ComboBox {
     id: control

--- a/src/plugin-personalization/qml/FontSizePage.qml
+++ b/src/plugin-personalization/qml/FontSizePage.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Dialogs
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccObject {

--- a/src/plugin-personalization/qml/IconThemeGridView.qml
+++ b/src/plugin-personalization/qml/IconThemeGridView.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Dialogs
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 ColumnLayout {
     id: root

--- a/src/plugin-personalization/qml/InterfaceEffectListview.qml
+++ b/src/plugin-personalization/qml/InterfaceEffectListview.qml
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccRepeater {
     enum WindowEffectType {

--- a/src/plugin-personalization/qml/Personalization.qml
+++ b/src/plugin-personalization/qml/Personalization.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     name: "personalization"

--- a/src/plugin-personalization/qml/PersonalizationMain.qml
+++ b/src/plugin-personalization/qml/PersonalizationMain.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc.personalization 1.0
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dcc.personalization
 
 DccObject {
     DccObject {

--- a/src/plugin-personalization/qml/ScreenIndicator.qml
+++ b/src/plugin-personalization/qml/ScreenIndicator.qml
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
+import QtQuick
 
-import org.deepin.ds 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.ds as DS
+import org.deepin.dcc
 
 Loader {
     id: root

--- a/src/plugin-personalization/qml/ScreenSaverPage.qml
+++ b/src/plugin-personalization/qml/ScreenSaverPage.qml
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 import QtQuick.Dialogs
 import Qt5Compat.GraphicalEffects
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dtk.private 1.0 as P
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dtk.private as P
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-personalization/qml/ScreenTab.qml
+++ b/src/plugin-personalization/qml/ScreenTab.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 Item {
     id: root

--- a/src/plugin-personalization/qml/ThemeSelectView.qml
+++ b/src/plugin-personalization/qml/ThemeSelectView.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 FocusScope {
     id: root

--- a/src/plugin-personalization/qml/WallpaperPage.qml
+++ b/src/plugin-personalization/qml/WallpaperPage.qml
@@ -8,9 +8,9 @@ import QtQuick.Layouts
 import QtQuick.Dialogs
 import Qt5Compat.GraphicalEffects
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc.personalization 1.0
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dcc.personalization
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-personalization/qml/WallpaperSelectView.qml
+++ b/src/plugin-personalization/qml/WallpaperSelectView.qml
@@ -7,11 +7,11 @@ import QtQuick.Layouts
 import QtQuick.Dialogs
 import Qt5Compat.GraphicalEffects
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 import org.deepin.dtk.private as P
-import org.deepin.dcc.personalization 1.0
+import org.deepin.dcc.personalization
 
 ColumnLayout {
     id: root

--- a/src/plugin-personalization/qml/WindowEffectPage.qml
+++ b/src/plugin-personalization/qml/WindowEffectPage.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-power/qml/BatteryPage.qml
+++ b/src/plugin-power/qml/BatteryPage.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-power/qml/CustomComboBox.qml
+++ b/src/plugin-power/qml/CustomComboBox.qml
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 import QtQuick
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
 D.ComboBox {
     id: control

--- a/src/plugin-power/qml/CustomTipsSlider.qml
+++ b/src/plugin-power/qml/CustomTipsSlider.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
+import QtQuick
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 D.TipsSlider {
     id: slider

--- a/src/plugin-power/qml/GeneralPage.qml
+++ b/src/plugin-power/qml/GeneralPage.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-power/qml/Power.qml
+++ b/src/plugin-power/qml/Power.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: power

--- a/src/plugin-power/qml/PowerMain.qml
+++ b/src/plugin-power/qml/PowerMain.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccObject {

--- a/src/plugin-power/qml/PowerPage.qml
+++ b/src/plugin-power/qml/PowerPage.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-power/qml/PowerPlansListview.qml
+++ b/src/plugin-power/qml/PowerPlansListview.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 DccRepeater {
     id: repeater

--- a/src/plugin-power/qml/ScheduledShutdownDialog.qml
+++ b/src/plugin-power/qml/ScheduledShutdownDialog.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 D.DialogWindow {
     id: selectDayDialog

--- a/src/plugin-privacy/qml/Camera.qml
+++ b/src/plugin-privacy/qml/Camera.qml
@@ -1,16 +1,16 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
-import org.deepin.dcc.privacy 1.0
+import org.deepin.dcc.privacy
 
 DccObject {
     DccObject {

--- a/src/plugin-privacy/qml/FileAndFolder.qml
+++ b/src/plugin-privacy/qml/FileAndFolder.qml
@@ -1,16 +1,16 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc.privacy 1.0
+import org.deepin.dcc
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc.privacy
 
 DccObject {
     DccObject {

--- a/src/plugin-privacy/qml/Privacy.qml
+++ b/src/plugin-privacy/qml/Privacy.qml
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     name: "privacy"

--- a/src/plugin-privacy/qml/PrivacyMain.qml
+++ b/src/plugin-privacy/qml/PrivacyMain.qml
@@ -1,14 +1,14 @@
-// SPDX-FileCopyrightText: 2025 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2025 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccObject {

--- a/src/plugin-sound/qml/DeviceListView.qml
+++ b/src/plugin-sound/qml/DeviceListView.qml
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk
+import org.deepin.dcc
 
 Rectangle {
     id: root

--- a/src/plugin-sound/qml/MicrophonePage.qml
+++ b/src/plugin-sound/qml/MicrophonePage.qml
@@ -2,14 +2,14 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick
-import QtQuick.Layouts 1.15
-import QtQuick.Controls 2.15
-import QtQuick.Window 2.15
+import QtQuick.Layouts
+import QtQuick.Controls
+import QtQuick.Window
 import QtQuick.Templates as T
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-sound/qml/Sound.qml
+++ b/src/plugin-sound/qml/Sound.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-sound/qml/SoundDevicemanagesPage.qml
+++ b/src/plugin-sound/qml/SoundDevicemanagesPage.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk
+import org.deepin.dcc
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-sound/qml/SoundEffectsPage.qml
+++ b/src/plugin-sound/qml/SoundEffectsPage.qml
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk
+import org.deepin.dcc
 
 DccObject {
     DccObject {

--- a/src/plugin-sound/qml/SoundMain.qml
+++ b/src/plugin-sound/qml/SoundMain.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccObject {

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 import QtQuick.Templates as T
-import org.deepin.dtk 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
-import SoundDeviceModel 1.0
+import SoundDeviceModel
 
 DccObject {
     id: root

--- a/src/plugin-system/qml/System.qml
+++ b/src/plugin-system/qml/System.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Controls.Material 2.15
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Controls.Material
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk
+import org.deepin.dcc
+import org.deepin.dtk.style as DS
 DccObject {
     id: root11
     DccObject {

--- a/src/plugin-systeminfo/qml/PrivacyPolicyPage.qml
+++ b/src/plugin-systeminfo/qml/PrivacyPolicyPage.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk
+import org.deepin.dcc
 //import org.deepin.dcc.systemInfo 1.0
 
 DccObject {

--- a/src/plugin-systeminfo/qml/SystemInfo.qml
+++ b/src/plugin-systeminfo/qml/SystemInfo.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dtk 1.0 as D
+import org.deepin.dtk as D
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccTitleObject {
     id: root

--- a/src/plugin-systeminfo/qml/SystemInfoMain.qml
+++ b/src/plugin-systeminfo/qml/SystemInfoMain.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
+import QtQuick
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import QtQuick.Layouts 1.15
+import org.deepin.dcc
+import QtQuick.Layouts
 
 DccObject {
     DccObject {

--- a/src/plugin-systeminfo/qml/UeProgramLicenseDialog.qml
+++ b/src/plugin-systeminfo/qml/UeProgramLicenseDialog.qml
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-import QtQuick 2.15
-import QtQuick.Controls 2.15
-import QtQuick.Layouts 1.15
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
-import org.deepin.dcc 1.0
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
+import org.deepin.dcc
 
 D.DialogWindow {
     id: dialog

--- a/src/plugin-systeminfo/qml/UserExperienceProgramPage.qml
+++ b/src/plugin-systeminfo/qml/UserExperienceProgramPage.qml
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dcc 1.0
+import org.deepin.dtk as D
+import org.deepin.dcc
 
 DccObject {
     name: "userExperienceProgramGrp"

--- a/src/plugin-systeminfo/qml/UserLicensePage.qml
+++ b/src/plugin-systeminfo/qml/UserLicensePage.qml
@@ -1,13 +1,13 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk
+import org.deepin.dcc
 
 
 DccObject {

--- a/src/plugin-systeminfo/qml/VersionProtocolPage.qml
+++ b/src/plugin-systeminfo/qml/VersionProtocolPage.qml
@@ -1,13 +1,13 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
-import QtQuick 2.15
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0
-import org.deepin.dcc 1.0
+import org.deepin.dtk
+import org.deepin.dcc
 
 DccObject {
     DccObject {

--- a/src/plugin-touchscreen/qml/TouchScreen.qml
+++ b/src/plugin-touchscreen/qml/TouchScreen.qml
@@ -1,15 +1,15 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
-import org.deepin.dcc.touchscreen 1.0
+import org.deepin.dcc
+import org.deepin.dcc.touchscreen
 
 DccObject {
     DccTitleObject {

--- a/src/plugin-touchscreen/qml/Touchscreen.qml
+++ b/src/plugin-touchscreen/qml/Touchscreen.qml
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-touchscreen/qml/TouchscreenMain.qml
+++ b/src/plugin-touchscreen/qml/TouchscreenMain.qml
@@ -1,11 +1,11 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.15
-import QtQuick.Window 2.15
-import QtQuick.Controls 2.3
+import QtQuick
+import QtQuick.Window
+import QtQuick.Controls
 
-import org.deepin.dcc 1.0
-import org.deepin.dtk 1.0 as D
+import org.deepin.dcc
+import org.deepin.dtk as D
 
 DccObject {
     DccObject {

--- a/src/plugin-wacom/qml/Wacom.qml
+++ b/src/plugin-wacom/qml/Wacom.qml
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     id: root

--- a/src/plugin-wacom/qml/WacomMain.qml
+++ b/src/plugin-wacom/qml/WacomMain.qml
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
-import QtQuick 2.0
-import QtQuick.Controls 2.0
-import QtQuick.Layouts 1.15
-import QtQuick.Window 2.15
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import QtQuick.Window
 
-import org.deepin.dtk 1.0 as D
-import org.deepin.dtk.style 1.0 as DS
+import org.deepin.dtk as D
+import org.deepin.dtk.style as DS
 
-import org.deepin.dcc 1.0
+import org.deepin.dcc
 
 DccObject {
     DccObject {


### PR DESCRIPTION
## 概述

对项目中改动的 `*.qml` 文件做两项机械变更，配合 Qt6 迁移：

1. 去除 QML import 语句的 `主版本.次版本` 版本号（Qt6 不再需要）。
2. 更新被改文件的 `SPDX-FileCopyrightText` 版权年份，使终止年统一为 2026（反映实际修改时间），并修复 2 处既有持有人名截断笔误。

关联 issue：**DDE-105**

## 变更范围（162 个 `*.qml` 文件，单 commit）

### 1. import 去版本号

- **162 文件 / 724 条 import** 去除版本号后缀
- `as` 别名完整保留（如 `import org.deepin.dtk 1.0 as D` → `import org.deepin.dtk as D`）
- 相对/脚本 import（如 `import "DccUtils.js" as DccUtils`）与已无版本号 import 原样保留
- **无 CMake / C++ 改动**：`qmlRegisterType` / `qt_add_qml_module VERSION` 注册代码保持不变

### 2. SPDX 版权年份统一至 2026

- **35 文件**：单年 → ` - 2026` 范围
  - `2024` → `2024 - 2026`（含 1 个 `//SPDX` 无空格前缀写法，共 19 个）
  - `2025` → `2025 - 2026`（16 个）
  - 采用 ` - `（带空格），与仓内主流写法一致
- **31 文件**：终止年 `2024 - 2027` → `2024 - 2026`（文件实际在 2026 年被修改，终止年应为 2026；起始年/分隔符/持有人文字保留）
- **2 文件**：`…Co., Lt` → `…Co., Ltd.`（既有截断笔误补全，年份不变）
  - `src/plugin-datetime/qml/RegionsChooserWindow.qml`
  - `src/plugin-datetime/qml/SearchableListViewPopup.qml`
- 改后 162 文件版权行终止年**全部统一为 2026**
- `SPDX-License-Identifier` 行未动

### 示例

| 类型 | 修改前 | 修改后 |
|---|---|---|
| import | `import QtQuick 2.15` | `import QtQuick` |
| import 别名 | `import org.deepin.dtk 1.0 as D` | `import org.deepin.dtk as D` |
| SPDX 单年 | `// SPDX-FileCopyrightText: 2024 UnionTech …` | `// SPDX-FileCopyrightText: 2024 - 2026 UnionTech …` |
| SPDX 终止年 | `// SPDX-FileCopyrightText: 2024 - 2027 UnionTech …` | `// SPDX-FileCopyrightText: 2024 - 2026 UnionTech …` |
| SPDX 笔误 | `… Co., Lt` | `… Co., Ltd.` |

## 验证

- ✅ `grep -rnE '^\s*import\s+[^ "]+\s+[0-9]+\.[0-9]+' --include=*.qml . | wc -l` == **0**
- ✅ 残留 `2027` 版权行 == 0；不含 2026 的 `SPDX-FileCopyrightText` 行 == 0（162 文件终止年已统一为 2026）
- ✅ 代码审核通过（import、35 单年/2 笔误、31 终止年 2027→2026 三轮均 100 分 / 风险 Low）
- ✅ 本地编译通过（Qt6 / V25，`qt_add_qml_module` 编译期 QML 类型检查全部通过；SPDX 纯注释变更无回归，warning/error 集合与改动前逐条一致）

## 说明

- 本 PR 为 **draft** 状态，待人工审核后再合并。
- 基于 master `01a845985` 的单次提交（`fac990b85`），由原 `eb626fdff`（import）→ `f57defcc6`（+ 35 单年/2 笔误）→ `fac990b85`（+ 31 终止年 2027→2026）逐步 amend 合入后强推更新，未新建 PR。
