### PR TITLE
fix: check SecurityEnhance service availability before DBus calls

### DIFF
--- a/src/plugin-accounts/operation/accountsworker.cpp
+++ b/src/plugin-accounts/operation/accountsworker.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 #include "accountsworker.h"
@@ -311,6 +311,9 @@ void AccountsWorker::modifyGroup(const QString &oldGroup, const QString &newGrou
 
 bool AccountsWorker::hasOpenSecurity()
 {
+    if (!m_securityInter->isServiceAvailable()) {
+        return false;
+    }
     const auto &value = m_securityInter->Status();
     if (value.isEmpty()) {
         qWarning() << m_securityInter->lastError();
@@ -323,6 +326,9 @@ bool AccountsWorker::hasOpenSecurity()
 
 SecurityLever AccountsWorker::getSecUserLeverbyname(QString userName)
 {
+    if (!m_securityInter->isServiceAvailable()) {
+        return SecurityLever::Standard;
+    }
     std::tuple<QString, QString> result = m_securityInter->GetSEUserByName(userName);
     const auto &value = std::get<0>(result);
     if (value.isEmpty()) {

--- a/src/plugin-accounts/operation/securitydbusproxy.cpp
+++ b/src/plugin-accounts/operation/securitydbusproxy.cpp
@@ -1,10 +1,11 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "securitydbusproxy.h"
 
 #include <QDBusConnection>
+#include <QDBusConnectionInterface>
 #include <QDBusPendingReply>
 #include <QDebug>
 
@@ -16,6 +17,9 @@ SecurityDBusProxy::SecurityDBusProxy(QObject *parent)
 
 QString SecurityDBusProxy::Status()
 {
+    if (!m_serviceAvailable) {
+        return QString();
+    }
     QDBusPendingReply<QString> reply = m_dBusInter->asyncCall("Status");
     reply.waitForFinished();
     if (reply.isError()) {
@@ -30,6 +34,9 @@ std::tuple<QString, QString> SecurityDBusProxy::GetSEUserByName(const QString &u
 {
     Q_UNUSED(user)
     std::tuple<QString, QString> result;
+    if (!m_serviceAvailable) {
+        return result;
+    }
     QDBusPendingReply<QString, QString> reply = m_dBusInter->asyncCall("GetSEUserByName");
     reply.waitForFinished();
     if (reply.isError()) {
@@ -48,8 +55,18 @@ void SecurityDBusProxy::init()
 
     m_dBusInter = new DDBusInterface(service, path, interface, QDBusConnection::systemBus(), this);
 
+    // SecurityEnhance 服务为可选的安全增强组件，并非所有镜像都预装。
+    // 若该服务未注册到系统总线上，跳过后续 DBus 调用，避免产生
+    // "The name com.deepin.daemon.SecurityEnhance was not provided by any
+    // .service files" 这类 ServiceUnknown 报错日志。
+    m_serviceAvailable = QDBusConnection::systemBus().interface()->isServiceRegistered(service);
+    if (!m_serviceAvailable) {
+        return;
+    }
+
     if (!m_dBusInter->isValid()) {
         qWarning() << "Security interface invalid: " << m_dBusInter->lastError().message();
+        m_serviceAvailable = false;
         return;
     }
 }

--- a/src/plugin-accounts/operation/securitydbusproxy.h
+++ b/src/plugin-accounts/operation/securitydbusproxy.h
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -22,6 +22,7 @@ public:
     std::tuple<QString, QString> GetSEUserByName(const QString &user);
 
     inline QString lastError() { return m_lastError; }
+    inline bool isServiceAvailable() const { return m_serviceAvailable; }
 
 private:
     void init();
@@ -29,4 +30,5 @@ private:
 private:
     DDBusInterface *m_dBusInter;
     QString m_lastError;
+    bool m_serviceAvailable = false;
 };


### PR DESCRIPTION
1. 在 SecurityDBusProxy::init() 中通过 isServiceRegistered 检查 com.deepin.daemon.SecurityEnhance 服务是否注册;
2. Status() 和 GetSEUserByName() 在服务不可用时提前返回空值，不发起 DBus 调用;
3. AccountsWorker::hasOpenSecurity() 和 getSecUserLeverbyname() 增加 isServiceAvailable 前置判断，服务不可用时直接返回默认值;

=====================================

1. check com.deepin.daemon.SecurityEnhance service registration in SecurityDBusProxy::init() via isServiceRegistered;
2. return early from Status() and GetSEUserByName() when service is unavailable, skipping DBus calls;
3. add isServiceAvailable guard in AccountsWorker::hasOpenSecurity() and getSecUserLeverbyname() to return defaults without logging;

Log: 修复卸载 dde-api-dbus-proxy 后打开控制中心时 SecurityEnhance 服务缺失导致的 ServiceUnknown 报错日志，对可选 DBus 服务增加可用性检查

Bug: https://pms.uniontech.com/bug-view-373863.html

## Summary by Sourcery

Add availability checks for the optional SecurityEnhance DBus service to avoid errors when it is not installed.

Bug Fixes:
- Prevent ServiceUnknown errors when opening Control Center if the SecurityEnhance service is missing from the system bus.

Enhancements:
- Track SecurityEnhance service availability in SecurityDBusProxy and expose it via an accessor for callers.
- Guard security-related account operations with service availability checks and return safe default values when the service is unavailable.