### PR TITLE
fix: make plugin translator loading optional

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -16,6 +16,7 @@
 #include <QCoreApplication>
 #include <QDBusConnection>
 #include <QDBusPendingCall>
+#include <QDir>
 #include <QElapsedTimer>
 #include <QFileInfo>
 #include <QGuiApplication>
@@ -119,11 +120,34 @@ DccManager::~DccManager()
     qCDebug(dccLog()) << "delete dccManger end";
 }
 
-bool DccManager::installTranslator(const QString &name)
+bool DccManager::installTranslator(const QString &name, bool optional)
 {
     const QStringList translateDirs = { TRANSLATE_READ_DIR,
                                         TRANSLATE_READ_DIR "/../v1.0", // 兼容旧版位置
                                         TRANSLATE_READ_DIR "/.." };
+
+    // 插件翻译可选：内置插件（system/device/accounts 等）通常无独立 .qm，复用主程序翻译，
+    // 此时直接跳过，避免触发 dtkgui "can not find qm files" 告警；
+    // 第三方/新增插件若提供了独立 .qm 仍会正常加载。
+    // 预检目录须与 DGuiApplicationHelper::loadTranslator 实际搜索路径保持一致：
+    // 除此处传入的三个目录外，loadTranslator 还会追加 applicationDirPath/translations
+    // 与 currentPath/translations。
+    if (optional) {
+        QStringList searchDirs = translateDirs;
+        searchDirs << QDir(qApp->applicationDirPath()).absoluteFilePath("translations");
+        searchDirs << QDir::current().absoluteFilePath("translations");
+
+        bool hasQm = false;
+        for (const QString &dir : std::as_const(searchDirs)) {
+            if (!QDir(dir).entryList({ name + "_*.qm" }, QDir::Files).isEmpty()) {
+                hasQm = true;
+                break;
+            }
+        }
+        if (!hasQm)
+            return false;
+    }
+
     return Dtk::Gui::DGuiApplicationHelper::loadTranslator(name, translateDirs, { QLocale() });
 }
 

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -33,7 +33,7 @@ public:
     explicit DccManager(QObject *parent = nullptr);
     ~DccManager() override;
 
-    static bool installTranslator(const QString &name);
+    static bool installTranslator(const QString &name, bool optional = false);
     void init();
     QQmlApplicationEngine *engine();
     void setMainWindow(QWindow *window);

--- a/src/dde-control-center/dccpluginloader.cpp
+++ b/src/dde-control-center/dccpluginloader.cpp
@@ -206,8 +206,8 @@ bool DccPluginLoader::loadMetaData()
         return false;
     }
 
-    // Install translator for this plugin
-    DccManager::installTranslator(name());
+    // Install translator for this plugin (可选：内置插件可能无独立 .qm)
+    DccManager::installTranslator(name(), true);
 
     // Skip hidden modules (this should be checked by the caller)
     if (m_pManager->hidden(name())) {


### PR DESCRIPTION
## 背景 / Background

控制中心启动时，每个无独立翻译的内置插件（system / device / accounts 等）都会打印告警：

`"system" can not find qm files for locales QList("zh_CN")`

根因：`DccPluginLoader::loadMetaData()` 无条件调用 `DccManager::installTranslator(name)`，而内置插件复用主程序翻译、自身没有 `${name}_*.qm`，进入 dtkgui 的 `DGuiApplicationHelper::loadTranslator` 后找不到 .qm 即告警。

## 改动 / Changes

为 `DccManager::installTranslator` 增加可选 `bool optional` 参数（默认 `false`）：

- 插件翻译路径（`dccpluginloader.cpp`）传 `true`：加载前先在翻译搜索目录预检 `${name}_*.qm` 是否存在，**无命中则直接返回**，不进入 `DGuiApplicationHelper::loadTranslator`，从而消除 `"... can not find qm files for locales"` 告警。
- 主程序翻译路径（`main.cpp`）保持默认 `false`：翻译缺失仍告警，诊断语义不变。
- 兼容含独立翻译的新增/第三方插件：预检发现 `${name}_*.qm` 存在则继续走 `loadTranslator` 正常加载，无需任何配置 / 注册。
- 未改动 dtkgui（告警语义对主程序是正确的，"插件翻译可选"的语义放在插件加载侧更内聚，也避免影响所有 DTK 应用）。

预检目录与 `DGuiApplicationHelper::loadTranslator` 实际搜索路径保持一致：原 3 个目录（`TRANSLATE_READ_DIR`、`…/v1.0`、`…/..`）外，补上 `applicationDirPath/translations` 与 `currentPath/translations`，避免漏判把 .qm 放在程序目录旁的第三方插件。新增 `#include <QDir>`。

## 改动文件 / Files (3)

- `src/dde-control-center/dccmanager.h` — 声明加默认参数 `bool optional = false`
- `src/dde-control-center/dccmanager.cpp` — 实现增加 `optional` 预检分支 + `#include <QDir>`
- `src/dde-control-center/dccpluginloader.cpp` — 插件加载处传 `true`
- `src/dde-control-center/main.cpp` — 未改动（保持默认 `false`，主程序翻译缺失仍告警）

## 自测 / 验证

- 代码审核：通过（98 分 / 低风险）。
- 本地编译 + deb 构建：通过（分支 `agent/developer/1fe6422a`，commit `52050c46a`，目标 `snipe-2500u1` / amd64，完整 cmake + 链接通过，主 deb `dde-control-center_6.1.104_amd64.deb` 已产出）。新增符号 `dccV25::DccManager::installTranslator(QString const&, bool)` 已在产物二进制中确认。
- 预期效果：system / device / accounts 等无独立翻译插件不再告警；`example` 等带独立翻译插件仍正常加载；主程序翻译缺失仍告警。

## 关联 / Related

Multica issue: **DDE-118** — 分析控制中心插件翻译加载警告并兼容独立翻译插件

---

> 本 PR 保持 draft / 待审核状态，合入由人工决定。

## Summary by Sourcery

Make plugin translation loading optional so plugins without dedicated translation files can reuse the main application translations without generating missing-file warnings.

Bug Fixes:
- Prevent warnings for plugins that do not provide dedicated translation files while preserving warnings for missing main-application translations.

Enhancements:
- Support optional plugin translation loading while continuing to load translations for plugins that provide matching QM files.
- Search all translation locations used by the application before attempting optional plugin translation loading.