### PR TITLE
fix(datetime): fit timezone search popup width, height and screen pos…

### DIFF
--- a/src/plugin-datetime/qml/SearchableListViewPopup.qml
+++ b/src/plugin-datetime/qml/SearchableListViewPopup.qml
@@ -12,6 +12,7 @@ import org.deepin.dtk.private 1.0 as P
 Popup {
     id: control
     width: windowWidth
+    implicitWidth: windowWidth
     height: windowHeight
     popupType: Popup.Window
     closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
@@ -25,7 +26,26 @@ Popup {
     property var viewWidth: 300
     property var anchorItem: null
     property int windowWidth: 300
-    property int windowHeight: 500
+    // Stable default height for the no-result placeholder so the menu keeps a
+    // consistent "default" height and the hint text can be centered (PMS #373823).
+    readonly property int noResultAreaHeight: control.maxVisibleItems * 36
+    // Height of the list area: capped at maxVisibleItems, scrolling otherwise.
+    readonly property int listAreaHeight: control.delegateModel.count > 0
+        ? Math.min(listView.contentHeight, control.maxVisibleItems * 36)
+          + (listView.interactive ? (upButton.height + downButton.height) : 0)
+        : control.noResultAreaHeight
+    // Content-driven popup height. Equals contentItem implicit height + insets,
+    // so it stays correct whether the Popup window honors `height` directly or
+    // sizes itself to the contentItem (PMS #373843, #373823).
+    property int windowHeight: 2 * (control.padding + 6)
+        + searchEdit.implicitHeight
+        + (control.delegateModel.count > 0 ? 14 : 0)
+        + control.listAreaHeight
+    // Conservative upper bound used only for screen-bounds clamping, so the menu
+    // is positioned safely even before the list finishes laying out.
+    readonly property int maxClampHeight: 2 * (control.padding + 6)
+        + searchEdit.implicitHeight + 14
+        + control.maxVisibleItems * 36 + 80
     property bool contentScrolling: false
     required property DelegateModel delegateModel
 
@@ -62,8 +82,33 @@ Popup {
         }
     }
 
+    // Fit the popup width to the widest entry of the (source) model so timezone
+    // names are no longer elided, restoring the content-based width removed for
+    // performance in 7bfbe1fb0 (PMS #373843). Measuring model data via
+    // TextMetrics avoids instantiating delegates and stays cheap.
+    function calculateOptimalWidth() {
+        var proxyModel = control.delegateModel && control.delegateModel.model
+                         ? control.delegateModel.model : null
+        var srcModel = proxyModel && proxyModel.sourceModel
+                       ? proxyModel.sourceModel : proxyModel
+        if (!srcModel || srcModel.rowCount() === 0) {
+            control.windowWidth = 300
+            return
+        }
+        var maxWidth = 0
+        for (var i = 0; i < srcModel.rowCount(); i++) {
+            var txt = srcModel.data(srcModel.index(i, 0), Qt.DisplayRole)
+            if (txt && txt.length > 0) {
+                textMetrics.text = txt
+                maxWidth = Math.max(maxWidth, textMetrics.advanceWidth)
+            }
+        }
+        // +indicator(20) +spacing(8) +scrollbar/menu padding; cap [300, 500]
+        control.windowWidth = Math.min(Math.max(maxWidth + 2 * (control.padding + 6) + 36, 300), 500)
+    }
 
     function show() {
+        calculateOptimalWidth()
         if (anchorItem) {
             positionWindow()
         }
@@ -86,11 +131,44 @@ Popup {
 
         var globalPos = anchorItem.mapToGlobal(0, 0)
         var w = Window.window
-        if (w) {
-            var localPos = w.mapFromGlobal(globalPos.x, globalPos.y)
-            x = localPos.x
-            y = localPos.y + anchorItem.height
-        }
+        if (!w) return
+
+        var popupW = control.width
+        // Clamp with the max possible height so the menu stays on screen even
+        // before the list finishes laying out.
+        var popupH = Math.max(control.height, control.maxClampHeight)
+
+        var posX = globalPos.x
+        var posY = globalPos.y + anchorItem.height
+
+        // QML's Screen attached object does not expose availableGeometry, so
+        // derive a taskbar-aware rect from it (falls back to the full screen
+        // when no panel space is reserved). Keep the menu 10px clear of the
+        // taskbar / screen edge (PMS #373843).
+        var availLeft = Screen.virtualX
+        var availTop = Screen.virtualY
+        var availRight = Screen.virtualX + Screen.width
+        var availBottom = Screen.virtualY + Screen.height
+        if (Screen.desktopAvailableHeight > 0
+                && Screen.desktopAvailableHeight < Screen.height)
+            availBottom = Screen.virtualY + Screen.desktopAvailableHeight
+        if (Screen.desktopAvailableWidth > 0
+                && Screen.desktopAvailableWidth < Screen.width)
+            availRight = Screen.virtualX + Screen.desktopAvailableWidth
+
+        var margin = 10
+        if (posX + popupW > availRight - margin)
+            posX = availRight - popupW - margin
+        if (posX < availLeft + margin)
+            posX = availLeft + margin
+        if (posY + popupH > availBottom - margin)
+            posY = availBottom - popupH - margin
+        if (posY < availTop + margin)
+            posY = availTop + margin
+
+        var localPos = w.mapFromGlobal(posX, posY)
+        x = localPos.x
+        y = localPos.y
     }
 
     onClosed: {
@@ -105,8 +183,7 @@ Popup {
 
     TextMetrics {
         id: textMetrics
-        font.family: DTK.fontManager.baseFont.family
-        font.pixelSize: DTK.fontManager.baseFont.pixelSize
+        font: DTK.fontManager.t6
     }
 
     contentItem: ColumnLayout {
@@ -177,8 +254,7 @@ Popup {
 
         ColumnLayout {
             Layout.fillWidth: true
-            Layout.preferredHeight: Math.min(listView.contentHeight + (listView.interactive ? upButton.height + downButton.height : 0),
-                                             control.maxVisibleItems * 36 + (listView.interactive ? upButton.height + downButton.height : 0))
+            Layout.preferredHeight: control.listAreaHeight
             visible: control.delegateModel.count > 0
             spacing: 0
 
@@ -274,22 +350,24 @@ Popup {
             }
         }
 
+        // No-result placeholder: a stable default-height area with the hint
+        // text centered, so the menu no longer collapses on no matches and the
+        // hint is vertically centered (PMS #373823, #373843).
         Item {
-            Layout.fillHeight: true
-            visible: control.delegateModel.count > 0
-        }
-
-        Text {
-            id: noResultsText
-            text: qsTr("No search results")
-            horizontalAlignment: Text.AlignHCenter
-            verticalAlignment: Text.AlignVCenter
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.preferredHeight: control.noResultAreaHeight
             visible: control.delegateModel.count === 0
-            color: this.palette.windowText
-            opacity: 0.4
-            font: DTK.fontManager.t6
+
+            Text {
+                anchors.centerIn: parent
+                text: qsTr("No search results")
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                color: this.palette.windowText
+                opacity: 0.4
+                font: DTK.fontManager.t6
+            }
         }
     }
 }


### PR DESCRIPTION
…ition

1. 恢复时区搜索弹窗按内容自适应宽度（calculateOptimalWidth），用 TextMetrics 遍历源模型测量最大项宽度并夹紧到 [300,500]，解决选项打点显示及宽度跳变；
2. 将弹窗高度改为内容驱动并确定化（windowHeight 显式绑定等于 contentItem 隐式高度 + 内边距），无结果态取默认高度且"无搜索结果"上下居中，解决无结果界面过小、未居中；
3. positionWindow 增加屏幕边界夹紧，菜单底部距任务栏/屏幕边缘保留 10px，解决菜单覆盖任务栏、溢出屏幕；
4. TextMetrics 字体改为 t6 与 delegate 一致以保证测量准确； =====================================
1. Restore content-based popup width (calculateOptimalWidth): measure the widest source-model entry via TextMetrics, clamped to [300,500], fixing elided timezone names and width jumping;
2. Make popup height content-driven and deterministic (explicit windowHeight binding equal to contentItem implicit height + insets); the no-result state uses a stable default height with the "No search results" hint vertically centered, fixing the collapsed/uncen-tered no-result page;
3. Clamp positionWindow to a taskbar-aware screen rect, keeping the menu 10px clear of the taskbar/screen edge, fixing taskbar overlap and off-screen overflow;
4. Use the t6 font for TextMetrics to match delegate text for accurate measurement;

Log: 修复系统时区搜索菜单宽度跳变、无结果界面过小未居中、菜单覆盖任务栏溢出屏幕的问题。

Bug/Task: https://pms.uniontech.com/bug-view-373843.html https://pms.uniontech.com/bug-view-373823.html

## Summary by Sourcery

Improve timezone search popup sizing and positioning for reliable display across content states and screen boundaries.

Bug Fixes:
- Fix timezone search popups that truncate entries or change width unexpectedly by sizing them to their content within defined bounds.
- Fix collapsed and improperly centered no-result states by giving them a stable, content-driven height.
- Prevent search popups from overlapping taskbars or extending beyond screen boundaries.

Enhancements:
- Align text measurement with the popup delegate font for accurate width calculation.