### PR TITLE
fix: move autoExitTimer to DccManager and add tryShow logs

### DIFF
--- a/src/dde-control-center/controlcenterdbusadaptor.cpp
+++ b/src/dde-control-center/controlcenterdbusadaptor.cpp
@@ -140,16 +140,7 @@ void ControlCenterDBusAdaptor::updateRect()
 
 DBusControlCenterGrandSearchService::DBusControlCenterGrandSearchService(DccManager *parent)
     : QDBusAbstractAdaptor(parent)
-    , m_autoExitTimer(new QTimer(this))
 {
-    m_autoExitTimer->setInterval(10000);
-    m_autoExitTimer->setSingleShot(true);
-    connect(m_autoExitTimer, &QTimer::timeout, this, [this]() {
-        // 当主界面show出来之后不再执行自动退出
-        if (!this->parent()->mainWindow()->isVisible())
-            QCoreApplication::quit();
-    });
-    m_autoExitTimer->start();
 }
 
 DBusControlCenterGrandSearchService::~DBusControlCenterGrandSearchService() { }
@@ -167,7 +158,6 @@ QString DBusControlCenterGrandSearchService::Search(const QString &json)
     }
     m_jsonCache = json;
     const QString &val = parent()->searchProxy(json);
-    m_autoExitTimer->start();
     return val;
 }
 
@@ -176,7 +166,6 @@ bool DBusControlCenterGrandSearchService::Stop(const QString &json)
 {
     m_jsonCache.clear();
     bool val = parent()->stop(json);
-    m_autoExitTimer->start();
     return val;
 }
 
@@ -185,6 +174,5 @@ bool DBusControlCenterGrandSearchService::Action(const QString &json)
 {
     m_jsonCache.clear();
     bool val = parent()->action(json);
-    m_autoExitTimer->start();
     return val;
 }

--- a/src/dde-control-center/controlcenterdbusadaptor.h
+++ b/src/dde-control-center/controlcenterdbusadaptor.h
@@ -74,7 +74,6 @@ public Q_SLOTS: // METHODS
     bool Action(const QString &json);
 
 private:
-    QTimer *m_autoExitTimer;
     QString m_jsonCache; // 缓存下对重复请求不处理(规避全局搜索会调两次Search)
 };
 

--- a/src/dde-control-center/controlcenterdbusadaptor.h
+++ b/src/dde-control-center/controlcenterdbusadaptor.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
@@ -74,7 +74,6 @@ public Q_SLOTS: // METHODS
     bool Action(const QString &json);
 
 private:
-    QTimer *m_autoExitTimer;
     QString m_jsonCache; // 缓存下对重复请求不处理(规避全局搜索会调两次Search)
 };
 

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -71,6 +71,7 @@ DccManager::DccManager(QObject *parent)
     , m_showPagePending(false)
     , m_showLoadPage(!isTreeland())
     , m_needShow(false)
+    , m_autoExitTimer(new QTimer(this))
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -109,6 +110,15 @@ DccManager::DccManager(QObject *parent)
     m_showFallbackTimer->setSingleShot(true);
     connect(m_showFallbackTimer, &QTimer::timeout, this, &DccManager::tryShowFallback);
     m_showFallbackTimer->start(5000); // 防止插件卡死不显示界面
+
+    m_autoExitTimer->setInterval(10000);
+    m_autoExitTimer->setSingleShot(true);
+    connect(m_autoExitTimer, &QTimer::timeout, this, [this]() {
+        // 当主界面show出来之后不再执行自动退出
+        if (!m_showPagePending && !m_needShow && (mainWindow() && !mainWindow()->isVisible()))
+            QCoreApplication::quit();
+    });
+    m_autoExitTimer->start();
 }
 
 DccManager::~DccManager()
@@ -295,12 +305,14 @@ void DccManager::showPage(const QString &url)
 
 void DccManager::showPage(DccObject *obj)
 {
+    qCInfo(dccLog) << "showPage:" << obj;
     m_showPagePending = true;
     QMetaObject::invokeMethod(this, "doShowPage", Qt::QueuedConnection, QPointer<DccObject>(obj), QString());
 }
 
 void DccManager::showPage(DccObject *obj, const QString &cmd)
 {
+    qCInfo(dccLog) << "showPage:" << obj << cmd;
     m_showPagePending = true;
     QMetaObject::invokeMethod(this, "doShowPage", Qt::QueuedConnection, QPointer<DccObject>(obj), cmd);
 }
@@ -404,6 +416,7 @@ QString DccManager::searchProxy(const QString &json) const
                     },
                     Qt::SingleShotConnection);
 
+            m_autoExitTimer->start();
             return {};
         }
     }
@@ -412,6 +425,7 @@ QString DccManager::searchProxy(const QString &json) const
 
 bool DccManager::stop(const QString &)
 {
+    m_autoExitTimer->start();
     return true;
 }
 
@@ -429,6 +443,7 @@ bool DccManager::action(const QString &json)
 
     show();
     showPage(searchName);
+    m_autoExitTimer->start();
     return true;
 }
 
@@ -871,6 +886,7 @@ void DccManager::clearShowParam()
 
 void DccManager::handleShowReady()
 {
+    qCInfo(dccLog) << "handleShowReady: loadAllFinished" << m_showUrl;
     if (!m_showUrl.isEmpty()) {
         tryShow();
     } else if (m_showFallbackTimer->isActive() && !m_activeObject && !m_showPagePending) {
@@ -881,19 +897,27 @@ void DccManager::handleShowReady()
 void DccManager::tryShow()
 {
     if (m_showUrl.isEmpty()) {
+        qCDebug(dccLog) << "tryShow: url is empty, skip";
         return;
     }
+
+    qCDebug(dccLog) << "tryShow: url =" << m_showUrl
+                       << "loadFinished =" << m_plugins->loadFinished()
+                       << "isDeleting =" << m_plugins->isDeleting();
 
     QString cmd;
     const QString path = parseShowPageUrl(m_showUrl, cmd);
     DccObject *obj = findObject(path);
+    qCDebug(dccLog) << "tryShow: parsed path =" << path << "cmd =" << cmd << "found obj =" << (void *)obj;
     if (obj) {
         const QString url = m_showUrl;
         const QDBusMessage message = m_showMessage;
         clearShowParam();
         showPage(obj, cmd);
+        qCInfo(dccLog) << "tryShow: page shown successfully, url =" << url;
         replyShowPageRequest(url, message, true);
     } else if (m_plugins->loadFinished()) {
+        qCWarning(dccLog) << "tryShow: plugins loaded but object not found, path =" << path << "url =" << m_showUrl;
         const QString url = m_showUrl;
         const QDBusMessage message = m_showMessage;
         clearShowParam();
@@ -902,7 +926,10 @@ void DccManager::tryShow()
             showPage(m_root, QString());
         }
     } else if (!m_plugins->isDeleting()) {
+        qCDebug(dccLog) << "tryShow: plugins not ready, retrying...";
         m_showTimer->start();
+    } else {
+        qCWarning(dccLog) << "tryShow: plugins deleting, abort show, url =" << m_showUrl;
     }
 }
 
@@ -911,7 +938,7 @@ void DccManager::tryShowFallback()
     if (m_plugins->isDeleting() || !m_showUrl.isEmpty() || m_activeObject || m_showPagePending) {
         return;
     }
-
+    qCInfo(dccLog) << "tryShowFallback: home";
     m_showFallbackTimer->stop();
     showPage(m_root, QString());
 }

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -77,6 +77,7 @@ DccManager::DccManager(QObject *parent)
     , m_windowShown(false)
     , m_pageShown(false)
     , m_allPluginsLoaded(false)
+    , m_autoExitTimer(new QTimer(this))
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -116,6 +117,15 @@ DccManager::DccManager(QObject *parent)
     m_showFallbackTimer->setSingleShot(true);
     connect(m_showFallbackTimer, &QTimer::timeout, this, &DccManager::tryShowFallback);
     m_showFallbackTimer->start(5000); // 防止插件卡死不显示界面
+
+    m_autoExitTimer->setInterval(10000);
+    m_autoExitTimer->setSingleShot(true);
+    connect(m_autoExitTimer, &QTimer::timeout, this, [this]() {
+        // 当主界面show出来之后不再执行自动退出
+        if (!m_showPagePending && !m_needShow && (mainWindow() && !mainWindow()->isVisible()))
+            QCoreApplication::quit();
+    });
+    m_autoExitTimer->start();
 }
 
 DccManager::~DccManager()
@@ -361,12 +371,14 @@ void DccManager::showPage(const QString &url)
 
 void DccManager::showPage(DccObject *obj)
 {
+    qCInfo(dccLog) << "showPage:" << obj;
     m_showPagePending = true;
     QMetaObject::invokeMethod(this, "doShowPage", Qt::QueuedConnection, QPointer<DccObject>(obj), QString());
 }
 
 void DccManager::showPage(DccObject *obj, const QString &cmd)
 {
+    qCInfo(dccLog) << "showPage:" << obj << cmd;
     m_showPagePending = true;
     QMetaObject::invokeMethod(this, "doShowPage", Qt::QueuedConnection, QPointer<DccObject>(obj), cmd);
 }
@@ -470,6 +482,7 @@ QString DccManager::searchProxy(const QString &json) const
                     },
                     Qt::SingleShotConnection);
 
+            m_autoExitTimer->start();
             return {};
         }
     }
@@ -478,6 +491,7 @@ QString DccManager::searchProxy(const QString &json) const
 
 bool DccManager::stop(const QString &)
 {
+    m_autoExitTimer->start();
     return true;
 }
 
@@ -495,6 +509,7 @@ bool DccManager::action(const QString &json)
 
     show();
     showPage(searchName);
+    m_autoExitTimer->start();
     return true;
 }
 
@@ -974,6 +989,7 @@ void DccManager::handleLoadFinished()
 
 void DccManager::handleShowReady()
 {
+    qCInfo(dccLog) << "handleShowReady:" << m_showUrl;
     if (!m_showUrl.isEmpty()) {
         tryShow();
     } else if (m_showFallbackTimer->isActive() && !m_activeObject && !m_showPagePending) {
@@ -991,6 +1007,7 @@ void DccManager::tryStopTimeline()
 void DccManager::tryShow()
 {
     if (m_showUrl.isEmpty()) {
+        qCDebug(dccLog) << "tryShow: url is empty, skip";
         return;
     }
     if (!m_plugins->loadFinished()) {
@@ -1000,16 +1017,23 @@ void DccManager::tryShow()
         return;
     }
 
+    qCDebug(dccLog) << "tryShow: url =" << m_showUrl
+                       << "loadFinished =" << m_plugins->loadFinished()
+                       << "isDeleting =" << m_plugins->isDeleting();
+
     QString cmd;
     const QString path = parseShowPageUrl(m_showUrl, cmd);
     DccObject *obj = findObject(path);
+    qCDebug(dccLog) << "tryShow: parsed path =" << path << "cmd =" << cmd << "found obj =" << (void *)obj;
     if (obj && isObjectAttached(obj)) {
         const QString url = m_showUrl;
         const QDBusMessage message = m_showMessage;
         clearShowParam();
         showPage(obj, cmd);
+        qCInfo(dccLog) << "tryShow: page shown successfully, url =" << url;
         replyShowPageRequest(url, message, true);
-    } else {
+    } else if (m_plugins->loadFinished()) {
+        qCWarning(dccLog) << "tryShow: plugins loaded but object not found, path =" << path << "url =" << m_showUrl;
         const QString url = m_showUrl;
         const QDBusMessage message = m_showMessage;
         clearShowParam();
@@ -1017,6 +1041,11 @@ void DccManager::tryShow()
         if (!m_activeObject) {
             showPage(m_root, QString());
         }
+    } else if (!m_plugins->isDeleting()) {
+        qCDebug(dccLog) << "tryShow: plugins not ready, retrying...";
+        m_showTimer->start();
+    } else {
+        qCWarning(dccLog) << "tryShow: plugins deleting, abort show, url =" << m_showUrl;
     }
 }
 
@@ -1025,7 +1054,7 @@ void DccManager::tryShowFallback()
     if (m_plugins->isDeleting() || !m_showUrl.isEmpty() || m_activeObject || m_showPagePending) {
         return;
     }
-
+    qCInfo(dccLog) << "tryShowFallback: home";
     m_showFallbackTimer->stop();
     showPage(m_root, QString());
 }

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -155,6 +155,7 @@ private:
     bool m_showPagePending;
     bool m_showLoadPage;
     bool m_needShow;
+    QTimer *m_autoExitTimer;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
 

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -180,6 +180,7 @@ private:
     bool m_windowShown;
     bool m_pageShown;
     bool m_allPluginsLoaded;
+    QTimer *m_autoExitTimer;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
 


### PR DESCRIPTION
1. Move m_autoExitTimer from ControlCenterDBusAdaptor to DccManager, where the actual show/hide logic lives
2. Add diagnostic logs to DccManager::tryShow covering all branches (empty url, object found, not found, plugins loading, plugins deleting)
3. Add qCInfo logs to showPage for page transition tracing

PMS: BUG-372823

fix: 将 autoExitTimer 移至 DccManager 并增加 tryShow 日志

1. 将 m_autoExitTimer 从 ControlCenterDBusAdaptor 迁移到 DccManager，界面显示/隐藏的实际控制逻辑所在处
2. 为 DccManager::tryShow 所有分支添加诊断日志（url 为空、 找到对象、未找到对象、插件加载中、插件删除中）
3. 为 showPage 添加 qCInfo 日志，便于追踪页面跳转

PMS: BUG-372823

Influence:
1. 触发 grand search 搜索控制中心后 10 秒内无操作，验证是否 正常自动退出
2. 通过 DBus 调用 ShowPage 并传入不存在路径，验证日志是否 输出 object not found 警告

## Summary by Sourcery

Move grand-search auto-exit handling into DccManager and improve page-display diagnostics and request handling.

Bug Fixes:
- Ensure the grand-search control-center process exits automatically only when no page is pending and the main window remains hidden.
- Handle page-show requests more explicitly when plugins are still loading or being deleted, including aborting requests that cannot be resolved.

Enhancements:
- Move auto-exit timer ownership into DccManager so its lifecycle follows page display and visibility handling.
- Add diagnostic logging for page transitions, fallback display, and all major page-show resolution branches.