### PR TITLE
fix: drop baseline anchor in AddFaceinfoDialog

### DIFF
--- a/src/plugin-authentication/qml/AddFaceinfoDialog.qml
+++ b/src/plugin-authentication/qml/AddFaceinfoDialog.qml
@@ -133,7 +133,6 @@ To ensure successful entry:\n\
                             background: null
                             font: agreeCheckbox.font
                             anchors.verticalCenter: parent.verticalCenter
-                            anchors.baseline: agreeCheckbox.baseline
                             textColor: D.Palette {
                                 normal {
                                     common: D.DTK.makeColor(D.Color.Highlight)


### PR DESCRIPTION
## Summary

Remove the conflicting `anchors.baseline: agreeCheckbox.baseline` line from the `disclaimerButton` (`D.ToolButton`) in `AddFaceinfoDialog.qml`, keeping only `anchors.verticalCenter: parent.verticalCenter`.

## Root cause

`disclaimerButton` set both `anchors.verticalCenter` and `anchors.baseline` simultaneously. Qt's anchor system forbids `baseline` together with `top`/`bottom`/`verticalCenter`, emitting the runtime warning:

```
QML ToolButton: Baseline anchor cannot be used in conjunction with top, bottom, or verticalCenter anchors.
```

Qt silently drops the `baseline` anchor and keeps `verticalCenter`, so the conflict anchor had no runtime effect — geometry is unchanged after removal; the warning is simply gone.

## Change

- File: `src/plugin-authentication/qml/AddFaceinfoDialog.qml`
- One line deleted inside the `disclaimerButton` block:
  - `- anchors.baseline: agreeCheckbox.baseline`
- `anchors.verticalCenter: parent.verticalCenter` is retained.

## Verification

- Single-line deletion; no C++ changes, runtime-only QML layout.
- `qmllint` passed (per review report).
- Code review approved (100/100, no changes required).

## Multica Issue

DDE-152 — 控制中心账户生物认证添加人脸出现 QML ToolButton baseline 锚点冲突警告

## Summary by Sourcery

Bug Fixes:
- Remove the conflicting baseline anchor from the face-information dialog to eliminate the QML anchor warning without changing the button layout.