### PR TITLE
fix: adjust ComboBox padding to fix arrow overlap

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -125,7 +125,8 @@ DccObject {
                     id: comboBox
                     property var serverList: dccData.ntpServerList
                     flat: true
-                    padding: 0
+                    topPadding: 0
+                    bottomPadding: 0
                     visible: dccData.ntpEnabled
                     anchors.fill: parent
                     hoverEnabled: true


### PR DESCRIPTION
## Summary

Replace `padding: 0` with `topPadding: 0; bottomPadding: 0` for the NTP server ComboBox in `TimeAndDate.qml`.

This change simultaneously addresses:
- **PMS #374473**: Restores horizontal DTK default padding to fix arrow/hover background overlap
- **BUG-322093**: Preserves vertical zero padding to prevent text clipping at maximum English font size

The `onParentItemChanged` handler (`item.rightPadding = DS.Style.comboBox.spacing`) is left unchanged.

## Testing

- Test NTP server ComboBox hover state, verify arrow has proper spacing
- Test with maximum English font size, verify no text clipping at bottom
- Verify ComboBox layout matches other dropdowns in control center

## References

- PMS: https://pms.uniontech.com/bug-view-374473.html
- Multica issue: [DDE-154](https://multica.uniontech.com/issue/269110c2-c0d6-4d26-8568-3d60c6ec4785)

## Summary by Sourcery

Bug Fixes:
- Fix NTP server ComboBox arrow and hover-background overlap while preserving zero vertical padding to prevent text clipping at large font sizes.