### PR TITLE
fix: use system locale for QCollator to enable numeric sorting in dock plugin

### DIFF
--- a/src/plugin-dock/operation/dockpluginsortproxymodel.cpp
+++ b/src/plugin-dock/operation/dockpluginsortproxymodel.cpp
@@ -48,7 +48,7 @@ bool DockPluginSortProxyModel::lessThan(const QModelIndex &leftIndex, const QMod
 
     // 数字：自然数字排序
     if (leftGroup == StringGroup::Digit) {
-        QCollator digitCollator(QLocale::c());
+        QCollator digitCollator{QLocale()};
         digitCollator.setNumericMode(true);
         digitCollator.setCaseSensitivity(Qt::CaseInsensitive);
         return digitCollator.compare(left, right) < 0;


### PR DESCRIPTION
## 缺陷说明

Dock 插件排序代理模型 `DockPluginSortProxyModel` 在对数字名称插件排序时，使用 `QCollator` 并设置了 `setNumericMode(true)`，期望按数值序排序。但该 `QCollator` 是用 `QLocale::c()`（C/POSIX locale）构造的。

在 ICU 实现的 collation 下，`setNumericMode(true)` 对 C/POSIX locale 不生效，导致数字名称仍按字典序排序——例如 `"10"` 会排在 `"2"` 之前。

相关代码位于 `src/plugin-dock/operation/dockpluginsortproxymodel.cpp`：

```cpp
if (leftGroup == StringGroup::Digit) {
    QCollator digitCollator(QLocale::c());          // <- C locale, numeric mode 失效
    digitCollator.setNumericMode(true);
    digitCollator.setCaseSensitivity(Qt::CaseInsensitive);
    return digitCollator.compare(left, right) < 0;
}
```

## 修改内容

将 `QCollator` 的构造 locale 由 `QLocale::c()` 改为系统默认 locale `QLocale()`，使 `setNumericMode(true)` 在 ICU 实现下正常生效，数字名称按数值序排序。同时使用花括号初始化以避免 C++ most vexing parse。

```diff
-        QCollator digitCollator(QLocale::c());
+        QCollator digitCollator{QLocale()};
```

仅修改 `src/plugin-dock/operation/dockpluginsortproxymodel.cpp` 第 51 行一处，CJK 段使用的显式中文 locale 不受影响。

## UT 验证结果

- UT 验证通过：27/27 用例通过（含 3 个原 SKIP 用例），覆盖率 100% 行/函数。
- 负向对照：回退为 `QLocale::c()` 后 3 个用例 FAILED，确认缺陷存在且修复有效。
- 编译验证：GCC 12.3.0 + Qt 6.8.0 编译通过。

## Summary by Sourcery

Bug Fixes:
- Fix numeric sorting of digit-named dock plugins by using the system locale for numeric collation.