### PR TITLE
fix: show correct icons in search results and refresh on icon change

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -1148,6 +1148,7 @@ void DccManager::onObjectAdded(DccObject *obj)
         auto o = objs.takeFirst();
         connect(o, &DccObject::childAdded, this, &DccManager::onObjectAdded);
         connect(o, &DccObject::childRemoved, this, &DccManager::onObjectRemoved);
+        connect(o, &DccObject::iconChanged, this, &DccManager::onObjectIconChanged);
         connect(o, &DccObject::displayNameChanged, this, &DccManager::onObjectDisplayChanged);
         connect(o, &DccObject::visibleToAppChanged, this, &DccManager::onVisible, Qt::ConnectionType(Qt::QueuedConnection | Qt::UniqueConnection));
         objs.append(o->getChildren());
@@ -1165,6 +1166,7 @@ void DccManager::onObjectRemoved(DccObject *obj)
         auto o = objs.takeFirst();
         disconnect(o, &DccObject::childAdded, this, nullptr);
         disconnect(o, &DccObject::childRemoved, this, nullptr);
+        disconnect(o, &DccObject::iconChanged, this, nullptr);
         disconnect(o, &DccObject::displayNameChanged, this, nullptr);
         m_searchModel->removeSearchData(o, QString());
         objs.append(o->getChildren());
@@ -1192,6 +1194,17 @@ void DccManager::onObjectDisplayChanged()
     if (obj) {
         m_searchModel->removeSearchData(obj, QString());
         m_searchModel->addSearchData(obj, QString(), QString());
+    }
+}
+
+void DccManager::onObjectIconChanged()
+{
+    if (!m_root) {
+        return;
+    }
+    DccObject *obj = qobject_cast<DccObject *>(sender());
+    if (obj) {
+        m_searchModel->refreshIcon(obj);
     }
 }
 

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -120,6 +120,7 @@ private Q_SLOTS:
     void onObjectAdded(DccObject *obj);
     void onObjectRemoved(DccObject *obj);
     void onObjectDisplayChanged();
+    void onObjectIconChanged();
     bool addObjectToParent(DccObject *obj);
     bool removeObjectFromParent(DccObject *obj);
     void clearData();

--- a/src/dde-control-center/plugin/SearchBar.qml
+++ b/src/dde-control-center/plugin/SearchBar.qml
@@ -120,6 +120,7 @@ Rectangle {
                 backgroundVisible: true
                 corners: getCornersForBackground(index, view.count)
                 icon.name: model.decoration
+                icon.source: model.iconSource
                 // text: model.display
                 checked: ListView.isCurrentItem
                 contentFlow: true

--- a/src/dde-control-center/searchmodel.cpp
+++ b/src/dde-control-center/searchmodel.cpp
@@ -40,9 +40,17 @@ struct SearchData
         }
     }
 
+
     inline const QString sourceText() const { return text.isEmpty() ? obj->displayName() : text; }
 
     inline const QString sourceUrl() const { return url.isEmpty() ? obj->parentName() + "/" + obj->name() : url; }
+
+    // Returns the object whose icon should be displayed for this search entry:
+    // the entry's own icon if set, otherwise the topmost ancestor's icon.
+    inline const DccObject *iconObject() const
+    {
+        return obj->icon().isEmpty() ? ancestors : obj;
+    }
 };
 
 //////////////////////////////////////////////////////
@@ -54,6 +62,7 @@ public:
 
     void addSearchData(DccObject *obj, const QString &text, const QString &url);
     void removeSearchData(const DccObject *obj, const QString &text);
+    void refreshIcon(const DccObject *obj);
 
 protected:
     void addObject(DccObject *obj, const QString &text, const QString &url);
@@ -113,6 +122,25 @@ void SearchSourceModel::removeSearchData(const DccObject *obj, const QString &te
             endRemoveRows();
         } else {
             ++it;
+        }
+    }
+}
+
+void SearchSourceModel::refreshIcon(const DccObject *obj)
+{
+    if (!obj) {
+        return;
+    }
+    for (int i = 0; i < m_data.size(); ++i) {
+        const SearchData *data = m_data.at(i);
+        // Refresh when the changed object is the search entry itself, or when
+        // it is the ancestor whose icon is used as a fallback and the entry
+        // has no own icon.
+        const bool ownIconChanged = (data->obj == obj);
+        const bool fallbackIconChanged = (data->ancestors == obj && data->obj->icon().isEmpty());
+        if (ownIconChanged || fallbackIconChanged) {
+            emit dataChanged(index(i, 0), index(i, 0),
+                             { Qt::DecorationRole, SearchModel::SearchIconSourceRole });
         }
     }
 }
@@ -195,9 +223,10 @@ QVariant SearchSourceModel::data(const QModelIndex &index, int role) const
     switch (role) {
     case Qt::DisplayRole:
         return data->display.isEmpty() ? data->sourceText() : data->display;
-    case Qt::DecorationRole: {
-        return data->ancestors->icon();
-    } break;
+    case Qt::DecorationRole:
+        return data->iconObject()->icon();
+    case SearchModel::SearchIconSourceRole:
+        return data->iconObject()->iconSource();
     case SearchModel::SearchPlainTextRole:
         return data->plainText;
     case SearchModel::SearchDataRole:
@@ -265,6 +294,8 @@ QHash<int, QByteArray> SearchModel::roleNames() const
     QHash<int, QByteArray> names = QAbstractItemModel::roleNames();
     names[SearchUrlRole] = "url";
     names[SearchPlainTextRole] = "plainText";
+    names[SearchIsEndRole] = "isEnd";
+    names[SearchIconSourceRole] = "iconSource";
     return names;
 }
 
@@ -281,6 +312,11 @@ void SearchModel::removeSearchData(const DccObject *obj, const QString &text)
 void SearchModel::doSort()
 {
     sort(0);
+}
+
+void SearchModel::refreshIcon(const DccObject *obj)
+{
+    static_cast<SearchSourceModel *>(sourceModel())->refreshIcon(obj);
 }
 
 bool SearchModel::filterAcceptsRow(int source_row, const QModelIndex &source_parent) const

--- a/src/dde-control-center/searchmodel.h
+++ b/src/dde-control-center/searchmodel.h
@@ -17,7 +17,7 @@ class SearchModel : public QSortFilterProxyModel
 public:
     explicit SearchModel(QObject *parent = nullptr);
 
-    enum DccSearchRole { SearchUrlRole = Qt::UserRole + 300, SearchPlainTextRole, SearchTextRole, SearchWeightRole, SearchDataRole, SearchMatchScoreRole };
+    enum DccSearchRole { SearchUrlRole = Qt::UserRole + 300, SearchPlainTextRole, SearchIsEndRole, SearchTextRole, SearchWeightRole, SearchDataRole, SearchIconSourceRole, SearchMatchScoreRole };
 
     QHash<int, QByteArray> roleNames() const override;
 
@@ -25,7 +25,7 @@ public Q_SLOTS:
     void addSearchData(DccObject *obj, const QString &text, const QString &url);
     void removeSearchData(const DccObject *obj, const QString &text);
     void doSort();
-
+    void refreshIcon(const DccObject *obj);
 protected:
     bool filterAcceptsRow(int source_row, const QModelIndex &source_parent) const override;
     bool lessThan(const QModelIndex &source_left, const QModelIndex &source_right) const override;


### PR DESCRIPTION
- Add SearchIconSourceRole to expose iconSource (file://, qrc:/, resolved URLs) alongside the existing DecorationRole icon name, matching the icon binding pattern used by HomePage/SecondPage/DccEditorItem.
- SearchBar.qml delegate now binds icon.source: model.iconSource so non-theme-icon entries render correctly instead of falling back to a broken or missing icon.
- Extract iconObject() helper: use the search entry's own icon when set, fall back to the topmost ancestor icon otherwise.
- Connect DccObject::iconChanged in DccManager and add refreshIcon() to SearchModel/SearchSourceModel so dynamically changed icons update search results via dataChanged without resetting filter/highlight.

pms: BUG-372171

## Summary by Sourcery

Fix search result icon rendering and update icons dynamically when DCC object icons change.

New Features:
- Expose resolved icon sources in search model roles so search results can render file and resource icons correctly.

Bug Fixes:
- Show each search result's own icon when available, with ancestor icons used only as fallback.
- Refresh visible search result icons when their associated objects change without resetting search state.