### PR TITLE
chore: add plugin filtering option to control center

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -158,6 +158,11 @@ void DccManager::setMainWindow(QWindow *window)
     m_window->installEventFilter(this);
 }
 
+void DccManager::setPlugins(const QStringList &plugins)
+{
+    m_plugins->setPlugins(plugins);
+}
+
 void DccManager::loadModules(bool async, const QStringList &dirs)
 {
     // onAddModule(m_rootModule);

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -37,6 +37,7 @@ public:
     void init();
     QQmlApplicationEngine *engine();
     void setMainWindow(QWindow *window);
+    void setPlugins(const QStringList &plugins);
     void loadModules(bool async, const QStringList &dirs);
 
     int width() const override;

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -112,6 +112,7 @@ int main(int argc, char *argv[])
     QCommandLineOption showTime(QStringList() << "z" << "time", "show control center exe time."); // 新增time参数自动测试启动速度
     QCommandLineOption loggingModuleOption(QStringList() << "l" << "logging-module", "Only output logs for the specified module", "loggingModule");
     QCommandLineOption pluginDir("spec", "load plugins from specialdir", "plugindir");
+    QCommandLineOption pluginOption(QStringList() << "P" << "plugin", "load specified plugins", "plugin");
     QCommandLineOption fd1Opt("fd1", "fd1 from security loader", "fd1");
     QCommandLineOption fd2Opt("fd2", "fd2 from security loader", "fd2");
 
@@ -127,6 +128,7 @@ int main(int argc, char *argv[])
     parser.addOption(showTime);
     parser.addOption(loggingModuleOption);
     parser.addOption(pluginDir);
+    parser.addOption(pluginOption);
     parser.addOption(fd1Opt);
     parser.addOption(fd2Opt);
     parser.process(*app);
@@ -227,6 +229,8 @@ int main(int argc, char *argv[])
         qDebug() << "dbus service already registered!" << "pid is:" << qApp->applicationPid();
         return -1;
     }
+    if (parser.isSet(pluginOption))
+        dccManager->setPlugins(parser.values(pluginOption));
     if (!refPluginDirs.isEmpty()) {
         dccManager->loadModules(true, refPluginDirs);
         adaptor->Show();

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -82,6 +82,11 @@ DccPluginManager::~DccPluginManager()
     m_plugins.clear();
 }
 
+void DccPluginManager::setPlugins(const QStringList &plugins)
+{
+    m_pluginsToLoad = plugins;
+}
+
 QThreadPool *DccPluginManager::threadPool()
 {
     if (!m_threadPool) {
@@ -160,10 +165,15 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
 
     const QStringList groupPlugins({ "system", "device" }); // 优先加载只是组的插件
     QList<DccPluginLoader *> loaders;
+    QSet<QString> matchedPlugins;
 
     for (auto &lib : pluginList) {
         const QString &filepath = lib.absoluteFilePath();
-        auto filename = lib.fileName();
+        const auto pluginName = lib.baseName();
+        if (!m_pluginsToLoad.isEmpty() && !m_pluginsToLoad.contains(pluginName)) {
+            continue;
+        }
+        matchedPlugins.insert(pluginName);
         DccPluginLoader *loader = new DccPluginLoader(lib.baseName(), filepath, this);
 
         // Set version type based on path
@@ -178,10 +188,16 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
         // Connect signals
         connect(loader, &DccPluginLoader::statusChanged, this, &DccPluginManager::onPluginStatusChanged, Qt::QueuedConnection);
 
-        if (groupPlugins.contains(filename)) {
+        if (groupPlugins.contains(pluginName)) {
             loaders.prepend(loader);
         } else {
             loaders.append(loader);
+        }
+    }
+
+    for (const auto &plugin : m_pluginsToLoad) {
+        if (!matchedPlugins.contains(plugin)) {
+            qCWarning(dccLog()) << "Requested plugin was not found:" << plugin;
         }
     }
 

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -24,6 +24,7 @@ class DccPluginManager : public QObject
 public:
     explicit DccPluginManager(DccManager *parent);
     ~DccPluginManager();
+    void setPlugins(const QStringList &plugins);
     void loadModules(DccObject *root, bool async, const QStringList &dirs, QQmlEngine *engine);
     bool loadFinished() const;
     void beginDelete();
@@ -58,6 +59,7 @@ private:
     QThreadPool *m_threadPool;
     std::atomic<bool> m_isDeleting;
     QQmlEngine *m_engine;
+    QStringList m_pluginsToLoad;
 };
 
 } // namespace dccV25


### PR DESCRIPTION
1. Add a new command-line option `-P`/`--plugin` to specify which plugins should be loaded
2. Implement `setPlugins` methods in both `DccManager` and `DccPluginManager` classes
3. Filter plugin loading based on the specified plugin list
4. Log a warning when a requested plugin is not found in the available plugin directories
5. This feature enables selective plugin loading for testing and debugging purposes

Log: Added ability to load only specified plugins via command-line

Influence:
1. Test launching control center with no plugin filter to verify all plugins load normally
2. Test with a single valid plugin name to verify only that plugin loads
3. Test with multiple valid plugin names to verify all specified plugins load
4. Test with an invalid plugin name to verify warning message appears
5. Test with a mix of valid and invalid plugin names
6. Verify the `-P` and `--plugin` options work correctly
7. Test that plugin groups (system/device) still load with priority when filtering is applied

chore: 为控制中心添加插件过滤选项

1. 添加新的命令行选项 `-P`/`--plugin` 用于指定要加载的插件
2. 在 `DccManager` 和 `DccPluginManager` 类中实现 `setPlugins` 方法
3. 根据指定的插件列表过滤插件加载
4. 当请求的插件在可用插件目录中未找到时记录警告日志
5. 该功能支持选择性插件加载，便于测试和调试

Log: 新增通过命令行仅加载指定插件的功能

Influence:
1. 测试无过滤条件下启动控制中心，验证所有插件正常加载
2. 测试使用单个有效插件名，验证仅该插件被加载
3. 测试使用多个有效插件名，验证所有指定插件均被加载
4. 测试使用无效插件名，验证出现警告提示
5. 测试混合有效和无效插件名的场景
6. 验证 `-P` 和 `--plugin` 选项工作正常
7. 测试过滤条件下插件组（系统/设备）的优先加载仍然有效

PMS: TASK-394433

## Summary by Sourcery

Enable selective control center plugin loading through a command-line filter for testing and debugging.

New Features:
- Add `-P`/`--plugin` command-line support for selecting control center plugins to load.

Enhancements:
- Filter plugin discovery and loading to the requested plugin names while preserving priority loading for system and device plugin groups.
- Warn when a requested plugin is unavailable in the configured plugin directories.