### PR TITLE
chore: add benchmark timing for plugin loading stages

### DIFF
--- a/src/dde-control-center/dccbenchmark.cpp
+++ b/src/dde-control-center/dccbenchmark.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dccbenchmark.h"
+
+#include <QDebug>
+
+Q_LOGGING_CATEGORY(dccBenchmarkLog, "dde.dcc.benchmark")
+
+namespace dccV25 {
+
+DccBenchmark::DccBenchmark(const QString &plugin, const char *stage)
+    : m_plugin(plugin)
+    , m_stage(stage)
+{
+    m_timer.start();
+}
+
+DccBenchmark::~DccBenchmark()
+{
+    const auto elapsed = m_timer.elapsed();
+
+    qCDebug(dccBenchmarkLog).noquote()
+            << QStringLiteral("\"%1\" %2 in %3 ms.")
+                       .arg(m_plugin, QString::fromLatin1(m_stage))
+                       .arg(elapsed);
+}
+
+} // namespace dccV25

--- a/src/dde-control-center/dccbenchmark.h
+++ b/src/dde-control-center/dccbenchmark.h
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QElapsedTimer>
+#include <QLoggingCategory>
+#include <QString>
+
+Q_DECLARE_LOGGING_CATEGORY(dccBenchmarkLog)
+
+namespace dccV25 {
+
+class DccBenchmark
+{
+public:
+    DccBenchmark(const QString &plugin, const char *stage);
+    ~DccBenchmark();
+
+    DccBenchmark(const DccBenchmark &) = delete;
+    DccBenchmark &operator=(const DccBenchmark &) = delete;
+
+private:
+    QString m_plugin;
+    const char *m_stage;
+    QElapsedTimer m_timer;
+};
+
+} // namespace dccV25
+
+#define DCC_BENCHMARK_CONCAT_IMPL(a, b) a##b
+#define DCC_BENCHMARK_CONCAT(a, b) DCC_BENCHMARK_CONCAT_IMPL(a, b)
+#define DCC_BENCHMARK(plugin, stage) \
+    const dccV25::DccBenchmark DCC_BENCHMARK_CONCAT(DccBenchmark_, __LINE__)(plugin, stage)

--- a/src/dde-control-center/dccpluginloader.cpp
+++ b/src/dde-control-center/dccpluginloader.cpp
@@ -4,6 +4,7 @@
 
 #include "dccpluginloader.h"
 
+#include "dccbenchmark.h"
 #include "dccfactory.h"
 #include "dccmanager.h"
 #include "dccobject.h"
@@ -219,6 +220,7 @@ bool DccPluginLoader::loadMetaData()
 
 bool DccPluginLoader::loadModule()
 {
+    DCC_BENCHMARK(name(), "loading-module-QML");
     if (!(m_type & T_HasModule)) {
         setLog("module qml not exists");
         return true;
@@ -267,6 +269,7 @@ bool DccPluginLoader::loadModule()
 
 void DccPluginLoader::loadData()
 {
+    DCC_BENCHMARK(name(), "loading-plugin-library");
     if (m_factory) {
         return;
     }
@@ -313,6 +316,7 @@ void DccPluginLoader::loadData()
 
 void DccPluginLoader::createData()
 {
+    DCC_BENCHMARK(name(), "creating-plugin-data");
     if (!m_factory) {
         setLog(": create data skipped");
         transitionStatus(DataErr);
@@ -354,6 +358,7 @@ void DccPluginLoader::updateParent()
 
 void DccPluginLoader::loadMain()
 {
+    DCC_BENCHMARK(name(), "creating-the-main-qml-object");
     if (!(m_type & T_HasMain)) {
         setLog("main qml not exists");
         transitionStatus(MainObjErr);

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -11,7 +11,6 @@
 
 #include <QDebug>
 #include <QDir>
-#include <QElapsedTimer>
 #include <QFileInfo>
 #include <QLoggingCategory>
 #include <QPluginLoader>
@@ -45,10 +44,7 @@ public:
         if (m_manager->isDeleting()) {
             return;
         }
-        QElapsedTimer timer;
-        timer.start();
         m_loader->loadData();
-        m_loader->setLog("load data finished. elapsed time :" + QString::number(timer.elapsed()));
         m_loader->transitionStatus(DccPluginLoader::DataLoad);
         if (m_manager->isDeleting()) {
             return;
@@ -56,7 +52,6 @@ public:
         // createData和moveThread需要完整，都执行或都不执行
         m_loader->createData();
         m_loader->moveThread();
-        m_loader->setLog("create data finished. elapsed time :" + QString::number(timer.elapsed()));
         m_loader->transitionStatus(DccPluginLoader::DataEnd);
     }
 


### PR DESCRIPTION
1. Add DccBenchmark utility class to measure plugin loading performance
2. Introduce a new logging category "dde.dcc.benchmark" for benchmark output
3. Integrate DccBenchmark into DccPluginLoader for four key stages: module QML loading, plugin library loading, plugin data creation, and main QML object creation
4. Remove inline QElapsedTimer usage from PluginManager as it's now handled by the new DccBenchmark class
5. Refactor code to use RAII-style timing with automatic duration logging on scope exit

Log: Added performance benchmark logging for plugin loading stages

Influence:
1. Trigger plugin loading for various plugin types (module, data, main) and verify benchmark log entries appear with correct stage names
2. Check log output format and timing values are printed correctly for each stage
3. Verify the removal of old timer logs doesn't break plugin loading functionality
4. Test with plugins at different load stages to ensure benchmark coverage is complete

chore: 为插件加载阶段添加基准计时

1. 添加 DccBenchmark 工具类用于测量插件加载性能
2. 引入新的日志分类 "dde.dcc.benchmark" 用于基准输出
3. 在 DccPluginLoader 中集成 DccBenchmark，覆盖四个关键阶段：模块 QML 加 载、插件库加载、插件数据创建和主 QML 对象创建
4. 移除 PluginManager 中的内联 QElapsedTimer 使用，现已由新的 DccBenchmark 类处理
5. 重构代码以使用 RAII 风格的计时，在作用域退出时自动记录耗时

Log: 新增插件加载阶段的性能基准日志

Influence:
1. 触发各类型插件（模块、数据、主）的加载，验证基准日志条目是否以正确的 阶段名称显示
2. 检查每个阶段日志输出格式和计时值是否正确打印
3. 验证移除旧计时器日志后不影响插件加载功能
4. 测试不同加载阶段的插件，确保基准覆盖完整

## Summary by Sourcery

Add scoped performance benchmark logging to measure plugin loading stages.

New Features:
- Add benchmark logging for the four major plugin loading stages: module QML loading, plugin library loading, plugin data creation, and main QML object creation.

Enhancements:
- Centralize plugin loading duration measurement in an RAII-based benchmarking utility with a dedicated logging category.
- Remove the previous aggregate timing logs from plugin data loading while preserving the loading workflow.