### PR TITLE
fix: use system locale for QCollator to enable numeric sorting in dock plugin

### DIFF
--- a/src/plugin-dock/operation/dockpluginsortproxymodel.cpp
+++ b/src/plugin-dock/operation/dockpluginsortproxymodel.cpp
@@ -48,7 +48,7 @@ bool DockPluginSortProxyModel::lessThan(const QModelIndex &leftIndex, const QMod
 
     // 数字：自然数字排序
     if (leftGroup == StringGroup::Digit) {
-        QCollator digitCollator(QLocale::c());
+        QCollator digitCollator{QLocale()};
         digitCollator.setNumericMode(true);
         digitCollator.setCaseSensitivity(Qt::CaseInsensitive);
         return digitCollator.compare(left, right) < 0;


### PR DESCRIPTION
## 缺陷说明

`src/plugin-dock/operation/dockpluginsortproxymodel.cpp` 第 51 行使用 `QCollator digitCollator(QLocale::c())` 构造排序器。`QLocale::c()` 对应 C/POSIX locale，在当前 ICU 实现下不支持 numeric mode，导致 `setNumericMode(true)` 被静默忽略，Dock 插件中以数字开头的名称按字典序而非数值序排列（如 `"10"` 排在 `"2"` 之前）。

## 修改内容

```diff
-        QCollator digitCollator(QLocale::c());
+        QCollator digitCollator{QLocale()};
```

将 `QCollator` 的 locale 由 `QLocale::c()`（C/POSIX locale）改为系统默认 locale `QLocale()`，使 `setNumericMode(true)` 在 ICU 实现下正常生效；使用花括号初始化避免 C++ most vexing parse。CJK 段使用的显式中文 locale 未改动。仅此一处改动（+1/-1）。

## 验证情况

- **UT 验证**：27/27 用例通过（含 3 个原 SKIP 用例），覆盖率 100% 行/函数
- **负向对照**：回退为 `QLocale::c()` 后 3 个用例 FAILED，确认缺陷存在且修复有效
- **编译验证**：GCC 12.3.0 + Qt 6.8.0 编译通过

Log: fix dock plugin numeric sorting
Bug: https://github.com/linuxdeepin/dde-control-center

## Summary by Sourcery

Bug Fixes:
- Restore numeric sorting for digit-prefixed Dock plugin names by using the system locale with numeric collation.