### PR TITLE
fix: refactor timezone and NTP combobox UI components

### DIFF
--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -111,22 +111,19 @@ DccObject {
             property bool showCustom: false
             property string customAddr
 
-            onParentItemChanged: item => {
-                if (item) {
-                    item.rightPadding = DS.Style.comboBox.spacing
-                }
-            }
-
             page: Item {
-                implicitHeight: 36
-                implicitWidth: dccData.ntpEnabled ? 280 : 80
+                implicitWidth: dccData.ntpEnabled ? comboBox.implicitWidth : settingsButton.implicitWidth
+                implicitHeight: dccData.ntpEnabled ? comboBox.implicitHeight : settingsButton.implicitHeight
 
                 ComboBox {
                     id: comboBox
                     property var serverList: dccData.ntpServerList
                     flat: true
-                    padding: 0
+                    padding: 10
+                    rightPadding: padding + 6
                     visible: dccData.ntpEnabled
+                    popup.implicitWidth: 220
+
                     anchors.fill: parent
                     hoverEnabled: true
                     model: serverList
@@ -375,27 +372,57 @@ DccObject {
 
             page: Item {
                 id: systemTimezoneItem
-                implicitWidth: rowlayout.implicitWidth
-                implicitHeight: rowlayout.implicitHeight
+                implicitWidth: zoneButton.implicitWidth
+                implicitHeight: zoneButton.implicitHeight
                 property var model: dccData.zoneSearchModel()
                 property var currentIndex: dccData.currentTimeZoneIndex
                 property string saveZoneId: ""
-                RowLayout {
-                    id: rowlayout
-                    Label {
-                        id: timezoneLabel
-                        text: dccData.timeZoneDispalyName
-                    }
-                    D.IconLabel {
-                        Layout.alignment: Qt.AlignRight | Qt.AlignHCenter
-                        icon.name: "arrow_ordinary_down"
-                        icon.palette: D.DTK.makeIconPalette(timezoneLabel.palette)
-                    }
-                }
 
-                MouseArea {
-                    id: mouseArea
-                    anchors.fill: parent
+                Button {
+                    id: zoneButton
+                    flat: true
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    topPadding: 0
+                    bottomPadding: 0
+                    leftPadding: DS.Style.comboBox.padding
+                    rightPadding: DS.Style.comboBox.padding
+
+                    background: P.ButtonPanel {
+                        button: zoneButton
+                        implicitWidth: zoneButton.implicitContentWidth + zoneButton.leftPadding + zoneButton.rightPadding
+                        implicitHeight: 30
+                        color1: DS.Style.comboBox.flatBackground
+                        color2: DS.Style.comboBox.flatBackground
+                        outsideBorderColor: null
+                    }
+
+                    contentItem: RowLayout {
+                        spacing: 4
+
+                        Label {
+                            id: timezoneLabel
+                            Layout.alignment: Qt.AlignVCenter
+                            verticalAlignment: Text.AlignVCenter
+                            horizontalAlignment: Text.AlignRight
+                            text: dccData.timeZoneDispalyName
+                        }
+
+                        D.DciIcon {
+                            Layout.alignment: Qt.AlignVCenter
+                            Layout.preferredWidth: DS.Style.comboBox.iconSize
+                            Layout.preferredHeight: DS.Style.comboBox.iconSize
+                            sourceSize {
+                                width: DS.Style.comboBox.iconSize
+                                height: DS.Style.comboBox.iconSize
+                            }
+                            name: "arrow_ordinary_down"
+                            palette: D.DTK.makeIconPalette(zoneButton.palette)
+                            mode: zoneButton.D.ColorSelector.controlState
+                            theme: zoneButton.D.ColorSelector.controlTheme
+                            fallbackToQIcon: false
+                        }
+                    }
 
                     Component.onCompleted: {
                         if (dccData.currentTimeZoneIndex >= 0) {
@@ -472,12 +499,12 @@ DccObject {
                         }
                     }
 
-                    onClicked: function (mouse) {
+                    onClicked: {
                         if (!timezoneWindow.isVisible()) {
                             // 保持当前选中项可见，但居中显示
                             timezoneWindow.highlightedIndex = systemTimezoneItem.currentIndex
                             timezoneWindow.show()
-                            timezoneWindow.setPositionByItem(parent)
+                            timezoneWindow.setPositionByItem(zoneButton)
                         }
                     }
                 }


### PR DESCRIPTION
1. Replace ComboBox parent item padding manipulation with proper ComboBox padding properties in TimeAndDate.qml
2. Refactor timezone display from RowLayout+MouseArea to a flat Button with custom background
3. Simplify item sizing by using component implicit sizes instead of fixed dimensions
4. Add proper DciIcon for dropdown arrow in timezone button
5. Improve popup width for NTP server combobox

Log: Refined timezone selection button and NTP server combobox appearance for better alignment and consistency

Influence:
1. Verify NTP server combobox displays correctly when NTP is enabled/ disabled
2. Test timezone button appearance and hover states in different themes
3. Confirm dropdown arrow icon renders correctly in both light and dark themes
4. Test timezone selection window positioning relative to timezone button
5. Verify text alignment and padding in both components
6. Test with different DPI scaling settings

fix: 重构时区和NTP下拉框UI组件

1. 在 TimeAndDate.qml 中用正确的 ComboBox padding 属性替代父项 padding 操作
2. 将时区显示从 RowLayout+MouseArea 重构为带自定义背景的扁平 Button
3. 使用组件隐式尺寸替代固定尺寸简化大小计算
4. 为时区按钮添加正确的 DciIcon 下拉箭头
5. 优化 NTP 服务器下拉框的弹出宽度

Log: 优化时区选择按钮和NTP服务器下拉框的外观，使其对齐更一致

Influence:
1. 验证启用/禁用 NTP 时服务器下拉框显示是否正确
2. 测试不同主题下时区按钮的外观和悬停状态
3. 确认下拉箭头图标在浅色和深色主题下正确渲染
4. 测试时区选择窗口相对于时区按钮的定位
5. 验证两个组件的文本对齐和内边距
6. 测试不同 DPI 缩放设置下的显示效果

PMS: BUG-374495 BUG-374473

## Summary by Sourcery

Refine the timezone and NTP server selector components for consistent alignment, sizing, spacing, and theme-aware presentation.

Bug Fixes:
- Improve the timezone selector and NTP server selector layout, sizing, padding, popup width, and themed dropdown icon rendering.

Enhancements:
- Refine timezone selection interaction and visual states by replacing the custom row and mouse area with a styled button.