### PR TITLE
feat(accounts): enable auto-login on treeland

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -557,7 +557,7 @@ DccObject {
         weight: 30
         pageType: DccObject.Item
         page: DccGroupView {}
-        visible: (autoLongin.visible || noPassword.visible || quickLogin.visible) && !DccApp.isTreeland()
+        visible: autoLongin.visible || noPassword.visible || quickLogin.visible
 
         DccObject {
             id: quickLogin
@@ -567,7 +567,7 @@ DccObject {
             canSearch: settings.canSearch
             weight: 20
             pageType: DccObject.Editor
-            visible: dccData.isQuickLoginVisible
+            visible: dccData.isQuickLoginVisible && !DccApp.isTreeland()
             enabled: dccData.currentUserId() === settings.userId
             page: Switch {
                 checked: settings.noQuickLoginChecked


### PR DESCRIPTION
Remove treeland restriction on auto login settings and only hide quick login option on treeland.

移除treeland对自动登录设置的限制，在treeland下仅隐藏快速登录选项。

Log: 启用treeland自动登录
PMS: BUG-294419
Influence: treeland环境下账户模块现在支持自动登录。

---

具体配置需 dde-daemon 处理  https://github.com/linuxdeepin/dde-daemon/pull/1224

## Summary by Sourcery

New Features:
- Enable automatic login settings in Treeland environments while keeping the quick login option hidden there.