### PR TITLE
fix: 修复 GetNearestZones 空输入越界访问 (DDE-142)

### DIFF
--- a/src/plugin-datetime/operation/timezoneMap/timezone_map_util.cpp
+++ b/src/plugin-datetime/operation/timezoneMap/timezone_map_util.cpp
@@ -40,6 +40,9 @@ double ConvertLongitudeToX(double longitude) {
 ZoneInfoList GetNearestZones(const ZoneInfoList& total_zones, double threshold,
                              int x, int y, int map_width, int map_height) {
   ZoneInfoList zones;
+  if (total_zones.isEmpty()) {
+    return zones;
+  }
   double minimum_distance = map_width * map_width + map_height * map_height;
   int nearest_zone_index = -1;
   for (int index = 0; index < total_zones.length(); index++) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,10 +3,13 @@ set(BIN_NAME unit-test)
 add_executable(${BIN_NAME}
     ut_pinyinsearch.cpp
     ${PROJECT_SOURCE_DIR}/src/plugin-keyboard/operation/pinyinsearch.cpp
+    ut_timezone_map_util.cpp
+    ${PROJECT_SOURCE_DIR}/src/plugin-datetime/operation/timezoneMap/timezone_map_util.cpp
 )
 
 target_include_directories(${BIN_NAME} PRIVATE
     ${PROJECT_SOURCE_DIR}/src/plugin-keyboard/operation
+    ${PROJECT_SOURCE_DIR}/src/plugin-datetime/operation/timezoneMap
 )
 
 target_link_libraries(${BIN_NAME} PRIVATE

--- a/tests/ut_timezone_map_util.cpp
+++ b/tests/ut_timezone_map_util.cpp
@@ -1,0 +1,166 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "timezone_map_util.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+// timezone_map_util.cpp 提供时区世界地图的坐标转换（经纬度 → 归一化
+// 矩形坐标 x/y ∈ [0,1]）与「点击点最近时区」算法，被 datetime 插件
+// datetimemodel.cpp 用于地图选时区。这些是纯函数/纯算法，无 Qt UI / D-Bus /
+// 文件系统依赖，断言可完全确定。参考值由公式精确计算得到（见注释）。
+
+namespace {
+
+using installer::ConvertLatitudeToY;
+using installer::ConvertLongitudeToX;
+using installer::GetNearestZones;
+using installer::ZoneInfo;
+using installer::ZoneInfoList;
+
+// tolerance for EXPECT_NEAR on the map-projection math
+constexpr double kTol = 1e-4;
+
+ZoneInfo makeZone(double latitude, double longitude, const QString &name = QStringLiteral("z"))
+{
+    ZoneInfo z;
+    z.country = QStringLiteral("C");
+    z.timezone = name;
+    z.latitude = latitude;
+    z.longitude = longitude;
+    z.distance = 0.0;
+    return z;
+}
+
+} // namespace
+
+// ---- ConvertLongitudeToX ----
+
+TEST(TimezoneMapUtil, ConvertLongitudeToXMapsKnownMeridians)
+{
+    // Formula: (180.0 + longitude) / 360.0 + (-6) / 180.0
+    EXPECT_NEAR(ConvertLongitudeToX(-180.0), -0.0333333333, kTol);
+    EXPECT_NEAR(ConvertLongitudeToX(0.0), 0.4666666667, kTol);
+    EXPECT_NEAR(ConvertLongitudeToX(180.0), 0.9666666667, kTol);
+}
+
+TEST(TimezoneMapUtil, ConvertLongitudeToXIsMonotonicallyIncreasing)
+{
+    EXPECT_LT(ConvertLongitudeToX(-90.0), ConvertLongitudeToX(0.0));
+    EXPECT_LT(ConvertLongitudeToX(0.0), ConvertLongitudeToX(90.0));
+    EXPECT_LT(ConvertLongitudeToX(90.0), ConvertLongitudeToX(180.0));
+}
+
+TEST(TimezoneMapUtil, ConvertLongitudeToXIsLinear)
+{
+    // The mapping is affine in longitude (slope 1/360), so deltas are equal
+    // for equal longitude increments.
+    const double d180 = ConvertLongitudeToX(180.0) - ConvertLongitudeToX(0.0);
+    const double d180b = ConvertLongitudeToX(0.0) - ConvertLongitudeToX(-180.0);
+    EXPECT_NEAR(d180, d180b, kTol);
+    EXPECT_NEAR(d180, 0.5, kTol); // 360/360 = 0.5 per 180 degrees
+}
+
+// ---- ConvertLatitudeToY ----
+
+TEST(TimezoneMapUtil, ConvertLatitudeToYMapsKnownParallels)
+{
+    // Reference values from the closed-form Mercator-like projection:
+    //   y(-59)=1.0, y(0)=0.6390, y(30)=0.4727, y(60)=0.2701, y(81)=0.0617
+    EXPECT_NEAR(ConvertLatitudeToY(-59.0), 1.0, kTol);
+    EXPECT_NEAR(ConvertLatitudeToY(0.0), 0.6390437968, kTol);
+    EXPECT_NEAR(ConvertLatitudeToY(81.0), 0.0617411490, kTol);
+}
+
+TEST(TimezoneMapUtil, ConvertLatitudeToYIsMonotonicallyDecreasing)
+{
+    // Higher latitude → smaller normalized y (further from the bottom edge).
+    EXPECT_GT(ConvertLatitudeToY(-59.0), ConvertLatitudeToY(0.0));
+    EXPECT_GT(ConvertLatitudeToY(0.0), ConvertLatitudeToY(30.0));
+    EXPECT_GT(ConvertLatitudeToY(60.0), ConvertLatitudeToY(81.0));
+}
+
+TEST(TimezoneMapUtil, ConvertLatitudeToYStaysInUnitRangeForSupportedLatitudes)
+{
+    // The function documents supported latitudes as [-59, 81].
+    for (double lat = -59.0; lat <= 81.0; lat += 10.0) {
+        const double y = ConvertLatitudeToY(lat);
+        EXPECT_GE(y, 0.0);
+        EXPECT_LE(y, 1.0);
+    }
+}
+
+// ---- GetNearestZones ----
+
+TEST(GetNearestZones, ReturnsZoneWithinThreshold)
+{
+    // One zone at longitude 0 (→ x≈0.4667) on a 1000px-wide map lands at
+    // pixel x = 466. Clicking at x=470 with a generous threshold should
+    // include it.
+    ZoneInfoList zones;
+    zones.append(makeZone(0.0, 0.0, QStringLiteral("z0")));
+
+    const int mapWidth = 1000;
+    const int mapHeight = 500;
+    const int clickX = int(ConvertLongitudeToX(0.0) * mapWidth);
+    const int clickY = int(ConvertLatitudeToY(0.0) * mapHeight);
+
+    const ZoneInfoList result = GetNearestZones(zones, 1e6 /* huge threshold */,
+                                                clickX, clickY, mapWidth, mapHeight);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first().timezone, QStringLiteral("z0"));
+}
+
+TEST(GetNearestZones, IncludesAllZonesWithinThresholdOrderedByInput)
+{
+    // With a large threshold every zone satisfies distance <= threshold, so
+    // all of them are appended (in iteration order). The first appended is
+    // the list's first element, not necessarily the globally nearest.
+    ZoneInfoList zones;
+    zones.append(makeZone(0.0, 10.0, QStringLiteral("near")));   // 10°E
+    zones.append(makeZone(0.0, 170.0, QStringLiteral("far")));   // 170°E
+
+    const int mapWidth = 1000;
+    const int mapHeight = 500;
+    // Click exactly at the projection of the "near" zone (10°E).
+    const int clickX = int(ConvertLongitudeToX(10.0) * mapWidth);
+    const int clickY = int(ConvertLatitudeToY(0.0) * mapHeight);
+
+    const ZoneInfoList result = GetNearestZones(zones, 1e9, clickX, clickY, mapWidth, mapHeight);
+    // Both zones qualify under the huge threshold.
+    EXPECT_EQ(result.size(), 2);
+    // Iteration order is preserved: "near" (index 0) was appended first.
+    EXPECT_EQ(result.first().timezone, QStringLiteral("near"));
+}
+
+TEST(GetNearestZones, FallsBackToNearestZoneWhenNoneWithinThreshold)
+{
+    // No zone is within threshold → the function appends the single nearest
+    // zone (nearest_zone_index branch, zones.isEmpty() == true).
+    ZoneInfoList zones;
+    zones.append(makeZone(0.0, 0.0, QStringLiteral("a")));
+    zones.append(makeZone(0.0, 120.0, QStringLiteral("b")));
+
+    const int mapWidth = 1000;
+    const int mapHeight = 500;
+    // Click near zone "a".
+    const int clickX = int(ConvertLongitudeToX(0.0) * mapWidth);
+    const int clickY = int(ConvertLatitudeToY(0.0) * mapHeight);
+
+    // Negative threshold → no zone satisfies distance <= threshold (distance
+    // is non-negative), so zones stays empty and the nearest-zone fallback
+    // branch (zones.isEmpty()) appends total_zones.at(nearest_zone_index).
+    const ZoneInfoList result = GetNearestZones(zones, -1.0, clickX, clickY, mapWidth, mapHeight);
+    ASSERT_EQ(result.size(), 1);
+    EXPECT_EQ(result.first().timezone, QStringLiteral("a"));
+}
+
+TEST(GetNearestZones, EmptyInputReturnsEmptyList)
+{
+    ZoneInfoList empty;
+    const ZoneInfoList result = GetNearestZones(empty, 64.0, 100, 100, 800, 400);
+    EXPECT_TRUE(result.isEmpty());
+}


### PR DESCRIPTION
## 关联 issue

- Multica issue: **DDE-142** — GetNearestZones 越界访问缺陷：空 total_zones 输入未保护
- Multica 平台: https://agent-dev.uniontech.com

## 修复内容

`GetNearestZones` 在 `total_zones` 为空时，循环不执行、`nearest_zone_index` 保持初值 -1，回退分支 `zones.append(total_zones.at(-1))` 对空 `QList` 越界访问（未定义行为），可能导致 datetime 模块地图选时区功能在 zone 数据未加载时崩溃。

在函数入口增加 `total_zones.isEmpty()` 判空保护，空输入直接返回空列表：

```cpp
ZoneInfoList zones;
if (total_zones.isEmpty()) {
  return zones;
}
```

调用方 `datetimemodel.cpp` 无需修改，无接口变更、无跨模块影响。

## 变更文件（仅 3 个）

1. `src/plugin-datetime/operation/timezoneMap/timezone_map_util.cpp` — `GetNearestZones` 入口增加空输入判空保护（+3 行）
2. `tests/ut_timezone_map_util.cpp`（新增）— 从 PR #3421 携带，并将原「空输入因 UB 故意省略」的 NOTE 替换为实际的 `GetNearestZones.EmptyInputReturnsEmptyList` 空输入测试用例
3. `tests/CMakeLists.txt` — 注册 `ut_timezone_map_util.cpp` 及被测源 `timezone_map_util.cpp`，添加 include 目录（已剥离 gcov 插桩，仅保留最小测试注册）

## 与 PR #3421 的关系

本 PR 的 `tests/ut_timezone_map_util.cpp` 是 #3421 对应文件的**超集**（新增了 `GetNearestZones.EmptyInputReturnsEmptyList` 空输入用例）。rebase #3421 时以本 PR 版本为准；#3421 可视情况关闭。

## 验证

| 阶段 | 结果 |
|---|---|
| 自测（单元测试） | 16/16 通过（含新增空输入用例），被测源行覆盖率 97.4%、函数覆盖率 100% |
| 代码审核 | 通过 ✅（3 次审核一致通过） |
| 编译打包 | deb 包构建成功，无编译错误无警告，Debian 规范检查通过 |

- 基线分支/commit: `master` / `307bdbf`
- 新增用例 `GetNearestZones.EmptyInputReturnsEmptyList` 验证：空 `total_zones` 输入时函数返回空列表，不再触发 `total_zones.at(-1)` 越界访问。

## Summary by Sourcery

Prevent crashes when timezone map data is unavailable and add regression coverage for timezone map utilities.

Bug Fixes:
- Prevent GetNearestZones from accessing an empty zone list out of bounds by returning an empty result for empty input.

Enhancements:
- Add unit coverage for timezone map coordinate conversions and nearest-zone selection behavior.

Build:
- Register the timezone map utility source and tests with the unit-test target and add the required include path.

Tests:
- Add comprehensive tests for coordinate conversion, threshold filtering, nearest-zone fallback, ordering, and empty-input handling.