### PR TITLE
fix: add Q_INTERFACES(QQmlParserStatus) to DccQuickDBusInterface

### DIFF
--- a/src/dde-control-center/plugin/dccquickdbusinterface.h
+++ b/src/dde-control-center/plugin/dccquickdbusinterface.h
@@ -12,6 +12,7 @@ namespace dccV25 {
 class DccQuickDBusInterface : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
     QML_NAMED_ELEMENT(DccDBusInterface)
 
     Q_PROPERTY(QString service READ service WRITE setService NOTIFY serviceChanged)


### PR DESCRIPTION
## 修改内容

在 `DccQuickDBusInterface` 类中补充 `Q_INTERFACES(QQmlParserStatus)` 声明，位于 `Q_OBJECT` 之后、`QML_NAMED_ELEMENT` 之前，与同仓库 `DccObject` 的写法保持一致。

## 背景

控制中心编译时出现 AutoMoc 警告：

> Class DccQuickDBusInterface implements the interface QQmlParserStatus but does not list it in Q_INTERFACES. qobject_cast to QQmlParserStatus will not work!

该类多重继承自 `QQmlParserStatus` 并 override 了 `classBegin()` / `componentComplete()`，但未声明 `Q_INTERFACES`，导致 `qobject_cast<QQmlParserStatus*>` 失效，QML 引擎无法可靠驱动该组件的 `QQmlParserStatus` 生命周期。

## 改动

仅新增一行宏声明，无逻辑 / API 变更（仅修正 MOC 接口元信息注册）：

```diff
 class DccQuickDBusInterface : public QObject, public QQmlParserStatus
 {
     Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
     QML_NAMED_ELEMENT(DccDBusInterface)
```

## 验证

- 本地全量构建通过，原 AutoMoc 警告在全量构建日志中出现 0 次，已确认消除。
- 代码审核已通过：`Q_INTERFACES` 位置正确（位于 `Q_OBJECT` 之后）、与 `DccObject` 风格一致、无多余改动。

## 关联

- PMS 任务：https://pms.uniontech.com/task-view-394823.html
- Multica Issue：DDE-194（5696e38c-4b5b-4499-a39a-297e12e4f20d）

> 当前为 draft 状态，待人工审核合并，请勿自动合并。

## Summary by Sourcery

Bug Fixes:
- Register DccQuickDBusInterface's QQmlParserStatus interface metadata so QML can reliably recognize and manage its parser-status lifecycle.