### PR TITLE
feat: add plugin loading performance logging

### DIFF
--- a/src/dde-control-center/dccbenchmark.cpp
+++ b/src/dde-control-center/dccbenchmark.cpp
@@ -27,4 +27,40 @@ DccBenchmark::~DccBenchmark()
                        .arg(elapsed);
 }
 
+void DccLoadTimer::start()
+{
+    qCDebug(dccBenchmarkLog).noquote() << QStringLiteral("Begin-to-load-plugins.");
+    m_totalTimer.start();
+    m_pluginStartTimes.clear();
+}
+
+void DccLoadTimer::addPlugin(const QString &name)
+{
+    m_pluginStartTimes.insert(name, m_totalTimer.elapsed());
+}
+
+void DccLoadTimer::finishPlugin(const QString &name)
+{
+    if (m_pluginStartTimes.contains(name)) {
+        const qint64 startTime = m_pluginStartTimes.value(name);
+        qCDebug(dccBenchmarkLog).noquote()
+                << QStringLiteral("\"%1\" total-loading-finished in %2 ms.")
+                           .arg(name)
+                           .arg(m_totalTimer.elapsed() - startTime);
+    }
+}
+
+void DccLoadTimer::stop()
+{
+    if (!m_totalTimer.isValid())
+        return;
+
+    qCDebug(dccBenchmarkLog).noquote()
+            << QStringLiteral("All %1 plugins-loaded in %2 ms.")
+                       .arg(m_pluginStartTimes.size())
+                       .arg(m_totalTimer.elapsed());
+    m_totalTimer.invalidate();
+    m_pluginStartTimes.clear();
+}
+
 } // namespace dccV25

--- a/src/dde-control-center/dccbenchmark.h
+++ b/src/dde-control-center/dccbenchmark.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <QElapsedTimer>
+#include <QHash>
 #include <QLoggingCategory>
 #include <QString>
 
@@ -25,6 +26,24 @@ private:
     QString m_plugin;
     const char *m_stage;
     QElapsedTimer m_timer;
+};
+
+class DccLoadTimer
+{
+public:
+    DccLoadTimer() = default;
+
+    DccLoadTimer(const DccLoadTimer &) = delete;
+    DccLoadTimer &operator=(const DccLoadTimer &) = delete;
+
+    void start();                          // Start global timer, clear per-plugin tracking
+    void addPlugin(const QString &name);  // Record a plugin's start timestamp
+    void finishPlugin(const QString &name);  // Calculate & log per-plugin total time
+    void stop();                           // Stop timer and log all-plugins total time
+
+private:
+    QElapsedTimer m_totalTimer;
+    QHash<QString, qint64> m_pluginStartTimes;
 };
 
 } // namespace dccV25

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -97,7 +97,9 @@ void DccPluginManager::loadPlugin(DccPluginLoader *loader)
         return;
     }
     if (loader->status() & DccPluginLoader::PluginEnd) {
+        m_loadTimer.finishPlugin(loader->name());
         if (loadFinished()) {
+            m_loadTimer.stop();
             Q_EMIT loadAllFinished();
             cancelLoad();
         }
@@ -143,6 +145,7 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
     Q_UNUSED(async)
     if (!root)
         return;
+    m_loadTimer.start();
     m_rootModule = root;
     m_engine = engine;
     qCDebug(dccLog()) << "plugin dir:" << dirs;
@@ -169,6 +172,7 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
         }
         matchedPlugins.insert(pluginName);
         DccPluginLoader *loader = new DccPluginLoader(lib.baseName(), filepath, this);
+        m_loadTimer.addPlugin(loader->name());
 
         // Set version type based on path
         DccPluginLoader::TypeFlags type = DccPluginLoader::T_Unknown;

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
+#include "dccbenchmark.h"
+
 #include <QObject>
 #include <QQmlContext>
 #include <QStringList>
@@ -60,6 +62,7 @@ private:
     std::atomic<bool> m_isDeleting;
     QQmlEngine *m_engine;
     QStringList m_pluginsToLoad;
+    DccLoadTimer m_loadTimer;
 };
 
 } // namespace dccV25


### PR DESCRIPTION
1. Implement DccLoadTimer class in dccbenchmark to track and log plugin loading performance
2. Add per-plugin loading time measurement using QElapsedTimer and QHash for start time tracking
3. Integrate timer into DccPluginManager to monitor plugin loading lifecycle
4. Add DccRepeater fix to optimize plugin item request handling with deferred queued invocation
5. Fix potential crash in DccRepeater by adding null checks for deletables vector

Log: Added plugin loading performance logging with detailed timing information

Influence:
1. Test plugin loading process to verify log output contains begin/total load messages
2. Verify each plugin's individual loading time is logged correctly
3. Test loading multiple plugins and verify total time accumulation
4. Test DccRepeater with various model changes to ensure no crashes
5. Verify queued item requests work correctly with rapid model updates
6. Test plugin unload scenarios and verify timer cleanup

feat: 添加插件加载性能日志

1. 在 dccbenchmark 中实现 DccLoadTimer 类，用于跟踪和记录插件加载性能
2. 使用 QElapsedTimer 和 QHash 添加单个插件的加载时间测量，用于起始时间 追踪
3. 将计时器集成到 DccPluginManager 中，监控插件加载生命周期
4. 修复 DccRepeater，通过延迟队列调用优化插件项请求处理
5. 修复 DccRepeater 中可能存在的崩溃问题，为 deletables 向量添加空值检查

Log: 新增插件加载性能日志功能，包含详细的计时信息

Influence:
1. 测试插件加载过程，验证日志输出包含开始/总加载消息
2. 验证每个插件的单独加载时间是否正确记录
3. 测试加载多个插件，验证总时间的累计
4. 测试 DccRepeater 在不同模型变更下的表现，确保无崩溃
5. 验证快速模型更新时队列项请求是否正常工作
6. 测试插件卸载场景，验证计时器清理是否正常

PMS: TASK-394433

## Summary by Sourcery

Add performance logging to track plugin loading durations.

New Features:
- Add plugin loading performance logging with per-plugin and total load-time measurements.

Enhancements:
- Integrate loading-time tracking into the plugin manager lifecycle.