### PR TITLE
fix: replace __DATE__ with DCC_BUILD_YEAR to fix -Werror=date-time

### DIFF
--- a/src/plugin-systeminfo/CMakeLists.txt
+++ b/src/plugin-systeminfo/CMakeLists.txt
@@ -21,4 +21,9 @@ target_link_libraries(${SystemInfo_Name} PRIVATE
     ${SystemInfo_Libraries}
 )
 
+string(TIMESTAMP DCC_BUILD_YEAR "%Y" UTC)
+target_compile_definitions(${SystemInfo_Name} PRIVATE
+    DCC_BUILD_YEAR=${DCC_BUILD_YEAR}
+)
+
 dcc_install_plugin(NAME ${SystemInfo_Name} TARGET ${SystemInfo_Name})

--- a/src/plugin-systeminfo/operation/systeminfowork.cpp
+++ b/src/plugin-systeminfo/operation/systeminfowork.cpp
@@ -251,7 +251,7 @@ void SystemInfoWork::initSystemCopyright()
     const QSettings settings("/etc/deepin-installer.conf", QSettings::IniFormat);
     QString oem_copyright = settings.value("system_info_vendor_name").toString().toUtf8();
 
-    const int buildYear = QString(__DATE__).right(4).toInt();
+    const int buildYear = DCC_BUILD_YEAR;
     int validYear = QDateTime::currentDateTime().date().year();
     validYear = qMax(buildYear, validYear);
     if (oem_copyright.isEmpty()) {


### PR DESCRIPTION
## 背景

`src/plugin-systeminfo/operation/systeminfowork.cpp` 使用 `__DATE__` 宏获取构建年份，触发 `-Werror=date-time` 编译警告/错误，阻碍可复现构建。

## 改动内容

1. `src/plugin-systeminfo/CMakeLists.txt`：在 configure 阶段使用 `string(TIMESTAMP DCC_BUILD_YEAR "%Y" UTC)` 生成构建年份（CMake ≥3.8 自动识别并优先使用 `SOURCE_DATE_EPOCH`，满足可复现构建要求），并通过 `target_compile_definitions` 以带值定义 `DCC_BUILD_YEAR=<整数>` 传入编译器。
2. `src/plugin-systeminfo/operation/systeminfowork.cpp`：将 `QString(__DATE__).right(4).toInt()` 替换为 `DCC_BUILD_YEAR`，彻底消除 `-Werror=date-time` 警告，版权年份行为保持不变。

变更范围：2 个文件，+6 / −1，最小化改动。

## 验证

- 代码审核：✅ APPROVE（逐行复核通过）
- 本地编译验证：✅ 通过（pbuilder 全量构建，0 error；`-Werror=date-time` 已消除，`-DDCC_BUILD_YEAR=2026` 正确传入）

## 关联

- PMS: https://pms.uniontech.com/task-view-394823.html
- Multica Issue: DDE-195

> 本 PR 处于 draft 状态，等待人工审核合并。

## Summary by Sourcery

Use a configuration-provided build year instead of __DATE__ to support warning-free, reproducible builds.

Bug Fixes:
- Replace compiler date macros with a CMake-provided build year to eliminate -Werror=date-time failures and preserve copyright year behavior.

Build:
- Generate and pass the build year as a target compile definition during configuration, supporting reproducible builds.