### PR TITLE
fix(wallpaper): refresh delegate load limit when model changes

### DIFF
--- a/src/plugin-personalization/qml/WallpaperSelectView.qml
+++ b/src/plugin-personalization/qml/WallpaperSelectView.qml
@@ -454,6 +454,19 @@ ColumnLayout {
             }
         }
 
+        Connections {
+            target: root.model
+            function onRowsInserted(parent, first, last) {
+                root.delegateLoadLimit += (last - first + 1)
+            }
+            function onRowsRemoved() {
+                root.delegateLoadLimit = Math.max(root.delegateLoadLimit - 1, 1)
+            }
+            function onModelReset() {
+                root.delegateLoadLimit = 1
+            }
+        }
+
         D.Menu {
             id: contextMenu
             MenuItem {


### PR DESCRIPTION
1. Sync delegateLoadLimit with the wallpaper model's row changes
2. Increment the load limit on row insert, so a newly added image at index 0 is rendered instead of replacing earlier ones
3. Decrement (clamped to 1) on row removal and reset to 1 on model reset
4. Fixes newly added images overwriting previously added images

Log: Refresh delegateLoadLimit on model changes so added images render correctly
Influence: Newly added images no longer replace earlier ones

fix(壁纸)：模型变化时同步刷新委托加载限制

1. delegateLoadLimit 与壁纸模型的行变化保持同步
2. 新插入图片时递增加载上限，避免 index 为 0 的新图未加载，显示错位
3. 删除行时递减（最小为 1），模型重置时重置为 1
4. 修复添加图片会替换掉先前添加图片的问题

Log: 模型变化时同步刷新加载上限，保证新增图片正常显示
PMS: BUG-375119
Influence: 新增图片后能正常显示，不再替换旧图

## Summary by Sourcery

Bug Fixes:
- Keep wallpaper delegate loading limits synchronized with model insertions, removals, and resets so newly added images render correctly without replacing existing images.