### PR TITLE
fix: improve account group list keyboard navigation

### DIFF
--- a/src/plugin-accounts/qml/AccountSettings.qml
+++ b/src/plugin-accounts/qml/AccountSettings.qml
@@ -762,6 +762,7 @@ DccObject {
                 property int lrMargin: DccUtils.getMargin(width)
                 property int conY: 0
                 property bool resetActive: false
+                property int focusIndex: 1
                 spacing: 0
                 currentIndex: -1
                 keyNavigationEnabled: true
@@ -818,7 +819,7 @@ DccObject {
 
                     DelegateChoice {
                         roleValue: "header"
-                        delegate: Item {
+                        delegate: FocusScope {
                             implicitHeight: 50
                             anchors {
                                 left: parent ? parent.left : undefined
@@ -861,6 +862,12 @@ DccObject {
                                     onCheckedChanged: {
                                         groupSettings.isEditing = headerEditButton.checked
                                     }
+                                    onActiveFocusChanged: {
+                                        if (activeFocus) {
+                                            groupview.currentIndex = 0
+                                            groupview.positionViewAtBeginning()
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -868,7 +875,7 @@ DccObject {
 
                     DelegateChoice {
                         roleValue: "footer"
-                        delegate: Item {
+                        delegate: FocusScope {
                             implicitHeight: 50
                             anchors {
                                 left: parent ? parent.left : undefined
@@ -886,6 +893,12 @@ DccObject {
                                     implicitHeight: 30
                                     focusPolicy: Qt.StrongFocus
                                     activeFocusOnTab: true
+                                    onActiveFocusChanged: {
+                                        if (activeFocus) {
+                                            groupview.currentIndex = groupview.count - 1
+                                            groupview.positionViewAtEnd()
+                                        }
+                                    }
                                     onClicked: {
                                         dccData.requestCreateGroup(settings.userId)
                                         groupview.positionViewAtEnd()
@@ -906,15 +919,25 @@ DccObject {
                             z: editLabel.showAlert ? 100 : 1
 
                             focusPolicy: Qt.StrongFocus
-                            activeFocusOnTab: true
+                            activeFocusOnTab: index === focusIndex
 
                             onActiveFocusChanged: {
                                 if (activeFocus) {
                                     groupview.currentIndex = index
+                                    groupview.focusIndex = index
+                                    groupview.positionViewAtIndex(index, ListView.Visible)
                                 }
                             }
 
                             Keys.onPressed: function(event) {
+                                if (event.key === Qt.Key_Up && index === 1) {
+                                    event.accepted = true
+                                    return
+                                }
+                                if (event.key === Qt.Key_Down && index === groupview.count - 2) {
+                                    event.accepted = true
+                                    return
+                                }
                                 if (!model.groupEnabled) {
                                     return
                                 }
@@ -982,8 +1005,9 @@ DccObject {
                                         verticalAlignment: TextInput.AlignVCenter
                                         editBtn.visible: readOnly && editAble
                                                         && !groupSettings.isEditing
+                                        editBtn.activeFocusOnTab: false
+                                        activeFocusOnTab: false
                                         readOnly: model.display.length > 0
-                                        activeFocusOnTab: !readOnly
                                         ToolTip {
                                             visible: parent.hovered && parent.readOnly && parent.completeText != "" && (parent.metrics.advanceWidth(parent.completeText) > (parent.width - parent.rightPadding - 10))
                                             text: parent.completeText


### PR DESCRIPTION
1. Auto-scroll group view to beginning when header edit button receives focus
2. Auto-scroll group view to end when create group button receives focus
3. Restrict active focus on tab to only the first group item to prevent focus traps
4. Ensure group view scrolls to the currently focused item when it receives focus
5. Remove redundant externalFocus property from item background to simplify focus handling
6. Set activeFocusOnTab to false for edit buttons and text inputs in group items

Log: Improved keyboard navigation in account group list with proper auto-scrolling

Influence:
1. Test tab key navigation through account settings page
2. Verify group list auto-scrolls to the focus position when using keyboard
3. Test focus behavior on header edit button and create group button
4. Verify tab order does not get trapped in group item edit fields
5. Test group item focus highlights and background display

fix: 改进账户组列表键盘导航

1. 当头部编辑按钮获得焦点时自动滚动组视图到起始位置
2. 当新建组按钮获得焦点时自动滚动组视图到末尾
3. 限制标签页焦点仅在第一个组项目上，防止焦点陷阱
4. 确保组视图在项目获得焦点时滚动到当前焦点项目
5. 移除项目背景中冗余的 externalFocus 属性，简化焦点处理
6. 将组项目中的编辑按钮和文本输入的 activeFocusOnTab 设置为 false

Log: 优化账户组列表的键盘导航和自动滚动功能

Influence:
1. 测试在账户设置页面使用 Tab 键进行导航
2. 验证使用键盘时组列表自动滚动到焦点位置
3. 测试头部编辑按钮和新建组按钮的焦点行为
4. 验证 Tab 键顺序不会被困在组项目编辑字段中
5. 测试组项目的焦点高亮和背景显示

PMS: BUG-375217

## Summary by Sourcery

Improve account group list keyboard navigation and focus-aware scrolling.

Bug Fixes:
- Improve keyboard navigation in the account group list by automatically scrolling to focused header, group, and footer controls and preventing focus traps.

Enhancements:
- Simplify group-item focus handling and restrict tab navigation to the intended group item while excluding nested editing controls from the tab order.