### PR TITLE
fix: sync volume adjustment in real time

### DIFF
--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -203,7 +203,6 @@ void SoundWorker::setSourceVolume(double volume)
 
 void SoundWorker::setSinkVolume(double volume)
 {
-    qWarning()<<__FUNCTION__<<volume;
     m_soundDBusInter->SetVolumeSink(volume, true);
     qCDebug(DdcSoundWorker) << "set sink volume to " << volume;
 }

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -106,6 +106,10 @@ DccObject {
                     value: dccData.model().speakerVolume
                     to: dccData.model().increaseVolume ? 1.5 : 1.0
                     stepSize: 0.01
+                    onMoved: {
+                        // 实时提交拖动过程中的音量，避免只在松手时生效
+                        dccData.worker().setSinkVolume(voiceTipsSlider.value)
+                    }
                     onPressedChanged: {
                         if (!pressed) {
                             dccData.worker().setSinkVolume(voiceTipsSlider.value)


### PR DESCRIPTION
1. Remove redundant debug log in setSinkVolume function
2. Add onMoved signal handler to SpeakerPage.qml that submits volume changes during slider drag, ensuring real-time volume response
3. Keep onPressedChanged handler for final commit when slider is released

Log: Volume adjustment now responds in real-time during slider drag

Influence:
1. Test volume slider dragging and verify volume changes immediately during drag
2. Verify final volume value is correct after releasing the slider
3. Test volume adjustment on systems with increased volume range (up to 1.5)
4. Verify no performance issues or audio stuttering during rapid slider movement
5. Check volume tooltip and displayed percentage updates correctly in real time
6. Test volume adjustment in different audio output devices

fix: 音量调节实时同步

1. 移除 setSinkVolume 函数中多余的调试日志
2. 在 SpeakerPage.qml 中添加 onMoved 信号处理器，在滑块拖动过程中即时提 交音量变更，确保音量实时响应
3. 保留 onPressedChanged 处理器，在滑块松开时最终确认音量

Log: 拖动音量滑块时音量实时变化

Influence:
1. 测试拖动音量滑块，验证拖动过程中音量即时变化
2. 验证松手后最终音量值正确
3. 测试支持增强音量（最大1.5倍）的系统上的音量调节
4. 验证快速拖动滑块时无性能问题或音频卡顿
5. 检查音量提示和显示百分比实时更新是否正确
6. 测试不同音频输出设备下的音量调节功能

PMS: BUG-375031
Change-Id: Ic1cea5c01283d1b1df77922726ee615b4fa3dada

## Summary by Sourcery

Enable real-time speaker volume synchronization during slider adjustments.

Bug Fixes:
- Synchronize speaker volume changes immediately while the volume slider is being dragged, while preserving final submission when the slider is released.

Chores:
- Remove redundant warning-level debug logging from sink volume updates.