### PR TITLE
fix: resolve shortcutView ReferenceError in Shortcuts.qml onDeactive handler

### DIFF
--- a/src/plugin-keyboard/qml/Shortcuts.qml
+++ b/src/plugin-keyboard/qml/Shortcuts.qml
@@ -36,7 +36,7 @@ DccObject {
         target: shortcutSettingsView
         function onDeactive() {
             dccData.endKeyCapture()
-            shortcutView.restoreShortcutView()
+            shortcutSettingsBody.requestRestore()
             shortcutSettingsBody.conflictAccels = ""
             shortcutSettingsBody.isEditing = false
         }


### PR DESCRIPTION
## 问题

控制中心-快捷键，运行警告：`qrc:/qt/qml/keyboard/Shortcuts.qml:39: ReferenceError: shortcutView is not defined`

每次离开快捷键页（触发 `deactive`）即抛出该警告。

## 根因

`id: shortcutView` 声明在 `shortcutSettingsBody.page:`（`QQmlComponent`）内部组件作用域中，对外层创建上下文不可见。而 `Connections { target: shortcutSettingsView; function onDeactive() {...} }`（Shortcuts.qml:35–43）位于根 `DccObject` 的外层作用域，其第 39 行 `shortcutView.restoreShortcutView()` 无法解析 `shortcutView`，故每次离开快捷键页触发 `deactive` 信号即抛 `ReferenceError: shortcutView is not defined`。

同 handler 其余三行（`dccData.endKeyCapture()`、`shortcutSettingsBody.conflictAccels`、`shortcutSettingsBody.isEditing`）均在外层作用域可正常解析，无需改动。

## 修复

将第 39 行直接调用改为通过已有信号转发：

```diff
     Connections {
         target: shortcutSettingsView
         function onDeactive() {
             dccData.endKeyCapture()
-            shortcutView.restoreShortcutView()
+            shortcutSettingsBody.requestRestore()
             shortcutSettingsBody.conflictAccels = ""
             shortcutSettingsBody.isEditing = false
         }
     }
```

`shortcutSettingsBody` 已声明 `signal requestRestore`（L53），其 `page` 内部已有转发 `Connections { target: shortcutSettingsBody; function onRequestRestore() { shortcutView.restoreShortcutView() } }`（L433–438，此处 `shortcutView` 在作用域内可解析）。

调用链：`onDeactive()` → `shortcutSettingsBody.requestRestore()`（外层发信号）→ page 内 Connections 接收 → `shortcutView.restoreShortcutView()`。

此模式与「恢复默认」按钮（L548）、「添加自定义快捷键」按钮（L612）既有调用方式完全一致，复用现有解耦机制，无需新增任何信号或属性。

## 行为等价性

- `restoreShortcutView()`（L424–431）清空 `pendingCommandId` 并在 `editItem` 存在时调用 `editItem.restore()`，与原意图一致；
- `onDeactive` 中其余三行不变，功能完全等价、无行为变化；
- 边界情况（page 已卸载时信号无接收者静默忽略）：第 38 行 `dccData.endKeyCapture()` 与第 40–41 行属性重置仍执行，安全性不降于现状。

## 影响范围

- 改动文件：1 个（`src/plugin-keyboard/qml/Shortcuts.qml`）
- 改动行数：1 行
- 纯 QML 改动，无 C++/API 变更
- 回归风险极低（`requestRestore` 信号路径已被日常使用持续验证）

## 关联

- PMS: https://pms.uniontech.com/task-view-392413.html

## Summary by Sourcery

Bug Fixes:
- Fix the shortcut settings deactivation handler to restore the shortcut view through its existing signal forwarding path, eliminating the QML ReferenceError.