### PR TITLE
fix: sync volume adjustment in real time

### DIFF
--- a/src/plugin-sound/operation/soundworker.cpp
+++ b/src/plugin-sound/operation/soundworker.cpp
@@ -203,7 +203,6 @@ void SoundWorker::setSourceVolume(double volume)
 
 void SoundWorker::setSinkVolume(double volume)
 {
-    qWarning()<<__FUNCTION__<<volume;
     m_soundDBusInter->SetVolumeSink(volume, true);
     qCDebug(DdcSoundWorker) << "set sink volume to " << volume;
 }

--- a/src/plugin-sound/qml/SpeakerPage.qml
+++ b/src/plugin-sound/qml/SpeakerPage.qml
@@ -106,6 +106,10 @@ DccObject {
                     value: dccData.model().speakerVolume
                     to: dccData.model().increaseVolume ? 1.5 : 1.0
                     stepSize: 0.01
+                    onMoved: {
+                        // 实时提交拖动过程中的音量，避免只在松手时生效
+                        dccData.worker().setSinkVolume(voiceTipsSlider.value)
+                    }
                     onPressedChanged: {
                         if (!pressed) {
                             dccData.worker().setSinkVolume(voiceTipsSlider.value)


### PR DESCRIPTION
## 问题描述
音量滑块拖动过程中音量不实时变化，只有松开滑块后才生效（BUG-375031）。

## 修复内容
1. 移除 `setSinkVolume` 函数中多余的调试日志
2. 在 `SpeakerPage.qml` 中添加 `onMoved` 信号处理器，在滑块拖动过程中即时提交音量变更，确保音量实时响应
3. 保留 `onPressedChanged` 处理器，在滑块松开时最终确认音量

## 影响范围
1. 测试拖动音量滑块，验证拖动过程中音量即时变化
2. 验证松手后最终音量值正确
3. 测试支持增强音量（最大 1.5 倍）的系统上的音量调节
4. 验证快速拖动滑块时无性能问题或音频卡顿
5. 检查音量提示和显示百分比实时更新是否正确
6. 测试不同音频输出设备下的音量调节功能

## 关联
- PMS: BUG-375031
- 源提交: 1a1c386c3 (`master`) → cherry-pick 至 `release/2500`

PR 提交内容：cherry-pick 源提交 `1a1c386c3`，包含 2 个文件变更（+4/-1）。

## Summary by Sourcery

Make speaker volume respond immediately to slider movement instead of waiting for release.

Bug Fixes:
- Synchronize speaker volume changes in real time while the volume slider is being dragged, while retaining final confirmation when the slider is released.

Enhancements:
- Remove redundant warning logging from sink-volume updates.