### PR TITLE
refactor: unify dde-apps loading in main thread

### DIFF
--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -12,6 +12,7 @@ if(${QT_NS}_VERSION VERSION_GREATER_EQUAL 6.10)
   find_package(${QT_NS} COMPONENTS QmlModelsPrivate QuickPrivate REQUIRED)
 endif()
 
+find_package(DDEShell REQUIRED)
 target_link_libraries(${DCCFrame_Name} PRIVATE
     ${QT_NS}::Core
 )
@@ -63,6 +64,7 @@ set(Control_Center_Libraries
     ${QT_NS}::Concurrent
     ${QT_NS}::Quick
     dde-control-center-lib
+    Dde::Shell
 )
 
 target_link_libraries(${Control_Center_Name} PRIVATE

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -10,6 +10,11 @@
 #include "pluginmanager.h"
 #include "searchmodel.h"
 
+#include <containment.h>
+#include <pluginloader.h>
+#include <appletbridge.h>
+#include <appletproxy.h>
+
 #include <DGuiApplicationHelper>
 #include <DIconTheme>
 
@@ -138,6 +143,8 @@ void DccManager::init()
     m_engine = new QQmlApplicationEngine(this);
     m_imageProvider = new DccImageProvider();
     m_engine->addImageProvider("DccImage", m_imageProvider);
+
+    loadAppInfos();
 }
 
 QQmlApplicationEngine *DccManager::engine()
@@ -840,6 +847,24 @@ void DccManager::startPendingShow(const QString &url, const QDBusMessage &messag
     m_showUrl = url;
     m_showMessage = message;
     m_showTimer->start();
+}
+
+void DccManager::loadAppInfos()
+{
+    DCC_BENCHMARK("dde-apps", "Load-dde-apps");
+    auto rootApplet = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
+    if (!rootApplet) {
+        qWarning() << "Failed to get root applet for dde-apps";
+        return;
+    }
+
+    auto applet = rootApplet->createApplet(DS_NAMESPACE::DAppletData{"org.deepin.ds.dde-apps"});
+    if (!applet) {
+        qWarning() << "Failed to create dde-apps applet";
+        return;
+    }
+    applet->load();
+    applet->init();
 }
 
 void DccManager::waitShowPage(const QString &url, const QDBusMessage message)

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -105,6 +105,7 @@ private:
     QString parseShowPageUrl(const QString &url, QString &cmd) const;
     void replyShowPageRequest(const QString &url, const QDBusMessage &message, bool found) const;
     void startPendingShow(const QString &url, const QDBusMessage &message);
+    void loadAppInfos();
 
 private Q_SLOTS:
     void saveSize();

--- a/src/plugin-notification/operation/appmgr.cpp
+++ b/src/plugin-notification/operation/appmgr.cpp
@@ -3,8 +3,6 @@
 
 #include "appmgr.h"
 
-#include <containment.h>
-#include <pluginloader.h>
 #include <appletbridge.h>
 #include <appletproxy.h>
 
@@ -81,22 +79,6 @@ void AppMgr::initApplet()
 {
     DS_NAMESPACE::DAppletBridge bridge("org.deepin.ds.dde-apps");
     auto appletProxy = bridge.applet();
-    if (!appletProxy) {
-        auto rootApplet = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
-        if (!rootApplet) {
-            qCWarning(DccNotificationAppMgr) << "Failed to get root applet for dde-apps";
-            return;
-        }
-
-        auto applet = rootApplet->createApplet(DS_NAMESPACE::DAppletData{"org.deepin.ds.dde-apps"});
-        if (!applet) {
-            qCWarning(DccNotificationAppMgr) << "Failed to create dde-apps applet";
-            return;
-        }
-        applet->load();
-        applet->init();
-        appletProxy = bridge.applet();
-    }
 
     if (!appletProxy) {
         qCWarning(DccNotificationAppMgr) << "Failed to get applet proxy for dde-apps";

--- a/src/plugin-privacy/operation/privacysecurityworker.cpp
+++ b/src/plugin-privacy/operation/privacysecurityworker.cpp
@@ -17,10 +17,7 @@
 #include "QCoreApplication"
 #include <QtConcurrent>
 
-#include "applet.h"
-#include <dsglobal.h>
-#include "pluginloader.h"
-#include "containment.h"
+#include <applet.h>
 #include <appletbridge.h>
 
 #include <polkit-qt6-1/PolkitQt1/Authority>
@@ -88,12 +85,7 @@ void PrivacySecurityWorker::init()
     if (!m_pathList.isEmpty())
         return;
     m_dataProxy->init();
-    // TODO：由于控制中心通过子线程加载插件后，会移动插件的加载线程->主线程，
-    // 并删除原有线程->未指定父的对象所处的线程会被删除，所以使用qApp->主线程调用initApp
-    QMetaObject::invokeMethod(qApp, [this]() {
-        initApp();
-    }, Qt::BlockingQueuedConnection);
-
+    initApp();
 
     connect(m_dataProxy, &PrivacySecurityDataProxy::ModeChanged, this, &PrivacySecurityWorker::onModeChanged, Qt::QueuedConnection);
     connect(m_dataProxy, &PrivacySecurityDataProxy::EntityChanged, this, &PrivacySecurityWorker::onEntityChanged, Qt::QueuedConnection);
@@ -120,11 +112,6 @@ void PrivacySecurityWorker::init()
 
 void PrivacySecurityWorker::initApp()
 {
-    auto rootApplet = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
-    auto applet = rootApplet->createApplet(DS_NAMESPACE::DAppletData{"org.deepin.ds.dde-apps"});
-    applet->load();
-    applet->init();
-
     DS_NAMESPACE::DAppletBridge bridge("org.deepin.ds.dde-apps");
     DS_NAMESPACE::DAppletProxy * amAppsProxy = bridge.applet();
 
@@ -148,7 +135,7 @@ void PrivacySecurityWorker::initApp()
                     m_model->removeApplictionItem(appId);
                 }
             }
-        }, Qt::DirectConnection);
+        });
     }
 }
 


### PR DESCRIPTION
Load the dde-apps applet once in DccManager during initialization instead of having each plugin create its own instance. This centralizes lifecycle management, avoids duplicate applet creation across plugins, and ensures applet initialization happens on the main thread natively without workarounds.

Removed redundant applet creation logic from notification AppMgr and privacy PrivacySecurityWorker, along with the BlockingQueuedConnection workaround previously needed for thread safety.

1. Add Dde Shell dependency to CMakeLists for control center
2. Create and load dde-apps applet in DccManager::init()
3. Remove duplicated applet creation from AppMgr
4. Simplify PrivacySecurityWorker to use existing applet
5. Replace BlockingQueuedConnection with direct method call
6. Remove obsolete thread-related comments and includes

Log: Unify dde-apps loading in main thread for control center initialization

Influence:
1. Verify control center starts without errors
2. Test DCC main window loads completely in main thread
3. Check plugin functionality that depends on dde-apps (notification, privacy)
4. Verify no duplicate applet instances are created
5. Test applet initialization order and performance
6. Confirm thread safety with no crashes during startup

refactor: 统一在主线程中加载dde-apps

在DccManager初始化阶段统一加载dde-apps组件，取代各插件自行创建实例的方
式。这集中了生命周期管理，避免跨插件的重复创建，并确保组件在主线程原生初
始化，无需额外线程处理。

移除了通知模块AppMgr和隐私模块PrivacySecurityWorker中重复的组件创建逻
辑，以及此前为线程安全而添加的BlockingQueuedConnection处理。

1. 在CMakeLists中添加Dde Shell依赖
2. 在DccManager::init()中创建并加载dde-apps组件
3. 移除AppMgr中的重复组件创建
4. 简化PrivacySecurityWorker使用现有组件
5. 将BlockingQueuedConnection替换为直接方法调用
6. 移除过时的线程相关注释和头文件

Log: 统一在主线程中加载dde-apps，优化控制中心初始化

Influence:
1. 验证控制中心启动无报错
2. 测试主窗口在主线程中完整加载
3. 检查依赖dde-apps的插件功能（通知、隐私）
4. 确认未创建重复组件实例
5. 测试组件初始化顺序和性能
6. 确认启动期间无线程安全问题崩溃

## Summary by Sourcery

Load the dde-apps applet centrally during control center initialization to provide consistent lifecycle management and eliminate duplicate plugin initialization.

Enhancements:
- Centralize dde-apps applet initialization in DccManager so it is loaded once during main-thread startup and shared by dependent plugins.
- Remove redundant dde-apps creation and thread-synchronization workarounds from notification and privacy plugins.

Build:
- Add the Dde Shell dependency required for centralized applet loading.