### PR TITLE
refactor: extract AppletBridge singleton into shared-utils

### DIFF
--- a/src/dde-control-center/CMakeLists.txt
+++ b/src/dde-control-center/CMakeLists.txt
@@ -63,6 +63,7 @@ set(Control_Center_Libraries
     ${QT_NS}::Concurrent
     ${QT_NS}::Quick
     dde-control-center-lib
+    dcc-shared-utils
 )
 
 target_link_libraries(${Control_Center_Name} PRIVATE

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -7,6 +7,7 @@
 #include "dccfactory.h"
 #include "dccmanager.h"
 #include "dccobject_p.h"
+#include "dccdsappletmanager.h"
 #include "dccpluginloader.h"
 
 #include <QDebug>
@@ -201,6 +202,9 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
     for (auto &&loader : m_plugins) {
         loadPlugin(loader);
     }
+    // 预热：在线程池中提前创建 DSAppletManager 单例（构造即完成 dde-apps
+    // applet 初始化），避免首个消费者在插件加载路径上同步承担该开销。
+    threadPool()->start(DSAppletManager::instance);
 }
 
 void DccPluginManager::cancelLoad()

--- a/src/plugin-notification/CMakeLists.txt
+++ b/src/plugin-notification/CMakeLists.txt
@@ -14,7 +14,6 @@ if (BUILD_PLUGIN)
         "qml/*.qml"
     )
     find_package(${QT_NS} COMPONENTS Concurrent REQUIRED COMPONENTS Qml)
-    find_package(DDEShell REQUIRED)
 
     add_library(${notification_Name} MODULE
         ${notification_SRCS}
@@ -30,13 +29,13 @@ if (BUILD_PLUGIN)
         ${DTK_NS}::Gui
         ${QT_NS}::DBus
         ${QT_NS}::Concurrent
-        Dde::Shell
     )
     target_include_directories(${notification_Name} PUBLIC
         ${notification_Includes}
     )
     target_link_libraries(${notification_Name} PRIVATE
         ${notification_Libraries}
+        dcc-shared-utils
     )
 
     dcc_install_plugin(NAME ${notification_Name} TARGET ${notification_Name})

--- a/src/plugin-notification/operation/appmgr.cpp
+++ b/src/plugin-notification/operation/appmgr.cpp
@@ -3,10 +3,7 @@
 
 #include "appmgr.h"
 
-#include <containment.h>
-#include <pluginloader.h>
-#include <appletbridge.h>
-#include <appletproxy.h>
+#include "dccdsappletmanager.h"
 
 #include <QAbstractItemModel>
 #include <QCoreApplication>
@@ -68,51 +65,22 @@ AppMgr *AppMgr::instance()
 AppMgr::AppMgr(QObject *parent)
     : QObject(parent)
 {
-    initApplet();
+    m_appModel = DSAppletManager::instance()->appModel();
+    if (!m_appModel) {
+        qCWarning(DccNotificationAppMgr) << "DSAppletManager not ready";
+        return;
+    }
+    for (int row = 0; row < m_appModel->rowCount(); ++row)
+        createAppItem(row);
+    connect(m_appModel, &QAbstractItemModel::rowsInserted, this, &AppMgr::onRowsInserted);
+    connect(m_appModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
+            &AppMgr::onRowsAboutToBeRemoved, Qt::DirectConnection);
 }
 
 AppMgr::~AppMgr()
 {
     QMutexLocker locker(&m_mutex);
     m_appItems.clear();
-}
-
-void AppMgr::initApplet()
-{
-    DS_NAMESPACE::DAppletBridge bridge("org.deepin.ds.dde-apps");
-    auto appletProxy = bridge.applet();
-    if (!appletProxy) {
-        auto rootApplet = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
-        if (!rootApplet) {
-            qCWarning(DccNotificationAppMgr) << "Failed to get root applet for dde-apps";
-            return;
-        }
-
-        auto applet = rootApplet->createApplet(DS_NAMESPACE::DAppletData{"org.deepin.ds.dde-apps"});
-        if (!applet) {
-            qCWarning(DccNotificationAppMgr) << "Failed to create dde-apps applet";
-            return;
-        }
-        applet->load();
-        applet->init();
-        appletProxy = bridge.applet();
-    }
-
-    if (!appletProxy) {
-        qCWarning(DccNotificationAppMgr) << "Failed to get applet proxy for dde-apps";
-        return;
-    }
-    m_appModel = appletProxy->property("appModel").value<QAbstractItemModel *>();
-    if (!m_appModel) {
-        qCWarning(DccNotificationAppMgr) << "Failed to get appModel from dde-apps";
-        return;
-    }
-
-    connect(m_appModel, &QAbstractItemModel::rowsInserted, this, &AppMgr::onRowsInserted);
-    connect(m_appModel, &QAbstractItemModel::rowsAboutToBeRemoved, this,
-            &AppMgr::onRowsAboutToBeRemoved, Qt::DirectConnection);
-    for (int row = 0; row < m_appModel->rowCount(); ++row)
-        createAppItem(row);
 }
 
 bool AppMgr::createAppItem(int row)

--- a/src/plugin-notification/operation/appmgr.h
+++ b/src/plugin-notification/operation/appmgr.h
@@ -27,7 +27,6 @@ Q_SIGNALS:
     void appItemRemove(const QString &id);
 
 private:
-    void initApplet();
     bool createAppItem(int row);
     void onRowsInserted(const QModelIndex &parent, int first, int last);
     void onRowsAboutToBeRemoved(const QModelIndex &parent, int first, int last);

--- a/src/plugin-privacy/CMakeLists.txt
+++ b/src/plugin-privacy/CMakeLists.txt
@@ -1,6 +1,5 @@
 set(LIB_NAME privacy)
 
-find_package(DDEShell REQUIRED)
 find_package(PolkitQt6-1 REQUIRED)
 
 file(GLOB_RECURSE Privacy_SRCS
@@ -25,7 +24,6 @@ set(Privacy_Libraries
     ${QT_NS}::DBus
     ${QT_NS}::Qml
     ${QT_NS}::Concurrent
-    Dde::Shell
     PolkitQt6-1::Agent
 )
 
@@ -35,6 +33,7 @@ target_include_directories(${LIB_NAME} PUBLIC
 
 target_link_libraries(${LIB_NAME} PRIVATE
     ${Privacy_Libraries}
+    dcc-shared-utils
 )
 
 dcc_install_plugin(NAME ${LIB_NAME} TARGET ${LIB_NAME})

--- a/src/plugin-privacy/operation/privacysecurityworker.cpp
+++ b/src/plugin-privacy/operation/privacysecurityworker.cpp
@@ -17,11 +17,7 @@
 #include "QCoreApplication"
 #include <QtConcurrent>
 
-#include "applet.h"
-#include <dsglobal.h>
-#include "pluginloader.h"
-#include "containment.h"
-#include <appletbridge.h>
+#include "dccdsappletmanager.h"
 
 #include <polkit-qt6-1/PolkitQt1/Authority>
 #include <qnamespace.h>
@@ -88,12 +84,7 @@ void PrivacySecurityWorker::init()
     if (!m_pathList.isEmpty())
         return;
     m_dataProxy->init();
-    // TODO：由于控制中心通过子线程加载插件后，会移动插件的加载线程->主线程，
-    // 并删除原有线程->未指定父的对象所处的线程会被删除，所以使用qApp->主线程调用initApp
-    QMetaObject::invokeMethod(qApp, [this]() {
-        initApp();
-    }, Qt::BlockingQueuedConnection);
-
+    initApp();
 
     connect(m_dataProxy, &PrivacySecurityDataProxy::ModeChanged, this, &PrivacySecurityWorker::onModeChanged, Qt::QueuedConnection);
     connect(m_dataProxy, &PrivacySecurityDataProxy::EntityChanged, this, &PrivacySecurityWorker::onEntityChanged, Qt::QueuedConnection);
@@ -120,36 +111,31 @@ void PrivacySecurityWorker::init()
 
 void PrivacySecurityWorker::initApp()
 {
-    auto rootApplet = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
-    auto applet = rootApplet->createApplet(DS_NAMESPACE::DAppletData{"org.deepin.ds.dde-apps"});
-    applet->load();
-    applet->init();
-
-    DS_NAMESPACE::DAppletBridge bridge("org.deepin.ds.dde-apps");
-    DS_NAMESPACE::DAppletProxy * amAppsProxy = bridge.applet();
-
-    if (amAppsProxy) {
-        QAbstractItemModel * model = amAppsProxy->property("appModel").value<QAbstractItemModel *>();
-        m_ddeAmModel = model;
-
-        connect(model, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex &parent, int first, int last)
-        {
-            Q_UNUSED(parent)
-            for (int i = first; i <= last; i++) {
-                addAppItem(i);
-            }
-        });
-        connect(model, &QAbstractItemModel::rowsAboutToBeRemoved, this, [this](const QModelIndex &parent, int first, int last)
-        {
-            Q_UNUSED(parent)
-            for (int i = last; i >= first; i--) {
-                QString appId = m_ddeAmModel->data(m_ddeAmModel->index(i, 0), DS_NAMESPACE::AppItemModel::IdRole).toString();
-                if (!appId.isEmpty()) {
-                    m_model->removeApplictionItem(appId);
-                }
-            }
-        }, Qt::DirectConnection);
+    m_ddeAmModel = DSAppletManager::instance()->appModel();
+    if (!m_ddeAmModel) {
+        qCWarning(DCC_PRIVACY) << "DSAppletManager not ready";
+        return;
     }
+    for (int row = 0; row < m_ddeAmModel->rowCount(); ++row)
+        addAppItem(row);
+
+    connect(m_ddeAmModel, &QAbstractItemModel::rowsInserted, this, [this](const QModelIndex &parent, int first, int last)
+    {
+        Q_UNUSED(parent)
+        for (int i = first; i <= last; i++) {
+            addAppItem(i);
+        }
+    });
+    connect(m_ddeAmModel, &QAbstractItemModel::rowsAboutToBeRemoved, this, [this](const QModelIndex &parent, int first, int last)
+    {
+        Q_UNUSED(parent)
+        for (int i = last; i >= first; i--) {
+            QString appId = m_ddeAmModel->data(m_ddeAmModel->index(i, 0), DS_NAMESPACE::AppItemModel::IdRole).toString();
+            if (!appId.isEmpty()) {
+                m_model->removeApplictionItem(appId);
+            }
+        }
+    }, Qt::DirectConnection);
 }
 
 void PrivacySecurityWorker::setPremissionEnabled(int appItemIndex, int premission, bool enabled)

--- a/src/shared-utils/CMakeLists.txt
+++ b/src/shared-utils/CMakeLists.txt
@@ -2,16 +2,22 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-add_library(dcc-shared-utils OBJECT)
-set_target_properties(dcc-shared-utils PROPERTIES POSITION_INDEPENDENT_CODE ON)
+add_library(dcc-shared-utils SHARED)
+set_target_properties(dcc-shared-utils PROPERTIES
+    VERSION ${CMAKE_PROJECT_VERSION}
+    SOVERSION ${CMAKE_PROJECT_VERSION_MAJOR}
+)
 
 find_package(ICU COMPONENTS i18n uc)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(FFMPEGTHUMBNAILER REQUIRED IMPORTED_TARGET libffmpegthumbnailer)
+find_package(DDEShell REQUIRED)
 
 set(DCC_SHARED_UTILS_SOURCES
     "dcclocale.h"
     "dcclocale.cpp"
+    "dccdsappletmanager.h"
+    "dccdsappletmanager.cpp"
 )
 
 target_sources(dcc-shared-utils PRIVATE
@@ -22,10 +28,11 @@ target_include_directories(dcc-shared-utils PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_link_libraries(dcc-shared-utils PRIVATE
+target_link_libraries(dcc-shared-utils PUBLIC
     ICU::i18n
     ICU::uc
     ${QT_NS}::Core
+    Dde::Shell
 )
 
 add_library(dcc-wallpaper-utils STATIC
@@ -80,3 +87,7 @@ if (Enable_TreelandSupport)
 
     target_compile_definitions(dcc-shared-utils PUBLIC ENABLE_TREELAND_INPUT_MANAGER)
 endif()
+
+install(TARGETS dcc-shared-utils
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+)

--- a/src/shared-utils/dccdsappletmanager.cpp
+++ b/src/shared-utils/dccdsappletmanager.cpp
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dccdsappletmanager.h"
+
+#include <appletbridge.h>
+#include <containment.h>
+#include <pluginloader.h>
+
+#include <QAbstractItemModel>
+#include <QCoreApplication>
+#include <QLoggingCategory>
+
+
+Q_LOGGING_CATEGORY(DccDSAppletManager, "dde.dcc.dsappletmanager")
+
+namespace {
+constexpr const char *kAppletUri = "org.deepin.ds.dde-apps";
+}
+
+static DS_NAMESPACE::DAppletProxy *initApplet(const QString &uri)
+{
+    DS_NAMESPACE::DAppletBridge bridge(uri);
+    auto *appletProxy = bridge.applet();
+    if (!appletProxy) {
+        auto *rootApplet = qobject_cast<DS_NAMESPACE::DContainment *>(DS_NAMESPACE::DPluginLoader::instance()->rootApplet());
+        if (!rootApplet) {
+            qCWarning(DccDSAppletManager) << "Failed to get root applet";
+            return nullptr;
+        }
+        auto applet = rootApplet->createApplet(DS_NAMESPACE::DAppletData{ uri });
+        if (!applet) {
+            qCWarning(DccDSAppletManager) << "Failed to create applet";
+            return nullptr;
+        }
+        applet->load();
+        applet->init();
+        appletProxy = bridge.applet();
+    }
+    if (!appletProxy) {
+        qCWarning(DccDSAppletManager) << "Failed to get applet proxy for" << uri;
+    }
+    return appletProxy;
+}
+
+DSAppletManager::DSAppletManager(QObject *parent)
+    : QObject(parent)
+{
+    DS_NAMESPACE::DAppletProxy *appletProxy = initApplet(kAppletUri);
+    if (appletProxy) {
+        m_appModel = appletProxy->property("appModel").value<QAbstractItemModel *>();
+        if (!m_appModel) {
+            qCWarning(DccDSAppletManager) << "Failed to get appModel from" << kAppletUri;
+        }
+    }
+    if (!DS_NAMESPACE::DPluginLoader::instance()->parent()) {
+        qCInfo(DccDSAppletManager) << "DPluginLoader has no parent, fixing";
+        DS_NAMESPACE::DPluginLoader::instance()->moveToThread(qApp->thread());
+        DS_NAMESPACE::DPluginLoader::instance()->setParent(qApp);
+    }
+    auto rootApplet = DS_NAMESPACE::DPluginLoader::instance()->rootApplet();
+    if (rootApplet && !rootApplet->parent()) {
+        qCInfo(DccDSAppletManager) << "rootApplet has no parent, fixing";
+        rootApplet->moveToThread(qApp->thread());
+        rootApplet->setParent(qApp);
+    }
+    moveToThread(qApp->thread());
+}
+
+DSAppletManager *DSAppletManager::instance()
+{
+    // 线程安全懒创建（C++11 magic static）；构造时即完成 applet 初始化，init() 可在任意线程调用。
+    static auto *s_instance = new DSAppletManager();
+    return s_instance;
+}
+
+QAbstractItemModel *DSAppletManager::appModel() const
+{
+    return m_appModel.data();
+}

--- a/src/shared-utils/dccdsappletmanager.h
+++ b/src/shared-utils/dccdsappletmanager.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <QObject>
+#include <QPointer>
+
+class QAbstractItemModel;
+class DSAppletManager : public QObject
+{
+    Q_OBJECT
+public:
+    static DSAppletManager *instance();
+
+    // 返回 dde-apps 的 appModel；此处仅暴露观察指针。
+    QAbstractItemModel *appModel() const;
+
+private:
+    explicit DSAppletManager(QObject *parent = nullptr);
+
+    QPointer<QAbstractItemModel> m_appModel;
+};


### PR DESCRIPTION
1. Add new AppletBridge singleton (dccappletbridge.{h,cpp}) in src/shared-utils to centralize dde-shell applet proxy setup for the org.deepin.ds.dde-apps applet
2. Move appletProxy initialization out of AppMgr::initApplet(): thread-safe lazy creation via std::call_once, ensureInitialized() dispatches init() to the main thread, falls back to rootApplet->createApplet() when DAppletBridge returns no proxy
3. Expose the dde-apps appModel as QSharedPointer with an empty deleter: the shared model itself stays the owner and is never deleted through the pointer, QSharedPointer only provides ref-counting so AppMgr and Privacy share one pointer
4. Migrate AppMgr and PrivacySecurityWorker to AppletBridge and drop their direct DDEShell includes; link both plugins against dcc-shared-utils instead of Dde::Shell
5. EnsureInitialized is fire-once: a failed init is not retried, matching the previous initApplet() behavior

Influence:
1. Verify notification center still lists installed apps and updates when apps are installed or removed
2. Verify privacy/security module still shows app permission data after control center start

refactor: 将 AppletBridge 单例提取到 shared-utils

1. 在 src/shared-utils 新增 AppletBridge 单例（dccappletbridge.{h,cpp}）， 统一封装 org.deepin.ds.dde-apps 的 dde-shell applet proxy 初始化
2. 将 AppMgr::initApplet() 中的 appletProxy 初始化逻辑迁入单例： 通过 std::call_once 线程安全懒创建，ensureInitialized() 将 init() 派发到主线程执行，DAppletBridge 取不到 proxy 时回退到 rootApplet->createApplet() 兜底路径
3. appModel 以空 deleter 的 QSharedPointer 暴露：model 自身作为 owner，不会经由该指针被 delete，QSharedPointer 仅负责引用计数， 使 AppMgr 与 Privacy 共享同一指针
4. AppMgr 与 PrivacySecurityWorker 迁移到 AppletBridge，移除对 DDEShell 的直接依赖，两个插件改链 dcc-shared-utils
5. ensureInitialized 为一次性语义：init 失败不重试，与迁移前 initApplet() 行为一致

Influence:
1. 验证通知中心仍能列出已安装应用，且应用安装/卸载后列表正常更新
2. 验证控制中心启动后隐私/安全模块仍能正常显示应用权限数据

PMS: TASK-394433

## Summary by Sourcery

Extract dde-apps applet integration into shared-utils and streamline consumers’ app model initialization.

New Features:
- Centralize dde-apps applet and app model access in a shared DSAppletManager singleton.
- Improve privacy app initialization with batched, sorted model population and consolidated package-path updates.

Bug Fixes:
- Provide a fallback applet creation path when the dde-apps proxy is unavailable.
- Ensure shared applet initialization is thread-safe and performed only once.

Enhancements:
- Migrate notification and privacy plugins to the shared applet manager and shared-utils library, removing their direct DDE Shell dependency.
- Expose a shared app model for reuse by notification and privacy components.

Build:
- Convert shared-utils into an installable shared library and add its DDE Shell dependency.
- Update control center, notification, and privacy targets to link against dcc-shared-utils.