### PR TITLE
chore: adjust logging levels for normal operation

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -196,13 +196,13 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
 void DccPluginManager::cancelLoad()
 {
     if (m_threadPool) {
-        qCWarning(dccLog()) << "delete threadPool";
+        qCDebug(dccLog()) << "delete threadPool";
         m_threadPool->clear();
         if (!m_threadPool->waitForDone(3000)) {
             qCWarning(dccLog()) << "thread pool waitForDone timeout, some tasks may still be running";
         }
         delete m_threadPool;
-        qCWarning(dccLog()) << "delete threadPool finish";
+        qCDebug(dccLog()) << "delete threadPool finish";
         m_threadPool = nullptr;
     }
 }

--- a/src/plugin-authentication/operation/charamangerworker.cpp
+++ b/src/plugin-authentication/operation/charamangerworker.cpp
@@ -375,7 +375,7 @@ void CharaMangerWorker::refreshFingerEnrollList(const QString &id)
 
 void CharaMangerWorker::stopFingerEnroll(const QString &userName)
 {
-    qDebug() << "stopEnroll";
+    qDebug() << "stopEnroll for user: " << userName;
     m_charaMangerInter->StopEnroll();
 }
 

--- a/src/plugin-personalization/operation/personalizationmodel.cpp
+++ b/src/plugin-personalization/operation/personalizationmodel.cpp
@@ -214,7 +214,7 @@ void PersonalizationModel::setLinePowerScreenSaverIdleTime(int value)
         return;
 
     m_linePowerScreenSaverIdleTime = value;
-    qWarning() << "model: setLinePowerScreenSaverIdleTime" << value << m_linePowerScreenSaverIdleTime;
+    qDebug() << "model: setLinePowerScreenSaverIdleTime" << value << m_linePowerScreenSaverIdleTime;
     Q_EMIT linePowerScreenSaverIdleTimeChanged(value);
 }
 


### PR DESCRIPTION
1. Change thread pool deletion messages in plugin manager from warning to debug level
2. Change screen saver idle time setter logging in personalization model from warning to debug
3. These messages represent normal lifecycle operations, not error conditions

Influence:
1. Run control center and verify plugin loading/unloading completes without errors
2. Navigate to personalization settings and adjust screen saver idle time
3. Check debug logs to verify the messages appear at debug level along with correct values

chore: 调整正常操作的日志级别

1. 将插件管理器中线程池删除消息从警告级别调整为调试级别
2. 将个性化设置中屏幕保护空闲时间设置器的日志从警告级别调整为调试级别
3. 这些消息代表正常的生命周期操作，而非错误条件

Log: 调整插件管理器和个性化设置中正常操作的日志级别

Influence:
1. 运行控制中心，验证插件加载/卸载过程无错误
2. 进入个性化设置，调整屏幕保护空闲时间
3. 检查调试日志，确认消息出现在调试级别且数值正确

PMS: TASK-392413

## Summary by Sourcery

Adjust routine operation logging to avoid treating expected lifecycle actions as warnings while retaining useful debug context.

Enhancements:
- Reduce normal plugin thread-pool lifecycle and personalization screen-saver updates from warning-level to debug-level logging.
- Add the affected username to fingerprint enrollment stop debug logs.