### PR TITLE
fix(grub2): pass fd to SetBackgroundSourceFile instead of file path

### DIFF
--- a/src/plugin-commoninfo/operation/commoninfoproxy.cpp
+++ b/src/plugin-commoninfo/operation/commoninfoproxy.cpp
@@ -1,4 +1,4 @@
-//SPDX-FileCopyrightText: 2018 - 2023 UnionTech Software Technology Co., Ltd.
+//SPDX-FileCopyrightText: 2018 - 2026 UnionTech Software Technology Co., Ltd.
 //
 //SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -12,6 +12,9 @@
 #include <QDBusArgument>
 #include <QDBusReply>
 #include <QDBusConnectionInterface>
+#include <QDBusUnixFileDescriptor>
+#include <QFile>
+#include <QFileInfo>
 #include <QLoggingCategory>
 
 namespace {
@@ -285,7 +288,28 @@ QString CommonInfoProxy::Background()
 
 void CommonInfoProxy::setBackground(const QString &name)
 {
-    m_grubThemeInter->asyncCallWithArgumentList("SetBackgroundSourceFile", { name });
+    QFileInfo info(name);
+    if (!info.isFile() || !info.isReadable()) {
+        qWarning(dcCommonLog) << "Background file is not readable:" << name;
+        Q_EMIT BackgroundChanged();
+        return;
+    }
+
+    QFile file(name);
+    if (!file.open(QIODevice::ReadOnly)) {
+        qWarning(dcCommonLog) << "Failed to open background file:" << name << file.errorString();
+        Q_EMIT BackgroundChanged();
+        return;
+    }
+
+    QDBusUnixFileDescriptor fd(file.handle());
+    if (!fd.isValid()) {
+        qWarning(dcCommonLog) << "Invalid file descriptor for background file:" << name;
+        Q_EMIT BackgroundChanged();
+        return;
+    }
+
+    m_grubThemeInter->asyncCallWithArgumentList("SetBackgroundSourceFile", { QVariant::fromValue(fd) });
 }
 
 int CommonInfoProxy::AuthorizationState()


### PR DESCRIPTION
1. Adapt to dde-daemon change: SetBackgroundSourceFile now accepts a D-Bus UnixFD instead of a file path
2. Validate the background file is a readable regular file, then open it and pass its file descriptor to the daemon service
3. Emit BackgroundChanged and skip the call on validation failures

Log: Send an open file descriptor instead of a file path to SetBackgroundSourceFile, matching the hardened daemon D-Bus interface

Influence:
1. Verify setting grub2 theme background from control center still works after the daemon interface change
2. Verify an unreadable or missing background file is skipped with a warning and the UI state refreshes via BackgroundChanged
3. Verify the daemon receives a valid UnixFD and the grub theme is applied as before

fix(grub2): SetBackgroundSourceFile 改为传递 fd 而非文件路径

1. 适配 dde-daemon 变更：SetBackgroundSourceFile 现接收 D-Bus UnixFD
2. 校验背景文件为可读的常规文件后打开文件，将文件描述符传给 daemon 服务
3. 校验失败时发出 BackgroundChanged 并跳过调用

Log: 向 SetBackgroundSourceFile 传递打开的文件描述符而非文件路径，
匹配 daemon 加固后的 D-Bus 接口

Influence:
1. 验证 daemon 接口变更后从控制中心设置 grub2 主题背景仍正常工作
2. 验证背景文件不可读或不存在时跳过调用并输出警告，UI 状态通过 BackgroundChanged 刷新
3. 验证 daemon 收到有效的 UnixFD 且 grub 主题照常生效

PMS: BUG-376055

## Summary by Sourcery

Pass validated, readable background file descriptors to the GRUB2 daemon when setting theme backgrounds.

Bug Fixes:
- Update GRUB2 background changes to use the daemon's Unix file descriptor interface, preserving theme application after the D-Bus API change.
- Handle missing, unreadable, or unopenable background files by warning, refreshing background state, and skipping the daemon request.