### PR TITLE
fix(SearchBar): use Popup.Window to allow popup beyond window boundary

### DIFF
--- a/src/dde-control-center/plugin/SearchBar.qml
+++ b/src/dde-control-center/plugin/SearchBar.qml
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.15
+import QtQuick.Window 2.15
 import org.deepin.dtk 1.0
 import QtQuick.Layouts 1.15
 
@@ -101,10 +102,28 @@ Rectangle {
     }
     Popup {
         id: popup
-        y: 35
+        popupType: Popup.Window
+        closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent
+
+        PopupHandle.enableBlurWindow: true
+
         width: searchEdit.width > 308 ? searchEdit.width : 308
         height: (view.count > 7 ? 7 : view.count) * 32 + 15
         padding: 5
+
+        function positionWindow() {
+            var globalPos = searchEdit.mapToGlobal(0, 0)
+            var w = Window.window
+            if (w) {
+                var localPos = w.mapFromGlobal(globalPos.x, globalPos.y)
+                x = localPos.x
+                y = localPos.y + searchEdit.height
+            }
+        }
+
+        onOpened: {
+            positionWindow()
+        }
         ListView {
             id: view
             clip: true
@@ -145,22 +164,11 @@ Rectangle {
                 to: 1.0
                 duration: 150
             }
-            NumberAnimation {
-                property: "scale"
-                from: 0.0
-                to: 1.0
-                duration: 150
-            }
         }
 
         exit: Transition {
             NumberAnimation {
                 property: "opacity"
-                to: 0.0
-                duration: 150
-            }
-            NumberAnimation {
-                property: "scale"
                 to: 0.0
                 duration: 150
             }


### PR DESCRIPTION
## 问题

控制中心搜索栏的 Popup 默认使用 `Popup.Item` 类型，弹窗在父窗口场景内渲染，被主窗口边界裁剪，无法超出窗口显示。

## 修复方案

将搜索结果 Popup 改为 `popupType: Popup.Window` 独立平台窗口模式，使其可超出主窗口边界渲染。

## 改动内容

1. 新增 `import QtQuick.Window 2.15`，提供 `Window.window` 附加属性用于全局坐标映射。
2. `popupType: Popup.Window` — 独立平台窗口渲染，解决裁剪问题。
3. `PopupHandle.enableBlurWindow: true` — 与 datetime 插件一致的模糊/圆角外观。
4. `closePolicy: Popup.CloseOnEscape | Popup.CloseOnPressOutsideParent` — Window 模式下点击外部和 Esc 可关闭。
5. 新增 `positionWindow()` 函数，通过 `searchEdit.mapToGlobal(0, 0)` + `Window.window.mapFromGlobal()` 映射坐标定位，在 `onOpened` 中调用。参考 datetime 插件 `SearchableListViewPopup.positionWindow()` 实现。
6. 移除 `enter`/`exit` 的 `scale` 动画，仅保留 `opacity` 过渡。

## 参考

- datetime 插件 commit `f4845fcc0`（`SearchableListViewPopup.qml`、`RegionsChooserWindow.qml`）
- [Qt 文档: popupType](https://doc.qt.io/qt-6/qml-qtquick-controls-popup.html#popupType-prop)

## 焦点说明

SearchBar 的 `searchEdit` 位于主窗口中（不在 Popup 内部），Up/Down/Enter/Escape 键盘导航由 `searchEdit.Keys.onPressed` 处理。`Popup.Window`（Qt::Tool 类型）不会抢占主窗口键盘焦点，`searchEdit` 保持焦点，现有键盘导航继续可用。

Log: fix popup clipping issue
Bug: https://github.com/linuxdeepin/dde-control-center

## Summary by Sourcery

Render SearchBar results in a separately positioned window so the popup can extend beyond the main window boundary.

Bug Fixes:
- Allow the SearchBar results popup to render beyond the main window boundary without being clipped.

Enhancements:
- Position the popup relative to the search field using global coordinates, preserve keyboard and outside-click dismissal behavior, and align its appearance with other window-based popups.
- Simplify popup transitions by retaining opacity animation without scale animation.