### PR TITLE
fix(time-range): restore field display on focus loss

### DIFF
--- a/src/dde-control-center/plugin/DccTimeRange.qml
+++ b/src/dde-control-center/plugin/DccTimeRange.qml
@@ -108,16 +108,18 @@ D.SpinBox {
             inputMethodHints: control.inputMethodHints
             selectByMouse: true
             mouseSelectionMode: TextInput.SelectCharacters
-            onFocusChanged: {
-                if (focus) {
+            onActiveFocusChanged: {
+                if (activeFocus) {
                     control.stepSize = 60
                     var minutes = value % 60
                     control.from = minutes
                     control.to = 23 * 60 + minutes
                 } else {
                     typingDigit = false
+                    text = control.formatText(Math.floor(control.value / 60))
                 }
             }
+
             Keys.onPressed: function(event) {
                 if (event.key >= Qt.Key_0 && event.key <= Qt.Key_9) {
                     typingDigit = true
@@ -155,6 +157,7 @@ D.SpinBox {
                     var m = control.value % 60
                     control.value = h * 60 + m
                 }
+                text = control.formatText(Math.floor(control.value / 60))
             }
         }
         Label {
@@ -187,12 +190,14 @@ D.SpinBox {
             inputMethodHints: control.inputMethodHints
             selectByMouse: true
             mouseSelectionMode: TextInput.SelectCharacters
-            onFocusChanged: {
-                if (focus) {
+            onActiveFocusChanged: {
+                if (activeFocus) {
                     control.stepSize = 1
                     var hours = Math.floor(value / 60)
                     control.from = hours * 60
                     control.to = hours * 60 + 59
+                } else {
+                    text = control.formatText(control.value % 60)
                 }
             }
             Keys.onLeftPressed: function(event) {
@@ -210,6 +215,7 @@ D.SpinBox {
                     var h = Math.floor(control.value / 60)
                     control.value = h * 60 + m
                 }
+                text = control.formatText(control.value % 60)
             }
         }
     }


### PR DESCRIPTION
## Summary
Fix BUG-375847: when deleting digits in the scheduled-shutdown time fields, clicking a blank area did not restore the display to the current value (e.g. leaving a partial "0" instead of "00").

## Root cause
- Editing a `TextInput` breaks the `text:` binding, so the display stops following `value`.
- `onFocusChanged` does not fire on window-level focus loss (clicking blank / Tab away), because `focus` is a FocusScope-local flag that stays set; only `activeFocus` (window-level) changes. Hence the fields never re-synced.

## Change
- Switch both hour/minute inputs from `onFocusChanged` to `onActiveFocusChanged`.
- On focus loss, restore the field text from the current `control.value` (unconditionally, covering both partially-deleted and fully-cleared fields).
- Keep the unconditional display resync in `onEditingFinished` so manually entered times still commit correctly (previous BUG-371785 fix).

## Verification
- QML behavioral tests (QtTest, real key events + window focus loss): delete one digit / delete all digits → blur → field restores to current value; typed values still apply.
- `qmllint` clean; rebuilt `dde-control-center`.

PMS: BUG-375847

## Summary by Sourcery

Restore scheduled-shutdown time field values after editing and focus loss while preserving committed manual input.

Bug Fixes:
- Restore hour and minute field displays to the current scheduled-shutdown value when focus is lost, including after partially or completely deleting input.
- Ensure manually entered time values continue to be reflected in the fields after editing completes.

Enhancements:
- Use window-level focus changes to reliably synchronize time-range input fields when focus leaves the control.