### PR TITLE
feat: refactor navigation page structure for system settings

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -216,6 +216,21 @@ bool DccManager::isTreeland() const
     return Dtk::Gui::DGuiApplicationHelper::testAttribute(Dtk::Gui::DGuiApplicationHelper::IsWaylandPlatform);
 }
 
+bool DccManager::isServerSystem() const
+{
+    return DSysInfo::uosType() == DSysInfo::UosServer;
+}
+
+bool DccManager::isCommunitySystem() const
+{
+    return DSysInfo::uosEditionType() == DSysInfo::UosCommunity;
+}
+
+bool DccManager::isDeepin() const
+{
+    return DSysInfo::isDeepin();
+}
+
 DccObject *DccManager::object(const QString &name)
 {
     return findObject(name);

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -57,6 +57,9 @@ public:
     Q_INVOKABLE Dtk::Core::DSysInfo::ProductType productType() const;
 
     Q_INVOKABLE bool isTreeland() const;
+    Q_INVOKABLE bool isServerSystem() const;
+    Q_INVOKABLE bool isCommunitySystem() const;
+    Q_INVOKABLE bool isDeepin() const;
 
     inline const QSet<QString> &hideModule() const { return m_hideModule; }
 

--- a/src/plugin-commoninfo/qml/CommonInfoMain.qml
+++ b/src/plugin-commoninfo/qml/CommonInfoMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
 import QtQuick 2.15
@@ -8,22 +8,6 @@ import org.deepin.dcc 1.0
 import QtQuick.Layouts 1.15
 
 DccObject {
-    DccObject {
-        name: "bootMenu"
-        parentName: "system"
-        displayName: qsTr("Boot Menu")
-        description: qsTr("Manage your boot menu")
-        icon: "meau"
-        weight: 80
-        BootPage {}
-    }
-    DccObject {
-        name: "developerMode"
-        parentName: "system"
-        displayName: qsTr("Developer Options")
-        description: !dccData.mode().isCommunitySystem() ? qsTr("Developer root permission management") : qsTr("Developer debugging options")
-        icon: "developer"
-        weight: 90
-        DevelopModePage {}
-    }
+    BootPage {}
+    DevelopModePage {}
 }

--- a/src/plugin-datetime/qml/Datetime.qml
+++ b/src/plugin-datetime/qml/Datetime.qml
@@ -3,10 +3,32 @@
 import org.deepin.dcc 1.0
 
 DccObject {
-    name: "datetime"
-    parentName: "system"
-    displayName: qsTr("Time and date")
-    description: qsTr("Time and date, time zone settings")
-    icon: "dcc_time_date"
-    weight: 40
+    DccObject {
+        name: "datetime"
+        parentName: "system"
+        displayName: qsTr("Time and date")
+        description: qsTr("Time and date, time zone settings")
+        icon: "dcc_time_date"
+        weight: 40
+    }
+    DccObject {
+        id: langAndFormat
+        name: "langAndFormat"
+        parentName: "system"
+        displayName: qsTr("Language and region")
+        description: qsTr("System language, regional formats")
+        icon: "dcc_lang_format"
+        weight: 45
+        visible: false
+        DccDBusInterface {
+            property var locales
+            service: "org.deepin.dde.LangSelector1"
+            path: "/org/deepin/dde/LangSelector1"
+            inter: "org.deepin.dde.LangSelector1"
+            connection: DccDBusInterface.SessionBus
+            onLocalesChanged: langAndFormat.visible = true
+        }
+    }
 }
+
+

--- a/src/plugin-datetime/qml/DatetimeMain.qml
+++ b/src/plugin-datetime/qml/DatetimeMain.qml
@@ -5,23 +5,5 @@
 import org.deepin.dcc 1.0
 
 TimeAndDate {
-    DccObject {
-        id: langAndFormat
-        name: "langAndFormat"
-        parentName: "system"
-        displayName: qsTr("Language and region")
-        description: qsTr("System language, regional formats")
-        icon: "dcc_lang_format"
-        weight: 45
-        visible: false
-        DccDBusInterface {
-            property var locales
-            service: "org.deepin.dde.LangSelector1"
-            path: "/org/deepin/dde/LangSelector1"
-            inter: "org.deepin.dde.LangSelector1"
-            connection: DccDBusInterface.SessionBus
-            onLocalesChanged: langAndFormat.visible = true
-        }
-        LangAndFormat {}
-    }
+    LangAndFormat {}
 }

--- a/src/plugin-systeminfo/operation/systeminfomodel.cpp
+++ b/src/plugin-systeminfo/operation/systeminfomodel.cpp
@@ -125,11 +125,6 @@ bool SystemInfoModel::showAuthorization() const
     return !(IS_COMMUNITY_SYSTEM || DSysInfo::UosEditionUnknown == DSysInfo::uosEditionType()) && DSysInfo::uosEditionType() != DSysInfo::UosEnterpriseC;
 }
 
-bool SystemInfoModel::showUserExperienceProgram() const
-{
-    return !IS_SERVER_SYSTEM && !IS_COMMUNITY_SYSTEM && DSysInfo::isDeepin();
-}
-
 bool SystemInfoModel::showGraphicsPlatform() const
 {
     return  IS_COMMUNITY_SYSTEM;

--- a/src/plugin-systeminfo/operation/systeminfomodel.h
+++ b/src/plugin-systeminfo/operation/systeminfomodel.h
@@ -118,7 +118,6 @@ public:
     void setSystemInstallationDate(const QString &newSystemInstallationDate);
 
     Q_INVOKABLE bool showAuthorization() const;
-    Q_INVOKABLE bool showUserExperienceProgram() const;
     Q_INVOKABLE bool showGraphicsPlatform() const;
 
     QString graphicsPlatform() const;

--- a/src/plugin-systeminfo/qml/SystemInfo.qml
+++ b/src/plugin-systeminfo/qml/SystemInfo.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 import QtQuick 2.0
 import QtQuick.Controls 2.0
@@ -17,5 +17,48 @@ DccTitleObject {
         if (parentItem) {
             parentItem.topPadding = 10
         }
+    }
+
+    DccObject {
+        name: "systemInfo"
+        parentName: "system"
+        displayName: qsTr("About This PC")
+        description: qsTr("System version, device information")
+        icon: "about"
+        weight: 1010
+    }
+    DccObject {
+        name: "versionProtocol"
+        parentName: "system"
+        displayName: qsTr("Open Source Software Notice")
+        description: qsTr("View the notice of open source software")
+        icon: "software_declaration"
+        weight: 1020
+    }
+    DccObject {
+        name: "userExperienceProgram"
+        parentName: "system"
+        displayName: qsTr("User Experience Program")
+        description: qsTr("Join the user experience program to help improve the product")
+        icon: "user_experience_plan"
+        visible: !DccApp.isServerSystem() && !DccApp.isCommunitySystem() && DccApp.isDeepin()
+        weight: 1030
+    }
+    DccObject {
+        name: "userLicense"
+        parentName: "system"
+        displayName: qsTr("End User License Agreement")
+        description: qsTr("View the end  user license agreement")
+        icon: "user_license_agreement"
+        visible: true
+        weight: 1040
+    }
+    DccObject {
+        name: "privacyPolicy"
+        parentName: "system"
+        displayName: qsTr("Privacy Policy")
+        description: qsTr("View information about privacy policy")
+        icon: "privacy_policy"
+        weight: 1050
     }
 }

--- a/src/plugin-systeminfo/qml/SystemInfoMain.qml
+++ b/src/plugin-systeminfo/qml/SystemInfoMain.qml
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2024 - 2027 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2024 - 2026 UnionTech Software Technology Co., Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 // import org.deepin.dtk 1.0 as D
 import QtQuick 2.15
@@ -8,51 +8,9 @@ import org.deepin.dcc 1.0
 import QtQuick.Layouts 1.15
 
 DccObject {
-    DccObject {
-        name: "systemInfo"
-        parentName: "system"
-        displayName: qsTr("About This PC")
-        description: qsTr("System version, device information")
-        icon: "about"
-        weight: 1010
-        NativeInfoPage{}
-    }
-    DccObject {
-        name: "versionProtocol"
-        parentName: "system"
-        displayName: qsTr("Open Source Software Notice")
-        description: qsTr("View the notice of open source software")
-        icon: "software_declaration"
-        weight: 1020
-        VersionProtocolPage{}
-    }
-    DccObject {
-        name: "userExperienceProgram"
-        parentName: "system"
-        displayName: qsTr("User Experience Program")
-        description: qsTr("Join the user experience program to help improve the product")
-        icon: "user_experience_plan"
-        weight: 1030
-        visible: dccData.systemInfoMode().showUserExperienceProgram()
-        UserExperienceProgramPage{}
-    }
-    DccObject {
-        name: "userLicense"
-        parentName: "system"
-        displayName: qsTr("End User License Agreement")
-        description: qsTr("View the end  user license agreement")
-        icon: "user_license_agreement"
-        visible: true
-        weight: 1040
-        UserLicensePage{}
-    }
-    DccObject {
-        name: "privacyPolicy"
-        parentName: "system"
-        displayName: qsTr("Privacy Policy")
-        description: qsTr("View information about privacy policy")
-        icon: "privacy_policy"
-        weight: 1050
-        PrivacyPolicyPage{}
-    }
+    NativeInfoPage{}
+    VersionProtocolPage{}
+    UserExperienceProgramPage{}
+    UserLicensePage{}
+    PrivacyPolicyPage{}
 }


### PR DESCRIPTION
1. Move navigation object definitions (name, parentName, displayName, etc.) from respective page QML files to a unified structure within the main QML files
2. Add `isServerSystem()`, `isCommunitySystem()`, and `isDeepin()` methods to DccManager for centralized system type detection
3. Relocate "About This PC", "Open Source Software Notice", "User Experience Program", "End User License Agreement", and "Privacy Policy" navigation entries to SystemInfo.qml
4. Relocate boot menu and developer mode entries to the top-level CommonInfoMain.qml structure
5. Move datetime and language/region entries within the Datetime.qml structure
6. Remove `showUserExperienceProgram()` method from SystemInfoModel and instead use DccManager methods for visibility checks

This refactoring consolidates navigation page definitions into their parent main QML files, making the navigation hierarchy more centralized and easier to maintain. It also reduces duplicate code by providing global system type check functions via DccManager.

Log: Refactored navigation structure for system settings pages

Influence:
1. Verify system settings pages appear correctly in the navigation sidebar
2. Test visibility of "User Experience Program" entry across different system types (server, community, deepin)
3. Check boot menu and developer options settings still function correctly
4. Verify datetime and language/region settings are accessible and properly ordered
5. Ensure all system info subpages (About This PC, Open Source Software Notice, etc.) open correctly

feat: 重构系统设置导航页面结构

1. 将导航对象定义（名称、父名称、显示名称等）从各个页面 QML 文件统一移动 到主 QML 文件结构中
2. 在 DccManager 中新增 `isServerSystem()`、`isCommunitySystem()` 和 `isDeepin()` 方法，用于集中式系统类型检测
3. 将"关于本机"、"开源软件声明"、"用户体验计划"、"最终用户许可协议"和"隐 私政策"导航项移至 SystemInfo.qml
4. 将启动菜单和开发者模式条目移至 CommonInfoMain.qml 顶层结构中
5. 将日期时间和语言/区域条目在 Datetime.qml 结构中重新调整位置
6. 从 SystemInfoModel 中移除 `showUserExperienceProgram()` 方法，改用 DccManager 方法进行可见性判断

此重构将导航页面定义整合到其父级主 QML 文件中，使导航层次结构更加集中且
易于维护，同时通过 DccManager 提供全局系统类型检查函数，减少重复代码。

Log: 重构系统设置导航页面结构

Influence:
1. 验证系统设置页面在导航侧边栏中正确显示
2. 测试"用户体验计划"条目在不同系统类型（服务器版、社区版、deepin）下的 可见性
3. 检查启动菜单和开发者模式设置功能是否正常
4. 验证日期时间和语言/区域设置可正常访问且排序正确
5. 确保系统信息所有子页面（关于本机、开源软件声明等）能正常打开

## Summary by Sourcery

Consolidate system settings navigation ownership and centralize platform-specific visibility checks.

Enhancements:
- Centralize system settings navigation definitions within their parent QML structures, including system information, boot/developer options, and date/time settings.
- Expose centralized system type detection through DccManager and use it to control User Experience Program visibility.

Chores:
- Remove the redundant SystemInfoModel user-experience visibility API.