### PR TITLE
fix: correct DccObject data access and page transition properties

### DIFF
--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -121,14 +121,15 @@ void DccPluginManager::loadPlugin(DccPluginLoader *loader)
         checkNavigationFinished();
     } else if ((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) {
         loader->transitionStatus(DccPluginLoader::ModuleLoad);
-        if (loader->loadModule()) {
+        const auto ret = loader->loadModule();
+        if (auto module = loader->module()) {
+            Q_EMIT addObject(module);
+        }
+        if (ret) {
             loader->transitionStatus(DccPluginLoader::ModuleEnd);
             Q_EMIT moduleLoaded(loader->name());
         } else {
             loader->transitionStatus(DccPluginLoader::ModuleEnd | DccPluginLoader::PluginEnd);
-        }
-        if (loader->module()) {
-            Q_EMIT addObject(loader->module());
         }
     } else {
         if (loader->loadMetaData()) {
@@ -202,8 +203,6 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
     for (auto &&loader : m_plugins) {
         loadPlugin(loader);
     }
-    // 预热：在线程池中提前创建 DSAppletManager 单例（构造即完成 dde-apps
-    // applet 初始化），避免首个消费者在插件加载路径上同步承担该开销。
     checkNavigationFinished();
 }
 
@@ -231,8 +230,10 @@ void DccPluginManager::checkNavigationFinished()
 
 void DccPluginManager::startDataPhase()
 {
-    threadPool()->start(DSAppletManager::instance);
     DccAppTimeline::instance().log(QStringLiteral("data-phase-start"));
+    // 预热：在线程池中提前创建 DSAppletManager 单例（构造即完成 dde-apps
+    // applet 初始化），避免首个消费者在插件加载路径上同步承担该开销。
+    threadPool()->start(DSAppletManager::instance);
     for (auto &&loader : m_plugins) {
         if ((loader->status() & DccPluginLoader::PluginEnd)
             || !(loader->status() & DccPluginLoader::ModuleEnd)

--- a/src/plugin-commoninfo/qml/CommonInfo.qml
+++ b/src/plugin-commoninfo/qml/CommonInfo.qml
@@ -16,7 +16,7 @@ DccObject {
         name: "developerMode"
         parentName: "system"
         displayName: qsTr("Developer Options")
-        description: !dccData.mode().isCommunitySystem() ? qsTr("Developer root permission management") : qsTr("Developer debugging options")
+        description: !DccApp.isCommunitySystem() ? qsTr("Developer root permission management") : qsTr("Developer debugging options")
         icon: "developer"
         weight: 90
     }


### PR DESCRIPTION
1. Replace `dccData.mode().isCommunitySystem()` with `DccApp.isCommunitySystem()` in CommonInfo.qml to use the proper singleton accessor
2. Change `popEnter`/`popExit` to `replaceEnter`/`replaceExit` transitions in SecondPage.qml for correct StackView behavior during page replacement

The previous code referenced `dccData`, which is not available in this plugin context. Switching to the `DccApp` singleton ensures the community system detection works correctly. Additionally, the StackView transitions were misnamed - when pages are replaced (not pushed/popped), the proper transition properties are `replaceEnter` and `replaceExit`.

Log: Fixed developer options description and page replacement animations

Influence:
1. Navigate to System Information > Developer Options and verify the description text displays correctly for both community and commercial systems
2. Test page navigation in the control center, verifying that page transitions appear smooth when replacing pages
3. Verify no runtime errors appear in console related to `dccData` access

fix: 修正 DccObject 数据访问和页面切换属性

1. 在 CommonInfo.qml 中将 `dccData.mode().isCommunitySystem()` 替换为 `DccApp.isCommunitySystem()` 以使用正确的单例访问器
2. 将 SecondPage.qml 中的 `popEnter`/`popExit` 转换为 `replaceEnter`/ `replaceExit` 过渡，以在页面替换时正确执行 StackView 行为

之前的代码引用了 `dccData`，但该对象在此插件上下文中不可用。切换到
`DccApp` 单例可确保社区系统检测正常工作。此外，StackView 过渡命名错误——
当页面被替换（而非推入/弹出）时，应使用 `replaceEnter` 和 `replaceExit` 作为过渡属性。

Log: 修复开发者选项描述和页面切换动画

Influence:
1. 导航到系统信息 > 开发者选项，验证社区版和商业版系统的描述文本是否显示 正确
2. 测试控制中心页面导航，验证页面替换时切换动画是否流畅
3. 验证控制台是否出现与 `dccData` 相关的运行时错误

## Summary by Sourcery

Correct plugin loading notifications, system-specific Developer Options descriptions, and startup/page transition behavior.

Bug Fixes:
- Use the available DccApp singleton to correctly determine the system type for Developer Options descriptions.
- Emit loaded plugin module objects as soon as they become available.
- Use the appropriate replacement transition behavior for page navigation.

Enhancements:
- Reorder data-phase initialization so application startup work is logged before prewarming the applet manager.