### PR TITLE
fix: refactor page switching and remove deferred transition logic

### DIFF
--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -71,9 +71,11 @@ DccManager::DccManager(QObject *parent)
     , m_showFallbackTimer(nullptr)
     , m_showPagePending(false)
     , m_showLoadPage(!isTreeland())
+    , m_showOnNavigationReady(false)
     , m_needShow(false)
     , m_windowShown(false)
     , m_pageShown(false)
+    , m_allPluginsLoaded(false)
 #ifdef HAVE_DDE_API_EVENTLOGGER
     , m_pageStayTimer(nullptr)
 #endif
@@ -103,7 +105,8 @@ DccManager::DccManager(QObject *parent)
 
     initConfig();
     connect(m_plugins, &DccPluginManager::addObject, this, &DccManager::addObject);
-    connect(m_plugins, &DccPluginManager::navigationReady, this, &DccManager::handleShowReady, Qt::QueuedConnection);
+    connect(m_plugins, &DccPluginManager::navigationReady, this, &DccManager::handleNavigationReady, Qt::QueuedConnection);
+    connect(m_plugins, &DccPluginManager::loadAllFinished, this, &DccManager::handleLoadFinished, Qt::QueuedConnection);
     m_showTimer = new QTimer(this);
     m_showTimer->setInterval(60);
     m_showTimer->setSingleShot(true);
@@ -170,6 +173,11 @@ void DccManager::setPlugins(const QStringList &plugins)
     m_plugins->setPlugins(plugins);
 }
 
+void DccManager::setShowOnNavigationReady(bool enabled)
+{
+    m_showOnNavigationReady = enabled;
+}
+
 void DccManager::loadModules(bool async, const QStringList &dirs)
 {
     // onAddModule(m_rootModule);
@@ -232,6 +240,11 @@ bool DccManager::isCommunitySystem() const
 bool DccManager::isDeepin() const
 {
     return DSysInfo::isDeepin();
+}
+
+void DccManager::logTimeline(const QString &stage, const QString &detail) const
+{
+    DccAppTimeline::instance().log(stage, detail);
 }
 
 DccObject *DccManager::object(const QString &name)
@@ -646,6 +659,14 @@ bool DccManager::isEqual(const QString &url, const DccObject *obj)
     return isEqualByName(url, obj->parentName() + "/" + obj->name());
 }
 
+bool DccManager::isObjectAttached(const DccObject *obj) const
+{
+    while (obj && obj != m_root) {
+        obj = DccObject::Private::FromObject(obj)->getParent();
+    }
+    return obj == m_root;
+}
+
 DccObject *DccManager::findObject(const QString &url)
 {
     if (!m_root || url.isEmpty()) {
@@ -880,14 +901,19 @@ void DccManager::waitShowPage(const QString &url, const QDBusMessage message)
         obj = m_root;
         showPage(obj, QString());
     } else {
-        const QString path = parseShowPageUrl(url, cmd);
-        const auto objs = findObjects(path, true);
-        obj = objs.isEmpty() ? nullptr : objs.first();
-        if (obj) {
-            showPage(obj, cmd);
-        } else if (!m_plugins->loadFinished()) {
+        if (!m_plugins->loadFinished()) {
             startPendingShow(url, message);
             return;
+        }
+
+        const QString path = parseShowPageUrl(url, cmd);
+        const auto objs = findObjects(path);
+        const auto it = std::find_if(objs.cbegin(), objs.cend(), [this](const DccObject *candidate) {
+            return isObjectAttached(candidate);
+        });
+        obj = it == objs.cend() ? nullptr : *it;
+        if (obj) {
+            showPage(obj, cmd);
         }
     }
 
@@ -903,6 +929,25 @@ void DccManager::clearShowParam()
     }
 }
 
+void DccManager::handleNavigationReady()
+{
+    if (m_showOnNavigationReady) {
+        if (m_showUrl.isEmpty()) {
+            handleShowReady();
+        }
+        QTimer::singleShot(100, m_plugins, &DccPluginManager::startDataPhase);
+    } else {
+        m_plugins->startDataPhase();
+    }
+}
+
+void DccManager::handleLoadFinished()
+{
+    m_allPluginsLoaded = true;
+    handleShowReady();
+    tryStopTimeline();
+}
+
 void DccManager::handleShowReady()
 {
     if (!m_showUrl.isEmpty()) {
@@ -912,22 +957,35 @@ void DccManager::handleShowReady()
     }
 }
 
+void DccManager::tryStopTimeline()
+{
+    if (m_allPluginsLoaded && m_pageShown) {
+        DccAppTimeline::instance().stop();
+    }
+}
+
 void DccManager::tryShow()
 {
     if (m_showUrl.isEmpty()) {
+        return;
+    }
+    if (!m_plugins->loadFinished()) {
+        if (!m_plugins->isDeleting()) {
+            m_showTimer->start();
+        }
         return;
     }
 
     QString cmd;
     const QString path = parseShowPageUrl(m_showUrl, cmd);
     DccObject *obj = findObject(path);
-    if (obj) {
+    if (obj && isObjectAttached(obj)) {
         const QString url = m_showUrl;
         const QDBusMessage message = m_showMessage;
         clearShowParam();
         showPage(obj, cmd);
         replyShowPageRequest(url, message, true);
-    } else if (m_plugins->loadFinished()) {
+    } else {
         const QString url = m_showUrl;
         const QDBusMessage message = m_showMessage;
         clearShowParam();
@@ -935,8 +993,6 @@ void DccManager::tryShow()
         if (!m_activeObject) {
             showPage(m_root, QString());
         }
-    } else if (!m_plugins->isDeleting()) {
-        m_showTimer->start();
     }
 }
 
@@ -1078,6 +1134,7 @@ void DccManager::doShowPage(QPointer<DccObject> obj, const QString &cmd)
     if (!m_pageShown) {
         DccAppTimeline::instance().log(QStringLiteral("first-page-visible"));
         m_pageShown = true;
+        tryStopTimeline();
     }
 }
 

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -38,6 +38,7 @@ public:
     QQmlApplicationEngine *engine();
     void setMainWindow(QWindow *window);
     void setPlugins(const QStringList &plugins);
+    void setShowOnNavigationReady(bool enabled);
     void loadModules(bool async, const QStringList &dirs);
 
     int width() const override;
@@ -60,6 +61,7 @@ public:
     Q_INVOKABLE bool isServerSystem() const;
     Q_INVOKABLE bool isCommunitySystem() const;
     Q_INVOKABLE bool isDeepin() const;
+    Q_INVOKABLE void logTimeline(const QString &stage, const QString &detail = QString()) const;
 
     inline const QSet<QString> &hideModule() const { return m_hideModule; }
 
@@ -100,6 +102,7 @@ private:
     bool isMatch(const QString &url, const DccObject *obj);
     bool isEqualByName(const QString &url, const QString &name);
     bool isEqual(const QString &url, const DccObject *obj);
+    bool isObjectAttached(const DccObject *obj) const;
     DccObject *findObject(const QString &url);
     QVector<DccObject *> findObjects(const QString &url, bool one = false);
     const DccObject *findParent(const DccObject *obj);
@@ -108,6 +111,7 @@ private:
     QString parseShowPageUrl(const QString &url, QString &cmd) const;
     void replyShowPageRequest(const QString &url, const QDBusMessage &message, bool found) const;
     void startPendingShow(const QString &url, const QDBusMessage &message);
+    void tryStopTimeline();
 
 private Q_SLOTS:
     void saveSize();
@@ -115,6 +119,8 @@ private Q_SLOTS:
     void handleScreenAdded(QScreen *screen);
     void waitShowPage(const QString &url, const QDBusMessage message);
     void clearShowParam();
+    void handleNavigationReady();
+    void handleLoadFinished();
     void handleShowReady();
     void tryShow();
     void tryShowFallback();
@@ -158,9 +164,11 @@ private:
     QDBusMessage m_showMessage;
     bool m_showPagePending;
     bool m_showLoadPage;
+    bool m_showOnNavigationReady;
     bool m_needShow;
     bool m_windowShown;
     bool m_pageShown;
+    bool m_allPluginsLoaded;
 
     QHash<QString, QVector<DccObject *>> m_objMap; // 映射对象名称到对象指针列表，用于快速查找
 

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -234,6 +234,7 @@ int main(int argc, char *argv[])
     }
     if (parser.isSet(pluginOption))
         dccManager->setPlugins(parser.values(pluginOption));
+    dccManager->setShowOnNavigationReady(reqPage.isEmpty() && !parser.isSet(dbusOption));
     if (!refPluginDirs.isEmpty()) {
         dccManager->loadModules(true, refPluginDirs);
         adaptor->Show();

--- a/src/dde-control-center/plugin/DccWindow.qml
+++ b/src/dde-control-center/plugin/DccWindow.qml
@@ -280,27 +280,25 @@ D.ApplicationWindow {
             Connections {
                 target: DccApp
                 function onActiveObjectChanged(activeObject) {
-                    Qt.callLater(function () {
-                        if (stackView.currentIndex !== DccWindow.PageIndex.LoadIndex && null === DccApp.activeObject) {
-                            mainWindow.sidebarPage = null
-                            stackView.currentIndex = DccWindow.PageIndex.LoadIndex
-                            mainWindow.currentIndex = DccWindow.PageIndex.LoadIndex
-                        } else if (stackView.currentIndex !== DccWindow.PageIndex.HomeIndex && DccApp.root === DccApp.activeObject) {
-                            if (!homeLoader.active) {
-                                homeLoader.active = true
-                            }
-                            mainWindow.sidebarPage = null
-                            stackView.currentIndex = DccWindow.PageIndex.HomeIndex
-                            mainWindow.currentIndex = DccWindow.PageIndex.HomeIndex
-                        } else if (stackView.currentIndex !== DccWindow.PageIndex.SecondIndex && DccApp.root !== DccApp.activeObject) {
-                            if(!secondLoader.active){
-                                secondLoader.active = true
-                            }
-                            stackView.currentIndex = DccWindow.PageIndex.SecondIndex
-                            mainWindow.currentIndex = DccWindow.PageIndex.SecondIndex
-                            mainWindow.sidebarPage = secondLoader.item
+                    if (stackView.currentIndex !== DccWindow.PageIndex.LoadIndex && null === DccApp.activeObject) {
+                        mainWindow.sidebarPage = null
+                        stackView.currentIndex = DccWindow.PageIndex.LoadIndex
+                        mainWindow.currentIndex = DccWindow.PageIndex.LoadIndex
+                    } else if (stackView.currentIndex !== DccWindow.PageIndex.HomeIndex && DccApp.root === DccApp.activeObject) {
+                        if (!homeLoader.active) {
+                            homeLoader.active = true
                         }
-                    })
+                        mainWindow.sidebarPage = null
+                        stackView.currentIndex = DccWindow.PageIndex.HomeIndex
+                        mainWindow.currentIndex = DccWindow.PageIndex.HomeIndex
+                    } else if (stackView.currentIndex !== DccWindow.PageIndex.SecondIndex && DccApp.root !== DccApp.activeObject) {
+                        if (!secondLoader.active) {
+                            secondLoader.active = true
+                        }
+                        stackView.currentIndex = DccWindow.PageIndex.SecondIndex
+                        mainWindow.currentIndex = DccWindow.PageIndex.SecondIndex
+                        mainWindow.sidebarPage = secondLoader.item
+                    }
                 }
             }
             Component.onCompleted: {

--- a/src/dde-control-center/plugin/SecondPage.qml
+++ b/src/dde-control-center/plugin/SecondPage.qml
@@ -252,7 +252,7 @@ Item {
                 XAnimator {
                     from: (rightView.mirrored ? -1 : 1) * -rightView.width
                     to: 0
-                    duration: 100
+                    duration: 400
                     easing.type: Easing.OutCubic
                 }
             }
@@ -261,11 +261,33 @@ Item {
                 XAnimator {
                     from: 0
                     to: (rightView.mirrored ? -1 : 1) * rightView.width
-                    duration: 100
+                    duration: 400
                     easing.type: Easing.OutCubic
                 }
             }
+            pushEnter: Transition {
+                XAnimator {
+                    from: (rightView.mirrored ? -1 : 1) * rightView.width
+                    to: 0
+                    duration: 400
+                    easing.type: Easing.OutCubic
+                }
+            }
+            pushExit: Transition {
+                XAnimator {
+                    from: 0
+                    to: (rightView.mirrored ? -1 : 1) * -rightView.width
+                    duration: 400
+                    easing.type: Easing.OutCubic
+                }
+            }
+            onBusyChanged: {
+                const pageName = currentItem && currentItem.dccObj ? currentItem.dccObj.name : ""
+                DccApp.logTimeline(busy ? "page-animation-start" : "page-animation-finished", pageName)
+            }
             onCurrentItemChanged: {
+                if (currentItem)
+                    DccApp.logTimeline("stack-current-item-changed")
                 if (currentItem && !root.isKeyboardNavigating) {
                     rightView.forceActiveFocus()
                 }
@@ -345,12 +367,15 @@ Item {
         if (!activeObj || activeObj === dccObj) {
             return
         }
+        DccApp.logTimeline("page-switch-request", activeObj.name)
         if (activeObj.page === null) {
             activeObj.page = rightLayout
         }
+        DccApp.logTimeline("page-replace-start", activeObj.name)
         rightView.replace(mainView, {
                               "dccObj": activeObj
                           }, DccApp.animationMode === DccApp.AnimationPush ? StackView.PushTransition : StackView.PopTransition)
+        DccApp.logTimeline("page-replace-return", activeObj.name)
     }
     Connections {
         target: DccApp

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -222,10 +222,6 @@ void DccPluginManager::checkNavigationFinished()
     m_navigationFinished = true;
     DccAppTimeline::instance().log(QStringLiteral("navigation-ready"));
     Q_EMIT navigationReady();
-
-    // Start data phase after navigation is ready, to avoid blocking the main thread with data loading
-    // Use a single-shot timer to ensure that the data phase starts after the current event loop iteration
-    QTimer::singleShot(100, this, &DccPluginManager::startDataPhase);
 }
 
 void DccPluginManager::startDataPhase()
@@ -255,7 +251,6 @@ void DccPluginManager::checkLoadFinished()
     m_allLoadFinished = true;
     m_loadTimer.stop();
     DccAppTimeline::instance().log(QStringLiteral("all-plugins-loaded"));
-    DccAppTimeline::instance().stop();
     Q_EMIT loadAllFinished();
     cancelLoad();
 }

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -30,6 +30,7 @@ public:
     void loadModules(DccObject *root, bool async, const QStringList &dirs, QQmlEngine *engine);
     bool loadFinished() const;
     void beginDelete();
+    void startDataPhase();
 
     QQmlEngine *engine();
     DccObject *rootModule();
@@ -58,7 +59,6 @@ private Q_SLOTS:
 
 private:
     void checkNavigationFinished();
-    void startDataPhase();
     void checkLoadFinished();
 
     DccManager *m_manager;


### PR DESCRIPTION
Remove unnecessary Qt.callLater deferral in page switching to simplify
transition handling and improve responsiveness. Add push/replace
transition direction handling for destination page animations.

Log: Improved page switching responsiveness and fixed animation
direction stack handling

Influence:
1. Navigate through modules from home page and verify smooth transitions
2. Test switching between modules with animation mode enabled and
disabled
3. Verify second-level page push animation moves in correct direction
4. Test rapid navigation to confirm no hanging or delayed transitions
5. Confirm page stack returns to load page on app restart

fix: 重构页面切换逻辑并移除延迟转换

将页面切换信号处理中的 Qt.callLater 延迟调用移除，简化转换处理流程并提升
响应性。为目标页面添加推送/替换转换方向处理，确保动画方向正确。

Log: 优化页面切换响应，修复动画方向栈处理

Influence:
1. 从首页进入各模块并验证转场动画流畅
2. 分别在开启和关闭动画模式下测试模块切换
3. 验证二级页面推送动画方向正确
4. 快速连续导航测试，确认无卡顿或延迟转换
5. 应用重启后确认页面栈正确返回加载页

## Summary by Sourcery

Refactor page switching and loading readiness to provide more responsive navigation with correct transition directions and startup state handling.

New Features:
- Add destination-page push and replace transition handling with timeline instrumentation for page navigation and animation state.

Bug Fixes:
- Correct page-stack navigation and startup page restoration by coordinating navigation readiness with plugin loading and validating attached page objects.

Enhancements:
- Simplify page switching by removing deferred QML transition handling and centralizing navigation/data-load readiness in the manager.
- Improve initial page display and application timeline completion tracking across plugin loading and first-page visibility.