### PR TITLE
fix: hide unsupported eye comfort controls

### DIFF
--- a/src/plugin-display/operation/displaymodule.cpp
+++ b/src/plugin-display/operation/displaymodule.cpp
@@ -82,6 +82,7 @@ void DisplayModulePrivate::init()
     q_ptr->connect(m_model, &DisplayModel::virtualOutputChanged, q_ptr, [this]() {
         updateVirtualScreens();
     });
+    q_ptr->connect(m_model, &DisplayModel::redshiftVaildChanged, q_ptr, &DisplayModule::colorTemperatureSupportedChanged);
     q_ptr->connect(m_model, &DisplayModel::colorTemperatureEnabledChanged, q_ptr, &DisplayModule::colorTemperatureEnabledChanged);
     q_ptr->connect(m_model, &DisplayModel::colorTemperatureChanged, q_ptr, &DisplayModule::colorTemperatureChanged);
     q_ptr->connect(m_model, &DisplayModel::customColorTempTimePeriodChanged, q_ptr, &DisplayModule::customColorTempTimePeriodChanged);
@@ -530,6 +531,13 @@ qreal DisplayModule::maxGlobalScale() const
 {
     Q_D(const DisplayModule);
     return d->m_maxGlobalScale;
+}
+
+bool DisplayModule::colorTemperatureSupported() const
+{
+    Q_D(const DisplayModule);
+    // Treeland uses its own color-control protocol instead of the daemon gamma path.
+    return WQt::Utils::isTreeland() || d->m_model->redshiftIsValid();
 }
 
 bool DisplayModule::colorTemperatureEnabled() const

--- a/src/plugin-display/operation/displaymodule.h
+++ b/src/plugin-display/operation/displaymodule.h
@@ -23,6 +23,7 @@ class DisplayModule : public QObject
     Q_PROPERTY(bool isX11 READ isX11 NOTIFY isX11Changed FINAL)
     Q_PROPERTY(qreal globalScale READ globalScale WRITE setGlobalScale NOTIFY globalScaleChanged FINAL)
     Q_PROPERTY(qreal maxGlobalScale READ maxGlobalScale NOTIFY maxGlobalScaleChanged FINAL)
+    Q_PROPERTY(bool colorTemperatureSupported READ colorTemperatureSupported NOTIFY colorTemperatureSupportedChanged FINAL)
     Q_PROPERTY(bool colorTemperatureEnabled READ colorTemperatureEnabled WRITE setColorTemperatureEnabled NOTIFY colorTemperatureEnabledChanged FINAL)
     Q_PROPERTY(int colorTemperatureMode READ colorTemperatureMode WRITE setColorTemperatureMode NOTIFY colorTemperatureModeChanged FINAL)
     Q_PROPERTY(int colorTemperature READ colorTemperature WRITE setColorTemperature NOTIFY colorTemperatureChanged FINAL)
@@ -48,6 +49,7 @@ public:
     qreal globalScale() const;
     void setGlobalScale(qreal scale);
     qreal maxGlobalScale() const;
+    bool colorTemperatureSupported() const;
     bool colorTemperatureEnabled() const;
     void setColorTemperatureEnabled(bool enabled);
     int colorTemperatureMode() const;
@@ -82,6 +84,7 @@ Q_SIGNALS:
     void globalScaleChanged();
     void globalScaleEnabledChanged();
     void maxGlobalScaleChanged();
+    void colorTemperatureSupportedChanged();
     void colorTemperatureEnabledChanged();
     void colorTemperatureModeChanged();
     void colorTemperatureChanged();

--- a/src/plugin-display/operation/private/displaydbusproxy.cpp
+++ b/src/plugin-display/operation/private/displaydbusproxy.cpp
@@ -85,6 +85,17 @@ BrightnessMap DisplayDBusProxy::brightness()
     return qvariant_cast<BrightnessMap>(m_dBusDisplayInter->property("Brightness"));
 }
 
+bool DisplayDBusProxy::supportColorTemperature() const
+{
+    const QVariant value = m_dBusDisplayInter->property("SupportColorTemperature");
+    if (!value.isValid()) {
+        qWarning("Failed to read SupportColorTemperature property; defaulting to false");
+        return false;
+    }
+
+    return qvariant_cast<bool>(value);
+}
+
 bool DisplayDBusProxy::colorTemperatureEnabled() const
 {
     return qvariant_cast<bool>(m_dBusDisplayInter->property("ColorTemperatureEnabled"));
@@ -384,9 +395,4 @@ QDBusPendingReply<> DisplayDBusProxy::SwitchMode(uchar in0, const QString &in1)
 QDBusReply<bool> DisplayDBusProxy::CanSetBrightnessSync(const QString &name)
 {
     return m_dBusDisplayInter->call("CanSetBrightness", name);
-}
-
-QDBusReply<bool> DisplayDBusProxy::SupportSetColorTemperatureSync()
-{
-    return m_dBusDisplayInter->call("SupportSetColorTemperature");
 }

--- a/src/plugin-display/operation/private/displaydbusproxy.h
+++ b/src/plugin-display/operation/private/displaydbusproxy.h
@@ -28,6 +28,9 @@ public:
     Q_PROPERTY(BrightnessMap Brightness READ brightness NOTIFY BrightnessChanged)
     BrightnessMap brightness();
 
+    Q_PROPERTY(bool SupportColorTemperature READ supportColorTemperature NOTIFY SupportColorTemperatureChanged FINAL)
+    bool supportColorTemperature() const;
+
     Q_PROPERTY(bool ColorTemperatureEnabled READ colorTemperatureEnabled WRITE setColorTemperatureEnabled NOTIFY ColorTemperatureEnabledChanged FINAL)
     bool colorTemperatureEnabled() const;
     void setColorTemperatureEnabled(bool enabled);
@@ -132,7 +135,6 @@ public Q_SLOTS: // METHODS
     QDBusPendingReply<> SwitchMode(uchar in0, const QString &in1);
     QDBusPendingReply<> SetConcatScreen(bool enable);
     QDBusReply<bool> CanSetBrightnessSync(const QString &name);
-    QDBusReply<bool> SupportSetColorTemperatureSync();
     // Appearance
     QDBusPendingReply<double> GetScaleFactor();
     QDBusPendingReply<QMap<QString, double> > GetScreenScaleFactors();
@@ -146,6 +148,7 @@ public Q_SLOTS: // METHODS
 Q_SIGNALS: // SIGNALS
     // begin property changed signals
     void BrightnessChanged(BrightnessMap value) const;
+    void SupportColorTemperatureChanged(bool value) const;
     void ColorTemperatureEnabledChanged(bool value) const;
     void ColorTemperatureManualChanged(int value) const;
     void ColorTemperatureModeChanged(int value) const;

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -92,6 +92,7 @@ DisplayWorker::DisplayWorker(DisplayModel *model, QObject *parent, bool isSync)
         connect(m_displayInter, &DisplayDBusProxy::ScreenWidthChanged, model, &DisplayModel::setScreenWidth);
         connect(m_displayInter, &DisplayDBusProxy::DisplayModeChanged, model, &DisplayModel::setDisplayMode);
         connect(m_displayInter, &DisplayDBusProxy::MaxBacklightBrightnessChanged, model, &DisplayModel::setmaxBacklightBrightness);
+        connect(m_displayInter, &DisplayDBusProxy::SupportColorTemperatureChanged, model, &DisplayModel::setRedshiftIsValid);
         connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureEnabledChanged, model, &DisplayModel::setColorTemperatureEnabled);
         connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureModeChanged, model, &DisplayModel::setAdjustCCTmode);
         connect(m_displayInter, &DisplayDBusProxy::ColorTemperatureManualChanged, this, [this](int kelvin) {
@@ -188,13 +189,7 @@ void DisplayWorker::active()
         // 初始化自动亮度
         initAutoBacklight();
 
-        bool isRedshiftValid = true;
-        QDBusReply<bool> reply = m_displayInter->SupportSetColorTemperatureSync();
-        if (QDBusError::NoError == reply.error().type())
-            isRedshiftValid = reply.value();
-        else
-            qCWarning(DdcDisplayWorker) << "Call SupportSetColorTemperature method failed: " << reply.error().message();
-        m_model->setRedshiftIsValid(isRedshiftValid);
+        m_model->setRedshiftIsValid(m_displayInter->supportColorTemperature());
         QVariant minBrightnessValue = 0.1f;
         minBrightnessValue = m_dconfig->value("minBrightnessValue", minBrightnessValue);
         m_model->setMinimumBrightnessScale(minBrightnessValue.toDouble());

--- a/src/plugin-display/qml/DisplayMain.qml
+++ b/src/plugin-display/qml/DisplayMain.qml
@@ -962,6 +962,7 @@ DccObject {
         name: "displayColorTemperature"
         parentName: "display"
         displayName: qsTr("Eye Comfort")
+        visible: dccData.colorTemperatureSupported
         onParentItemChanged: item => { if (item) { item.topInset = 12; item.leftPadding = 14 } }
         weight: 90
     }
@@ -971,7 +972,7 @@ DccObject {
         displayName: qsTr("Enable eye comfort")
         description: qsTr("Adjust screen display to warmer colors, reducing screen blue light")
         weight: 100
-        visible: dccData.isX11
+        visible: dccData.isX11 && dccData.colorTemperatureSupported
         backgroundType: DccObject.Normal
         pageType: DccObject.Editor
         onParentItemChanged: item => { if (item) { item.rightItemTopMargin = 6; item.rightItemBottomMargin = 6 } }
@@ -984,7 +985,7 @@ DccObject {
         name: "eyeComfortGroup"
         parentName: "display"
         weight: 110
-        // visible: dccData.colorTemperatureEnabled
+        visible: dccData.colorTemperatureSupported
         pageType: DccObject.Item
         onParentItemChanged: item => { if (item) item.topInset = 6 }
         page: DccGroupView {}


### PR DESCRIPTION
## BUG-376203

Eye Comfort controls remain visible on X11 even when the display service reports that color temperature adjustment is unsupported. Bind their visibility to `SupportColorTemperature` and propagate property changes through the display model so the UI follows capability changes.

Return `false` and log a warning when the capability property cannot be read, so unavailable backends do not expose Eye Comfort controls. Keep Treeland's separate color-control behavior available.

## Validation

- Reviewed the D-Bus property contract, error fallback, Qt signal chain, and X11/Treeland branches.
- Built `display` and `display_qml` with Qt 6.8 and warnings treated as errors, using a source snapshot verified against every current tracked file.
- Parsed `DisplayMain.qml` with Qt's `qmlformat`.
- `git diff --check` passed.
- Live D-Bus, X11, and Treeland integration was not exercised. Hardware verification should cover supported/unsupported displays and capability changes.

## Summary by Sourcery

Bind Eye Comfort visibility to the display’s color-temperature support capability.

Bug Fixes:
- Hide Eye Comfort controls when the display service reports that color temperature adjustment is unsupported.

Enhancements:
- Expose color-temperature support through the display module and propagate capability changes to the UI while preserving Treeland’s independent color-control behavior.
- Use the display service property for capability detection with a safe fallback when it cannot be read.
