### PR TITLE
fix(display): scale screen snap threshold with screen width

### DIFF
--- a/src/plugin-display/operation/private/concatscreen.cpp
+++ b/src/plugin-display/operation/private/concatscreen.cpp
@@ -89,7 +89,11 @@ void ConcatScreen::adsorption()
     qreal leftTop = 0.0;
     qreal leftBottom = 0.0;
 
-    int space = 200;
+    // 吸附阈值按屏幕宽度比例计算：以 1080p(1920px) 下 200 逻辑像素为基准，
+    // 保证不同分辨率(如 4K)下吸附手感一致，避免固定值过小导致边缘无法对齐
+    qreal space = m_movingItem->rect().width() * (200.0 / 1920.0);
+    qDebug() << "[adsorption] space threshold =" << space
+             << ", movingItem width =" << m_movingItem->rect().width();
 
     auto minMoveLen = [=](qreal temp, qreal &len) {
         if (fabs(len) > 0.0) {


### PR DESCRIPTION
1. Replace the fixed 200 logical-pixel snap threshold with a value proportional to the dragged screen's width, using 1080p (1920px) as the baseline so the snap distance stays consistent across resolutions
2. Add debug logging for the computed snap threshold and the dragged screen's width

fix(display): 吸附阈值按屏幕宽度等比缩放

1. 将固定的 200 逻辑像素吸附阈值改为按被拖动屏幕宽度等比计算，以 1080p（1920px）为基准，保证不同分辨率下吸附手感一致
2. 增加计算后的吸附阈值与被拖动屏幕宽度的调试日志

PMS: BUG-376319

## Summary by Sourcery

Scale display screen snapping by resolution so edge alignment remains consistent across screen sizes.

Bug Fixes:
- Scale the screen snap threshold according to the dragged screen width to maintain consistent snapping behavior across display resolutions.

Enhancements:
- Add debug logging for the calculated snap threshold and dragged screen width.