### PR TITLE
fix(datetime): unify left padding of list items in LangAndFormat

### DIFF
--- a/src/plugin-datetime/qml/LangAndFormat.qml
+++ b/src/plugin-datetime/qml/LangAndFormat.qml
@@ -270,7 +270,6 @@ DccObject {
             onParentItemChanged: item => {
                 if (item) {
                     item.implicitHeight = 40
-                    item.leftPadding = 7
                     item.rightPadding = 11
                 }
             }
@@ -354,7 +353,6 @@ DccObject {
         onParentItemChanged: item => {
             if (item) {
                 item.bottomInset = 3
-                item.leftPadding = 7
                 item.activeFocusOnTab = true
             }
         }
@@ -443,7 +441,6 @@ DccObject {
         onParentItemChanged: item => {
             if (item) {
                 item.topInset = 3
-                item.leftPadding = 7
                 item.activeFocusOnTab = true
             }
         }
@@ -485,7 +482,6 @@ DccObject {
                 onParentItemChanged: item => {
                     if (item) {
                         item.implicitHeight = 40
-                        item.leftPadding = 7
                         item.rightPadding = 0
                     }
                 }
@@ -529,7 +525,6 @@ DccObject {
                 onParentItemChanged: item => {
                     if (item) {
                         item.implicitHeight = 40
-                        item.leftPadding = 7
                         item.rightPadding = 0
                     }
                 }
@@ -571,7 +566,6 @@ DccObject {
                 onParentItemChanged: item => {
                     if (item) {
                         item.implicitHeight = 40
-                        item.leftPadding = 7
                         item.rightPadding = 0
                     }
                 }


### PR DESCRIPTION
The list items in the language and region settings page had inconsistent left padding (7px) compared to the first item, causing text misalignment. Change all 6 occurrences of `item.leftPadding = 7` to `12` to align with the language list header item.

Bug: https://pms.uniontech.com/bug-view-374507.html

## Summary by Sourcery

Bug Fixes:
- Align the left padding of language and region list items to eliminate text misalignment.