### PR TITLE
feat(dcc): add --list option to dump module tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Execute `dde-control-center -h` to get more details.
 
 Note: `--spec` can be used to debug plugins. The passed in value is the path where the so of plugin is in.
 
-Note: `--list` prints all modules (`url` and display name, hidden modules marked with `[hidden]`) and exits, e.g. `dde-control-center --list | grep display`.
+Note: `--list` prints all modules (`url` and display name, hidden modules marked with `[hidden]`) and exits, e.g. `dde-control-center --list | grep display`. If some plugins do not finish loading within the timeout, the list is still printed and the command exits non-zero.
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Execute `dde-control-center -h` to get more details.
 
 Note: `--spec` can be used to debug plugins. The passed in value is the path where the so of plugin is in.
 
+Note: `--list` prints all modules (`url` and display name, hidden modules marked with `[hidden]`) and exits, e.g. `dde-control-center --list | grep display`.
+
 ## Getting help
 
 You can press `F1` to start [deepin-manual](https://github.com/linuxdeepin/deepin-manual) when you focus on DDE Control Center window.

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -38,7 +38,7 @@ $ dpkg-buildpackage -uc -us -nc -b # 构建二进制软件包
 
 Execute `dde-control-center -h` to get more details.
 
-`--list` 用于列出所有模块（`url` 与显示名，被隐藏的模块标记 `[hidden]`）后直接退出，例如 `dde-control-center --list | grep display`。
+`--list` 用于列出所有模块（`url` 与显示名，被隐藏的模块标记 `[hidden]`）后直接退出，例如 `dde-control-center --list | grep display`。若有插件在超时时间内未加载完成，列表仍会输出，但命令以非 0 退出。
 
 ## 帮助
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -38,6 +38,8 @@ $ dpkg-buildpackage -uc -us -nc -b # 构建二进制软件包
 
 Execute `dde-control-center -h` to get more details.
 
+`--list` 用于列出所有模块（`url` 与显示名，被隐藏的模块标记 `[hidden]`）后直接退出，例如 `dde-control-center --list | grep display`。
+
 ## 帮助
 
 任何使用问题都可以通过以下方式寻求帮助:

--- a/docs/v25-dcc-interface.zh_CN.md
+++ b/docs/v25-dcc-interface.zh_CN.md
@@ -43,7 +43,7 @@ ${CMAKE_INSTALL_LIBDIR}/dde-control-center/plugins_v1.1/example/
 5.  将example.so导出的对象设置为dccData,加载ExampleMain.qml。此时，ExampleMain.qml中可以使用dccData.xxx()调用example.so导出的函数
 6.  加载完成，将DccObject对象插入到模块树中
 ## V25控制中心插件开发必要说明
-1.  控制中心有一个option,可以用来加载一个文件夹下的插件，比如一般插件会放置到`build`文件夹下，这时候可以`dde-control-center --spec ./lib/plugins_v1.1/`来加载单独一个插件进行调试。另外提醒，调试时候不要使用asan，因为没有使用asan的控制中心无法加载使用了asan编译的插件
+1.  控制中心有一个option,可以用来加载一个文件夹下的插件，比如一般插件会放置到`build`文件夹下，这时候可以`dde-control-center --spec ./lib/plugins_v1.1/`来加载单独一个插件进行调试。另外提醒，调试时候不要使用asan，因为没有使用asan的控制中心无法加载使用了asan编译的插件。配合`--list`可查看当前加载出的模块树（url 与显示名，隐藏项标记`[hidden]`），如`dde-control-center --spec ./lib/plugins_v1.1/ --list`
 2.  控制中心插件加载是在线程中，但最终会将插件对象移到主线程。所以example.so构造函数中创建的对象需要在example.so导出类的树结构中(即子对象的父对象或祖先对象是example.so导出类)，否则不会被移动到主线程，导致其中信号槽线程等不到，无法正常使用。
 3.  example.so导出类是唯一的，插件中不建议使用单例，可在example.so导出类中创建一个单例对象
 ## V25控制中心开发接口说明

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -1286,6 +1286,11 @@ void DccManager::waitLoadFinished() const
     }
 }
 
+bool DccManager::loadFinished() const
+{
+    return m_plugins->loadFinished();
+}
+
 QList<ModuleInfo> DccManager::moduleList() const
 {
     waitLoadFinished();

--- a/src/dde-control-center/dccmanager.cpp
+++ b/src/dde-control-center/dccmanager.cpp
@@ -1286,29 +1286,51 @@ void DccManager::waitLoadFinished() const
     }
 }
 
-void DccManager::doGetAllModule(const QDBusMessage message) const
+QList<ModuleInfo> DccManager::moduleList() const
 {
     waitLoadFinished();
-    DccObject *root = m_root;
-    QList<QPair<DccObject *, QStringList>> modules;
-    for (auto &&child : root->getChildren()) {
-        modules.append({ child, { child->name(), child->displayName() } });
+
+    struct Entry
+    {
+        DccObject *obj;
+        ModuleInfo info;
+    };
+
+    QList<Entry> pending;
+    for (auto &&child : m_root->getChildren()) {
+        pending.append({ child, { child->name(), child->displayName(), child->displayName(), (int)child->weight(), false } });
     }
     for (auto &&child : m_hideObjects->getChildren()) {
-        modules.append({ child, { child->name(), child->displayName() } });
+        pending.append({ child, { child->name(), child->displayName(), child->displayName(), (int)child->weight(), true } });
     }
 
+    QList<ModuleInfo> modules;
+    while (!pending.isEmpty()) {
+        const Entry entry = pending.takeFirst();
+        modules.append(entry.info);
+        const QList<DccObject *> &children = entry.obj->getChildren();
+        for (auto it = children.crbegin(); it != children.crend(); ++it) {
+            ModuleInfo info;
+            info.url = entry.info.url + "/" + (*it)->name();
+            info.displayName = (*it)->displayName();
+            info.pathDisplayName = entry.info.pathDisplayName + "/" + info.displayName;
+            info.weight = (int)(*it)->weight();
+            info.hidden = entry.info.hidden;
+            pending.prepend({ *it, info });
+        }
+    }
+    return modules;
+}
+
+void DccManager::doGetAllModule(const QDBusMessage message) const
+{
     QJsonArray arr;
-    while (!modules.isEmpty()) {
-        const auto &urlInfo = modules.takeFirst();
+    for (const auto &module : moduleList()) {
         QJsonObject obj;
-        obj.insert("url", urlInfo.second.at(0));
-        obj.insert("displayName", urlInfo.second.at(1));
-        obj.insert("weight", (int)(urlInfo.first->weight()));
+        obj.insert("url", module.url);
+        obj.insert("displayName", module.pathDisplayName);
+        obj.insert("weight", module.weight);
         arr.append(obj);
-        const QList<DccObject *> &children = urlInfo.first->getChildren();
-        for (auto it = children.crbegin(); it != children.crend(); ++it)
-            modules.prepend({ *it, { urlInfo.second.at(0) + "/" + (*it)->name(), urlInfo.second.at(1) + "/" + (*it)->displayName() } });
     }
 
     QJsonDocument doc;

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -92,6 +92,7 @@ public Q_SLOTS:
     bool action(const QString &json);
     QString GetAllModule();
     QList<ModuleInfo> moduleList() const;
+    bool loadFinished() const;
     void onDccObjectDestroyed(DccObject *obj);
 
 Q_SIGNALS:

--- a/src/dde-control-center/dccmanager.h
+++ b/src/dde-control-center/dccmanager.h
@@ -26,6 +26,15 @@ class SearchModel;
 class DccPluginManager;
 class DccImageProvider;
 
+struct ModuleInfo
+{
+    QString url;
+    QString displayName;
+    QString pathDisplayName;
+    int weight = 0;
+    bool hidden = false;
+};
+
 class DccManager : public DccApp, protected QDBusContext
 {
     Q_OBJECT
@@ -82,6 +91,7 @@ public Q_SLOTS:
     bool stop(const QString &json);
     bool action(const QString &json);
     QString GetAllModule();
+    QList<ModuleInfo> moduleList() const;
     void onDccObjectDestroyed(DccObject *obj);
 
 Q_SIGNALS:

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -76,6 +76,19 @@ static void refreshQmlCache(const QString &version)
     dir.mkpath(version);
 }
 
+static void printModules(const QList<dccV25::ModuleInfo> &modules)
+{
+    for (const auto &module : modules) {
+        QString line = QString(module.url.count(QLatin1Char('/')) * 4, QLatin1Char(' ')) + module.url;
+        if (!module.displayName.isEmpty())
+            line += QLatin1String("  ") + module.displayName;
+        if (module.hidden)
+            line += QLatin1String("  [hidden]");
+        fprintf(stdout, "%s\n", qUtf8Printable(line));
+    }
+    fflush(stdout);
+}
+
 int main(int argc, char *argv[])
 {
     QGuiApplication *app = new QGuiApplication(argc, argv);
@@ -112,6 +125,7 @@ int main(int argc, char *argv[])
     QCommandLineOption showTime(QStringList() << "z" << "time", "show control center exe time."); // 新增time参数自动测试启动速度
     QCommandLineOption loggingModuleOption(QStringList() << "l" << "logging-module", "Only output logs for the specified module", "loggingModule");
     QCommandLineOption pluginDir("spec", "load plugins from specialdir", "plugindir");
+    QCommandLineOption listOption("list", "list all modules and exit.");
     QCommandLineOption fd1Opt("fd1", "fd1 from security loader", "fd1");
     QCommandLineOption fd2Opt("fd2", "fd2 from security loader", "fd2");
 
@@ -127,9 +141,16 @@ int main(int argc, char *argv[])
     parser.addOption(showTime);
     parser.addOption(loggingModuleOption);
     parser.addOption(pluginDir);
+    parser.addOption(listOption);
     parser.addOption(fd1Opt);
     parser.addOption(fd2Opt);
     parser.process(*app);
+
+    const bool listMode = parser.isSet(listOption);
+    if (listMode) {
+        // 保持 stdout 只有模块列表
+        QLoggingCategory::setFilterRules(QStringLiteral("*.debug=false\n*.info=false\n*.warning=false"));
+    }
 
     int fd1 = -1, fd2 = -1;
     if (parser.isSet(fd1Opt)) fd1 = parser.value(fd1Opt).toInt();
@@ -148,13 +169,13 @@ int main(int argc, char *argv[])
 
     const QStringList &refPluginDirs = parser.values(pluginDir);
 
-    if (!DGuiApplicationHelper::setSingleInstance("org.deepin.dde.control-center")) {
+    if (!listMode && !DGuiApplicationHelper::setSingleInstance("org.deepin.dde.control-center")) {
         qDebug() << "dde-control-center is already running, pid:" << qApp->applicationPid();
         return -1;
     }
 
     QDBusConnection conn = QDBusConnection::sessionBus();
-    if (!conn.registerService(DccDBusService)) {
+    if (!listMode && !conn.registerService(DccDBusService)) {
         qDebug() << "dbus service already registered!"
                  << "pid is:" << qApp->applicationPid();
         return -1;
@@ -202,6 +223,21 @@ int main(int argc, char *argv[])
         return 1;
     }
 
+    auto shutdown = [&](int exitCode) {
+        conn.unregisterService(DccDBusService);
+#ifdef DCC_ENABLE_MEMORY_MANAGEMENT
+        delete dccManager;
+        delete app;
+#endif
+        return exitCode;
+    };
+
+    if (listMode) {
+        dccManager->loadModules(false, refPluginDirs.isEmpty() ? defaultpath() : refPluginDirs);
+        printModules(dccManager->moduleList());
+        return shutdown(0);
+    }
+
     // 监听 DTK 单例信号：当有新实例尝试启动时，在原进程内直接解析其参数并响应.
     QObject::connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::newProcessInstance,
                      [&](qint64 pid, const QStringList &arguments) {
@@ -239,7 +275,7 @@ int main(int argc, char *argv[])
             adaptor->Show();
         } else if (parser.isSet(showTime)) {
             adaptor->Show();
-            return 0;
+            return shutdown(0);
         }
 
 #ifdef QT_DEBUG
@@ -251,11 +287,5 @@ int main(int argc, char *argv[])
         }
 #endif
     }
-    int exitCode = app->exec();
-    conn.unregisterService(DccDBusService);
-#ifdef DCC_ENABLE_MEMORY_MANAGEMENT
-    delete dccManager;
-    delete app;
-#endif
-    return exitCode;
+    return shutdown(app->exec());
 }

--- a/src/dde-control-center/main.cpp
+++ b/src/dde-control-center/main.cpp
@@ -235,6 +235,10 @@ int main(int argc, char *argv[])
     if (listMode) {
         dccManager->loadModules(false, refPluginDirs.isEmpty() ? defaultpath() : refPluginDirs);
         printModules(dccManager->moduleList());
+        if (!dccManager->loadFinished()) {
+            fprintf(stderr, "Some plugins did not finish loading, the list above is incomplete.\n");
+            return shutdown(1);
+        }
         return shutdown(0);
     }
 


### PR DESCRIPTION
Add a `--list` option that prints the loaded module tree (url, display name, hidden items marked `[hidden]`) and exits, so a page url can be located with `dde-control-center --list | grep <keyword>`.

- Extract the tree traversal from `GetAllModule` into `DccManager::moduleList()`; DBus and CLI now share one implementation, and `GetAllModule` output is unchanged
- `--list` skips the single-instance lock and DBus service registration so it can run while another instance is running, and quiets console logs to keep stdout clean
- `--list`, `-z` and the normal quit path now share a `shutdown()` that destroys plugin objects and waits for their thread pools, fixing a crash when a plugin background thread outlives process teardown

Verification:
- `dde-control-center --list` prints the whole tree and exits 0
- `GetAllModule` JSON compared with the running daemon: same urls and weights; display names differ only where a dev build does not load plugin translations

---

新增 `--list` 参数，打印已加载的模块树（url、显示名，隐藏项标记 `[hidden]`）后退出，可用 `dde-control-center --list | grep <关键字>` 定位页面 url。

- 模块树遍历从 `GetAllModule` 抽取为 `DccManager::moduleList()`，DBus 与命令行复用同一实现，`GetAllModule` 输出不变
- `--list` 跳过单实例锁与 DBus 服务注册，可与已运行实例共存，并压低日志保证 stdout 干净
- `--list`、`-z` 与正常退出统一走 `shutdown()`，退出前销毁插件对象并等待其线程池，修复插件后台线程活过进程析构导致的崩溃

Task: https://pms.uniontech.com/task-view-395397.html

## Summary by Sourcery

Add a standalone module-tree listing mode and unify shutdown handling for reliable, scriptable control-center introspection.

New Features:
- Add a `--list` command-line mode that prints the loaded module tree with URLs, display names, and hidden-item markers before exiting.

Bug Fixes:
- Ensure plugin objects and their thread pools are cleaned up during command-line and application shutdown to prevent teardown crashes.

Enhancements:
- Share module-tree enumeration between the DBus API and command-line listing while preserving existing `GetAllModule` output.
- Allow listing alongside a running control-center instance and keep module-list output clean by suppressing console logs.

Documentation:
- Document the `--list` option and its use with plugin development and module search workflows.