### PR TITLE
fix(datetime): adapt timezone list and editor item to removed windowT…

### DIFF
--- a/src/dde-control-center/plugin/DccEditorItem.qml
+++ b/src/dde-control-center/plugin/DccEditorItem.qml
@@ -68,7 +68,7 @@ D.ItemDelegate {
             mirrored: control.mirrored
             display: control.display
             alignment: control.display === D.IconLabel.IconOnly || control.display === D.IconLabel.TextUnderIcon ? Qt.AlignCenter : Qt.AlignLeft | Qt.AlignVCenter
-            color: control.palette.windowText
+            color: control.resolvedTextColor
             icon {
                 name: control.icon.name
                 source: control.icon.source

--- a/src/plugin-datetime/qml/TimeAndDate.qml
+++ b/src/plugin-datetime/qml/TimeAndDate.qml
@@ -440,7 +440,7 @@ DccObject {
                                         Layout.alignment: Qt.AlignVCenter
                                         text: parent.parent.text
                                         font: D.DTK.fontManager.t6
-                                        color: parent.parent.palette.windowText
+                                        color: parent.parent.D.ColorSelector.textColor
                                         elide: Text.ElideRight
                                         horizontalAlignment: Text.AlignLeft
                                         verticalAlignment: Text.AlignVCenter
@@ -519,7 +519,7 @@ DccObject {
                                         Layout.alignment: Qt.AlignVCenter
                                         text: parent.parent.text
                                         font: D.DTK.fontManager.t6
-                                        color: parent.parent.palette.windowText
+                                        color: parent.parent.D.ColorSelector.textColor
                                         elide: Text.ElideRight
                                         horizontalAlignment: Text.AlignLeft
                                         verticalAlignment: Text.AlignVCenter


### PR DESCRIPTION
…ext writes

1. TimeAndDate: read the timezone menu item text color from `D.ColorSelector.textColor` instead of the removed `palette.windowText`, restoring white text on the highlighted item
2. DccEditorItem: read the item text color from `resolvedTextColor` instead of `palette.windowText`

Log: Adapt dde-control-center to dtkdeclarative removing palette.windowText writes (windowText now returns the inherited default foreground instead of the state-dependent text color)

Influence:
1. Timezone dropdown highlighted item text stays white in light theme
2. Settings editor list item selected text color is correct

fix(datetime): 适配时区列表与设置列表项到已移除的 windowText 写入

1. TimeAndDate：时区菜单项文字色改由 `D.ColorSelector.textColor` 获取，替代已 移除的 `palette.windowText`，恢复高亮项白色文字
2. DccEditorItem：列表项文字色改由 `resolvedTextColor` 获取，替代 `palette.windowText`

Log: 适配 dtkdeclarative 移除 palette.windowText 写入（windowText 现返回继承 默认前景色而非随状态变化的文字色）

Influence:
1. 浅色主题下时区下拉高亮项文字保持白色
2. 设置页列表项选中文字色正确

PMS: TASK-392413

## Summary by Sourcery

Bug Fixes:
- Restore correct text colors for highlighted timezone menu items and selected settings editor items after the removal of state-dependent palette.windowText writes.