### PR TITLE
feat(systeminfo): add configurable customer logo on About This PC page

### DIFF
--- a/misc/configs/org.deepin.dde.control-center.systeminfo.json
+++ b/misc/configs/org.deepin.dde.control-center.systeminfo.json
@@ -1,0 +1,28 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "customerLogoEnabled": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "enable customer logo",
+            "name[zh_CN]": "启用客户标识",
+            "description": "Whether to show the customer logo below the system logo on the About This PC page",
+            "description[zh_CN]": "是否在“关于本机”页面的系统 logo 下方显示客户标识",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "customerLogoPath": {
+            "value": "",
+            "serial": 0,
+            "flags": [],
+            "name": "customer logo path",
+            "name[zh_CN]": "客户标识资源路径",
+            "description": "Absolute path of the customer logo image, no customer logo is shown when it is empty",
+            "description[zh_CN]": "客户标识图片的绝对路径，为空时不显示客户标识",
+            "permissions": "readwrite",
+            "visibility": "public"
+        }
+    }
+}

--- a/src/plugin-systeminfo/operation/systeminfomodel.cpp
+++ b/src/plugin-systeminfo/operation/systeminfomodel.cpp
@@ -161,6 +161,19 @@ void SystemInfoModel::setLogoPath(const QString &newLogoPath)
     Q_EMIT logoPathChanged();
 }
 
+QString SystemInfoModel::customerLogoSource() const
+{
+    return m_customerLogoSource;
+}
+
+void SystemInfoModel::setCustomerLogoSource(const QString &newCustomerLogoSource)
+{
+    if (m_customerLogoSource == newCustomerLogoSource)
+        return;
+    m_customerLogoSource = newCustomerLogoSource;
+    Q_EMIT customerLogoSourceChanged();
+}
+
 bool SystemInfoModel::showDetail() const
 {
     return m_showDetail;

--- a/src/plugin-systeminfo/operation/systeminfomodel.h
+++ b/src/plugin-systeminfo/operation/systeminfomodel.h
@@ -54,6 +54,7 @@ class SystemInfoModel : public QObject
     Q_PROPERTY(QColor licenseStatusColor READ licenseStatusColor NOTIFY licenseStatusColorChanged FINAL)
     Q_PROPERTY(bool showDetail READ showDetail NOTIFY showDetailChanged FINAL)
     Q_PROPERTY(QString logoPath READ logoPath NOTIFY logoPathChanged FINAL)
+    Q_PROPERTY(QString customerLogoSource READ customerLogoSource NOTIFY customerLogoSourceChanged FINAL)
     Q_PROPERTY(QString systemInstallationDate READ systemInstallationDate NOTIFY systemInstallationDateChanged FINAL)
     Q_PROPERTY(QString graphicsPlatform READ graphicsPlatform NOTIFY graphicsPlatformChanged FINAL)
 
@@ -113,6 +114,8 @@ public:
 
     QString logoPath() const;
     void setLogoPath(const QString &newLogoPath);
+    QString customerLogoSource() const;
+    void setCustomerLogoSource(const QString &newCustomerLogoSource);
 
     QString systemInstallationDate() const;
     void setSystemInstallationDate(const QString &newSystemInstallationDate);
@@ -164,6 +167,7 @@ Q_SIGNALS:
     void showDetailChanged();
 
     void logoPathChanged();
+    void customerLogoSourceChanged();
 
     void systemInstallationDateChanged();
 
@@ -212,6 +216,7 @@ private:
     QString m_licenseActionText;
 
     QString m_logoPath;
+    QString m_customerLogoSource;
 
     bool m_showDetail;
     QString m_systemInstallationDate;

--- a/src/plugin-systeminfo/operation/systeminfowork.cpp
+++ b/src/plugin-systeminfo/operation/systeminfowork.cpp
@@ -11,12 +11,15 @@
 
 #include <DGuiApplicationHelper>
 #include <DSysInfo>
+#include <DConfig>
 #include <QDBusInterface>
 
 #include <QDateTime>
 #include <QFutureWatcher>
 #include <QtConcurrent/qtconcurrentrun.h>
 #include <QClipboard>
+#include <QUrl>
+#include <QFileInfo>
 
 #include <qregularexpression.h>
 #include <qtimezone.h>
@@ -27,6 +30,9 @@ DCORE_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
 const QString USER_EXPERIENCE_SERVICE = "com.deepin.userexperience.Daemon";
+
+static const QString CUSTOMER_LOGO_ENABLED_KEY = QStringLiteral("customerLogoEnabled");
+static const QString CUSTOMER_LOGO_PATH_KEY = QStringLiteral("customerLogoPath");
 
 
 namespace DCC_NAMESPACE{
@@ -68,6 +74,15 @@ SystemInfoWork::SystemInfoWork(SystemInfoModel *model, QObject *parent)
             &Dtk::Gui::DGuiApplicationHelper::themeTypeChanged,
             this,
             &SystemInfoWork::onThemeTypeChanged);
+
+    m_systemInfoConfig = DConfig::create("org.deepin.dde.control-center",
+                                         "org.deepin.dde.control-center.systeminfo",
+                                         QString(), this);
+    connect(m_systemInfoConfig, &DConfig::valueChanged, this, [this](const QString &key) {
+        if (key == CUSTOMER_LOGO_ENABLED_KEY || key == CUSTOMER_LOGO_PATH_KEY)
+            updateCustomerLogo();
+    });
+    updateCustomerLogo();
 
 
     updateFrequency(false);
@@ -266,6 +281,23 @@ void SystemInfoWork::initSystemCopyright()
     }
 
     m_model->setSystemCopyright(oem_copyright);
+}
+
+void SystemInfoWork::updateCustomerLogo()
+{
+    QString source;
+    if (m_systemInfoConfig && m_systemInfoConfig->isValid()
+            && m_systemInfoConfig->value(CUSTOMER_LOGO_ENABLED_KEY, false).toBool()) {
+        const QString path = m_systemInfoConfig->value(CUSTOMER_LOGO_PATH_KEY).toString().trimmed();
+        if (!path.isEmpty()) {
+            const QFileInfo logoFile(path);
+            if (!logoFile.isAbsolute() || !logoFile.exists())
+                qWarning() << "Invalid customer logo path:" << path;
+            else
+                source = QUrl::fromLocalFile(path).toString();
+        }
+    }
+    m_model->setCustomerLogoSource(source);
 }
 
 void SystemInfoWork::updateFrequency(bool state)

--- a/src/plugin-systeminfo/operation/systeminfowork.h
+++ b/src/plugin-systeminfo/operation/systeminfowork.h
@@ -11,6 +11,12 @@
 
 class QApplication;
 class SystemInfoDBusProxy;
+namespace Dtk {
+namespace Core {
+class DConfig;
+}
+}
+
 namespace DCC_NAMESPACE{
 
 class SystemInfoModel;
@@ -60,12 +66,14 @@ public Q_SLOTS:
 private:
     void getLicenseState();
     void updateUserExperienceProgramText();
+    void updateCustomerLogo();
 
 private:
     SystemInfoModel *m_model;
     SystemInfoDBusProxy *m_systemInfoDBusProxy;
     QString m_title;
     QDBusInterface *m_dBusUeProgram; // for user experience program
+    Dtk::Core::DConfig *m_systemInfoConfig = nullptr;
 
 };
 

--- a/src/plugin-systeminfo/qml/NativeInfoPage.qml
+++ b/src/plugin-systeminfo/qml/NativeInfoPage.qml
@@ -51,12 +51,19 @@ DccObject {
         backgroundType: DccObject.Normal
         visible: dccData.systemInfoMode().showDetail
         page: ColumnLayout{
+            spacing: 0
             Image {
                 Layout.topMargin: 25
                 Layout.alignment: Qt.AlignHCenter
                 source: "file://" + dccData.systemInfoMode().logoPath
             }
+            Image {
+                Layout.alignment: Qt.AlignHCenter
+                visible: source !== ""
+                source: dccData.systemInfoMode().customerLogoSource
+            }
             Label {
+                Layout.topMargin: 5
                 Layout.alignment: Qt.AlignHCenter
                 text: dccData.systemInfoMode().systemCopyright
                 Layout.bottomMargin: 25


### PR DESCRIPTION
1. Add DConfig meta org.deepin.dde.control-center.systeminfo with customerLogoEnabled (default false) and customerLogoPath (default empty)
2. Read the config in SystemInfoWork and expose a QML-ready customerLogoSource on SystemInfoModel; only an existing absolute path is accepted and converted to a file:// URL, otherwise nothing is shown
3. Render the customer logo below the system logo on the About This PC page, and hide it when the switch is off or the path is empty or invalid

Log: The customer logo is disabled by default and can be enabled per project through a DConfig override pointing at the project's own image.

Influence:
1. Verify no customer logo is shown by default
2. Verify the logo appears below the system logo when enabled with an existing absolute path
3. Verify the logo stays hidden when enabled but the path is empty, missing or relative, and a warning is logged

feat(systeminfo): 关于本机页面支持配置客户标识

1. 新增 DConfig 配置 org.deepin.dde.control-center.systeminfo，包含 customerLogoEnabled（默认关闭）和 customerLogoPath（默认空）
2. SystemInfoWork 读取配置并在 SystemInfoModel 上暴露 QML 可直接使用的 customerLogoSource；只接受存在的绝对路径并转换为 file:// URL，其余情况不显示
3. 在关于本机页面系统 logo 下方渲染客户标识，开关关闭、路径为空或无效时隐藏

Log: 客户标识默认关闭，各项目可通过 DConfig override 指向自己的图片开启。

Influence:
1. 验证默认不显示客户标识
2. 验证开启并配置存在的绝对路径后，标识显示在系统 logo 下方
3. 验证开启但路径为空、不存在或为相对路径时仍不显示，并打印告警

PMS: TASK-395369
Change-Id: I21f85f4b5b1621334848f85b808ca68c3d9547ad

## Summary by Sourcery

Enable projects to configure an optional customer logo displayed beneath the system logo on the About This PC page.

New Features:
- Add configurable customer logo support to the About This PC page.

Enhancements:
- Expose a validated customer logo source through the system information model and update it when configuration changes.