### PR TITLE
feat(plugin-display): migrate treeland output protocol v1 to v2

### DIFF
--- a/src/plugin-display/CMakeLists.txt
+++ b/src/plugin-display/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.18)
 
 find_package(${QT_NS} REQUIRED COMPONENTS WaylandClient Concurrent)
 find_package(PkgConfig REQUIRED)
-find_package(TreelandProtocols REQUIRED)
+find_package(TreelandProtocols 0.6 REQUIRED)
 pkg_check_modules(WaylandClient REQUIRED IMPORTED_TARGET wayland-client)
 pkg_check_modules(WLR_PROTOCOLS REQUIRED wlr-protocols)
 
@@ -25,7 +25,7 @@ add_library(display-wayland-client
 qt_generate_wayland_protocol_client_sources(display-wayland-client
     FILES
         ${WLR_PROTOCOLS_XML_DIR}/unstable/wlr-output-management-unstable-v1.xml
-        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-v1.xml
+        ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-output-manager-unstable-v2.xml
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-virtual-output-manager-v1.xml
         ${TREELAND_PROTOCOLS_DATA_DIR}/treeland-wallpaper-manager-unstable-v1.xml
 )

--- a/src/plugin-display/operation/private/displayworker.cpp
+++ b/src/plugin-display/operation/private/displayworker.cpp
@@ -753,8 +753,27 @@ void DisplayWorker::setMonitorRotate(Monitor *mon, const quint16 rotate)
 void DisplayWorker::setPrimary(const QString &name)
 {
     if (WQt::Utils::isTreeland()) {
-        if (m_treelandOutputMgr)
-            m_treelandOutputMgr->setPrimaryOutput(name.toStdString().c_str());
+        if (m_treelandOutputMgr) {
+            // v2 protocol takes a wl_output* instead of an output name string;
+            // resolve the name to the wl_output owned by the matching QScreen.
+            struct wl_output *output = nullptr;
+            for (auto it(m_screen_outputs.cbegin()); it != m_screen_outputs.cend(); ++it) {
+                if (it.key()->name() == name) {
+                    output = it.value();
+                    break;
+                }
+            }
+            // The v2 set_primary_output request does not declare allow-null for
+            // its output argument, so do not send a null object — the compositor
+            // would reject it (or worse, treat it as a protocol error).  This
+            // happens when the screen has not been registered yet; the primary
+            // output is left unchanged and the user can retry later.
+            if (!output) {
+                qCWarning(DdcDisplayWorker) << "cannot set primary output: no wl_output found for" << name;
+                return;
+            }
+            m_treelandOutputMgr->setPrimaryOutput(output);
+        }
     } else {
         m_displayInter->SetPrimary(name);
     }
@@ -1399,7 +1418,7 @@ void DisplayWorker::updateControl()
             }
 
             if (controlContext == m_control_monitors.end()) {
-                auto *control = m_treelandOutputMgr->getColorControl(it.value());
+                auto *control = m_treelandOutputMgr->getPictureControl(it.value());
                 if (control) {
                     connect(control, &WQt::ColorControl::brightnessChanged, this, [this, control](double brightness) {
                         onBrightnessChanged(control, brightness);

--- a/src/plugin-display/wayland/client/TreeLandOutputManager.cpp
+++ b/src/plugin-display/wayland/client/TreeLandOutputManager.cpp
@@ -10,13 +10,17 @@
 #include <wayland-client.h>
 
 #include <QDebug>
+#include <QGuiApplication>
 #include <QLoggingCategory>
+#include <QScreen>
+
+#include "wayland-treeland-output-manager-unstable-v2-client-protocol.h"
 
 // ── WQt::ColorControl ──────────────────────────────────────────────
 
-WQt::ColorControl::ColorControl(::treeland_output_color_control_v1 *obj, QObject *parent)
-    : QWaylandClientExtensionTemplate<WQt::ColorControl>(1)
-    , QtWayland::treeland_output_color_control_v1(obj)
+WQt::ColorControl::ColorControl(::treeland_output_picture_control_v2 *obj, QObject *parent)
+    : QWaylandClientExtensionTemplate<WQt::ColorControl>(treeland_output_picture_control_v2_interface.version)
+    , QtWayland::treeland_output_picture_control_v2(obj)
 {
     setParent(parent);
 }
@@ -24,34 +28,48 @@ WQt::ColorControl::ColorControl(::treeland_output_color_control_v1 *obj, QObject
 WQt::ColorControl::~ColorControl()
 {
     if (isInitialized())
-        QtWayland::treeland_output_color_control_v1::destroy();
+        QtWayland::treeland_output_picture_control_v2::destroy();
 }
 
 void WQt::ColorControl::setBrightness(double brightness)
 {
+    // An out-of-range value is a fatal protocol error that terminates the
+    // connection, so clamp before sending.
+    if (brightness < 0.0 || brightness > 100.0) {
+        qCWarning(DccWayQt) << "clamping brightness" << brightness << "to [0.0, 100.0]";
+        brightness = qBound(0.0, brightness, 100.0);
+    }
     qCDebug(DccWayQt) << "ColorControl::setBrightness" << brightness;
-    QtWayland::treeland_output_color_control_v1::set_brightness(wl_fixed_from_double(brightness));
+    QtWayland::treeland_output_picture_control_v2::set_brightness(wl_fixed_from_double(brightness));
     commit();
 }
 
 void WQt::ColorControl::setColorTemperature(uint32_t temperature)
 {
+    // An out-of-range value is a fatal protocol error that terminates the
+    // connection, so clamp before sending.
+    if (temperature < 1000 || temperature > 20000) {
+        qCWarning(DccWayQt) << "clamping color temperature" << temperature << "to [1000, 20000]";
+        temperature = qBound<uint32_t>(1000, temperature, 20000);
+    }
     qCDebug(DccWayQt) << "ColorControl::setColorTemperature" << temperature;
-    QtWayland::treeland_output_color_control_v1::set_color_temperature(temperature);
+    QtWayland::treeland_output_picture_control_v2::set_color_temperature(temperature);
     commit();
 }
 
-void WQt::ColorControl::treeland_output_color_control_v1_result(uint32_t success)
+void WQt::ColorControl::treeland_output_picture_control_v2_result(uint32_t commitResult)
 {
-    Q_EMIT result(success);
+    // The parameter cannot be named "result": it would shadow the
+    // result(uint32_t) signal and break the emit below.
+    Q_EMIT result(commitResult);
 }
 
-void WQt::ColorControl::treeland_output_color_control_v1_color_temperature(uint32_t temperature)
+void WQt::ColorControl::treeland_output_picture_control_v2_color_temperature(uint32_t temperature)
 {
     Q_EMIT colorTemperatureChanged(temperature);
 }
 
-void WQt::ColorControl::treeland_output_color_control_v1_brightness(int32_t brightness)
+void WQt::ColorControl::treeland_output_picture_control_v2_brightness(int32_t brightness)
 {
     Q_EMIT brightnessChanged(wl_fixed_to_double(brightness));
 }
@@ -59,26 +77,24 @@ void WQt::ColorControl::treeland_output_color_control_v1_brightness(int32_t brig
 // ── WQt::TreeLandOutputManager ─────────────────────────────────────
 
 WQt::TreeLandOutputManager::TreeLandOutputManager(QObject *parent)
-    : QWaylandClientExtensionTemplate<WQt::TreeLandOutputManager>(2)
+    : QWaylandClientExtensionTemplate<WQt::TreeLandOutputManager>(treeland_output_manager_v2_interface.version)
 {
     setParent(parent);
 }
 
 WQt::TreeLandOutputManager::~TreeLandOutputManager()
 {
-    // The destroy request was introduced in version 2; older compositors
-    // reject it as an unknown method.
-    if (isInitialized() && QtWayland::treeland_output_manager_v1::version() >= 2)
-        QtWayland::treeland_output_manager_v1::destroy();
+    if (isInitialized())
+        QtWayland::treeland_output_manager_v2::destroy();
 }
 
-void WQt::TreeLandOutputManager::setPrimaryOutput(const char *name)
+void WQt::TreeLandOutputManager::setPrimaryOutput(struct wl_output *output)
 {
-    qCDebug(DccWayQt) << "TreeLandOutputManager::setPrimaryOutput" << name;
-    QtWayland::treeland_output_manager_v1::set_primary_output(name);
+    qCDebug(DccWayQt) << "TreeLandOutputManager::setPrimaryOutput" << output;
+    QtWayland::treeland_output_manager_v2::set_primary_output(output);
 }
 
-WQt::ColorControl *WQt::TreeLandOutputManager::getColorControl(struct wl_output *output)
+WQt::ColorControl *WQt::TreeLandOutputManager::getPictureControl(struct wl_output *output)
 {
     if (!output)
         return nullptr;
@@ -86,20 +102,31 @@ WQt::ColorControl *WQt::TreeLandOutputManager::getColorControl(struct wl_output 
     // Same guard as WallpaperManager::getWallpaper: a removed output turns this
     // request into a fatal protocol error.
     if (!WQt::Utils::isOutputAlive(output)) {
-        qCWarning(DccWayQt) << "skipping get_color_control for a removed output" << output;
+        qCWarning(DccWayQt) << "skipping get_picture_control for a removed output" << output;
         return nullptr;
     }
 
-    auto *colorControl = get_color_control(output);
-    if (!colorControl)
+    auto *pictureControl = get_picture_control(output);
+    if (!pictureControl)
         return nullptr;
 
-    return new WQt::ColorControl(colorControl, this);
+    return new WQt::ColorControl(pictureControl, this);
 }
 
-void WQt::TreeLandOutputManager::treeland_output_manager_v1_primary_output(const QString &output_name)
+void WQt::TreeLandOutputManager::treeland_output_manager_v2_primary_output(struct wl_output *output)
 {
-    qCDebug(DccWayQt) << "TreeLandOutputManager::primary output changed" << output_name;
-    mPrimaryOutput = output_name;
-    Q_EMIT primaryOutputChanged(output_name);
+    QString name;
+    if (output) {
+        auto *screen = WQt::Utils::qScreenFromWlOutput(output);
+        if (screen)
+            name = screen->name();
+    }
+    qCDebug(DccWayQt) << "TreeLandOutputManager::primary output changed" << name;
+    mPrimaryOutput = name;
+    Q_EMIT primaryOutputChanged(name);
+}
+
+void WQt::TreeLandOutputManager::treeland_output_manager_v2_primary_output_failed(uint32_t reason)
+{
+    qCWarning(DccWayQt) << "TreeLandOutputManager::set_primary_output rejected, reason" << reason;
 }

--- a/src/plugin-display/wayland/client/TreeLandOutputManager.h
+++ b/src/plugin-display/wayland/client/TreeLandOutputManager.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-#include "qwayland-treeland-output-manager-v1.h"
+#include "qwayland-treeland-output-manager-unstable-v2.h"
 
 #include <QMap>
 #include <QObject>
@@ -20,29 +20,36 @@ class TreeLandOutputManager;
 class ColorControl;
 } // namespace WQt
 
-class WQt::ColorControl : public QWaylandClientExtensionTemplate<WQt::ColorControl>, public QtWayland::treeland_output_color_control_v1
+class WQt::ColorControl : public QWaylandClientExtensionTemplate<WQt::ColorControl>, public QtWayland::treeland_output_picture_control_v2
 {
     Q_OBJECT
 
 public:
-    ColorControl(::treeland_output_color_control_v1 *obj, QObject *parent = nullptr);
+    ColorControl(::treeland_output_picture_control_v2 *obj, QObject *parent = nullptr);
     ~ColorControl() override;
 
     void setBrightness(double brightness);
     void setColorTemperature(uint32_t temperature);
 
 protected:
-    void treeland_output_color_control_v1_result(uint32_t success) override;
-    void treeland_output_color_control_v1_color_temperature(uint32_t temperature) override;
-    void treeland_output_color_control_v1_brightness(int32_t brightness) override;
+    void treeland_output_picture_control_v2_result(uint32_t result) override;
+    void treeland_output_picture_control_v2_color_temperature(uint32_t temperature) override;
+    void treeland_output_picture_control_v2_brightness(int32_t brightness) override;
 
 Q_SIGNALS:
-    void result(uint32_t success);
+    // v2 commit_result enum: 0 = success, 1 = failed, 2 = unsupported,
+    // 3 = invalid_output. Out-of-range set_* values never reach a commit:
+    // they are rejected at request time with a fatal protocol error that
+    // terminates the connection (see the clamps in setBrightness and
+    // setColorTemperature).
+    // (v1 used uint success with 1 = success / 0 = failure — the polarity is
+    // inverted in v2, so do not treat a non-zero value as success.)
+    void result(uint32_t result);
     void colorTemperatureChanged(uint32_t temperature);
     void brightnessChanged(double brightness);
 };
 
-class WQt::TreeLandOutputManager : public QWaylandClientExtensionTemplate<WQt::TreeLandOutputManager>, public QtWayland::treeland_output_manager_v1
+class WQt::TreeLandOutputManager : public QWaylandClientExtensionTemplate<WQt::TreeLandOutputManager>, public QtWayland::treeland_output_manager_v2
 {
     Q_OBJECT
     Q_PROPERTY(bool active READ isActive NOTIFY activeChanged)
@@ -51,13 +58,14 @@ public:
     TreeLandOutputManager(QObject *parent = nullptr);
     ~TreeLandOutputManager() override;
 
-    void setPrimaryOutput(const char *);
-    WQt::ColorControl *getColorControl(struct wl_output *output);
+    void setPrimaryOutput(struct wl_output *output);
+    WQt::ColorControl *getPictureControl(struct wl_output *output);
 
     QString mPrimaryOutput;
 
 protected:
-    void treeland_output_manager_v1_primary_output(const QString &output_name) override;
+    void treeland_output_manager_v2_primary_output(struct wl_output *output) override;
+    void treeland_output_manager_v2_primary_output_failed(uint32_t reason) override;
 
 Q_SIGNALS:
     void primaryOutputChanged(const QString &);

--- a/src/plugin-display/wayland/client/WayQtUtils.cpp
+++ b/src/plugin-display/wayland/client/WayQtUtils.cpp
@@ -27,6 +27,19 @@ wl_output *WQt::Utils::wlOutputFromQScreen(QScreen *screen)
     return native->output();
 }
 
+QScreen *WQt::Utils::qScreenFromWlOutput(wl_output *output)
+{
+    if (!output)
+        return nullptr;
+
+    for (QScreen *screen : QGuiApplication::screens()) {
+        if (wlOutputFromQScreen(screen) == output)
+            return screen;
+    }
+
+    return nullptr;
+}
+
 bool WQt::Utils::isOutputAlive(wl_output *output)
 {
     if (!output)

--- a/src/plugin-display/wayland/client/WayQtUtils.h
+++ b/src/plugin-display/wayland/client/WayQtUtils.h
@@ -18,6 +18,15 @@ namespace Utils {
 struct wl_output *wlOutputFromQScreen(QScreen *screen);
 
 /**
+ * The QScreen whose Qt Wayland platform screen owns @a output, or nullptr
+ * if no current screen backs this wl_output.
+ *
+ * Reverse lookup of wlOutputFromQScreen; used to recover a screen name
+ * from a wl_output object received in a Wayland event.
+ */
+QScreen *qScreenFromWlOutput(struct wl_output *output);
+
+/**
  * Whether @a output still backs one of the screens Qt currently knows about.
  *
  * A wl_output proxy stays valid for the client after the compositor removed the


### PR DESCRIPTION
## 概述

将 dde-control-center 中 treeland output v1 协议消费者迁移到 v2，参照 dde-shell 的迁移方式。

Ref: DDE-233

## 变更内容

### `src/plugin-display/CMakeLists.txt`
- `find_package(TreelandProtocols REQUIRED)` → `find_package(TreelandProtocols 0.6 REQUIRED)`
- XML 引用 `treeland-output-manager-v1.xml` → `treeland-output-manager-unstable-v2.xml`

### `src/plugin-display/wayland/client/TreeLandOutputManager.h`
- include `qwayland-treeland-output-manager-v1.h` → `qwayland-treeland-output-manager-unstable-v2.h`
- 基类 `treeland_output_manager_v1` → `treeland_output_manager_v2`
- `treeland_output_color_control_v1` → `treeland_output_picture_control_v2`
- `setPrimaryOutput(const char *)` → `setPrimaryOutput(struct wl_output *)`
- `getColorControl` → `getPictureControl`
- `primary_output` 事件 override 签名从 `(const QString &)` → `(struct wl_output *)`
- 新增 `primary_output_failed` 事件 override

### `src/plugin-display/wayland/client/TreeLandOutputManager.cpp`
- 全部 `treeland_output_*_v1::` 调用更名
- `get_color_control` → `get_picture_control`
- `set_primary_output` 参数从 string 改为 `wl_output *`
- `primary_output` 事件：从 `wl_output *` 反查 QScreen → 名称（处理 null 情况）
- `result` 事件参数从 `success`（1/0）改为 `result`（commit_result 枚举）
- 接口版本从 2 重置为 1（v2 是新接口）
- 新增 `primary_output_failed` 事件处理（日志告警）

### `src/plugin-display/wayland/client/WayQtUtils.h` / `.cpp`
- 新增 `qScreenFromWlOutput(wl_output *)` 辅助函数，用于 `wl_output *` → `QScreen *` 反查

### `src/plugin-display/operation/private/displayworker.cpp`
- `setPrimary`：按名称查找 `QScreen` → `wl_output *` 后调用 `setPrimaryOutput`
- `updateControl`：`getColorControl` → `getPictureControl`

## 协议 v1→v2 关键变更对照

| v1 | v2 |
|:--|:--|
| `treeland_output_manager_v1` | `treeland_output_manager_v2` |
| `treeland_output_color_control_v1` | `treeland_output_picture_control_v2` |
| `get_color_control(output)` | `get_picture_control(output)` |
| `set_primary_output(string name)` | `set_primary_output(struct wl_output*)` |
| `primary_output(string name)` 事件 | `primary_output(struct wl_output*)` 事件（allow-null） |
| `result(uint success)` 事件 | `result(uint result)` 事件 + `commit_result` 枚举 |
| — | `primary_output_failed` 事件（新增） |

## 约束
- 构建依赖 treeland-protocols ≥ 0.6
- 此 PR 为 draft，待人工审核，**不要合并**

## Summary by Sourcery

Migrate Treeland output management in the display plugin to protocol v2 while preserving primary-output and picture-control functionality.

Enhancements:
- Migrate the display plugin’s Treeland output integration from protocol v1 to unstable v2, including picture-control access and wl_output-based primary-output handling.
- Resolve Wayland outputs back to Qt screens and handle primary-output failures and nullable output events.
- Clamp brightness and color-temperature requests to protocol-supported ranges before submission.

Build:
- Require treeland-protocols 0.6 or newer and generate the client from the unstable Treeland output manager v2 protocol.