### PR TITLE
refactor: make effect support checks async via dbus

### DIFF
--- a/src/plugin-personalization/operation/personalizationdbusproxy.cpp
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.cpp
@@ -500,8 +500,13 @@ bool PersonalizationDBusProxy::isEffectLoaded(const QString &name, QObject *rece
 
 bool PersonalizationDBusProxy::isEffectSupported(const QString &name)
 {
+    return isEffectSupportedAsync(name);
+}
+
+QDBusPendingReply<bool> PersonalizationDBusProxy::isEffectSupportedAsync(const QString &name)
+{
     if (!m_EffectsInter) {
-        return false;
+        return {};
     }
     return QDBusPendingReply<bool>(m_EffectsInter->asyncCall(QStringLiteral("isEffectSupported"), QVariant::fromValue(name)));
 }

--- a/src/plugin-personalization/operation/personalizationdbusproxy.h
+++ b/src/plugin-personalization/operation/personalizationdbusproxy.h
@@ -190,6 +190,7 @@ public slots:
     bool isEffectLoaded(const QString &name);
     bool isEffectLoaded(const QString &name, QObject *receiver, const char *member);
     bool isEffectSupported(const QString &name);
+    QDBusPendingReply<bool> isEffectSupportedAsync(const QString &name);
 
 private:
     Dtk::Core::DDBusInterface *m_AppearanceInter = nullptr;

--- a/src/plugin-personalization/operation/x11worker.cpp
+++ b/src/plugin-personalization/operation/x11worker.cpp
@@ -7,6 +7,8 @@
 #include "operation/personalizationworker.h"
 
 #include <QLoggingCategory>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
 #include <QTimer>
 #include <DConfig>
 
@@ -43,17 +45,32 @@ void X11Worker::active()
     m_personalizationDBusProxy->isEffectLoaded(EffectMiniLampArg, this, SLOT(onMiniEffectChanged(bool)));
     m_model->setIsMoveWindow(m_personalizationDBusProxy->isEffectLoaded(EffectMoveWindowArg));
 
-    QStringList supportEffects;
-    if (m_personalizationDBusProxy->isEffectSupported(EffectMiniLampArg)) {
-        supportEffects.append(EffectMiniLampArg);
+    loadSupportedEffects();
+}
+
+void X11Worker::loadSupportedEffects()
+{
+    const QStringList effectNames = {EffectMiniLampArg, EffectMiniScaleArg, EffectMoveWindowArg};
+    for (const QString &effectName : effectNames) {
+        auto *watcher = new QDBusPendingCallWatcher(
+            m_personalizationDBusProxy->isEffectSupportedAsync(effectName), this);
+
+        connect(watcher, &QDBusPendingCallWatcher::finished, this,
+                [this, watcher, effectName] {
+            const QDBusPendingReply<bool> reply = *watcher;
+            QStringList supportEffects = m_model->supportEffects();
+            if (reply.isValid() && !reply.isError() && reply.value()) {
+                if (!supportEffects.contains(effectName)) {
+                    supportEffects.append(effectName);
+                }
+            } else {
+                supportEffects.removeAll(effectName);
+            }
+            m_model->setSupportEffects(supportEffects);
+
+            watcher->deleteLater();
+        });
     }
-    if (m_personalizationDBusProxy->isEffectSupported(EffectMiniScaleArg)) {
-        supportEffects.append(EffectMiniScaleArg);
-    }
-    if (m_personalizationDBusProxy->isEffectSupported(EffectMoveWindowArg)) {
-        supportEffects.append(EffectMoveWindowArg);
-    }
-    m_model->setSupportEffects(supportEffects);
 }
 
 void X11Worker::setTitleBarHeight(int value)

--- a/src/plugin-personalization/operation/x11worker.h
+++ b/src/plugin-personalization/operation/x11worker.h
@@ -29,6 +29,7 @@ private Q_SLOTS:
 private:
     void onKWinConfigChanged(const QString &key);
     void onTitleHeightChanged();
+    void loadSupportedEffects();
 
 private:
     Dtk::Core::DConfig *m_kwinTitleBarConfig = nullptr;


### PR DESCRIPTION
1. Convert isEffectSupported to return QDBusPendingReply<bool> through a
new isEffectSupportedAsync method
2. Keep the synchronous isEffectSupported API by delegating to the async
version
3. Replace blocking sequential checks in X11Worker::active with a new
loadSupportedEffects method
4. Use QDBusPendingCallWatcher to handle each effect check result
asynchronously
5. Update the model's supportEffects list incrementally based on each
reply
6. Handle invalid or errored replies by removing the corresponding
effect from the list
7. Avoid UI blocking caused by multiple synchronous DBus calls during
activation

Influence:
1. Verify the supported effects list is correctly populated after the
window manager activates
2. Test behavior when the DBus interface is unavailable
3. Confirm the UI does not freeze during the effect support checks
4. Verify effects are removed from the list when isEffectSupported
returns false or an error
5. Test with all effect combinations enabled and disabled
6. Verify no duplicate entries appear in the supportEffects list

refactor: 将特效支持检测改为异步 DBus 调用

1. 将 isEffectSupported 改为通过新增的 isEffectSupportedAsync 方法返回
QDBusPendingReply<bool>
2. 保留同步的 isEffectSupported 接口，内部委托给异步版本
3. 在 X11Worker::active 中用新的 loadSupportedEffects 方法替换阻塞式的顺
序检测
4. 使用 QDBusPendingCallWatcher 异步处理每个特效检测结果
5. 根据每个返回结果增量更新模型的 supportEffects 列表
6. 对无效或出错的返回结果，从列表中移除对应特效
7. 避免激活过程中多次同步 DBus 调用造成的界面阻塞

Influence:
1. 验证窗口管理器激活后支持的特效列表是否正确填充
2. 测试 DBus 接口不可用时的行为
3. 确认特效支持检测期间界面不会卡顿
4. 验证 isEffectSupported 返回 false 或出错时特效是否从列表中移除
5. 测试各种特效组合的开启和关闭情况
6. 验证 supportEffects 列表中不会出现重复条目

PMS: TASK-394433

## Summary by Sourcery

Make effect support detection asynchronous to keep activation responsive and maintain an accurate supported-effects list.

Bug Fixes:
- Prevent UI blocking during effect support detection by replacing sequential synchronous D-Bus checks with asynchronous requests.
- Remove effects from the supported-effects list when support checks fail, return false, or produce invalid replies.

Enhancements:
- Add asynchronous effect support checks while retaining the existing synchronous API.
- Populate the supported-effects model incrementally as each D-Bus reply completes, without duplicate entries.