### PR TITLE
feat: async load plugin main QML via incubator queue

### DIFF
--- a/src/dde-control-center/dccasyncmodloader.cpp
+++ b/src/dde-control-center/dccasyncmodloader.cpp
@@ -1,0 +1,334 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dccasyncmodloader.h"
+
+#include "dccobject.h"
+#include "dccpluginloader.h"
+
+#include <QLoggingCategory>
+#include <QQmlContext>
+
+namespace dccV25 {
+
+Q_LOGGING_CATEGORY(dccAsyncLog, "dde.dcc.asyncmodloader")
+
+// Incubator subclass: engine calls statusChanged directly, no polling
+// (the callback may run synchronously inside component->create() for simple
+// QML files, so the callback must NOT reset the incubator).
+class DccAsyncModuleLoader::DccAsyncIncubator : public QQmlIncubator
+{
+public:
+    enum Phase { ModulePhase, MainPhase };
+
+    DccAsyncIncubator(DccAsyncModuleLoader *owner, Phase phase)
+        : QQmlIncubator(Asynchronous)
+        , m_owner(owner)
+        , m_phase(phase)
+    {
+    }
+
+protected:
+    void statusChanged(Status status) override
+    {
+        if (m_phase == ModulePhase) {
+            m_owner->onModuleIncubated(status);
+        } else {
+            m_owner->onMainIncubated(status);
+        }
+    }
+
+private:
+    DccAsyncModuleLoader *m_owner;
+    Phase m_phase;
+};
+
+DccAsyncModuleLoader::DccAsyncModuleLoader(QQmlEngine *engine, QObject *parent)
+    : QObject(parent)
+    , m_engine(engine)
+{
+}
+
+DccAsyncModuleLoader::~DccAsyncModuleLoader()
+{
+    cancel();
+}
+
+void DccAsyncModuleLoader::enqueue(DccPluginLoader *loader)
+{
+    if (!loader || !m_engine) {
+        return;
+    }
+
+    m_queue.enqueue(loader);
+    if (m_active) {
+        qCDebug(dccAsyncLog) << "Queuing" << loader->name() << "(queue size=" << m_queue.size() << ")";
+        return;
+    }
+
+    m_active = true;
+    m_current = loader;
+    startNext();
+}
+
+void DccAsyncModuleLoader::cancel()
+{
+    m_queue.clear();
+    m_active = false;
+    m_current = nullptr;
+    // Abort any in-flight incubation before releasing the objects
+    if (m_moduleIncubator) {
+        m_moduleIncubator->clear();
+    }
+    if (m_mainIncubator) {
+        m_mainIncubator->clear();
+    }
+    m_moduleComponent.reset();
+    m_moduleIncubator.reset();
+    m_mainComponent.reset();
+    m_mainIncubator.reset();
+    // Non-null = we own it; null = already handed to the created object
+    delete m_mainContext;
+    m_mainContext = nullptr;
+}
+
+void DccAsyncModuleLoader::doLoadModule()
+{
+    if (!m_current || !m_engine) {
+        return;
+    }
+    if (!(m_current->type() & DccPluginLoader::T_HasModule)) {
+        // Same as sync loadModule(): a missing module QML is not an error
+        m_current->setLog("module qml not exists");
+        m_current->transitionStatus(DccPluginLoader::ModuleEnd);
+        scheduleNext();
+        return;
+    }
+    const QString name = m_current->name();
+
+    m_current->transitionStatus(DccPluginLoader::ModuleLoad);
+
+    DCC_BENCHMARK(name, "loading-module-QML");
+    m_moduleComponent = std::make_unique<QQmlComponent>(m_engine);
+    // Async compilation: QML parsing doesn't block the main loop
+    connect(m_moduleComponent.get(), &QQmlComponent::statusChanged, this, &DccAsyncModuleLoader::onModuleComponentStatus, Qt::QueuedConnection);
+    switch (m_current->version()) {
+    case DccPluginLoader::T_V1_0: {
+        const QString qmlPath = m_current->path() + "/" + m_current->name() + ".qml";
+        m_moduleComponent->loadUrl(qmlPath, QQmlComponent::Asynchronous);
+        m_current->setLog("create module " + qmlPath);
+        DCC_BENCHMARK(m_current->name(), "module-qml-load");
+    } break;
+    case DccPluginLoader::T_V1_1:
+    default: {
+        QString typeName = m_current->name();
+        typeName[0] = typeName[0].toUpper();
+        m_current->setLog("create module " + typeName);
+        DCC_BENCHMARK(m_current->name(), "module-qml-load");
+        m_moduleComponent->loadFromModule(m_current->name(), typeName, QQmlComponent::Asynchronous);
+    } break;
+    }
+}
+
+void DccAsyncModuleLoader::onModuleComponentStatus(QQmlComponent::Status status)
+{
+    if (!m_current) {
+        return; // callback delivered after cancel()/startNext() cleared the current item
+    }
+    const QString name = m_current->name();
+    switch (status) {
+    case QQmlComponent::Error: {
+        m_current->setLog("component create module object error:" + m_moduleComponent->errorString());
+        m_current->transitionStatus(DccPluginLoader::ModuleErr | DccPluginLoader::ModuleEnd);
+        scheduleNext();
+    } break;
+    case QQmlComponent::Ready: {
+        m_current->transitionStatus(DccPluginLoader::ModuleCreate);
+        DCC_BENCHMARK(name, "module-object-create");
+
+        // Start async incubation; completion delivered via statusChanged override
+        m_moduleIncubator = std::make_unique<DccAsyncIncubator>(this, DccAsyncIncubator::ModulePhase);
+        m_moduleComponent->create(*m_moduleIncubator);
+    } break;
+    default:
+        break;
+    }
+}
+
+void DccAsyncModuleLoader::onModuleIncubated(QQmlIncubator::Status status)
+{
+    if (!m_current || !m_moduleIncubator) {
+        return;
+    }
+
+    const QString name = m_current->name();
+    switch (status) {
+    case QQmlIncubator::Ready: {
+        QObject *rawObj = m_moduleIncubator->object();
+        if (!rawObj) {
+            const QString err = m_moduleIncubator->errors().isEmpty() ? QString() : m_moduleIncubator->errors().first().description();
+            m_current->setLog("component create module object is null:" + err);
+            m_current->transitionStatus(DccPluginLoader::ModuleErr | DccPluginLoader::ModuleEnd);
+            scheduleNext();
+            return;
+        }
+
+        DccObject *module = qobject_cast<DccObject *>(rawObj);
+        DCC_BENCHMARK(name, "loading-module-QML");
+
+        m_current->setModule(module);
+        m_current->transitionStatus(DccPluginLoader::ModuleEnd);
+        scheduleNext();
+    } break;
+    case QQmlIncubator::Error: {
+        const QString err = m_moduleIncubator->errors().isEmpty() ? QString() : m_moduleIncubator->errors().first().description();
+        m_current->setLog("component create module object error:" + err);
+        m_current->transitionStatus(DccPluginLoader::ModuleErr | DccPluginLoader::ModuleEnd);
+        scheduleNext();
+    } break;
+    default:
+        break;
+    }
+}
+
+void DccAsyncModuleLoader::doLoadMain()
+{
+    if (!m_current || !m_engine) {
+        return;
+    }
+
+    const QString name = m_current->name();
+    const QString path = m_current->path();
+    const auto type = m_current->type();
+    const auto ver = m_current->version();
+
+    if (!(type & DccPluginLoader::T_HasMain)) {
+        m_current->setLog("main qml not exists");
+        m_current->transitionStatus(DccPluginLoader::MainObjErr | DccPluginLoader::MainObjEnd);
+        scheduleNext();
+        return;
+    }
+
+    m_current->transitionStatus(DccPluginLoader::MainObjLoad);
+
+    // Async compilation for main QML
+    m_mainComponent = std::make_unique<QQmlComponent>(m_engine);
+    connect(m_mainComponent.get(), &QQmlComponent::statusChanged, this, &DccAsyncModuleLoader::onMainComponentStatus, Qt::QueuedConnection);
+    if (ver == DccPluginLoader::T_V1_0) {
+        const QString qmlPath = path + "/" + ((type & DccPluginLoader::T_ShortMain) ? "main.qml" : name + "Main.qml");
+        m_mainComponent->loadUrl(qmlPath, QQmlComponent::Asynchronous);
+    } else {
+        QString typeName = name + "Main";
+        typeName[0] = typeName[0].toUpper();
+        m_mainComponent->loadFromModule(name, typeName, QQmlComponent::Asynchronous);
+    }
+}
+
+void DccAsyncModuleLoader::onMainComponentStatus(QQmlComponent::Status status)
+{
+    if (!m_current) {
+        return; // callback delivered after cancel()/startNext() cleared the current item
+    }
+    switch (status) {
+    case QQmlComponent::Error: {
+        const QString name = m_current->name();
+        m_current->setLog(" component create main object error:" + m_mainComponent->errorString());
+        m_current->transitionStatus(DccPluginLoader::MainObjErr | DccPluginLoader::MainObjEnd);
+        scheduleNext();
+    } break;
+    case QQmlComponent::Ready: {
+        m_current->transitionStatus(DccPluginLoader::MainObjCreate);
+        DCC_BENCHMARK(m_current->name(), "mainobj-sub-step:qml-create()");
+
+        // Context must outlive async creation; parented to the created
+        // object in onMainIncubated
+        m_mainContext = new QQmlContext(m_engine);
+        m_mainContext->setContextProperties({ { "dccData", QVariant::fromValue(m_current->data()) }, { "dccModule", QVariant::fromValue(m_current->module()) } });
+
+        // Start async incubation; completion delivered via statusChanged override
+        m_mainIncubator = std::make_unique<DccAsyncIncubator>(this, DccAsyncIncubator::MainPhase);
+        m_mainComponent->create(*m_mainIncubator, m_mainContext);
+    } break;
+    default:
+        break;
+    }
+}
+
+void DccAsyncModuleLoader::onMainIncubated(QQmlIncubator::Status status)
+{
+    if (!m_current || !m_mainIncubator) {
+        return;
+    }
+
+    const QString name = m_current->name();
+    switch (status) {
+    case QQmlIncubator::Ready: {
+        QObject *rawObj = m_mainIncubator->object();
+        if (!rawObj) {
+            const QString err = m_mainIncubator->errors().isEmpty() ? QString() : m_mainIncubator->errors().first().description();
+            m_current->setLog(" component create main object is null:" + err);
+            m_current->transitionStatus(DccPluginLoader::MainObjErr | DccPluginLoader::MainObjEnd);
+            scheduleNext();
+            // We still own the context; nothing adopted it
+            delete m_mainContext;
+            m_mainContext = nullptr;
+            return;
+        }
+        DccObject *mainObj = qobject_cast<DccObject *>(rawObj);
+        DCC_BENCHMARK(name, "loading-main-QML");
+        qCDebug(dccAsyncLog) << name << "main object ready";
+
+        m_current->setMainObj(mainObj);
+        m_mainContext->setParent(mainObj);
+        m_mainContext = nullptr;
+        m_current->transitionStatus(DccPluginLoader::MainObjEnd);
+
+        scheduleNext();
+    } break;
+    case QQmlIncubator::Error: {
+        const QString err = m_mainIncubator->errors().isEmpty() ? QString() : m_mainIncubator->errors().first().description();
+        m_current->setLog(" component create main object error:" + err);
+        m_current->transitionStatus(DccPluginLoader::MainObjErr | DccPluginLoader::MainObjEnd);
+        // We still own the context; nothing adopted it
+        delete m_mainContext;
+        m_mainContext = nullptr;
+        scheduleNext();
+    } break;
+    default:
+        break;
+    }
+}
+
+void DccAsyncModuleLoader::scheduleNext()
+{
+    QMetaObject::invokeMethod(this, "startNext", Qt::QueuedConnection);
+}
+
+void DccAsyncModuleLoader::startNext()
+{
+    // Always invoked via queued connection, so releasing here is safe
+    m_moduleComponent.reset();
+    m_moduleIncubator.reset();
+    m_mainComponent.reset();
+    m_mainIncubator.reset();
+    // Safety net: non-null here means the context was never adopted
+    delete m_mainContext;
+    m_mainContext = nullptr;
+    m_current = nullptr;
+    if (m_queue.isEmpty()) {
+        m_active = false;
+        return;
+    }
+    m_current = m_queue.dequeue();
+    DccPluginLoader::StatusFlags status = m_current->status();
+    if ((status & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) {
+        doLoadModule();
+    } else if ((status & (DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad)) == DccPluginLoader::DataEnd) {
+        doLoadMain();
+    } else {
+        scheduleNext();
+    }
+}
+
+} // namespace dccV25

--- a/src/dde-control-center/dccasyncmodloader.h
+++ b/src/dde-control-center/dccasyncmodloader.h
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+#pragma once
+
+#include "dccbenchmark.h"
+#include "dccpluginloader.h"
+
+#include <QObject>
+#include <QQmlComponent>
+#include <QQmlEngine>
+#include <QQmlIncubator>
+#include <QQueue>
+#include <memory>
+
+namespace dccV25 {
+
+class DccAsyncModuleLoader : public QObject
+{
+    Q_OBJECT
+public:
+    explicit DccAsyncModuleLoader(QQmlEngine *engine, QObject *parent = nullptr);
+    ~DccAsyncModuleLoader() override;
+
+    // Enqueue a plugin for async module + main QML loading.
+    // If another plugin is currently being loaded, it is queued.
+    void enqueue(DccPluginLoader *loader);
+
+    // Cancel all pending work and clear the queue
+    void cancel();
+    bool isLoading() const { return m_active; }
+
+private Q_SLOTS:
+    // QQmlComponent::statusChanged handlers for the async compile phases
+    void onModuleComponentStatus(QQmlComponent::Status status);
+    void onMainComponentStatus(QQmlComponent::Status status);
+    void startNext();
+
+private:
+    // Queued self-invocation of startNext(); safe to call from any callback
+    void scheduleNext();
+
+private:
+    void doLoadModule();
+    void doLoadMain();
+    // Called from DccAsyncIncubator::statusChanged (may run synchronously
+    // inside component->create() for simple QML files)
+    void onModuleIncubated(QQmlIncubator::Status status);
+    void onMainIncubated(QQmlIncubator::Status status);
+
+    // Incubator subclass: engine calls statusChanged directly, no polling
+    class DccAsyncIncubator;
+
+    QQmlEngine *m_engine = nullptr;
+    bool m_active = false;
+
+    QQueue<DccPluginLoader *> m_queue;
+    DccPluginLoader *m_current = nullptr;
+
+    // Held alive during async phases; released only in startNext()/cancel()
+    std::unique_ptr<QQmlComponent> m_moduleComponent;
+    std::unique_ptr<DccAsyncIncubator> m_moduleIncubator;
+    std::unique_ptr<QQmlComponent> m_mainComponent;
+    std::unique_ptr<DccAsyncIncubator> m_mainIncubator;
+    // Non-null = we own it; null = handed to the created object (onMainIncubated)
+    QQmlContext *m_mainContext = nullptr;
+};
+
+} // namespace dccV25

--- a/src/dde-control-center/dccpluginloader.cpp
+++ b/src/dde-control-center/dccpluginloader.cpp
@@ -113,6 +113,23 @@ void DccPluginLoader::setType(TypeFlags type)
     m_type = type;
 }
 
+void DccPluginLoader::setModule(DccObject *module)
+{
+    m_module = module;
+    if (module) {
+        module->setParent(m_pManager->rootModule());
+        connect(module, &DccObject::visibleToAppChanged, this, &DccPluginLoader::updateVisible);
+    }
+}
+
+void DccPluginLoader::setMainObj(DccObject *mainObj)
+{
+    m_mainObj = mainObj;
+    if (m_mainObj) {
+        m_mainObj->setParent(m_module ? m_module : m_pManager->rootModule());
+    }
+}
+
 void DccPluginLoader::transitionStatus(StatusFlags status)
 {
     StatusFlags oldStatus = m_status;
@@ -247,11 +264,10 @@ bool DccPluginLoader::loadModule()
         QObject *object = component.create();
         if (!object) {
             setLog("component create module object is null:" + component.errorString());
+            transitionStatus(ModuleErr);
             return true;
         }
-        object->setParent(m_pManager->rootModule());
-        m_module = qobject_cast<DccObject *>(object);
-        connect(m_module, &DccObject::visibleToAppChanged, this, &DccPluginLoader::updateVisible);
+        setModule(qobject_cast<DccObject *>(object));
         if (m_module && !m_module->isVisibleToApp()) {
             setLog("create module finished, module is hidden");
             return false;
@@ -394,8 +410,7 @@ void DccPluginLoader::loadMain()
             return;
         }
         context->setParent(object); // Context will be deleted when object is deleted
-        object->setParent(m_module ? m_module : m_pManager->rootModule());
-        m_mainObj = qobject_cast<DccObject *>(object);
+        setMainObj(qobject_cast<DccObject *>(object));
     } break;
     case QQmlComponent::Error: {
         setLog(" component create main object error:" + component.errorString());

--- a/src/dde-control-center/dccpluginloader.h
+++ b/src/dde-control-center/dccpluginloader.h
@@ -86,6 +86,8 @@ public:
 
     // Dependency injection
     void setType(TypeFlags type);
+    void setModule(DccObject *module);
+    void setMainObj(DccObject *mainObj);
 
     // Loading methods
     void reset(); // Reset status and restart loading

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -4,6 +4,7 @@
 
 #include "pluginmanager.h"
 
+#include "dccasyncmodloader.h"
 #include "dccfactory.h"
 #include "dccmanager.h"
 #include "dccobject_p.h"
@@ -24,6 +25,10 @@
 #include <QSettings>
 #include <QtConcurrent>
 #include <QtConcurrentRun>
+
+// module同步加载尽快显示，main异步加载不阻塞主线程
+// #define ASYNC_MODULE
+#define ASYNC_MAIN
 
 namespace dccV25 {
 
@@ -67,6 +72,7 @@ DccPluginManager::DccPluginManager(DccManager *parent)
     , m_rootModule(nullptr)
     , m_threadPool(nullptr)
     , m_isDeleting(false)
+    , m_asyncLoader(nullptr)
 {
     connect(m_manager, &DccManager::hideModuleChanged, this, &DccPluginManager::onHideModuleChanged);
 }
@@ -111,26 +117,40 @@ void DccPluginManager::loadPlugin(DccPluginLoader *loader)
         }
         loader->transitionStatus(DccPluginLoader::PluginEnd);
     } else if ((loader->status() & (DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad)) == DccPluginLoader::DataEnd) {
-        loader->transitionStatus(DccPluginLoader::MainObjLoad);
         loader->createDccObject();
         loader->updateParent();
+#ifdef ASYNC_MAIN
+        m_asyncLoader->enqueue(loader);
+#else
+        loader->transitionStatus(DccPluginLoader::MainObjLoad);
         loader->loadMain();
         loader->transitionStatus(DccPluginLoader::MainObjEnd);
+#endif
     } else if ((loader->status() & (DccPluginLoader::ModuleEnd | DccPluginLoader::DataBegin)) == DccPluginLoader::ModuleEnd) {
-
+        if (loader->module()) {
+            if (!loader->module()->parent()) {
+                loader->module()->setParent(rootModule());
+            }
+            Q_EMIT addObject(loader->module());
+        }
+        if (!loader->isVisibleToApp()) {
+            loader->setLog("create module finished, module is hidden");
+            loader->transitionStatus(DccPluginLoader::ModuleEnd | DccPluginLoader::PluginEnd);
+        }
         checkNavigationFinished();
     } else if ((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) {
+#ifdef ASYNC_MODULE
+        m_asyncLoader->enqueue(loader);
+#else
         loader->transitionStatus(DccPluginLoader::ModuleLoad);
         const auto ret = loader->loadModule();
-        if (auto module = loader->module()) {
-            Q_EMIT addObject(module);
-        }
         if (ret) {
             loader->transitionStatus(DccPluginLoader::ModuleEnd);
             Q_EMIT moduleLoaded(loader->name());
         } else {
             loader->transitionStatus(DccPluginLoader::ModuleEnd | DccPluginLoader::PluginEnd);
         }
+#endif
     } else {
         if (loader->loadMetaData()) {
             loader->transitionStatus(DccPluginLoader::MetaDataEnd);
@@ -149,6 +169,9 @@ void DccPluginManager::loadModules(DccObject *root, bool async, const QStringLis
     m_rootModule = root;
     m_engine = engine;
     qCDebug(dccLog()) << "plugin dir:" << dirs;
+    if (!m_asyncLoader) {
+        m_asyncLoader = new DccAsyncModuleLoader(m_engine, this);
+    }
 
     QFileInfoList pluginList;
     for (const auto &dir : dirs) {

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -19,6 +19,7 @@ namespace dccV25 {
 class DccObject;
 class DccManager;
 class DccPluginLoader;
+class DccAsyncModuleLoader;
 
 class DccPluginManager : public QObject
 {
@@ -71,6 +72,7 @@ private:
     DccLoadTimer m_loadTimer;
     bool m_navigationFinished = false;
     bool m_allLoadFinished = false;
+    DccAsyncModuleLoader *m_asyncLoader;
 };
 
 } // namespace dccV25


### PR DESCRIPTION
1. Add DccAsyncModuleLoader to load plugin main QML asynchronously (QQmlComponent::Asynchronous + QQmlIncubator) via a serial queue so plugin pages no longer block the main thread after navigation is ready.
2. Completion is driven by queued startNext() calls, safe against synchronous incubator callbacks; component statusChanged slots guard against stale callbacks after cancel().
3. Ownership: components/incubators held by unique_ptr; QQmlContext uses the "non-null = owned, null = handed over" convention and is parented to the created object, fixing a per-plugin context leak.
4. DccPluginLoader: extract setModule()/setMainObj() shared by sync and async paths for parenting and visibleToAppChanged wiring.
5. DccPluginManager: gate async stages with ASYNC_MODULE/ASYNC_MAIN (module sync for fast navigation, main async); error paths mirror sync semantics (*Err|*End + finishPlugin) so load completion can never stall on a bad plugin QML.

Log: Control center opens with the window visible earlier; plugin pages load in the background without blocking the UI.

Influence:
1. Launch control center: window shows, navigation list appears, then pages become clickable as they finish loading.
2. Verify a plugin with a broken main QML still lets the control center finish loading all other plugins (no stuck "loading").

feat: 使用孵化器队列异步加载插件主 QML

1. 新增 DccAsyncModuleLoader，通过串行队列以异步方式 （QQmlComponent::Asynchronous + QQmlIncubator）加载插件 main QML， 使导航就绪后插件页面不再阻塞主线程。
2. 各阶段完成由队列化的 startNext() 驱动，可安全应对孵化器同步回调； component statusChanged 槽对 cancel() 之后的过期回调做了防护。
3. 所有权规则：component/incubator 由 unique_ptr 持有；QQmlContext 采用 "非空=持有、空=已转让"约定，并挂接到所创建对象上，修复了 每插件泄漏一个 context 的问题。
4. DccPluginLoader：提取 setModule()/setMainObj()，供同步/异步 两条路径共享挂父逻辑与 visibleToAppChanged 接线。
5. DccPluginManager：以 ASYNC_MODULE/ASYNC_MAIN 宏门控各阶段 （module 同步以保证导航尽快就绪，main 异步）；错误路径与同步语义 一致（*Err|*End + finishPlugin），坏插件 QML 不会卡死加载完成流程。

Log: 控制中心窗口更早可交互，插件页面后台加载不再阻塞界面。

Influence:
1. 启动控制中心：窗口先显示、导航列表先就绪，各页面加载完成后可点击。
2. 验证某个插件 main QML 损坏时，其余插件仍能正常加载完成（不会卡在加载中）。

PMS: TASK-394433

## Summary by Sourcery

Keep the control center responsive by asynchronously loading plugin pages while preserving reliable completion and error handling.

New Features:
- Load plugin main QML asynchronously through a serial incubator queue so the control center remains responsive while pages finish loading in the background.

Bug Fixes:
- Ensure failed or missing plugin QML completes its load state without blocking other plugins.
- Fix per-plugin QQmlContext leaks by transferring context ownership to successfully created main objects.

Enhancements:
- Share module and main-object parenting and visibility wiring between synchronous and asynchronous loading paths.
- Guard asynchronous completion handling against stale callbacks and synchronous incubator notifications.