### PR TITLE
feat: async load plugin QML via incubator queue

### DIFF
--- a/src/dde-control-center/dccpluginloader.cpp
+++ b/src/dde-control-center/dccpluginloader.cpp
@@ -24,6 +24,32 @@
 
 namespace dccV25 {
 
+Q_LOGGING_CATEGORY(dccAsyncLog, "dde.dcc.asyncmodloader")
+
+// Incubator subclass: engine calls statusChanged directly, no polling
+// (the callback may run synchronously inside component->create() for simple
+// QML files). Dispatches back to the owning loader.
+class DccPluginLoader::AsyncIncubator : public QQmlIncubator
+{
+public:
+    explicit AsyncIncubator(DccPluginLoader *owner)
+        : QQmlIncubator(Asynchronous)
+        , m_owner(owner)
+    {
+    }
+
+protected:
+    void statusChanged(Status status) override
+    {
+        if (m_owner) {
+            m_owner->onIncubated(status);
+        }
+    }
+
+private:
+    DccPluginLoader *m_owner;
+};
+
 DccPluginLoader::DccPluginLoader(const QString &name, const QString &path, DccPluginManager *manager)
     : QObject(manager)
     , m_path(path)
@@ -113,6 +139,23 @@ void DccPluginLoader::setType(TypeFlags type)
     m_type = type;
 }
 
+void DccPluginLoader::setModule(DccObject *module)
+{
+    m_module = module;
+    if (module) {
+        module->setParent(m_pManager->rootModule());
+        connect(module, &DccObject::visibleToAppChanged, this, &DccPluginLoader::updateVisible);
+    }
+}
+
+void DccPluginLoader::setMainObj(DccObject *mainObj)
+{
+    m_mainObj = mainObj;
+    if (m_mainObj) {
+        m_mainObj->setParent(m_module ? m_module : m_pManager->rootModule());
+    }
+}
+
 void DccPluginLoader::transitionStatus(StatusFlags status)
 {
     StatusFlags oldStatus = m_status;
@@ -140,7 +183,7 @@ void DccPluginLoader::updateVisible(bool visibleToApp)
     if ((m_status.load() & PluginEnd) && (!(m_status.load() & (DataEnd | DataErr)))) {
         // 加载完成，没检查MetaData也没错误，不在hideModule中，则需要重新加载
         StatusFlags status = m_status.load() & ~PluginEnd;
-        m_status = PluginBegin;
+        m_status = PluginBegin; // 清理m_status，transitionStatus是只添加状态
         transitionStatus(status);
     }
 }
@@ -218,12 +261,19 @@ bool DccPluginLoader::loadMetaData()
     return true;
 }
 
-bool DccPluginLoader::loadModule()
+void DccPluginLoader::loadModule()
+{
+    transitionStatus(DccPluginLoader::ModuleLoad);
+    doLoadModule();
+    transitionStatus(DccPluginLoader::ModuleEnd);
+}
+
+void DccPluginLoader::doLoadModule()
 {
     DCC_BENCHMARK(name(), "loading-module-QML");
     if (!(m_type & T_HasModule)) {
         setLog("module qml not exists");
-        return true;
+        return;
     }
 
     QQmlComponent component(m_pManager->engine());
@@ -247,15 +297,10 @@ bool DccPluginLoader::loadModule()
         QObject *object = component.create();
         if (!object) {
             setLog("component create module object is null:" + component.errorString());
-            return true;
+            transitionStatus(ModuleErr);
+            return;
         }
-        object->setParent(m_pManager->rootModule());
-        m_module = qobject_cast<DccObject *>(object);
-        connect(m_module, &DccObject::visibleToAppChanged, this, &DccPluginLoader::updateVisible);
-        if (m_module && !m_module->isVisibleToApp()) {
-            setLog("create module finished, module is hidden");
-            return false;
-        }
+        setModule(qobject_cast<DccObject *>(object));
     } break;
     case QQmlComponent::Error: {
         setLog("component create module object error:" + component.errorString());
@@ -264,7 +309,6 @@ bool DccPluginLoader::loadModule()
     default:
         break;
     }
-    return true;
 }
 
 void DccPluginLoader::loadData()
@@ -358,6 +402,13 @@ void DccPluginLoader::updateParent()
 
 void DccPluginLoader::loadMain()
 {
+    transitionStatus(DccPluginLoader::MainObjLoad);
+    doLoadMain();
+    transitionStatus(DccPluginLoader::MainObjEnd);
+}
+
+void DccPluginLoader::doLoadMain()
+{
     DCC_BENCHMARK(name(), "creating-the-main-qml-object");
     if (!(m_type & T_HasMain)) {
         setLog("main qml not exists");
@@ -394,8 +445,7 @@ void DccPluginLoader::loadMain()
             return;
         }
         context->setParent(object); // Context will be deleted when object is deleted
-        object->setParent(m_module ? m_module : m_pManager->rootModule());
-        m_mainObj = qobject_cast<DccObject *>(object);
+        setMainObj(qobject_cast<DccObject *>(object));
     } break;
     case QQmlComponent::Error: {
         setLog(" component create main object error:" + component.errorString());
@@ -404,6 +454,191 @@ void DccPluginLoader::loadMain()
     default:
         break;
     }
+}
+
+void DccPluginLoader::asyncLoadModule()
+{
+    Q_ASSERT(m_asyncPhase == AsyncPhase::None);
+
+    if (!(m_type & T_HasModule)) {
+        // Same as sync loadModule(): a missing module QML is not an error
+        setLog("module qml not exists");
+        transitionStatus(ModuleEnd);
+        finishAsync();
+        return;
+    }
+
+    m_asyncPhase = AsyncPhase::Module;
+    transitionStatus(ModuleLoad);
+
+    DCC_BENCHMARK(name(), "loading-module-QML");
+    m_asyncComponent = std::make_unique<QQmlComponent>(m_pManager->engine());
+    // Async compilation: QML parsing doesn't block the main loop
+    connect(m_asyncComponent.get(), &QQmlComponent::statusChanged, this, &DccPluginLoader::onComponentStatus, Qt::QueuedConnection);
+    switch (version()) {
+    case T_V1_0: {
+        const QString qmlPath = m_path + "/" + name() + ".qml";
+        m_asyncComponent->loadUrl(qmlPath, QQmlComponent::Asynchronous);
+        setLog("create module " + qmlPath);
+        DCC_BENCHMARK(name(), "module-qml-load");
+    } break;
+    case T_V1_1:
+    default: {
+        QString typeName = name();
+        typeName[0] = typeName[0].toUpper();
+        setLog("create module " + typeName);
+        DCC_BENCHMARK(name(), "module-qml-load");
+        m_asyncComponent->loadFromModule(name(), typeName, QQmlComponent::Asynchronous);
+    } break;
+    }
+}
+
+void DccPluginLoader::asyncLoadMain()
+{
+    Q_ASSERT(m_asyncPhase == AsyncPhase::None);
+
+    if (!(m_type & T_HasMain)) {
+        setLog("main qml not exists");
+        transitionStatus(MainObjErr | MainObjEnd);
+        finishAsync();
+        return;
+    }
+
+    m_asyncPhase = AsyncPhase::Main;
+    transitionStatus(MainObjLoad);
+
+    DCC_BENCHMARK(name(), "loading-main-QML");
+
+    m_asyncComponent = std::make_unique<QQmlComponent>(m_pManager->engine());
+    connect(m_asyncComponent.get(), &QQmlComponent::statusChanged, this, &DccPluginLoader::onComponentStatus, Qt::QueuedConnection);
+    if (version() == T_V1_0) {
+        const QString qmlPath = m_path + "/" + ((m_type & T_ShortMain) ? "main.qml" : name() + "Main.qml");
+        m_asyncComponent->loadUrl(qmlPath, QQmlComponent::Asynchronous);
+    } else {
+        QString typeName = name() + "Main";
+        typeName[0] = typeName[0].toUpper();
+        m_asyncComponent->loadFromModule(name(), typeName, QQmlComponent::Asynchronous);
+    }
+}
+
+void DccPluginLoader::onComponentStatus(QQmlComponent::Status status)
+{
+    if (m_asyncPhase == AsyncPhase::None) {
+        return; // 回调迟到（cancelAsync()/finishAsync() 已清理）
+    }
+    const bool isModule = (m_asyncPhase == AsyncPhase::Module);
+    switch (status) {
+    case QQmlComponent::Error: {
+        setLog((isModule ? "component create module object error:" : "component create main object error:") + m_asyncComponent->errorString());
+        transitionStatus(isModule ? (ModuleErr | ModuleEnd) : (MainObjErr | MainObjEnd));
+        finishAsync();
+        break;
+    }
+    case QQmlComponent::Ready: {
+        if (isModule) {
+            transitionStatus(ModuleCreate);
+            DCC_BENCHMARK(name(), "module-object-create");
+        } else {
+            transitionStatus(MainObjCreate);
+            DCC_BENCHMARK(name(), "mainobj-sub-step:qml-create()");
+            // Context must outlive async creation; adopted by the object in
+            // onIncubated
+            m_asyncContext = new QQmlContext(m_pManager->engine());
+            m_asyncContext->setContextProperties({ { "dccData", QVariant::fromValue(m_data) }, { "dccModule", QVariant::fromValue(m_module) } });
+        }
+        m_incubator = std::make_unique<AsyncIncubator>(this);
+        m_asyncComponent->create(*m_incubator, m_asyncContext);
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void DccPluginLoader::onIncubated(QQmlIncubator::Status status)
+{
+    if (m_asyncPhase == AsyncPhase::None) {
+        return;
+    }
+    const bool isModule = (m_asyncPhase == AsyncPhase::Module);
+    switch (status) {
+    case QQmlIncubator::Ready: {
+        QObject *rawObj = m_incubator->object();
+        if (!rawObj) {
+            const QString err = m_incubator->errors().isEmpty() ? QString() : m_incubator->errors().first().description();
+            if (isModule) {
+                setLog("component create module object is null:" + err);
+                // Sync loadModule() treats a null object as non-error
+                transitionStatus(ModuleEnd);
+            } else {
+                // We still own the context; nothing adopted it
+                delete m_asyncContext;
+                m_asyncContext = nullptr;
+                setLog(" component create main object is null:" + err);
+                transitionStatus(MainObjErr | MainObjEnd);
+            }
+            finishAsync();
+            return;
+        }
+        if (isModule) {
+            DccObject *module = qobject_cast<DccObject *>(rawObj);
+            DCC_BENCHMARK(name(), "loading-module-QML");
+            qCDebug(dccAsyncLog) << name() << "module ready, visible=" << (module ? module->isVisibleToApp() : false);
+
+            setModule(module);
+            transitionStatus(ModuleEnd);
+            finishAsync();
+        } else {
+            DCC_BENCHMARK(name(), "loading-main-QML");
+            qCDebug(dccAsyncLog) << name() << "main object ready";
+            DccObject *mainObj = qobject_cast<DccObject *>(rawObj);
+            // 先定对象归属，再挂 context，最后置空（所有权转移点）
+            setMainObj(mainObj);
+            m_asyncContext->setParent(mainObj);
+            m_asyncContext = nullptr;
+            transitionStatus(MainObjEnd);
+        }
+        finishAsync();
+        break;
+    }
+    case QQmlIncubator::Error: {
+        const QString err = m_incubator->errors().isEmpty() ? QString() : m_incubator->errors().first().description();
+        if (isModule) {
+            setLog("component create module object error:" + err);
+            transitionStatus(ModuleErr | ModuleEnd);
+        } else {
+            setLog(" component create main object error:" + err);
+            transitionStatus(MainObjErr | MainObjEnd);
+            // We still own the context; nothing adopted it
+            delete m_asyncContext;
+            m_asyncContext = nullptr;
+        }
+        finishAsync();
+        break;
+    }
+    default:
+        break;
+    }
+}
+
+void DccPluginLoader::finishAsync()
+{
+    m_asyncPhase = AsyncPhase::None;
+    m_asyncComponent.reset();
+    m_incubator.reset();
+    // Safety net: non-null here means the context was never adopted
+    if (m_asyncContext) {
+        delete m_asyncContext;
+    }
+    m_asyncContext = nullptr;
+}
+
+void DccPluginLoader::cancelAsync()
+{
+    if (m_incubator) {
+        m_incubator->clear(); // abort in-flight incubation
+    }
+    finishAsync();
 }
 
 void DccPluginLoader::addMainObject()
@@ -447,6 +682,7 @@ void DccPluginLoader::cancel()
 void DccPluginLoader::reset()
 {
     // Reset status to begin state
+    cancelAsync(); // clear any async state so the reload starts clean
     m_status = PluginBegin;
     m_module = nullptr;
     m_mainObj = nullptr;

--- a/src/dde-control-center/dccpluginloader.h
+++ b/src/dde-control-center/dccpluginloader.h
@@ -3,6 +3,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 #pragma once
 
+#include <QQmlComponent>
+#include <QQmlContext>
+#include <QQmlIncubator>
+#include <memory>
 #include <QObject>
 #include <QQmlEngine>
 #include <QString>
@@ -29,6 +33,7 @@ public:
         // module 0x00FF0000
         ModuleLoad = 0x00010000,
         ModuleCreate = 0x00020000,
+        ModuleAdd = 0x00040000,
         ModuleEnd = 0x00400000,
         ModuleErr = 0x00800000,
         // data 0x0000FF00
@@ -86,11 +91,13 @@ public:
 
     // Dependency injection
     void setType(TypeFlags type);
+    void setModule(DccObject *module);
+    void setMainObj(DccObject *mainObj);
 
     // Loading methods
     void reset(); // Reset status and restart loading
     bool loadMetaData();
-    bool loadModule();
+    void loadModule();
     void loadData(); // For async loading in worker thread
     void createData();
     void createDccObject();
@@ -100,6 +107,12 @@ public:
     void addMainObject();
     void cancel();
 
+    // Async loading (module / main QML), driven by DccPluginManager's queue
+    void asyncLoadModule();
+    void asyncLoadMain();
+    void cancelAsync();
+    bool isAsyncBusy() const { return m_asyncPhase != AsyncPhase::None; }
+
     // Utility
     uint version() const;
     void transitionStatus(StatusFlags status);
@@ -107,9 +120,13 @@ public:
 private:
     // Private helper methods
     bool updateType();
+    void doLoadModule();
+    void doLoadMain();
+
 
 public Q_SLOTS:
     void updateVisible(bool visibleToApp);
+    void onComponentStatus(QQmlComponent::Status status);
 
 Q_SIGNALS:
     void statusChanged(DccPluginLoader *loader, StatusFlags status);
@@ -126,6 +143,23 @@ private:
 
     DccPluginManager *m_pManager;
     QStringList m_log;
+
+    // Incubator subclass: engine calls statusChanged directly, no polling
+    // (the callback may run synchronously inside component->create() for
+    // simple QML files). Dispatches back to the owning loader.
+    class AsyncIncubator;
+    friend class AsyncIncubator;
+
+    // Async loading state (module / main QML)
+    enum class AsyncPhase { None, Module, Main };
+    AsyncPhase m_asyncPhase = AsyncPhase::None;
+    std::unique_ptr<QQmlComponent> m_asyncComponent;   // module / main 分时复用
+    std::unique_ptr<AsyncIncubator> m_incubator;
+    // 约定：非空=持有，空=已转让给所创建对象
+    QQmlContext *m_asyncContext = nullptr;
+
+    void onIncubated(QQmlIncubator::Status status);
+    void finishAsync();
 };
 
 } // namespace dccV25

--- a/src/dde-control-center/pluginmanager.cpp
+++ b/src/dde-control-center/pluginmanager.cpp
@@ -25,6 +25,10 @@
 #include <QtConcurrent>
 #include <QtConcurrentRun>
 
+// module同步加载尽快显示，main异步加载不阻塞主线程
+// #define ASYNC_MODULE
+#define ASYNC_MAIN
+
 namespace dccV25 {
 
 const static QString TranslateReadDir = QStringLiteral(TRANSLATE_READ_DIR);
@@ -111,26 +115,35 @@ void DccPluginManager::loadPlugin(DccPluginLoader *loader)
         }
         loader->transitionStatus(DccPluginLoader::PluginEnd);
     } else if ((loader->status() & (DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad)) == DccPluginLoader::DataEnd) {
-        loader->transitionStatus(DccPluginLoader::MainObjLoad);
         loader->createDccObject();
         loader->updateParent();
+#ifdef ASYNC_MAIN
+        m_asyncQueue.enqueue(loader);
+        startNextAsync();
+#else
         loader->loadMain();
-        loader->transitionStatus(DccPluginLoader::MainObjEnd);
+#endif
     } else if ((loader->status() & (DccPluginLoader::ModuleEnd | DccPluginLoader::DataBegin)) == DccPluginLoader::ModuleEnd) {
-
+        if (!(loader->status() & DccPluginLoader::ModuleAdd) && loader->module()) {
+            if (!loader->module()->parent()) {
+                loader->module()->setParent(rootModule());
+            }
+            Q_EMIT addObject(loader->module());
+            Q_EMIT moduleLoaded(loader->name());
+            loader->transitionStatus(DccPluginLoader::ModuleAdd);
+        }
+        if (!loader->isVisibleToApp()) {
+            loader->setLog("create module finished, module is hidden");
+            loader->transitionStatus(DccPluginLoader::PluginEnd);
+        }
         checkNavigationFinished();
     } else if ((loader->status() & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad)) == DccPluginLoader::MetaDataEnd) {
-        loader->transitionStatus(DccPluginLoader::ModuleLoad);
-        const auto ret = loader->loadModule();
-        if (auto module = loader->module()) {
-            Q_EMIT addObject(module);
-        }
-        if (ret) {
-            loader->transitionStatus(DccPluginLoader::ModuleEnd);
-            Q_EMIT moduleLoaded(loader->name());
-        } else {
-            loader->transitionStatus(DccPluginLoader::ModuleEnd | DccPluginLoader::PluginEnd);
-        }
+#ifdef ASYNC_MODULE
+        m_asyncQueue.enqueue(loader);
+        startNextAsync();
+#else
+        loader->loadModule();
+#endif
     } else {
         if (loader->loadMetaData()) {
             loader->transitionStatus(DccPluginLoader::MetaDataEnd);
@@ -257,6 +270,12 @@ void DccPluginManager::checkLoadFinished()
 
 void DccPluginManager::cancelLoad()
 {
+    // Abort any in-flight / queued async QML loading
+    m_asyncQueue.clear();
+    m_asyncBusy = false;
+    for (auto *loader : std::as_const(m_plugins)) {
+        loader->cancelAsync();
+    }
     if (m_threadPool) {
         qCDebug(dccLog()) << "delete threadPool";
         m_threadPool->clear();
@@ -306,6 +325,37 @@ void DccPluginManager::onPluginStatusChanged(DccPluginLoader *loader, uint statu
     }
     if ((status & DccPluginLoader::PluginEndMask)) {
         loadPlugin(loader);
+    }
+    // Advance the serial async queue when the in-flight loader finished an
+    // async stage (module QML or main QML)
+    if ((status & (DccPluginLoader::ModuleEnd | DccPluginLoader::MainObjEnd))) {
+        m_asyncBusy = false;
+        startNextAsync();
+    }
+}
+
+void DccPluginManager::startNextAsync()
+{
+    if (m_asyncBusy) {
+        return; // a loader is mid-flight
+    }
+    if (m_asyncQueue.isEmpty()) {
+        return;
+    }
+    m_asyncBusy = true;
+    DccPluginLoader *loader = m_asyncQueue.dequeue();
+    const auto status = loader->status();
+    if ((status & (DccPluginLoader::MetaDataEnd | DccPluginLoader::ModuleLoad))
+        == DccPluginLoader::MetaDataEnd) {
+        loader->asyncLoadModule();
+    } else if ((status & (DccPluginLoader::DataEnd | DccPluginLoader::MainObjLoad))
+               == DccPluginLoader::DataEnd) {
+        loader->asyncLoadMain();
+    } else {
+        // 状态不匹配（如中途被 hide 短路等），此 loader 不会再经异步路径发 End，
+        // 同步跳过。递归安全：队列单调减小。
+        m_asyncBusy = false;
+        startNextAsync();
     }
 }
 

--- a/src/dde-control-center/pluginmanager.h
+++ b/src/dde-control-center/pluginmanager.h
@@ -7,6 +7,7 @@
 
 #include <QObject>
 #include <QQmlContext>
+#include <QQueue>
 #include <QStringList>
 #include <QVector>
 
@@ -60,6 +61,7 @@ private Q_SLOTS:
 private:
     void checkNavigationFinished();
     void checkLoadFinished();
+    void startNextAsync();
 
     DccManager *m_manager;
     QList<DccPluginLoader *> m_plugins; // cache for other plugin
@@ -71,6 +73,9 @@ private:
     DccLoadTimer m_loadTimer;
     bool m_navigationFinished = false;
     bool m_allLoadFinished = false;
+    // Serial async-loading queue (module / main QML via DccPluginLoader)
+    QQueue<DccPluginLoader *> m_asyncQueue;
+    bool m_asyncBusy = false;
 };
 
 } // namespace dccV25


### PR DESCRIPTION
1. Load plugin module/main QML asynchronously (QQmlComponent::Asynchronous
   + QQmlIncubator) inside DccPluginLoader: AsyncIncubator subclasses QQmlIncubator so the engine drives completion via statusChanged directly, with guards against stale callbacks after cancelAsync().
2. DccPluginManager drives a serial async queue (m_asyncQueue, m_asyncBusy, startNextAsync): module QML stays synchronous (ASYNC_MODULE off) so navigation appears fast, main QML loads asynchronously (ASYNC_MAIN on) without blocking the main thread.
3. Split loadModule()/loadMain() into sync wrappers (transitionStatus Load/End) and doLoadModule()/doLoadMain() implementations; extract setModule()/setMainObj() shared by both paths for parenting and visibleToAppChanged wiring.
4. Add ModuleAdd status; move addObject emission and the hidden-module short-circuit into DccPluginManager::loadPlugin with a ModuleAdd guard against duplicate adds on reload.
5. cancelLoad()/reset() abort queued and in-flight async loading; QQmlContext ownership follows "non-null = owned, null = handed over" and is parented to the created object to avoid leaks.

Log: Control center navigation appears earlier; plugin pages load in the background without blocking the UI.

Influence:
1. Launch control center: window shows and navigation appears first, plugin pages finish loading in the background without freezing.
2. Verify a plugin with broken main QML does not stall overall loading; other plugins still finish and cancel/reload paths stay clean.

feat: 通过孵化器队列异步加载插件 QML

1. 在 DccPluginLoader 内以异步方式（QQmlComponent::Asynchronous + QQmlIncubator）加载插件 module/main QML：AsyncIncubator 继承 QQmlIncubator，由引擎的 statusChanged 直接驱动完成，并对 cancelAsync() 之后的过期回调做了防护。
2. DccPluginManager 以串行异步队列驱动（m_asyncQueue、m_asyncBusy、 startNextAsync）：module QML 保持同步（ASYNC_MODULE 关闭）保证导航 尽快出现，main QML 异步加载（ASYNC_MAIN 开启）不阻塞主线程。
3. 将 loadModule()/loadMain() 拆分为同步包装（transitionStatus Load/End）与 doLoadModule()/doLoadMain() 实现；提取 setModule()/ setMainObj() 供同步/异步两条路径共享挂父逻辑与 visibleToAppChanged 接线。
4. 新增 ModuleAdd 状态；将 addObject 发送与隐藏插件短路移入 DccPluginManager::loadPlugin，并以 ModuleAdd 防止重新加载时重复添加。
5. cancelLoad()/reset() 会中止排队与进行中的异步加载；QQmlContext 所有权遵循"非空=持有、空=已转让"约定并挂接到所创建对象，避免泄漏。

Log: 控制中心导航更早出现，插件页面后台加载不阻塞界面。

Influence:
1. 启动控制中心：窗口与导航列表先就绪，各插件页面后台加载完成， 过程中界面不卡顿。
2. 验证某个插件 main QML 损坏时不会卡死整体加载，其余插件正常完成， 取消/重新加载路径无残留。

PMS: TASK-394433

## Summary by Sourcery

Enable non-blocking background loading of plugin pages while preserving fast synchronous navigation initialization.

New Features:
- Load plugin main QML asynchronously through a serial incubator queue so navigation becomes available sooner without blocking the UI.

Bug Fixes:
- Prevent broken or cancelled QML loads from stalling subsequent plugins and avoid duplicate module additions during reloads.
- Clean up asynchronous loading state and QML contexts reliably across cancellation, reset, and failed creation paths.

Enhancements:
- Separate synchronous and asynchronous loading flows while sharing object setup and visibility handling.